### PR TITLE
vmotherboard: Fix restore errors from pci rename (#1786)

### DIFF
--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -450,7 +450,7 @@ impl<'a> BaseChipsetBuilder<'a> {
         }) = deps_hyperv_ide
         {
             builder
-                .arc_mutex_device("pci-ide")
+                .arc_mutex_device("ide")
                 .on_pci_bus(attached_to)
                 .try_add(|services| {
                     // hard-coded to iRQ lines 14 and 15, as per PIIX4 spec


### PR DESCRIPTION
I originally made this change to make it a little clearer where the ide device was, but apparently this device label is being used as part of save state, so this change broke servicing. Just set the name back.

Cherry-pick of #1786