### PR TITLE
wip: flowey: publish openvmm and openhcl via github release

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3235,6 +3235,123 @@ jobs:
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
       run: flowey e 20 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
+  job21:
+    name: publish openvmm gh release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job1
+    - job10
+    - job11
+    - job12
+    - job13
+    - job14
+    - job15
+    - job16
+    - job17
+    - job18
+    - job19
+    - job2
+    - job20
+    - job3
+    - job4
+    - job5
+    - job6
+    - job7
+    - job8
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-6,aarch64-openhcl-igvm,aarch64-windows-openvmm,x64-linux-openvmm,x64-openhcl-igvm,x64-windows-openvmm}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-6/flowey
+
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 21 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-openhcl-igvm" | flowey v 21 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-openvmm" | flowey v 21 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-openhcl-igvm" | flowey v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-openvmm" | flowey v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_gh_cli 1
+        flowey v 21 'flowey_lib_hvlite::_jobs::publish_openvmm_gh_release:20:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --is-secret --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: |-
+        flowey e 21 flowey_lib_common::use_gh_cli 0
+        flowey v 21 'flowey_lib_hvlite::_jobs::publish_openvmm_gh_release:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.repository <<EOF
+        ${{ github.repository }}
+        EOF
+        flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_lib_hvlite::_jobs::publish_openvmm_gh_release 7
+        flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_lib_hvlite::_jobs::publish_openvmm_gh_release 8
+        flowey e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey e 21 flowey_lib_hvlite::_jobs::publish_openvmm_gh_release 9
+        flowey e 21 flowey_lib_hvlite::_jobs::publish_openvmm_gh_release 10
+        flowey e 21 flowey_lib_hvlite::_jobs::publish_openvmm_gh_release 11
+        flowey v 21 'flowey_lib_hvlite::_jobs::publish_openvmm_gh_release:1:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.ref_name <<EOF
+        ${{ github.ref_name }}
+        EOF
+        flowey v 21 'flowey_lib_hvlite::_jobs::publish_openvmm_gh_release:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.run_id <<EOF
+        ${{ github.run_id }}
+        EOF
+        flowey e 21 flowey_lib_hvlite::_jobs::publish_openvmm_gh_release 3
+        flowey e 21 flowey_lib_hvlite::_jobs::publish_openvmm_gh_release 4
+        flowey e 21 flowey_lib_hvlite::_jobs::publish_openvmm_gh_release 5
+        flowey v 21 'flowey_lib_hvlite::_jobs::publish_openvmm_gh_release:9:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.sha <<EOF
+        ${{ github.sha }}
+        EOF
+      shell: bash
+    - name: publish github releases
+      run: flowey e 21 flowey_lib_common::publish_gh_release 0
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 21 flowey_lib_common::cache 3
+      shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on: windows-latest

--- a/flowey/flowey_core/src/node/github_context.rs
+++ b/flowey/flowey_core/src/node/github_context.rs
@@ -121,6 +121,21 @@ impl GhContextVarReader<'_, state::Global> {
     pub fn token(self) -> ReadVar<String> {
         self.read_var("github.token", true, false)
     }
+
+    /// `github.sha`
+    pub fn sha(self) -> ReadVar<String> {
+        self.read_var("github.sha", false, false)
+    }
+
+    /// `github.run_id`
+    pub fn run_id(self) -> ReadVar<String> {
+        self.read_var("github.run_id", false, false)
+    }
+
+    /// `github.ref_name`
+    pub fn ref_name(self) -> ReadVar<String> {
+        self.read_var("github.ref_name", false, false)
+    }
 }
 
 impl GhContextVarReader<'_, state::Event> {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -159,11 +159,13 @@ impl IntoPipeline for CheckinGatesCli {
         // are used to "skim off" various artifacts that the VMM test jobs
         // require.
         let mut vmm_tests_artifacts_linux_x86 =
-            vmm_tests_artifact_builders::VmmTestsArtifactsBuilderLinuxX86::default();
+            artifact_builders::VmmTestsArtifactsBuilderLinuxX86::default();
         let mut vmm_tests_artifacts_windows_x86 =
-            vmm_tests_artifact_builders::VmmTestsArtifactsBuilderWindowsX86::default();
+            artifact_builders::VmmTestsArtifactsBuilderWindowsX86::default();
         let mut vmm_tests_artifacts_windows_aarch64 =
-            vmm_tests_artifact_builders::VmmTestsArtifactsBuilderWindowsAarch64::default();
+            artifact_builders::VmmTestsArtifactsBuilderWindowsAarch64::default();
+
+        let mut gh_release_artifacts = artifact_builders::GhReleaseArtifactsBuilder::default();
 
         // We need to maintain a list of all jobs, so we can hang the "all good"
         // job off of them. This is requires because github status checks only allow
@@ -244,12 +246,14 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_windows_x86.use_pipette_windows =
                         Some(use_pipette_windows.clone());
                     vmm_tests_artifacts_windows_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                    gh_release_artifacts.use_openvmm_windows_x64 = Some(use_openvmm.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_openvmm = Some(use_openvmm.clone());
                     vmm_tests_artifacts_windows_aarch64.use_pipette_windows =
                         Some(use_pipette_windows.clone());
                     vmm_tests_artifacts_windows_aarch64.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                    gh_release_artifacts.use_openvmm_windows_aarch64 = Some(use_openvmm.clone());
                 }
             }
             // emit a job for artifacts which _are not_ in the VMM tests "hot
@@ -437,6 +441,7 @@ impl IntoPipeline for CheckinGatesCli {
                         Some(use_guest_test_uefi.clone());
                     vmm_tests_artifacts_windows_x86.use_tmks = Some(use_tmks.clone());
                     vmm_tests_artifacts_linux_x86.use_tmks = Some(use_tmks.clone());
+                    gh_release_artifacts.use_openvmm_linux_x64 = Some(use_openvmm.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_guest_test_uefi =
@@ -864,7 +869,7 @@ impl IntoPipeline for CheckinGatesCli {
             gh_pool: GhRunner,
             label: &'a str,
             target: CommonTriple,
-            resolve_vmm_tests_artifacts: vmm_tests_artifact_builders::ResolveVmmTestsDepArtifacts,
+            resolve_vmm_tests_artifacts: artifact_builders::ResolveVmmTestsDepArtifacts,
             nextest_filter_expr: String,
             test_artifacts: Vec<KnownTestArtifacts>,
         }
@@ -1025,37 +1030,66 @@ impl IntoPipeline for CheckinGatesCli {
             all_jobs.push(job);
         }
 
-        if matches!(config, PipelineConfig::Pr) {
-            // Add a job that depends on all others as a workaround for
-            // https://github.com/orgs/community/discussions/12395.
-            //
-            // This workaround then itself requires _another_ workaround, requiring
-            // the use of `gh_dangerous_override_if`, and some additional custom job
-            // logic, to deal with https://github.com/actions/runner/issues/2566.
-            //
-            // TODO: Add a way for this job to skip flowey setup and become a true
-            // no-op.
-            let all_good_job = pipeline
-                .new_job(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                    FlowArch::X86_64,
-                    "openvmm checkin gates",
-                )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::default_gh_hosted(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                ))
-                // always run this job, regardless whether or not any previous jobs failed
-                .gh_dangerous_override_if("always() && github.event.pull_request.draft == false")
-                .gh_dangerous_global_env_var("ANY_JOBS_FAILED", "${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}")
-                .dep_on(|ctx| flowey_lib_hvlite::_jobs::all_good_job::Params {
-                    did_fail_env_var: "ANY_JOBS_FAILED".into(),
-                    done: ctx.new_done_handle(),
-                })
-                .finish();
+        match config {
+            PipelineConfig::Pr => {
+                // Add a job that depends on all others as a workaround for
+                // https://github.com/orgs/community/discussions/12395.
+                //
+                // This workaround then itself requires _another_ workaround, requiring
+                // the use of `gh_dangerous_override_if`, and some additional custom job
+                // logic, to deal with https://github.com/actions/runner/issues/2566.
+                //
+                // TODO: Add a way for this job to skip flowey setup and become a true
+                // no-op.
+                let all_good_job = pipeline
+                        .new_job(
+                            FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                            FlowArch::X86_64,
+                            "openvmm checkin gates",
+                        )
+                        .gh_set_pool(crate::pipelines_shared::gh_pools::default_gh_hosted(
+                            FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                        ))
+                        // always run this job, regardless whether or not any previous jobs failed
+                        .gh_dangerous_override_if("always() && github.event.pull_request.draft == false")
+                        .gh_dangerous_global_env_var("ANY_JOBS_FAILED", "${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}")
+                        .dep_on(|ctx| flowey_lib_hvlite::_jobs::all_good_job::Params {
+                            did_fail_env_var: "ANY_JOBS_FAILED".into(),
+                            done: ctx.new_done_handle(),
+                        })
+                        .finish();
 
-            for job in all_jobs.iter() {
-                pipeline.non_artifact_dep(&all_good_job, job);
+                for job in all_jobs.iter() {
+                    pipeline.non_artifact_dep(&all_good_job, job);
+                }
             }
+            PipelineConfig::Ci => {
+                let gh_release_artifacts = gh_release_artifacts.finish().map_err(|missing| {
+                    anyhow::anyhow!("missing required gh release artifact: {missing}")
+                })?;
+
+                let publish_job = pipeline
+                    .new_job(
+                        FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                        FlowArch::X86_64,
+                        "publish openvmm gh release",
+                    )
+                    .gh_set_pool(crate::pipelines_shared::gh_pools::default_gh_hosted(
+                        FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                    ))
+                    // always run this job, regardless whether or not any previous jobs failed
+                    .dep_on(
+                        |ctx| flowey_lib_hvlite::_jobs::publish_openvmm_gh_release::Request {
+                            done: ctx.new_done_handle(),
+                        },
+                    )
+                    .finish();
+
+                for job in all_jobs.iter() {
+                    pipeline.non_artifact_dep(&publish_job, job);
+                }
+            }
+            PipelineConfig::PrRelease => {}
         }
 
         Ok(pipeline)
@@ -1063,13 +1097,14 @@ impl IntoPipeline for CheckinGatesCli {
 }
 
 /// Utility builders which make it easy to "skim off" artifacts required by VMM
-/// test execution from other pipeline jobs.
+/// test execution or release publishing from other pipeline jobs.
 //
 // FUTURE: if we end up having a _lot_ of VMM test jobs, this would be the sort
 // of thing that would really benefit from a derive macro.
-mod vmm_tests_artifact_builders {
+mod artifact_builders {
     use flowey::pipeline::prelude::*;
     use flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive::VmmTestsDepArtifacts;
+    use flowey_lib_hvlite::_jobs::publish_openvmm_gh_release::OpenvmmGhReleaseArtifacts;
     use flowey_lib_hvlite::build_guest_test_uefi::GuestTestUefiOutput;
     use flowey_lib_hvlite::build_openvmm::OpenvmmOutput;
     use flowey_lib_hvlite::build_pipette::PipetteOutput;
@@ -1220,6 +1255,44 @@ mod vmm_tests_artifact_builders {
                 tmk_vmm: Some(ctx.use_typed_artifact(&use_tmk_vmm)),
                 tmk_vmm_linux_musl: Some(ctx.use_typed_artifact(&use_tmk_vmm_linux_musl)),
                 tmks: Some(ctx.use_typed_artifact(&use_tmks)),
+            }))
+        }
+    }
+
+    #[derive(Default, Clone)]
+    pub struct GhReleaseArtifactsBuilder {
+        pub use_openvmm_windows_x64: Option<UseTypedArtifact<OpenvmmOutput>>,
+        pub use_openvmm_windows_aarch64: Option<UseTypedArtifact<OpenvmmOutput>>,
+        pub use_openvmm_linux_x64: Option<UseTypedArtifact<OpenvmmOutput>>,
+        pub use_openhcl_igvm_files_x64: Option<UseArtifact>,
+        pub use_openhcl_igvm_files_aarch64: Option<UseArtifact>,
+    }
+
+    impl GhReleaseArtifactsBuilder {
+        pub fn finish(self) -> Result<OpenvmmGhReleaseArtifacts, &'static str> {
+            let GhReleaseArtifactsBuilder {
+                use_openvmm_windows_x64,
+                use_openvmm_windows_aarch64,
+                use_openvmm_linux_x64,
+                use_openhcl_igvm_files_x64,
+                use_openhcl_igvm_files_aarch64,
+            } = self;
+
+            let use_openvmm_windows_x64 = use_openvmm_windows_x64.ok_or("openvmm_windows_x64")?;
+            let use_openvmm_windows_aarch64 =
+                use_openvmm_windows_aarch64.ok_or("openvmm_windows_aarch64")?;
+            let use_openvmm_linux_x64 = use_openvmm_linux_x64.ok_or("openvmm_linux_x64")?;
+            let use_openhcl_igvm_files_x64 =
+                use_openhcl_igvm_files_x64.ok_or("openhcl_igvm_files")?;
+            let use_openhcl_igvm_files_aarch64 =
+                use_openhcl_igvm_files_aarch64.ok_or("openhcl_igvm_files")?;
+
+            Ok(Box::new(move |ctx| OpenvmmGhReleaseArtifacts {
+                openvmm_windows_x64: ctx.use_typed_artifact(&use_openvmm_windows_x64),
+                openvmm_windows_aarch64: ctx.use_typed_artifact(&use_openvmm_windows_aarch64),
+                openvmm_linux_x64: ctx.use_typed_artifact(&use_openvmm_linux_x64),
+                openhcl_igvm_files_x64: ctx.use_typed_artifact(&use_openhcl_igvm_files_x64),
+                openhcl_igvm_files_aarch64: ctx.use_typed_artifact(&use_openhcl_igvm_files_aarch64),
             }))
         }
     }

--- a/flowey/flowey_lib_common/src/lib.rs
+++ b/flowey/flowey_lib_common/src/lib.rs
@@ -45,6 +45,7 @@ pub mod install_nodejs;
 pub mod install_nuget_azure_credential_provider;
 pub mod install_rust;
 pub mod nuget_install_package;
+pub mod publish_gh_release;
 pub mod publish_test_results;
 pub mod run_cargo_build;
 pub mod run_cargo_clippy;

--- a/flowey/flowey_lib_common/src/publish_gh_release.rs
+++ b/flowey/flowey_lib_common/src/publish_gh_release.rs
@@ -5,95 +5,82 @@
 
 use flowey::node::prelude::*;
 
-#[derive(Serialize, Deserialize)]
-pub struct GhReleaseParams<C = VarNotClaimed> {
-    /// The github repo path
-    pub repo: ReadVar<String, C>,
-    /// Release tag
-    pub tag: ReadVar<String, C>,
-    /// Release title
-    pub title: ReadVar<String, C>,
-    /// Target branch or full commit SHA
-    pub target: ReadVar<String, C>,
-
-    /// Files to upload
-    pub files: Vec<ReadVar<PathBuf, C>>,
-
-    pub done: WriteVar<SideEffect, C>,
-}
-
 flowey_request! {
-    pub struct Request(pub GhReleaseParams);
+    pub struct Request{
+        /// The github repo path
+        pub repo: ReadVar<String>,
+        /// Release tag
+        pub tag: ReadVar<String>,
+        /// Release title
+        pub title: ReadVar<String>,
+        /// Target branch or full commit SHA
+        pub target: ReadVar<String>,
+        /// Files to upload
+        pub files: Vec<ReadVar<PathBuf>>,
+        /// Github token to authenticate with
+        pub gh_token: ReadVar<String>,
+
+        pub done: WriteVar<SideEffect>,
+    }
 }
 
-new_flow_node!(struct Node);
+new_simple_flow_node!(struct Node);
 
-impl FlowNode for Node {
+impl SimpleFlowNode for Node {
     type Request = Request;
 
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::use_gh_cli::Node>();
     }
 
-    fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
-        if requests.is_empty() {
-            return Ok(());
-        }
+    fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
+        let Request {
+            repo,
+            tag,
+            title,
+            target,
+            files,
+            gh_token,
+            done,
+        } = request;
 
+        ctx.req(crate::use_gh_cli::Request::WithAuth(
+            crate::use_gh_cli::GhCliAuth::AuthToken(gh_token),
+        ));
         let gh_cli = ctx.reqv(crate::use_gh_cli::Request::Get);
 
         ctx.emit_rust_step("publish github releases", |ctx| {
             let gh_cli = gh_cli.claim(ctx);
-            let requests = requests
-                .into_iter()
-                .map(|r| r.0.claim(ctx))
-                .collect::<Vec<_>>();
+
+            let repo = repo.claim(ctx);
+            let tag = tag.claim(ctx);
+            let title = title.claim(ctx);
+            let target = target.claim(ctx);
+            let files=  files.claim(ctx);
+
+            done.claim(ctx);
 
             move |rt| {
                 let gh_cli = rt.read(gh_cli);
 
+                let repo = rt.read(repo);
+                let tag = rt.read(tag);
+                let title = rt.read(title);
+                let target = rt.read(target);
+                let files = rt.read(files);
+
                 let sh = xshell::Shell::new()?;
 
-                for req in requests {
-                    let repo = rt.read(req.repo);
-                    let tag = rt.read(req.tag);
-                    let title = rt.read(req.title);
-                    let target = rt.read(req.target);
-                    let files = rt.read(req.files);
-
-                    xshell::cmd!(
-                        sh,
-                        "{gh_cli} release create --repo {repo} --title {title} --target {target} {tag} {files...}"
-                    )
-                    .run()?;
-                }
+                xshell::cmd!(
+                    sh,
+                    "{gh_cli} release create --repo {repo} --title {title} --target {target} {tag} {files...}"
+                )
+                .run()?;
 
                 Ok(())
             }
         });
 
         Ok(())
-    }
-}
-
-impl GhReleaseParams {
-    pub fn claim(self, ctx: &mut StepCtx<'_>) -> GhReleaseParams<VarClaimed> {
-        let GhReleaseParams {
-            repo,
-            tag,
-            title,
-            target,
-            files,
-            done,
-        } = self;
-
-        GhReleaseParams {
-            repo: repo.claim(ctx),
-            tag: tag.claim(ctx),
-            title: title.claim(ctx),
-            target: target.claim(ctx),
-            files: files.claim(ctx),
-            done: done.claim(ctx),
-        }
     }
 }

--- a/flowey/flowey_lib_common/src/publish_gh_release.rs
+++ b/flowey/flowey_lib_common/src/publish_gh_release.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Download a github release artifact
+
+use flowey::node::prelude::*;
+
+#[derive(Serialize, Deserialize)]
+pub struct GhReleaseParams<C = VarNotClaimed> {
+    /// The github repo path
+    pub repo: ReadVar<String, C>,
+    /// Release tag
+    pub tag: ReadVar<String, C>,
+    /// Release title
+    pub title: ReadVar<String, C>,
+    /// Target branch or full commit SHA
+    pub target: ReadVar<String, C>,
+
+    /// Files to upload
+    pub files: Vec<ReadVar<PathBuf, C>>,
+
+    pub done: WriteVar<SideEffect, C>,
+}
+
+flowey_request! {
+    pub struct Request(pub GhReleaseParams);
+}
+
+new_flow_node!(struct Node);
+
+impl FlowNode for Node {
+    type Request = Request;
+
+    fn imports(ctx: &mut ImportCtx<'_>) {
+        ctx.import::<crate::use_gh_cli::Node>();
+    }
+
+    fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
+        if requests.is_empty() {
+            return Ok(());
+        }
+
+        let gh_cli = ctx.reqv(crate::use_gh_cli::Request::Get);
+
+        ctx.emit_rust_step("publish github releases", |ctx| {
+            let gh_cli = gh_cli.claim(ctx);
+            let requests = requests
+                .into_iter()
+                .map(|r| r.0.claim(ctx))
+                .collect::<Vec<_>>();
+
+            move |rt| {
+                let gh_cli = rt.read(gh_cli);
+
+                let sh = xshell::Shell::new()?;
+
+                for req in requests {
+                    let repo = rt.read(req.repo);
+                    let tag = rt.read(req.tag);
+                    let title = rt.read(req.title);
+                    let target = rt.read(req.target);
+                    let files = rt.read(req.files);
+
+                    xshell::cmd!(
+                        sh,
+                        "{gh_cli} release create --repo {repo} --title {title} --target {target} {tag} {files...}"
+                    )
+                    .run()?;
+                }
+
+                Ok(())
+            }
+        });
+
+        Ok(())
+    }
+}
+
+impl GhReleaseParams {
+    pub fn claim(self, ctx: &mut StepCtx<'_>) -> GhReleaseParams<VarClaimed> {
+        let GhReleaseParams {
+            repo,
+            tag,
+            title,
+            target,
+            files,
+            done,
+        } = self;
+
+        GhReleaseParams {
+            repo: repo.claim(ctx),
+            tag: tag.claim(ctx),
+            title: title.claim(ctx),
+            target: target.claim(ctx),
+            files: files.claim(ctx),
+            done: done.claim(ctx),
+        }
+    }
+}

--- a/flowey/flowey_lib_hvlite/src/_jobs/mod.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/mod.rs
@@ -23,4 +23,5 @@ pub mod local_build_and_run_nextest_vmm_tests;
 pub mod local_build_igvm;
 pub mod local_custom_vmfirmwareigvm_dll;
 pub mod local_restore_packages;
+pub mod publish_openvmm_gh_release;
 pub mod test_local_flowey_build_igvm;

--- a/flowey/flowey_lib_hvlite/src/_jobs/publish_openvmm_gh_release.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/publish_openvmm_gh_release.rs
@@ -42,19 +42,18 @@ impl SimpleFlowNode for Node {
         });
         let title = tag.map(ctx, |t| format!("OpenVMM {t}"));
         let target = ctx.get_gh_context_var().global().sha();
-
         let files = artifacts.into_paths(ctx);
+        let gh_token = ctx.get_gh_context_var().global().token();
 
-        ctx.req(flowey_lib_common::publish_gh_release::Request(
-            flowey_lib_common::publish_gh_release::GhReleaseParams {
-                repo,
-                tag,
-                title,
-                target,
-                files,
-                done,
-            },
-        ));
+        ctx.req(flowey_lib_common::publish_gh_release::Request {
+            repo,
+            tag,
+            title,
+            target,
+            files,
+            gh_token,
+            done,
+        });
 
         Ok(())
     }

--- a/flowey/flowey_lib_hvlite/src/_jobs/publish_openvmm_gh_release.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/publish_openvmm_gh_release.rs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Publishes a github release for OpenVMM
+
+use crate::build_openvmm::OpenvmmOutput;
+use flowey::node::prelude::*;
+
+#[derive(Serialize, Deserialize)]
+pub struct OpenvmmGhReleaseArtifacts {
+    pub openvmm_windows_x64: ReadVar<OpenvmmOutput>,
+    pub openvmm_windows_aarch64: ReadVar<OpenvmmOutput>,
+    pub openvmm_linux_x64: ReadVar<OpenvmmOutput>,
+    pub openhcl_igvm_files_x64: ReadVar<PathBuf>,
+    pub openhcl_igvm_files_aarch64: ReadVar<PathBuf>,
+}
+
+flowey_request! {
+    pub struct Request {
+        pub artifacts: OpenvmmGhReleaseArtifacts,
+        pub done: WriteVar<SideEffect>,
+    }
+}
+
+new_simple_flow_node!(struct Node);
+
+impl SimpleFlowNode for Node {
+    type Request = Request;
+
+    fn imports(ctx: &mut ImportCtx<'_>) {
+        ctx.import::<flowey_lib_common::publish_gh_release::Node>();
+    }
+
+    fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
+        let Request { artifacts, done } = request;
+
+        let repo = ctx.get_gh_context_var().global().repository();
+        let branch = ctx.get_gh_context_var().global().ref_name();
+        let run_id = ctx.get_gh_context_var().global().run_id();
+        let tag = branch.zip(ctx, run_id).map(ctx, |(b, r)| {
+            format!("{}.{r}", b.trim_start_matches("release/"))
+        });
+        let title = tag.map(ctx, |t| format!("OpenVMM {t}"));
+        let target = ctx.get_gh_context_var().global().sha();
+
+        let files = artifacts.into_paths(ctx);
+
+        ctx.req(flowey_lib_common::publish_gh_release::Request(
+            flowey_lib_common::publish_gh_release::GhReleaseParams {
+                repo,
+                tag,
+                title,
+                target,
+                files,
+                done,
+            },
+        ));
+
+        Ok(())
+    }
+}
+
+impl OpenvmmGhReleaseArtifacts {
+    fn into_paths(self, ctx: &mut NodeCtx<'_>) -> Vec<ReadVar<PathBuf>> {
+        vec![
+            self.openvmm_windows_x64.map(ctx, |x| match x {
+                OpenvmmOutput::WindowsBin { exe, .. } => exe,
+                _ => unreachable!(),
+            }),
+            self.openvmm_windows_aarch64.map(ctx, |x| match x {
+                OpenvmmOutput::WindowsBin { exe, .. } => exe,
+                _ => unreachable!(),
+            }),
+            self.openvmm_linux_x64.map(ctx, |x| match x {
+                OpenvmmOutput::LinuxBin { bin, .. } => bin,
+                _ => unreachable!(),
+            }),
+            self.openhcl_igvm_files_x64.map(ctx, |x| x.join("*")),
+            self.openhcl_igvm_files_aarch64.map(ctx, |x| x.join("*")),
+        ]
+    }
+}


### PR DESCRIPTION
Implements the necessary flowey code to publish a github release in flowey, and publishes a barebones release of OpenVMM and OpenHCL. 

Note that this code still needs to be tested