### PR TITLE
hvdef: Add HvCallGetSystemProperty

### DIFF
--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -288,6 +288,7 @@ open_enum! {
         HvCallPostMessage = 0x005C,
         HvCallSignalEvent = 0x005D,
         HvCallOutputDebugCharacter = 0x0071,
+        HvCallGetSystemProperty = 0x007b,
         HvCallRetargetDeviceInterrupt = 0x007e,
         HvCallNotifyPartitionEvent = 0x0087,
         HvCallAssertVirtualInterrupt = 0x0094,


### PR DESCRIPTION
Chris saw this hypercall pop up as an unknown in some logs recently. We're not sure if we need to do anything with it yet, so for now just add it to the list so we get a proper name in logs going forward.