### PR TITLE
CVM: Move logic around memory faults from TDX to be shared with SNP, send memory intercepts (#1764)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7635,6 +7635,7 @@ dependencies = [
  "parking_lot",
  "sparse_mmap",
  "thiserror 2.0.12",
+ "tracelimit",
  "tracing",
  "underhill_threadpool",
  "virt",

--- a/openhcl/underhill_mem/Cargo.toml
+++ b/openhcl/underhill_mem/Cargo.toml
@@ -22,6 +22,7 @@ cvm_tracing.workspace = true
 inspect.workspace = true
 pal_async.workspace = true
 sparse_mmap.workspace = true
+tracelimit.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -249,7 +249,7 @@ unsafe impl GuestMemoryAccess for GuestMemoryView {
                     };
 
                     if !check_bitmap.page_state(gpn) {
-                        tracing::warn!(?address, ?len, ?write, ?self.view_type, "VTL 1 permissions violation");
+                        tracelimit::warn_ratelimited!(?address, ?len, ?write, ?self.view_type, "VTL 1 permissions violation");
 
                         return guestmem::PageFaultAction::Fail(guestmem::PageFaultError::new(
                             guestmem::GuestMemoryErrorKind::VtlProtected,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -21,18 +21,25 @@ use crate::processor::UhHypercallHandler;
 use crate::validate_vtl_gpa_flags;
 use cvm_tracing::CVM_ALLOWED;
 use guestmem::GuestMemory;
+use guestmem::GuestMemoryErrorKind;
 use hv1_emulator::RequestInterrupt;
 use hv1_hypercall::HvRepResult;
 use hv1_structs::ProcessorSet;
 use hv1_structs::VtlArray;
 use hvdef::HvCacheType;
 use hvdef::HvError;
+use hvdef::HvInterceptAccessType;
 use hvdef::HvInterruptType;
 use hvdef::HvMapGpaFlags;
+use hvdef::HvMessage;
+use hvdef::HvMessageType;
 use hvdef::HvRegisterVsmPartitionConfig;
 use hvdef::HvRegisterVsmVpSecureVtlConfig;
 use hvdef::HvResult;
 use hvdef::HvVtlEntryReason;
+use hvdef::HvX64InterceptMessageHeader;
+use hvdef::HvX64MemoryAccessInfo;
+use hvdef::HvX64MemoryInterceptMessage;
 use hvdef::HvX64PendingExceptionEvent;
 use hvdef::HvX64RegisterName;
 use hvdef::Vtl;
@@ -52,9 +59,11 @@ use virt::x86::MsrErrorExt;
 use virt_support_x86emu::emulate::TranslateGvaSupport;
 use virt_support_x86emu::translate::TranslateCachingInfo;
 use virt_support_x86emu::translate::TranslationRegisters;
+use vm_topology::memory::AddressType;
 use x86defs::cpuid;
 use x86defs::cpuid::CpuidFunction;
 use zerocopy::FromZeros;
+use zerocopy::IntoBytes;
 
 impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
     fn validate_register_access(
@@ -2353,7 +2362,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         self.backing.cvm_state_mut().hv[target_vtl].set_return_reason(entry_reason);
     }
 
-    fn send_intercept_message(&mut self, vtl: GuestVtl, message: &hvdef::HvMessage) {
+    fn send_intercept_message(&mut self, vtl: GuestVtl, message: &HvMessage) {
         tracing::trace!(?message, "sending intercept to {:?}", vtl);
 
         if let Err(e) = self.backing.cvm_state_mut().hv[vtl]
@@ -2443,6 +2452,148 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             }
             self.deliver_synic_messages(vtl, ready_sints);
             // Loop around to process the synic again.
+        }
+    }
+
+    /// Checks if a memory fault for the given VTL and GPA should be emulated,
+    /// or otherwise handled. Returns true if emulation is required, false if
+    /// all the necessary work is now done.
+    pub(crate) fn check_mem_fault(
+        &mut self,
+        vtl: GuestVtl,
+        gpa: u64,
+        is_write: bool,
+        extra_info: impl std::fmt::Debug,
+    ) -> bool {
+        let vtom = self.partition.caps.vtom.unwrap_or(0);
+        let is_shared = (gpa & vtom) == vtom && vtom != 0;
+        let canonical_gpa = gpa & !vtom;
+
+        // Only emulate the access if the gpa is mmio or outside of ram.
+        let address_type = self
+            .partition
+            .lower_vtl_memory_layout
+            .probe_address(canonical_gpa);
+
+        match address_type {
+            Some(AddressType::Mmio) => {
+                // Emulate the access.
+                true
+            }
+            Some(AddressType::Ram) => {
+                let (access_check, access_type) = if is_write {
+                    (
+                        self.partition.gm[vtl].probe_gpa_writable(gpa),
+                        HvInterceptAccessType::WRITE,
+                    )
+                } else {
+                    (
+                        self.partition.gm[vtl].probe_gpa_readable(gpa),
+                        HvInterceptAccessType::READ,
+                    )
+                };
+
+                match access_check {
+                    Ok(()) => {
+                        tracelimit::warn_ratelimited!(
+                            CVM_ALLOWED,
+                            gpa,
+                            ?vtl,
+                            ?extra_info,
+                            ?access_type,
+                            "possible spurious memory access violation, ignoring"
+                        );
+                    }
+                    Err(GuestMemoryErrorKind::VtlProtected) if vtl == GuestVtl::Vtl0 => {
+                        tracelimit::warn_ratelimited!(
+                            CVM_ALLOWED,
+                            gpa,
+                            ?vtl,
+                            ?extra_info,
+                            ?access_type,
+                            "guest accessed protected gpa, sending intercept"
+                        );
+                        let state = B::intercept_message_state(self, vtl, false);
+                        // TODO: We may want to fill in tpr_priority and gva
+                        // but tests pass without them.
+                        self.send_intercept_message(
+                            GuestVtl::Vtl1,
+                            &HvMessage::new(
+                                HvMessageType::HvMessageTypeGpaIntercept,
+                                0,
+                                HvX64MemoryInterceptMessage {
+                                    header: HvX64InterceptMessageHeader {
+                                        vp_index: self.vp_index().index(),
+                                        instruction_length_and_cr8: state
+                                            .instruction_length_and_cr8,
+                                        intercept_access_type: access_type,
+                                        execution_state: hvdef::HvX64VpExecutionState::new()
+                                            .with_cpl(state.cpl)
+                                            .with_vtl(vtl.into())
+                                            .with_efer_lma(state.efer_lma),
+                                        cs_segment: state.cs,
+                                        rip: state.rip,
+                                        rflags: state.rflags,
+                                    },
+                                    cache_type: HvCacheType::HvCacheTypeWriteBack,
+                                    memory_access_info: HvX64MemoryAccessInfo::new(),
+                                    tpr_priority: 0,
+                                    reserved: 0,
+                                    guest_virtual_address: 0,
+                                    guest_physical_address: gpa,
+                                    instruction_byte_count: 0,
+                                    instruction_bytes: [0; 16],
+                                }
+                                .as_bytes(),
+                            ),
+                        );
+                    }
+                    // TODO: Handle other error kinds differently?
+                    Err(_) => {
+                        tracelimit::warn_ratelimited!(
+                            CVM_ALLOWED,
+                            gpa,
+                            ?vtl,
+                            is_shared,
+                            ?extra_info,
+                            ?access_type,
+                            "guest accessed inaccessible gpa, injecting MC"
+                        );
+                        // TODO: Implement IA32_MCG_STATUS MSR for more reporting
+                        B::set_pending_exception(
+                            self,
+                            vtl,
+                            HvX64PendingExceptionEvent::new()
+                                .with_vector(x86defs::Exception::MACHINE_CHECK.0 as u16),
+                        );
+                    }
+                }
+                false
+            }
+            None => {
+                if !self.cvm_partition().hide_isolation {
+                    // TODO: Addresses outside of ram and mmio probably should
+                    // not be accessed by the guest, if it has been told about
+                    // isolation. While it's okay as we will return FFs or
+                    // discard writes for addresses that are not mmio, we should
+                    // consider if instead we should also inject a machine check
+                    // for such accesses. The guest should not access any
+                    // addresses not described to it.
+                    //
+                    // For now, log that the guest did this.
+                    tracelimit::warn_ratelimited!(
+                        CVM_ALLOWED,
+                        gpa,
+                        ?vtl,
+                        is_shared,
+                        ?extra_info,
+                        "guest accessed gpa not described in memory layout, emulating anyways"
+                    );
+                }
+
+                // Emulate the access.
+                true
+            }
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -75,6 +75,7 @@ use x86defs::snp::SevInvlpgbEcx;
 use x86defs::snp::SevInvlpgbEdx;
 use x86defs::snp::SevInvlpgbRax;
 use x86defs::snp::SevIoAccessInfo;
+use x86defs::snp::SevNpfInfo;
 use x86defs::snp::SevSelector;
 use x86defs::snp::SevStatusMsr;
 use x86defs::snp::SevVmsa;
@@ -280,8 +281,15 @@ impl HardwareIsolatedBacking for SnpBacked {
     ) -> InterceptMessageState {
         let vmsa = this.runner.vmsa(vtl);
 
+        // next_rip may not be set properly for NPFs, so don't read it.
+        let instr_len = if SevExitCode(vmsa.guest_error_code()) == SevExitCode::NPF {
+            0
+        } else {
+            (vmsa.next_rip() - vmsa.rip()) as u8
+        };
+
         InterceptMessageState {
-            instruction_length_and_cr8: (vmsa.next_rip() - vmsa.rip()) as u8,
+            instruction_length_and_cr8: instr_len,
             cpl: vmsa.cpl(),
             efer_lma: vmsa.efer() & x86defs::X64_EFER_LMA != 0,
             cs: virt_seg_from_snp(vmsa.cs()).into(),
@@ -1400,11 +1408,12 @@ impl UhProcessor<'_, SnpBacked> {
                 // #VC inside the guest for accesses to unmapped memory. This
                 // means that accesses to unmapped memory for lower VTLs will be
                 // forwarded to underhill as a #VC exception.
-                let exit_info2 = vmsa.exit_info2();
+                let gpa = vmsa.exit_info2();
                 let interruption_pending = vmsa.event_inject().valid()
                     || SevEventInjectInfo::from(vmsa.exit_int_info()).valid();
+                let exit_info = SevNpfInfo::from(vmsa.exit_info1());
                 let exit_message = self.runner.exit_message();
-                let emulate = match exit_message.header.typ {
+                let real = match exit_message.header.typ {
                     HvMessageType::HvMessageTypeExceptionIntercept => {
                         let exception_message =
                             exit_message.as_message::<hvdef::HvX64ExceptionInterceptMessage>();
@@ -1423,15 +1432,18 @@ impl UhProcessor<'_, SnpBacked> {
 
                         // Only the page numbers need to match.
                         (gpa_message.guest_physical_address >> hvdef::HV_PAGE_SHIFT)
-                            == (exit_info2 >> hvdef::HV_PAGE_SHIFT)
+                            == (gpa >> hvdef::HV_PAGE_SHIFT)
                     }
                     _ => false,
                 };
 
-                if emulate {
+                if real {
                     has_intercept = false;
-                    self.emulate(dev, interruption_pending, entered_from_vtl, ())
-                        .await?;
+                    if self.check_mem_fault(entered_from_vtl, gpa, exit_info.is_write(), exit_info)
+                    {
+                        self.emulate(dev, interruption_pending, entered_from_vtl, ())
+                            .await?;
+                    }
                     &mut self.backing.exit_stats[entered_from_vtl].npf
                 } else {
                     &mut self.backing.exit_stats[entered_from_vtl].npf_spurious

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -77,7 +77,6 @@ use virt_support_x86emu::emulate::emulate_insn_memory_op;
 use virt_support_x86emu::emulate::emulate_io;
 use virt_support_x86emu::emulate::emulate_translate_gva;
 use virt_support_x86emu::translate::TranslationRegisters;
-use vm_topology::memory::AddressType;
 use vmcore::vmtime::VmTimeAccess;
 use x86defs::RFlags;
 use x86defs::X64_CR0_ET;
@@ -2065,7 +2064,18 @@ impl UhProcessor<'_, TdxBacked> {
                         .into();
                     assert!(!old_interruptibility.blocked_by_nmi());
                 } else {
-                    self.handle_ept(intercepted_vtl, dev, gpa, ept_info).await?;
+                    let is_write = ept_info.access_mask() & 0b10 != 0;
+                    if self.check_mem_fault(intercepted_vtl, gpa, is_write, ept_info) {
+                        self.emulate(
+                            dev,
+                            self.backing.vtls[intercepted_vtl]
+                                .interruption_information
+                                .valid(),
+                            intercepted_vtl,
+                            TdxEmulationCache::default(),
+                        )
+                        .await?;
+                    }
                 }
 
                 &mut self.backing.vtls[intercepted_vtl].exit_stats.ept_violation
@@ -2445,120 +2455,6 @@ impl UhProcessor<'_, TdxBacked> {
             .with_interruption_type(INTERRUPT_TYPE_HARDWARE_EXCEPTION)
             .with_deliver_error_code(true);
         self.backing.vtls[vtl].exception_error_code = 0;
-    }
-
-    fn inject_mc(&mut self, vtl: GuestVtl) {
-        self.backing.vtls[vtl].interruption_information = InterruptionInformation::new()
-            .with_valid(true)
-            .with_vector(x86defs::Exception::MACHINE_CHECK.0)
-            .with_interruption_type(INTERRUPT_TYPE_HARDWARE_EXCEPTION);
-    }
-
-    async fn handle_ept(
-        &mut self,
-        intercepted_vtl: GuestVtl,
-        dev: &impl CpuIo,
-        gpa: u64,
-        ept_info: VmxEptExitQualification,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let vtom = self.partition.caps.vtom.unwrap_or(0);
-        let is_shared = (gpa & vtom) == vtom && vtom != 0;
-        let canonical_gpa = gpa & !vtom;
-
-        // Only emulate the access if the gpa is mmio or outside of ram.
-        let address_type = self
-            .partition
-            .lower_vtl_memory_layout
-            .probe_address(canonical_gpa);
-
-        match address_type {
-            Some(AddressType::Mmio) => {
-                // Emulate the access.
-                self.emulate(
-                    dev,
-                    self.backing.vtls[intercepted_vtl]
-                        .interruption_information
-                        .valid(),
-                    intercepted_vtl,
-                    TdxEmulationCache::default(),
-                )
-                .await?;
-            }
-            Some(AddressType::Ram) => {
-                // TODO TDX: This path changes when we support VTL page
-                // protections and MNF. That will require injecting events to
-                // VTL1 or other handling.
-                //
-                // For now, we just check if the exit was suprious or if we
-                // should inject a machine check. An exit is considered spurious
-                // if the gpa is accessible.
-                if self.partition.gm[intercepted_vtl]
-                    .probe_gpa_readable(gpa)
-                    .is_ok()
-                {
-                    tracelimit::warn_ratelimited!(
-                        CVM_ALLOWED,
-                        gpa,
-                        "possible spurious EPT violation, ignoring"
-                    );
-                } else {
-                    // TODO: It would be better to show what exact bitmap check
-                    // failed, but that requires some refactoring of how the
-                    // different bitmaps are stored. Do this when we support VTL
-                    // protections or MNF.
-                    //
-                    // If we entered this path, it means the bitmap check on
-                    // `check_gpa_readable` failed, so we can assume that if the
-                    // address is shared, the actual state of the page is
-                    // private, and vice versa. This is because the address
-                    // should have already been checked to be valid memory
-                    // described to the guest or not.
-                    tracelimit::warn_ratelimited!(
-                        CVM_ALLOWED,
-                        gpa,
-                        is_shared,
-                        ?ept_info,
-                        "guest accessed inaccessible gpa, injecting MC"
-                    );
-
-                    // TODO: Implement IA32_MCG_STATUS MSR for more reporting
-                    self.inject_mc(intercepted_vtl);
-                }
-            }
-            None => {
-                if !self.cvm_partition().hide_isolation {
-                    // TODO: Addresses outside of ram and mmio probably should
-                    // not be accessed by the guest, if it has been told about
-                    // isolation. While it's okay as we will return FFs or
-                    // discard writes for addresses that are not mmio, we should
-                    // consider if instead we should also inject a machine check
-                    // for such accesses. The guest should not access any
-                    // addresses not described to it.
-                    //
-                    // For now, log that the guest did this.
-                    tracelimit::warn_ratelimited!(
-                        CVM_ALLOWED,
-                        gpa,
-                        is_shared,
-                        ?ept_info,
-                        "guest accessed gpa not described in memory layout, emulating anyways"
-                    );
-                }
-
-                // Emulate the access.
-                self.emulate(
-                    dev,
-                    self.backing.vtls[intercepted_vtl]
-                        .interruption_information
-                        .valid(),
-                    intercepted_vtl,
-                    TdxEmulationCache::default(),
-                )
-                .await?;
-            }
-        }
-
-        Ok(())
     }
 
     fn handle_tdvmcall(&mut self, dev: &impl CpuIo, intercepted_vtl: GuestVtl) {

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1956,6 +1956,14 @@ impl GuestMemory {
         self.read_at_inner(gpa, &mut b).map_err(|err| err.kind)
     }
 
+    /// Check if a given GPA is writeable or not.
+    pub fn probe_gpa_writable(&self, gpa: u64) -> Result<(), GuestMemoryErrorKind> {
+        let _ = self
+            .compare_exchange(gpa, 0u8, 0)
+            .map_err(|err| err.kind())?;
+        Ok(())
+    }
+
     /// Gets a slice of guest memory assuming the memory was already locked via
     /// [`GuestMemory::lock_gpns`].
     ///

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -184,7 +184,7 @@ pub struct SevIoAccessInfo {
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq)]
 pub struct SevNpfInfo {
     pub present: bool,
-    pub read_write: bool,
+    pub is_write: bool,
     pub user: bool,
     pub reserved_bit_set: bool,
     pub fetch: bool,


### PR DESCRIPTION
This fixes some crashes within OpenHCL when memory protections are violated in SNP that were already handled properly in TDX. Also updates the logic to send memory intercepts on VTL 1 permissions violations.

Fixes #689, and some OS repo tests

Cherry-pick of #1764 