### PR TITLE
petri: use cloudinit even if not using pipette

### DIFF
--- a/petri/guest-bootstrap/user-data-no-agent
+++ b/petri/guest-bootstrap/user-data-no-agent
@@ -1,0 +1,16 @@
+#cloud-config
+
+users:
+  # Allow logins via petri/petri for debugging.
+  - name: petri
+    passwd: "$6$EO8qjMcfYFra1zR8$ZHzeU29UoO49S3gJMivhgsP7farZgEbfOkKeXfswZeT7go1SpyPbL68whWCG5.YEdS4NeyPYYZYiLo5Fq4igV0"
+    lock_passwd: false
+    groups: users, admin
+
+bootcmd:
+  # Mounts module is not configured in some (all?) distros, so mount /cidata manually.
+  - [mkdir, -p, /cidata]
+  - [mount, LABEL=cidata, /cidata, -o, ro]
+  # Disable snapd, which takes a long time to start and is not needed.
+  - systemctl disable snapd.service snapd.apparmor snapd.seeded.service || true
+  - systemctl mask snapd.service || true

--- a/petri/petri-tool/src/main.rs
+++ b/petri/petri-tool/src/main.rs
@@ -56,7 +56,10 @@ fn main() -> anyhow::Result<()> {
                     )
             })?;
 
-            let disk = image.build().context("failed to build disk image")?;
+            let disk = image
+                .build()
+                .context("failed to build disk image")?
+                .context("no files for the this platform")?;
             disk.persist(output)
                 .context("failed to persist disk image")?;
 

--- a/petri/petri-tool/src/main.rs
+++ b/petri/petri-tool/src/main.rs
@@ -42,14 +42,18 @@ fn main() -> anyhow::Result<()> {
     match args.command {
         Command::CloudInit { output, arch } => {
             let image = build_with_artifacts(|resolver: ArtifactResolver<'_>| {
-                petri::disk_image::AgentImage::new(
-                    &resolver,
-                    match arch {
-                        MachineArch::X86_64 => petri_artifacts_common::tags::MachineArch::X86_64,
-                        MachineArch::Aarch64 => petri_artifacts_common::tags::MachineArch::Aarch64,
-                    },
-                    petri_artifacts_common::tags::OsFlavor::Linux,
-                )
+                petri::disk_image::AgentImage::new(petri_artifacts_common::tags::OsFlavor::Linux)
+                    .with_pipette(
+                        &resolver,
+                        match arch {
+                            MachineArch::X86_64 => {
+                                petri_artifacts_common::tags::MachineArch::X86_64
+                            }
+                            MachineArch::Aarch64 => {
+                                petri_artifacts_common::tags::MachineArch::Aarch64
+                            }
+                        },
+                    )
             })?;
 
             let disk = image.build().context("failed to build disk image")?;

--- a/petri/src/disk_image.rs
+++ b/petri/src/disk_image.rs
@@ -57,7 +57,9 @@ impl AgentImage {
                     .require(common_artifacts::PIPETTE_LINUX_AARCH64)
                     .erase(),
             ),
-            (OsFlavor::FreeBsd | OsFlavor::Uefi, _) => None,
+            (OsFlavor::FreeBsd | OsFlavor::Uefi, _) => {
+                todo!("No pipette binary yet for os");
+            }
         };
         self
     }
@@ -113,10 +115,8 @@ impl AgentImage {
                 ]);
                 b"cidata     " // cloud-init looks for a volume label of "cidata",
             }
-            OsFlavor::FreeBsd | OsFlavor::Uefi => {
-                // No pipette binary yet.
-                todo!()
-            }
+            // Nothing OS-specific yet for other flavors
+            _ => b"cidata     ",
         };
         build_disk_image(volume_label, &files)
     }

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -19,6 +19,7 @@ use crate::PetriVmmBackend;
 use crate::SecureBootTemplate;
 use crate::ShutdownKind;
 use crate::UefiConfig;
+use crate::disk_image::AgentImage;
 use crate::hyperv::powershell::HyperVSecureBootTemplate;
 use crate::openhcl_diag::OpenHclDiagHandler;
 use crate::vm::append_cmdline;
@@ -267,35 +268,35 @@ impl PetriVmmBackend for HyperVPetriBackend {
         if let Some(agent_image) = agent_image {
             // Construct the agent disk.
             let agent_disk_path = temp_dir.path().join("cidata.vhd");
-            {
-                let agent_disk = agent_image.build().context("failed to build agent image")?;
-                disk_vhd1::Vhd1Disk::make_fixed(agent_disk.as_file())
-                    .context("failed to make vhd for agent image")?;
-                agent_disk.persist(&agent_disk_path)?;
-            }
 
-            if agent_image.contains_pipette() && matches!(firmware.os_flavor(), OsFlavor::Windows) {
-                // Make a file for the IMC hive. It's not guaranteed to be at a fixed
-                // location at runtime.
-                let imc_hive = temp_dir.path().join("imc.hiv");
+            if build_and_persist_agent_image(agent_image, &agent_disk_path)
+                .context("vtl0 agent disk")?
+            {
+                if agent_image.contains_pipette()
+                    && matches!(firmware.os_flavor(), OsFlavor::Windows)
                 {
-                    let mut imc_hive_file = fs::File::create_new(&imc_hive)?;
-                    imc_hive_file
-                        .write_all(include_bytes!("../../../guest-bootstrap/imc.hiv"))
-                        .context("failed to write imc hive")?;
+                    // Make a file for the IMC hive. It's not guaranteed to be at a fixed
+                    // location at runtime.
+                    let imc_hive = temp_dir.path().join("imc.hiv");
+                    {
+                        let mut imc_hive_file = fs::File::create_new(&imc_hive)?;
+                        imc_hive_file
+                            .write_all(include_bytes!("../../../guest-bootstrap/imc.hiv"))
+                            .context("failed to write imc hive")?;
+                    }
+
+                    // Set the IMC
+                    vm.set_imc(&imc_hive)?;
                 }
 
-                // Set the IMC
-                vm.set_imc(&imc_hive)?;
+                let controller_number = vm.add_scsi_controller(0)?;
+                vm.add_vhd(
+                    &agent_disk_path,
+                    powershell::ControllerType::Scsi,
+                    Some(0),
+                    Some(controller_number),
+                )?;
             }
-
-            let controller_number = vm.add_scsi_controller(0)?;
-            vm.add_vhd(
-                &agent_disk_path,
-                powershell::ControllerType::Scsi,
-                Some(0),
-                Some(controller_number),
-            )?;
         }
 
         let openhcl_diag_handler = if let Some((
@@ -332,24 +333,20 @@ impl PetriVmmBackend for HyperVPetriBackend {
 
             vm.set_vmbus_redirect(*vmbus_redirect)?;
 
-            if let Some(openhcl_agent_image) = openhcl_agent_image {
+            if let Some(agent_image) = openhcl_agent_image {
                 let agent_disk_path = temp_dir.path().join("paravisor_cidata.vhd");
-                {
-                    let agent_disk = openhcl_agent_image
-                        .build()
-                        .context("failed to build openhcl agent image")?;
-                    disk_vhd1::Vhd1Disk::make_fixed(agent_disk.as_file())
-                        .context("failed to make vhd for agent image")?;
-                    agent_disk.persist(&agent_disk_path)?;
-                }
 
-                let controller_number = vm.add_scsi_controller(2)?;
-                vm.add_vhd(
-                    &agent_disk_path,
-                    powershell::ControllerType::Scsi,
-                    Some(0),
-                    Some(controller_number),
-                )?;
+                if build_and_persist_agent_image(agent_image, &agent_disk_path)
+                    .context("vtl2 agent disk")?
+                {
+                    let controller_number = vm.add_scsi_controller(2)?;
+                    vm.add_vhd(
+                        &agent_disk_path,
+                        powershell::ControllerType::Scsi,
+                        Some(0),
+                        Some(controller_number),
+                    )?;
+                }
             }
 
             let openhcl_log_file = log_source.log_file("openhcl")?;
@@ -508,4 +505,20 @@ fn acl_read_for_vm(path: &Path, id: Option<guid::Guid>) -> anyhow::Result<()> {
         anyhow::bail!("icacls failed: {stderr}");
     }
     Ok(())
+}
+
+fn build_and_persist_agent_image(
+    agent_image: &AgentImage,
+    agent_disk_path: &Path,
+) -> anyhow::Result<bool> {
+    Ok(
+        if let Some(agent_disk) = agent_image.build().context("failed to build agent image")? {
+            disk_vhd1::Vhd1Disk::make_fixed(agent_disk.as_file())
+                .context("failed to make vhd for agent image")?;
+            agent_disk.persist(agent_disk_path)?;
+            true
+        } else {
+            false
+        },
+    )
 }

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -274,7 +274,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
                 agent_disk.persist(&agent_disk_path)?;
             }
 
-            if matches!(firmware.os_flavor(), OsFlavor::Windows) {
+            if agent_image.contains_pipette() && matches!(firmware.os_flavor(), OsFlavor::Windows) {
                 // Make a file for the IMC hive. It's not guaranteed to be at a fixed
                 // location at runtime.
                 let imc_hive = temp_dir.path().join("imc.hiv");

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -57,36 +57,38 @@ impl PetriVmConfigOpenVmm {
             const UH_CIDATA_SCSI_INSTANCE: Guid =
                 guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48a7c");
 
-            let uh_agent_disk = resources
+            if let Some(openhcl_agent_disk) = resources
                 .openhcl_agent_image
                 .as_ref()
                 .unwrap()
                 .build()
-                .context("failed to build agent image")?;
-
-            config.vmbus_devices.push((
-                DeviceVtl::Vtl2,
-                ScsiControllerHandle {
-                    instance_id: UH_CIDATA_SCSI_INSTANCE,
-                    max_sub_channel_count: 1,
-                    io_queue_depth: None,
-                    devices: vec![ScsiDeviceAndPath {
-                        path: ScsiPath {
-                            path: 0,
-                            target: 0,
-                            lun: 0,
-                        },
-                        device: SimpleScsiDiskHandle {
-                            read_only: true,
-                            parameters: Default::default(),
-                            disk: FileDiskHandle(uh_agent_disk.into_file()).into_resource(),
-                        }
-                        .into_resource(),
-                    }],
-                    requests: None,
-                }
-                .into_resource(),
-            ));
+                .context("failed to build agent image")?
+            {
+                config.vmbus_devices.push((
+                    DeviceVtl::Vtl2,
+                    ScsiControllerHandle {
+                        instance_id: UH_CIDATA_SCSI_INSTANCE,
+                        max_sub_channel_count: 1,
+                        io_queue_depth: None,
+                        devices: vec![ScsiDeviceAndPath {
+                            path: ScsiPath {
+                                path: 0,
+                                target: 0,
+                                lun: 0,
+                            },
+                            device: SimpleScsiDiskHandle {
+                                read_only: true,
+                                parameters: Default::default(),
+                                disk: FileDiskHandle(openhcl_agent_disk.into_file())
+                                    .into_resource(),
+                            }
+                            .into_resource(),
+                        }],
+                        requests: None,
+                    }
+                    .into_resource(),
+                ));
+            }
         }
 
         // Add the GED and VTL 2 settings.
@@ -160,34 +162,34 @@ impl PetriVmConfigOpenVmm {
             const CIDATA_SCSI_INSTANCE: Guid = guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48a7b");
 
             // Construct the agent disk.
-            let agent_disk = agent_image.build().context("failed to build agent image")?;
-
-            // Add a SCSI controller to contain the agent disk. Don't reuse an
-            // existing controller so that we can avoid interfering with
-            // test-specific configuration.
-            self.config.vmbus_devices.push((
-                DeviceVtl::Vtl0,
-                ScsiControllerHandle {
-                    instance_id: CIDATA_SCSI_INSTANCE,
-                    max_sub_channel_count: 1,
-                    io_queue_depth: None,
-                    devices: vec![ScsiDeviceAndPath {
-                        path: ScsiPath {
-                            path: 0,
-                            target: 0,
-                            lun: 0,
-                        },
-                        device: SimpleScsiDiskHandle {
-                            read_only: true,
-                            parameters: Default::default(),
-                            disk: FileDiskHandle(agent_disk.into_file()).into_resource(),
-                        }
-                        .into_resource(),
-                    }],
-                    requests: None,
-                }
-                .into_resource(),
-            ));
+            if let Some(agent_disk) = agent_image.build().context("failed to build agent image")? {
+                // Add a SCSI controller to contain the agent disk. Don't reuse an
+                // existing controller so that we can avoid interfering with
+                // test-specific configuration.
+                self.config.vmbus_devices.push((
+                    DeviceVtl::Vtl0,
+                    ScsiControllerHandle {
+                        instance_id: CIDATA_SCSI_INSTANCE,
+                        max_sub_channel_count: 1,
+                        io_queue_depth: None,
+                        devices: vec![ScsiDeviceAndPath {
+                            path: ScsiPath {
+                                path: 0,
+                                target: 0,
+                                lun: 0,
+                            },
+                            device: SimpleScsiDiskHandle {
+                                read_only: true,
+                                parameters: Default::default(),
+                                disk: FileDiskHandle(agent_disk.into_file()).into_resource(),
+                            }
+                            .into_resource(),
+                        }],
+                        requests: None,
+                    }
+                    .into_resource(),
+                ));
+            }
 
             if matches!(self.firmware.os_flavor(), OsFlavor::Windows) {
                 // Make a file for the IMC hive. It's not guaranteed to be at a fixed

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -210,7 +210,7 @@ impl PetriVmConfigOpenVmm {
                 ));
             }
 
-            self.firmware.is_linux_direct()
+            self.firmware.is_linux_direct() && agent_image.contains_pipette()
         } else {
             false
         };

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -211,6 +211,7 @@ fn resolve_openhcl_tmks<T: PetriVmmBackend>(
             openhcl_config: Default::default(),
         },
         arch,
+        false,
     )?;
     Some(OpenhclTmkArtifacts { vm, tmk_vmm, tmk })
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -25,13 +25,15 @@ use petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY;
 use std::time::Duration;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
+use vmm_test_macros::openvmm_test_no_agent;
 use vmm_test_macros::vmm_test;
+use vmm_test_macros::vmm_test_no_agent;
 
 // Servicing tests.
 pub(crate) mod openhcl_servicing;
 
 /// Boot through the UEFI firmware, it will shut itself down after booting.
-#[vmm_test(
+#[vmm_test_no_agent(
     openvmm_uefi_x64(none),
     openvmm_openhcl_uefi_x64(none),
     openvmm_uefi_aarch64(none),
@@ -100,7 +102,7 @@ async fn secure_boot<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::R
 
 /// Verify that secure boot fails with a mismatched template.
 /// TODO: Allow Hyper-V VMs to load a UEFI firmware per VM, not system wide.
-#[vmm_test(
+#[vmm_test_no_agent(
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -163,7 +165,7 @@ async fn boot_reset_expected(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
 ///   - kmsg support in Hyper-V
 ///   - openhcl_uefi_aarch64 support
 ///   - uefi_x64 + uefi_aarch64 trace searching support
-#[openvmm_test(openhcl_uefi_x64(none))]
+#[openvmm_test_no_agent(openhcl_uefi_x64(none))]
 async fn efi_diagnostics_no_boot(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {
@@ -352,7 +354,7 @@ async fn reboot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyho
 /// Basic boot test without agent
 // TODO: investigate why the shutdown ic doesn't work reliably with hyper-v
 // in our ubuntu image
-#[vmm_test(
+#[vmm_test_no_agent(
     openvmm_linux_direct_x64,
     openvmm_openhcl_linux_direct_x64,
     openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
@@ -384,7 +386,7 @@ async fn boot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow:
 }
 
 // Basic vp "heavy" boot test without agent with 16 VPs.
-#[vmm_test(
+#[vmm_test_no_agent(
     openvmm_linux_direct_x64,
     openvmm_openhcl_linux_direct_x64,
     openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
@@ -430,7 +432,7 @@ async fn boot_no_agent_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> a
 
 // Test for vmbus relay
 // TODO: VBS isolation was failing and other targets too
-#[vmm_test(
+#[vmm_test_no_agent(
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64))
 )]
@@ -474,7 +476,7 @@ async fn vmbus_relay_force_mnf<T: PetriVmmBackend>(
 //
 // TODO: Shortened test name to make it work on Hyper-V, but it should use the
 // full name once petri is fixed.
-#[vmm_test(
+#[vmm_test_no_agent(
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
@@ -494,7 +496,7 @@ async fn vmbr_force_mnf_no_agent<T: PetriVmmBackend>(
 
 // Test for vmbus relay
 // TODO: VBS isolation was failing and other targets too
-#[vmm_test(
+#[vmm_test_no_agent(
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64))
 )]
@@ -515,7 +517,7 @@ async fn vmbus_relay_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> any
 }
 
 /// Basic boot test without agent and with a single VP.
-#[vmm_test(
+#[vmm_test_no_agent(
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
@@ -540,7 +542,7 @@ async fn boot_no_agent_single_proc<T: PetriVmmBackend>(
 
 /// Basic reboot test without agent
 // TODO: Reenable guests that use the framebuffer once #74 is fixed.
-#[openvmm_test(
+#[openvmm_test_no_agent(
     openvmm_linux_direct_x64,
     openvmm_openhcl_linux_direct_x64,
     // openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
@@ -569,7 +571,7 @@ async fn reboot_no_agent(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow:
 /// Boot our guest-test UEFI image, which will run some tests,
 /// and then purposefully triple fault itself via an expiring
 /// watchdog timer.
-#[vmm_test(
+#[vmm_test_no_agent(
     openvmm_uefi_x64(guest_test_uefi_x64),
     openvmm_uefi_aarch64(guest_test_uefi_aarch64),
     openvmm_openhcl_uefi_x64(guest_test_uefi_x64)
@@ -717,7 +719,7 @@ async fn clear_vmgs(
 ///
 /// This test exists to ensure we are not getting a false positive for
 /// the `default_boot` and `clear_vmgs` test above.
-#[openvmm_test(
+#[openvmm_test_no_agent(
     // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -18,7 +18,9 @@ use petri::pipette::cmd;
 use petri_artifacts_common::tags::OsFlavor;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
+use vmm_test_macros::openvmm_test_no_agent;
 use vmm_test_macros::vmm_test;
+use vmm_test_macros::vmm_test_no_agent;
 
 /// Basic boot test with the VTL 0 alias map.
 // TODO: Remove once #73 is fixed.
@@ -174,7 +176,7 @@ async fn boot_with_tpm(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::R
 // }
 
 /// Basic VBS boot test with TPM enabled.
-#[openvmm_test(
+#[openvmm_test_no_agent(
     openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64))
 )]
@@ -343,7 +345,7 @@ fn configure_for_sidecar<T: PetriVmmBackend>(
 // into VTL2 Linux.
 //
 // Sidecar isn't supported on aarch64 yet.
-#[vmm_test(openvmm_openhcl_uefi_x64(none), hyperv_openhcl_uefi_x64(none))]
+#[vmm_test_no_agent(openvmm_openhcl_uefi_x64(none), hyperv_openhcl_uefi_x64(none))]
 async fn sidecar_aps_unused<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> Result<(), anyhow::Error> {

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -13,6 +13,7 @@ use petri::openvmm::OpenVmmPetriBackend;
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
+use vmm_test_macros::openvmm_test_no_agent;
 
 async fn nvme_relay_test_core(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
@@ -119,7 +120,7 @@ async fn nvme_keepalive(
 
 /// Boot the UEFI firmware, with a VTL2 range automatically configured by
 /// hvlite.
-#[openvmm_test(openhcl_uefi_x64(none))]
+#[openvmm_test_no_agent(openhcl_uefi_x64(none))]
 async fn auto_vtl2_range(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     let mut vm = config
         .modify_backend(|b| {
@@ -141,7 +142,7 @@ async fn auto_vtl2_range(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<
 ///
 /// TODO: OpenVMM doesn't support multiple numa nodes yet, but when it does, we
 /// should also validate that the kernel gets two different numa nodes.
-#[openvmm_test(openhcl_uefi_x64(none))]
+#[openvmm_test_no_agent(openhcl_uefi_x64(none))]
 async fn no_numa_errors(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     let mut vm = config
         .with_openhcl_command_line("OPENHCL_WAIT_FOR_START=1")


### PR DESCRIPTION
This change makes using pipette for vtl0 optional, which allows us to use the unrelated parts of cloudinit to speed up boot on Ubuntu 24.04. 