### PR TITLE
relabel_backported: add release in PR comment

### DIFF
--- a/repo_support/relabel_backported.py
+++ b/repo_support/relabel_backported.py
@@ -78,7 +78,7 @@ for pr, backports in backported_prs.items():
         if update:
             subprocess.check_output(
                 ['gh', 'pr', 'comment', pr,
-                 '-b', f'Backported to {release} in #{backport_pr}']
+                 '-b', f'Backported to release/{release} in #{backport_pr}']
             )
             subprocess.check_output(
                 ['gh', 'pr', 'edit', pr,

--- a/repo_support/relabel_backported.py
+++ b/repo_support/relabel_backported.py
@@ -78,7 +78,7 @@ for pr, backports in backported_prs.items():
         if update:
             subprocess.check_output(
                 ['gh', 'pr', 'comment', pr,
-                 '-b', f'Backported in #{backport_pr}']
+                 '-b', f'Backported to {release} in #{backport_pr}']
             )
             subprocess.check_output(
                 ['gh', 'pr', 'edit', pr,

--- a/repo_support/relabel_backported.py
+++ b/repo_support/relabel_backported.py
@@ -78,7 +78,7 @@ for pr, backports in backported_prs.items():
         if update:
             subprocess.check_output(
                 ['gh', 'pr', 'comment', pr,
-                 '-b', f'Backported to release/{release} in #{backport_pr}']
+                 '-b', f'Backported to [release/{release}](https://github.com/microsoft/openvmm/tree/release/{release}) in #{backport_pr}']
             )
             subprocess.check_output(
                 ['gh', 'pr', 'edit', pr,


### PR DESCRIPTION
Minor update to the backport relabeling script to include the release the change was backported to. This will be useful for PRs that are backported to multiple release branches.