### PR TITLE
openhcl/loader: increase aarch64 dev manifest default memory size

### DIFF
--- a/vm/loader/manifests/openhcl-aarch64-dev.json
+++ b/vm/loader/manifests/openhcl-aarch64-dev.json
@@ -7,7 +7,7 @@
             "isolation_type": "none",
             "image": {
                 "openhcl": {
-                    "memory_page_count": 24576,
+                    "memory_page_count": 126976,
                     "command_line": "console=null",
                     "uefi": true
                 }


### PR DESCRIPTION
The default size is too small and does not actually boot and we instead get an OOM error. Increase it to match the x64 one. 