### PR TITLE
TEST inspect: reduce object sizes (#1400) on 2505

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -84,9 +84,9 @@ impl Inspect for NvmeManager {
             Err(req) => req.value(""),
         });
         // Send the remaining fields directly to the worker.
-        self.client
-            .sender
-            .send(Request::Inspect(resp.request().defer()));
+        resp.merge(inspect::adhoc(|req| {
+            self.client.sender.send(Request::Inspect(req.defer()))
+        }));
     }
 }
 

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -2563,9 +2563,9 @@ impl LoadedVm {
                 while let Some(rpc) = worker_rpc.next().await {
                     match rpc {
                         WorkerRpc::Inspect(req) => req.respond(|resp| {
-                            worker_rpc_send.send(WorkerRpc::Inspect(
-                                resp.merge(&state_units).request().defer(),
-                            ));
+                            resp.merge(&state_units).merge(inspect::adhoc(|req| {
+                                worker_rpc_send.send(WorkerRpc::Inspect(req.defer()));
+                            }));
                         }),
                         rpc => worker_rpc_send.send(rpc),
                     }

--- a/support/inspect/src/defer.rs
+++ b/support/inspect/src/defer.rs
@@ -6,13 +6,15 @@
 use super::InspectMut;
 use super::InternalNode;
 use super::Request;
-use super::RequestRoot;
 use super::Response;
 use super::SensitivityLevel;
 use super::UpdateRequest;
 use crate::NumberFormat;
+use crate::RequestParams;
+use crate::RootParams;
 use crate::ValueKind;
 use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
 use alloc::string::String;
 use mesh::MeshPayload;
 
@@ -22,14 +24,14 @@ impl Request<'_> {
     pub fn defer(self) -> Deferred {
         let (send, recv) = mesh::oneshot();
         *self.node = InternalNode::Deferred(recv);
-        Deferred {
-            path: self.path.to_owned(),
-            value: self.value.map(|x| x.to_owned()),
-            depth: self.depth,
+        Deferred(Box::new(DeferredInner {
+            path: self.params.path().to_owned(),
+            value: self.params.root.value.map(|x| x.to_owned()),
+            depth: self.params.depth,
             node: send,
-            sensitivity: self.sensitivity,
-            number_format: self.number_format,
-        }
+            sensitivity: self.params.root.sensitivity,
+            number_format: self.params.number_format,
+        }))
     }
 }
 
@@ -51,7 +53,10 @@ impl UpdateRequest<'_> {
 /// A deferred inspection, which can provide inspection results asynchronously
 /// from a call to [`inspect`](crate::Inspect::inspect).
 #[derive(Debug, MeshPayload)]
-pub struct Deferred {
+pub struct Deferred(Box<DeferredInner>);
+
+#[derive(Debug, MeshPayload)]
+struct DeferredInner {
     path: String,
     value: Option<String>,
     depth: usize,
@@ -62,19 +67,15 @@ pub struct Deferred {
 
 impl Deferred {
     /// Inspect an object as part of a deferred inspection.
-    pub fn inspect(self, mut obj: impl InspectMut) {
-        let mut root = self.root();
-        obj.inspect_mut(root.request());
-        let node = root.node;
-        self.node.send(node);
+    pub fn inspect(self, obj: impl InspectMut) {
+        let node = self.params(&self.root()).inspect(obj);
+        self.0.node.send(node);
     }
 
     /// Responds to the deferred inspection, calling `f` with a [`Response`].
     pub fn respond<F: FnOnce(&mut Response<'_>)>(self, f: F) {
-        let mut root = self.root();
-        f(&mut root.request().respond());
-        let node = root.node;
-        self.node.send(node);
+        let node = self.params(&self.root()).with(|req| f(&mut req.respond()));
+        self.0.node.send(node);
     }
 
     /// Responds to the deferred request with a value.
@@ -82,40 +83,45 @@ impl Deferred {
         self.value_(value.into())
     }
     fn value_(self, value: ValueKind) {
-        let mut root = self.root();
-        root.request().value(value);
-        let node = root.node;
-        self.node.send(node);
+        let node = self.params(&self.root()).with(|req| req.value(value));
+        self.0.node.send(node);
     }
 
     /// Returns an object used for handling an update request.
     ///
     /// If this is not an update request, returns `Err(self)`.
     pub fn update(self) -> Result<DeferredUpdate, Self> {
-        if self.value.is_some() && self.path.is_empty() {
+        if self.0.value.is_some() && self.0.path.is_empty() {
             Ok(DeferredUpdate {
-                value: self.value.unwrap(),
-                node: self.node,
-                number_format: self.number_format,
+                value: self.0.value.unwrap(),
+                node: self.0.node,
+                number_format: self.0.number_format,
             })
         } else {
             Err(self)
         }
     }
 
-    fn root(&self) -> RequestRoot<'_> {
-        RequestRoot::new(
-            &self.path,
-            self.depth,
-            self.value.as_deref(),
-            self.sensitivity,
-            self.number_format,
-        )
+    fn root(&self) -> RootParams<'_> {
+        RootParams {
+            full_path: &self.0.path,
+            sensitivity: self.0.sensitivity,
+            value: self.0.value.as_deref(),
+        }
+    }
+
+    fn params<'a>(&'a self, root: &'a RootParams<'a>) -> RequestParams<'a> {
+        RequestParams {
+            root,
+            path_start: 0,
+            depth: self.0.depth,
+            number_format: self.0.number_format,
+        }
     }
 
     /// Removes this node from the inspection output.
     pub fn ignore(self) {
-        self.node.send(InternalNode::Ignored);
+        self.0.node.send(InternalNode::Ignored);
     }
 
     /// Gets the request information for sending to a remote node via a non-mesh
@@ -139,10 +145,12 @@ impl Deferred {
     #[cfg(feature = "initiate")]
     pub fn external_request(&self) -> ExternalRequest<'_> {
         ExternalRequest {
-            path: &self.path,
-            sensitivity: self.sensitivity,
-            request_type: match &self.value {
-                None => ExternalRequestType::Inspect { depth: self.depth },
+            path: &self.0.path,
+            sensitivity: self.0.sensitivity,
+            request_type: match &self.0.value {
+                None => ExternalRequestType::Inspect {
+                    depth: self.0.depth,
+                },
                 Some(value) => ExternalRequestType::Update { value },
             },
         }
@@ -157,14 +165,15 @@ impl Deferred {
     #[cfg(feature = "initiate")]
     pub fn complete_external(self, node: super::Node, sensitivity: SensitivityLevel) {
         // If the returned sensitivity level is not allowed for this request, drop it.
-        if sensitivity > self.sensitivity {
+        if sensitivity > self.0.sensitivity {
             return;
         }
-        if let Some(node) = InternalNode::from_node(node, self.sensitivity) {
+        if let Some(node) = InternalNode::from_node(node, self.0.sensitivity) {
             // Add the prefixed path back on as a sequence of directory nodes. This
             // is necessary so that they can be skipped in post-processing.
             let node =
-                self.path
+                self.0
+                    .path
                     .split('/')
                     .filter(|s| !s.is_empty())
                     .rev()
@@ -176,13 +185,13 @@ impl Deferred {
                         }])
                     });
 
-            self.node.send(node);
+            self.0.node.send(node);
         }
     }
 
     /// Gets the sensitivity level for this request.
     pub fn sensitivity(&self) -> SensitivityLevel {
-        self.sensitivity
+        self.0.sensitivity
     }
 }
 
@@ -283,7 +292,7 @@ impl DeferredUpdate {
     }
 
     /// Report that the update failed, with the reason in `err`.
-    pub fn fail<E: Into<alloc::boxed::Box<dyn core::error::Error + Send + Sync>>>(self, err: E) {
+    pub fn fail<E: Into<Box<dyn core::error::Error + Send + Sync>>>(self, err: E) {
         self.node.send(InternalNode::failed(err.into()));
     }
 }

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -467,12 +467,32 @@ use core::num::Wrapping;
 
 /// An inspection request.
 pub struct Request<'a> {
-    path: &'a str,
-    depth: usize,
+    params: RequestParams<'a>,
     node: &'a mut InternalNode,
+}
+
+struct RootParams<'a> {
+    full_path: &'a str,
     value: Option<&'a str>,
     sensitivity: SensitivityLevel,
+}
+
+#[derive(Copy, Clone)]
+struct RequestParams<'a> {
+    root: &'a RootParams<'a>,
+    path_start: usize,
+    depth: usize,
     number_format: NumberFormat,
+}
+
+impl<'a> RequestParams<'a> {
+    fn path(&self) -> &'a str {
+        &self.root.full_path[self.path_start..]
+    }
+
+    fn is_leaf(&self) -> bool {
+        self.path_start >= self.root.full_path.len()
+    }
 }
 
 #[cfg_attr(
@@ -486,16 +506,6 @@ enum NumberFormat {
     Hex,
     Binary,
     Counter,
-}
-
-#[cfg(any(feature = "defer", feature = "initiate"))]
-struct RequestRoot<'a> {
-    path: &'a str,
-    node: InternalNode,
-    depth: usize,
-    value: Option<&'a str>,
-    sensitivity: SensitivityLevel,
-    number_format: NumberFormat,
 }
 
 /// The sensitivity level for an inspection node or request.
@@ -527,56 +537,25 @@ pub enum SensitivityLevel {
     Sensitive,
 }
 
-#[cfg(any(feature = "defer", feature = "initiate"))]
-impl<'a> RequestRoot<'a> {
-    fn new(
-        path: &'a str,
-        depth: usize,
-        value: Option<&'a str>,
-        sensitivity: SensitivityLevel,
-        number_format: NumberFormat,
-    ) -> Self {
-        Self {
-            path,
-            node: InternalNode::Unevaluated,
-            depth,
-            value,
-            sensitivity,
-            number_format,
-        }
-    }
-
-    fn request(&mut self) -> Request<'_> {
-        Request::new(
-            self.path,
-            self.depth,
-            &mut self.node,
-            self.value,
-            self.sensitivity,
-            self.number_format,
-        )
-    }
-}
-
 /// A type used to build an inspection response.
 pub struct Response<'a> {
-    /// Full remaining path, including leading `/`s.
-    path: &'a str,
-    /// Cache of remaining path without leading '/'s.
-    path_without_slashes: Option<&'a str>,
-    depth: usize,
-    cell: &'a mut InternalNode,
-    value: Option<&'a str>,
-    sensitivity: SensitivityLevel,
-    number_format: NumberFormat,
+    params: RequestParams<'a>,
+    /// Remaining path without leading '/'s.
+    path_without_slashes: &'a str,
+    /// The list of inspected children.
+    ///
+    /// This is `None` when the depth is exhaused (in which case all children
+    /// are ignored--the response object was just created to report that this
+    /// node in the inspect tree is a directory and not a value).
+    children: Option<&'a mut Vec<InternalEntry>>,
 }
 
 #[derive(Debug)]
-enum Action<'a, 'b> {
+enum Action<'a> {
     Process {
         name: &'a str,
         sensitivity: SensitivityLevel,
-        new_path: &'b str,
+        new_path_start: usize,
         new_depth: usize,
     },
     Skip,
@@ -586,17 +565,16 @@ enum Action<'a, 'b> {
     },
 }
 
-impl<'a, 'b> Action<'a, 'b> {
+impl<'a> Action<'a> {
     // Determine which action to take for the field with `name`, given the
     // remaining `path` and the remaining `depth`.
-    fn eval(child: Child<'a>, resp: &Response<'b>) -> Self {
-        let path = resp.path_without_slashes.unwrap();
-        if resp.depth == 0 {
+    fn eval(child: Child<'a>, params: &RequestParams<'_>, path: &str) -> Self {
+        if params.depth == 0 {
             // Don't return any subfields if the depth is exhausted, since depth
             // exhausted will be reported for the current node.
             return Self::Skip;
         }
-        if resp.sensitivity < child.sensitivity {
+        if params.root.sensitivity < child.sensitivity {
             // Don't return any subfields if the request's sensitivity level is too low.
             return Self::Skip;
         }
@@ -607,8 +585,8 @@ impl<'a, 'b> Action<'a, 'b> {
                 Self::Process {
                     name: child.name,
                     sensitivity: child.sensitivity,
-                    new_path: rest,
-                    new_depth: resp.depth,
+                    new_path_start: params.root.full_path.len() - rest.len(),
+                    new_depth: params.depth,
                 }
             } else {
                 // Mismatch, e.g. name is "foo", path is "foobar", or this is a
@@ -628,12 +606,12 @@ impl<'a, 'b> Action<'a, 'b> {
                 &child.name[path.len() + 1..]
             };
             // Ensure there is enough depth for the name.
-            match remaining_name.match_indices('/').nth(resp.depth - 1) {
+            match remaining_name.match_indices('/').nth(params.depth - 1) {
                 None => Self::Process {
                     name: child.name,
                     sensitivity: child.sensitivity,
-                    new_path: "",
-                    new_depth: resp.depth - 1,
+                    new_path_start: params.root.full_path.len(),
+                    new_depth: params.depth - 1,
                 },
                 Some((n, _)) => Self::DepthExhausted {
                     name: &child.name[..child.name.len() - remaining_name.len() + n],
@@ -822,36 +800,33 @@ impl Response<'_> {
     }
 
     fn child_request(&mut self, child: Child<'_>) -> Option<Request<'_>> {
-        if self.path_without_slashes.is_none() {
-            self.path_without_slashes = Some(self.path.trim_start_matches('/'));
-        }
-
-        match Action::eval(child, self) {
+        let children = &mut **self.children.as_mut()?;
+        let action = Action::eval(child, &self.params, self.path_without_slashes);
+        match action {
             Action::Process {
                 name,
                 sensitivity,
-                new_path,
+                new_path_start,
                 new_depth,
             } => {
-                let children = self.cell.as_dir();
                 children.push(InternalEntry {
                     name: name.to_owned(),
                     node: InternalNode::Unevaluated,
                     sensitivity,
                 });
                 let entry = children.last_mut().unwrap();
-                Some(Request::new(
-                    new_path,
-                    new_depth,
-                    &mut entry.node,
-                    self.value,
-                    self.sensitivity,
-                    self.number_format,
-                ))
+                Some(
+                    RequestParams {
+                        path_start: new_path_start,
+                        depth: new_depth,
+                        ..self.params
+                    }
+                    .request(&mut entry.node),
+                )
             }
             Action::Skip => None,
             Action::DepthExhausted { name, sensitivity } => {
-                self.cell.as_dir().push(InternalEntry {
+                children.push(InternalEntry {
                     name: name.to_owned(),
                     node: InternalNode::DepthExhausted,
                     sensitivity,
@@ -1008,88 +983,74 @@ assert_eq!(
     /// Inspects an object and merges its responses into this node without
     /// creating a child node.
     pub fn merge(&mut self, mut child: impl InspectMut) -> &mut Self {
-        child.inspect_mut(self.request());
+        if let Some(req) = self.request() {
+            child.inspect_mut(req);
+        }
         self
     }
 
     /// Gets another request for this response. The response to that request
     /// will be merged into this response.
-    pub fn request(&mut self) -> Request<'_> {
-        let children = self.cell.as_dir();
+    ///
+    /// Returns `None` if the depth is already exhausted, in which case there is
+    /// no need (or ability--requests must have nodes) to propagate the request.
+    fn request(&mut self) -> Option<Request<'_>> {
+        let children = &mut **self.children.as_mut()?;
         children.push(InternalEntry {
             name: String::new(),
             node: InternalNode::Unevaluated,
             sensitivity: SensitivityLevel::Unspecified,
         });
         let entry = children.last_mut().unwrap();
-        Request::new(
-            self.path,
-            self.depth,
-            &mut entry.node,
-            self.value,
-            self.sensitivity,
-            self.number_format,
-        )
+        Some(self.params.request(&mut entry.node))
     }
 }
 
-impl Drop for Response<'_> {
-    fn drop(&mut self) {
-        if self.depth > 0 {
-            // Ensure the children node was created.
-            let _ = self.cell.as_dir();
-        } else {
-            // No children were collected, but this node had to be inspected in
-            // case it was a value and not a directory node.
-            *self.cell = InternalNode::DepthExhausted;
-        }
+impl<'a> RequestParams<'a> {
+    #[cfg_attr(not(any(feature = "defer", feature = "initiate")), expect(dead_code))]
+    fn inspect(self, mut obj: impl InspectMut) -> InternalNode {
+        self.with(|req| {
+            obj.inspect_mut(req);
+        })
+    }
+
+    fn with(self, f: impl FnOnce(Request<'_>)) -> InternalNode {
+        let mut node = InternalNode::Unevaluated;
+        f(self.request(&mut node));
+        node
+    }
+
+    fn request(self, node: &'a mut InternalNode) -> Request<'a> {
+        Request { params: self, node }
     }
 }
 
 impl<'a> Request<'a> {
-    fn new(
-        path: &'a str,
-        depth: usize,
-        cell: &'a mut InternalNode,
-        value: Option<&'a str>,
-        sensitivity: SensitivityLevel,
-        number_format: NumberFormat,
-    ) -> Self {
-        Self {
-            path,
-            depth,
-            node: cell,
-            value,
-            sensitivity,
-            number_format,
-        }
-    }
-
     /// Sets numeric values to be displayed in decimal format.
     #[must_use]
     pub fn with_decimal_format(mut self) -> Self {
-        self.number_format = NumberFormat::Decimal;
+        self.params.number_format = NumberFormat::Decimal;
         self
     }
 
     /// Sets numeric values to be displayed in hexadecimal format.
     #[must_use]
     pub fn with_hex_format(mut self) -> Self {
-        self.number_format = NumberFormat::Hex;
+        self.params.number_format = NumberFormat::Hex;
         self
     }
 
     /// Sets numeric values to be displayed in binary format.
     #[must_use]
     pub fn with_binary_format(mut self) -> Self {
-        self.number_format = NumberFormat::Binary;
+        self.params.number_format = NumberFormat::Binary;
         self
     }
 
     /// Sets numeric values to be displayed as counters.
     #[must_use]
     pub fn with_counter_format(mut self) -> Self {
-        self.number_format = NumberFormat::Counter;
+        self.params.number_format = NumberFormat::Counter;
         self
     }
 
@@ -1098,9 +1059,9 @@ impl<'a> Request<'a> {
         self.value_(value.into());
     }
     fn value_(self, value: ValueKind) {
-        let node = if self.path.is_empty() {
-            if self.value.is_none() {
-                InternalNode::Value(value.with_format(self.number_format))
+        let node = if self.params.is_leaf() {
+            if self.params.root.value.is_none() {
+                InternalNode::Value(value.with_format(self.params.number_format))
             } else {
                 InternalNode::Failed(InternalError::Immutable)
             }
@@ -1114,14 +1075,14 @@ impl<'a> Request<'a> {
     ///
     /// If this is not an update request, returns `Err(self)`.
     pub fn update(self) -> Result<UpdateRequest<'a>, Self> {
-        if let Some(value) = self.value {
-            if !self.path.is_empty() {
+        if let Some(value) = self.params.root.value {
+            if !self.params.is_leaf() {
                 return Err(self);
             }
             Ok(UpdateRequest {
                 node: self.node,
                 value,
-                number_format: self.number_format,
+                number_format: self.params.number_format,
             })
         } else {
             Err(self)
@@ -1132,14 +1093,22 @@ impl<'a> Request<'a> {
     ///
     /// Returns an object that can be used to provide the inspection results.
     pub fn respond(self) -> Response<'a> {
+        let children = if self.params.depth > 0 {
+            *self.node = InternalNode::Dir(Vec::new());
+            let InternalNode::Dir(children) = self.node else {
+                unreachable!()
+            };
+            Some(children)
+        } else {
+            // No children will be collected, but this node had to be inspected
+            // in case it was a value and not a directory node.
+            *self.node = InternalNode::DepthExhausted;
+            None
+        };
         Response {
-            path: self.path,
-            path_without_slashes: None,
-            depth: self.depth,
-            cell: self.node,
-            value: self.value,
-            sensitivity: self.sensitivity,
-            number_format: self.number_format,
+            params: self.params,
+            path_without_slashes: self.params.path().trim_start_matches('/'),
+            children,
         }
     }
 
@@ -1150,12 +1119,12 @@ impl<'a> Request<'a> {
 
     /// If true, this is an update request.
     pub fn is_update(&self) -> bool {
-        self.value.is_some()
+        self.params.root.value.is_some()
     }
 
     /// Gets the sensitivity level for this request.
     pub fn sensitivity(&self) -> SensitivityLevel {
-        self.sensitivity
+        self.params.root.sensitivity
     }
 }
 
@@ -1681,14 +1650,14 @@ macro_rules! hexbincount {
     ($tr:ident, $fmt:expr) => {
         impl<T: Inspect> Inspect for $tr<T> {
             fn inspect(&self, mut req: Request<'_>) {
-                req.number_format = $fmt;
+                req.params.number_format = $fmt;
                 self.0.inspect(req);
             }
         }
 
         impl<T: InspectMut> InspectMut for $tr<T> {
             fn inspect_mut(&mut self, mut req: Request<'_>) {
-                req.number_format = $fmt;
+                req.params.number_format = $fmt;
                 self.0.inspect_mut(req);
             }
         }
@@ -1903,21 +1872,6 @@ struct InternalEntry {
     name: String,
     node: InternalNode,
     sensitivity: SensitivityLevel,
-}
-
-impl InternalNode {
-    fn as_dir(&mut self) -> &mut Vec<InternalEntry> {
-        match self {
-            Self::Dir(children) => children,
-            _ => {
-                *self = Self::Dir(Vec::new());
-                let Self::Dir(children) = self else {
-                    unreachable!()
-                };
-                children
-            }
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -2424,11 +2378,9 @@ mod tests {
     #[test]
     fn test_merge() {
         let mut obj = adhoc(|req| {
-            req.respond()
-                .field("a", 1)
-                .request()
-                .respond()
-                .field("b", 2);
+            req.respond().field("a", 1).merge(adhoc(|req| {
+                req.respond().field("b", 2);
+            }));
         });
 
         inspect_sync_expect(

--- a/support/mesh/mesh_process/src/lib.rs
+++ b/support/mesh/mesh_process/src/lib.rs
@@ -535,17 +535,19 @@ impl MeshInner {
                                         &host.pid.to_string(),
                                         SensitivityLevel::Safe,
                                         &mut inspect::adhoc(|req| {
-                                            let mut resp = req.respond();
-                                            resp.merge(&HostInspect {
-                                                name: &host.name,
-                                                node_id: host.node_id,
-                                                #[cfg(target_os = "linux")]
-                                                rlimit: inspect_rlimit::InspectRlimit::for_pid(
-                                                    host.pid,
-                                                ),
-                                            });
-                                            host.send
-                                                .send(HostRequest::Inspect(resp.request().defer()));
+                                            req.respond()
+                                                .merge(&HostInspect {
+                                                    name: &host.name,
+                                                    node_id: host.node_id,
+                                                    #[cfg(target_os = "linux")]
+                                                    rlimit: inspect_rlimit::InspectRlimit::for_pid(
+                                                        host.pid,
+                                                    ),
+                                                })
+                                                .merge(inspect::adhoc(|req| {
+                                                    host.send
+                                                        .send(HostRequest::Inspect(req.defer()));
+                                                }));
                                         }),
                                     );
                                 }

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -3668,8 +3668,8 @@ impl InspectTaskMut<Coordinator> for CoordinatorState {
             });
 
             // Get the shared channel state from the primary channel.
-            {
-                let deferred = resp.request().defer();
+            resp.merge(inspect::adhoc_mut(|req| {
+                let deferred = req.defer();
                 coordinator.workers[0].update_with(|_, worker| {
                     if let Some(state) = worker.and_then(|worker| worker.state.ready()) {
                         deferred.respond(|resp| {
@@ -3682,7 +3682,7 @@ impl InspectTaskMut<Coordinator> for CoordinatorState {
                         });
                     }
                 })
-            }
+            }));
         }
     }
 }

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -984,9 +984,11 @@ impl ChannelList {
                     // Merge in the inspection state from outside. Skip this if
                     // the channel is revoked (and not reoffered) since in that
                     // case the caller won't recognize the channel ID.
-                    if !matches!(channel.state, ChannelState::Revoked) {
-                        notifier.inspect(version, offer_id, resp.request());
-                    }
+                    resp.merge(inspect::adhoc(|req| {
+                        if !matches!(channel.state, ChannelState::Revoked) {
+                            notifier.inspect(version, offer_id, req);
+                        }
+                    }));
                 },
             );
         }

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -260,8 +260,8 @@ where
 {
     fn inspect_vtl(&mut self, gm: Option<&GuestMemory>, req: inspect::Request<'_>, vtl: Vtl) {
         let mut resp = req.respond();
-        resp.field("enabled", true);
-        self.vp.access_state(vtl).inspect_all(resp.request());
+        resp.field("enabled", true)
+            .merge(self.vp.access_state(vtl).inspect_all());
 
         let _ = gm;
         #[cfg(all(guest_arch = "x86_64", feature = "gdb"))]
@@ -735,10 +735,12 @@ struct Vp {
 
 impl Inspect for Vp {
     fn inspect(&self, req: inspect::Request<'_>) {
-        let mut resp = req.respond();
-        resp.merge(&self.vp_info);
-        self.send
-            .send(VpEvent::State(StateEvent::Inspect(resp.request().defer())));
+        req.respond()
+            .merge(&self.vp_info)
+            .merge(inspect::adhoc(|req| {
+                self.send
+                    .send(VpEvent::State(StateEvent::Inspect(req.defer())))
+            }));
     }
 }
 
@@ -1253,8 +1255,10 @@ impl RunnerInner {
         match event {
             StateEvent::Inspect(deferred) => {
                 deferred.respond(|resp| {
-                    resp.field("state", self.state);
-                    vp.inspect_vp(&self.inner.vtl_guest_memory, resp.request());
+                    resp.field("state", self.state)
+                        .merge(inspect::adhoc_mut(|req| {
+                            vp.inspect_vp(&self.inner.vtl_guest_memory, req)
+                        }));
                 });
             }
             StateEvent::SetInitialRegs(rpc) => {

--- a/vmm_core/state_unit/src/lib.rs
+++ b/vmm_core/state_unit/src/lib.rs
@@ -333,9 +333,10 @@ impl Inspect for Inner {
                             .join(",")
                     });
                 }
-                resp.field("unit_state", unit.state);
-                unit.send
-                    .send(StateRequest::Inspect(resp.request().defer()))
+                resp.field("unit_state", unit.state)
+                    .merge(inspect::adhoc(|req| {
+                        unit.send.send(StateRequest::Inspect(req.defer()))
+                    }));
             });
         }
     }

--- a/vmm_core/virt/src/state.rs
+++ b/vmm_core/virt/src/state.rs
@@ -136,13 +136,15 @@ mod macros {
                 }
 
                 #[allow(unused_variables, unused_mut)]
-                fn inspect_all(&mut self, req: ::inspect::Request<'_>) {
-                    let mut resp = req.respond();
-                    $(
-                        if <$ty as $crate::state::StateElement<$caps, $vp>>::is_present(self.caps()) {
-                            resp.field_with($id, || self.$get().ok());
-                        }
-                    )*
+                fn inspect_all(&mut self) -> impl ::inspect::InspectMut {
+                    inspect::adhoc_mut(|req| {
+                        let mut resp = req.respond();
+                        $(
+                            if <$ty as $crate::state::StateElement<$caps, $vp>>::is_present(self.caps()) {
+                                resp.field_with($id, || self.$get().ok());
+                            }
+                        )*
+                    })
                 }
             }
 


### PR DESCRIPTION
Wrap `Deferred` in a `Box` so that it's cheaper to pass around. Move immutable parts of `Request` into a structure that can be stored at the base of the call stack. Remove some deferred initialization in `Response`.

As part of this, eliminate the `Response::request` method for getting a new `Request` from an existing `Response`. Instead, use the `merge` method along with `adhoc`. This is necessary to avoid needing extra checks in the common path. It's also more consistent with other uses of `Response`.