### PR TITLE
petri: don't try to start pipette on reboot if it doesn't exist

### DIFF
--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -453,7 +453,15 @@ impl PetriVmInner {
         // On linux direct pipette won't auto start, start it over serial
         if let Some(agent) = self.resources.linux_direct_serial_agent.as_mut() {
             agent.reset();
-            self.launch_linux_direct_pipette().await?;
+
+            if self
+                .resources
+                .agent_image
+                .as_ref()
+                .is_some_and(|x| x.contains_pipette())
+            {
+                self.launch_linux_direct_pipette().await?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Only try launch pipette for linux direct on reboot if pipette is included in the CI data disk.

Fix bug introduced in https://github.com/microsoft/openvmm/commit/2e8760d1a970b04ec6b98ee120063d9f76b41ed7, which caused linux direct reboot tests to fail intermittently.