### PR TITLE
kernel: update main and dev kernel to 6.12.36

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,8 +29,8 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.6";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.10";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.36.1";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.36.1";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 


### PR DESCRIPTION
Update the Linux kernel to the latest available version with upstream stable patches. See https://github.com/microsoft/OHCL-Linux-Kernel/pull/91 for more details.

The dev and main kernels are currently identical.