### PR TITLE
hvlite_core: handle guest-initialiated reset in LoadedVm

### DIFF
--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -191,7 +191,7 @@ impl Manifest {
             chipset_devices: config.chipset_devices,
             generation_id_recv: config.generation_id_recv,
             rtc_delta_milliseconds: config.rtc_delta_milliseconds,
-            enable_guest_reset: config.enable_guest_reset,
+            automatic_guest_reset: config.automatic_guest_reset,
         }
     }
 }
@@ -232,7 +232,7 @@ pub struct Manifest {
     chipset_devices: Vec<ChipsetDeviceHandle>,
     generation_id_recv: Option<mesh::Receiver<[u8; 16]>>,
     rtc_delta_milliseconds: i64,
-    enable_guest_reset: bool,
+    automatic_guest_reset: bool,
 }
 
 #[derive(Protobuf, SavedStateRoot)]
@@ -551,7 +551,7 @@ struct LoadedVmInner {
     halt_recv: mesh::Receiver<HaltReason>,
     client_notify_send: mesh::Sender<HaltReason>,
     /// allow the guest to reset without notifying the client
-    enable_guest_reset: bool,
+    automatic_guest_reset: bool,
 }
 
 fn choose_hypervisor() -> anyhow::Result<Hypervisor> {
@@ -2303,7 +2303,7 @@ impl InitializedVm {
                 vmgs_client_inspect_handle,
                 halt_recv,
                 client_notify_send,
-                enable_guest_reset: cfg.enable_guest_reset,
+                automatic_guest_reset: cfg.automatic_guest_reset,
             },
         };
 
@@ -2758,7 +2758,7 @@ impl LoadedVm {
                 },
                 Event::Halt(Err(_)) => break,
                 Event::Halt(Ok(reason)) => {
-                    if matches!(reason, HaltReason::Reset) && self.inner.enable_guest_reset {
+                    if matches!(reason, HaltReason::Reset) && self.inner.automatic_guest_reset {
                         tracing::info!("guest-initiated reset");
                         if let Err(err) = self.reset(true).await {
                             tracing::error!(?err, "failed to reset VM");
@@ -2920,7 +2920,7 @@ impl LoadedVm {
             chipset_devices: vec![],   // TODO
             generation_id_recv: None,  // TODO
             rtc_delta_milliseconds: 0, // TODO
-            enable_guest_reset: self.inner.enable_guest_reset,
+            automatic_guest_reset: self.inner.automatic_guest_reset,
         };
         RestartState {
             hypervisor: self.inner.hypervisor,

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -55,7 +55,7 @@ pub struct Config {
     // This is used for testing. TODO: resourcify, and also store this in VMGS.
     pub rtc_delta_milliseconds: i64,
     /// allow the guest to reset without notifying the client
-    pub enable_guest_reset: bool,
+    pub automatic_guest_reset: bool,
 }
 
 // ARM64 needs a larger low gap.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1370,7 +1370,7 @@ fn vm_config_from_command_line(
         debugger_rpc: None,
         generation_id_recv: None,
         rtc_delta_milliseconds: 0,
-        enable_guest_reset: !opt.halt_on_reset,
+        automatic_guest_reset: !opt.halt_on_reset,
     };
 
     storage.build_config(&mut cfg, &mut resources, opt.scsi_sub_channels)?;

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -506,7 +506,7 @@ impl VmService {
             chipset_devices: chipset.chipset_devices,
             generation_id_recv: None,
             rtc_delta_milliseconds: 0,
-            enable_guest_reset: true,
+            automatic_guest_reset: true,
         };
 
         let mut scsi_rpc = None;

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -428,8 +428,8 @@ impl PetriVmConfigOpenVmm {
             custom_uefi_vars,
             vmgs,
 
-            // Don't allow guest resets by default
-            enable_guest_reset: false,
+            // Don't automatically reset the guest by default
+            automatic_guest_reset: false,
 
             // Disabled for VMM tests by default
             #[cfg(windows)]


### PR DESCRIPTION
This change allows a `LoadedVm` to intercept a halt event and optionally reset the VM when the guest requests it. This allows the guest to reboot when using the ttrpc/grpc interface for OpenVMM. The configuration also accepts a number of allowed restarts, which should make it easier to allow extra restarts for certain guests in petri tests.