### PR TITLE
openvmm,openhcl: describe and parse the pmu via dt

### DIFF
--- a/openhcl/bootloader_fdt_parser/src/lib.rs
+++ b/openhcl/bootloader_fdt_parser/src/lib.rs
@@ -508,7 +508,7 @@ fn parse_pmu(node: &Node<'_>) -> anyhow::Result<u32> {
 
     // The index is the index off of the PPI base of 16. PPIs only exist from 16
     // to 31, so the index should be < 16.
-    if interrupts_ppi_index > 16 {
+    if interrupts_ppi_index >= 16 {
         bail!("pmu node has unexpected interrupt index {interrupts_ppi_index}");
     }
 

--- a/openhcl/bootloader_fdt_parser/src/lib.rs
+++ b/openhcl/bootloader_fdt_parser/src/lib.rs
@@ -160,8 +160,6 @@ pub struct ParsedBootDtInfo {
     /// guest.
     #[inspect(iter_by_index)]
     pub accepted_ranges: Vec<MemoryRange>,
-    /// GIC information
-    pub gic: Option<GicInfo>,
     /// The memory allocation mode the bootloader decided to use.
     pub memory_allocation_mode: MemoryAllocationMode,
     /// The isolation type of the partition.
@@ -169,6 +167,11 @@ pub struct ParsedBootDtInfo {
     /// VTL2 range for private pool memory.
     #[inspect(iter_by_index)]
     pub private_pool_ranges: Vec<MemoryRangeWithNode>,
+
+    /// GIC information, on AArch64.
+    pub gic: Option<GicInfo>,
+    /// PMU GSIV, on AArch64.
+    pub pmu_gsiv: Option<u32>,
 }
 
 fn err_to_owned(e: fdt::parser::Error<'_>) -> anyhow::Error {
@@ -485,6 +488,34 @@ fn parse_gic(node: &Node<'_>) -> anyhow::Result<GicInfo> {
     })
 }
 
+fn parse_pmu(node: &Node<'_>) -> anyhow::Result<u32> {
+    let interrupts =
+        try_find_property(node, "interrupts").context("pmu node missing interrupts")?;
+    let interrupts_typ = interrupts
+        .read_u32(0)
+        .map_err(err_to_owned)
+        .context("missing pmu interrupts typ")?;
+    let interrupts_ppi_index = interrupts
+        .read_u32(1)
+        .map_err(err_to_owned)
+        .context("missing pmu interrupts index")?;
+
+    // The interrupt is expected to be a PPI.
+    const GIC_PPI: u32 = 1;
+    if interrupts_typ != GIC_PPI {
+        bail!("pmu node has unexpected interrupt type {interrupts_typ}");
+    }
+
+    // The index is the index off of the PPI base of 16. PPIs only exist from 16
+    // to 31, so the index should be < 16.
+    if interrupts_ppi_index > 16 {
+        bail!("pmu node has unexpected interrupt index {interrupts_ppi_index}");
+    }
+
+    const PPI_BASE: u32 = 16;
+    Ok(PPI_BASE + interrupts_ppi_index)
+}
+
 impl ParsedBootDtInfo {
     /// Read parameters passed via device tree by openhcl_boot, at
     /// /sys/firmware/fdt.
@@ -502,6 +533,7 @@ impl ParsedBootDtInfo {
         let mut config_ranges = Vec::new();
         let mut vtl2_memory = Vec::new();
         let mut gic = None;
+        let mut pmu_gsiv = None;
         let mut partition_memory_map = Vec::new();
         let mut accepted_ranges = Vec::new();
         let mut vtl0_alias_map = None;
@@ -559,6 +591,11 @@ impl ParsedBootDtInfo {
                     gic = Some(parse_gic(&child)?);
                 }
 
+                _ if child.name.starts_with("pmu") => {
+                    // TODO: make sure we are on aarch64
+                    pmu_gsiv = Some(parse_pmu(&child)?);
+                }
+
                 _ => {
                     // Ignore other nodes.
                 }
@@ -576,6 +613,7 @@ impl ParsedBootDtInfo {
             vtl0_alias_map,
             accepted_ranges,
             gic,
+            pmu_gsiv,
             memory_allocation_mode,
             isolation,
             vtl2_reserved_range,
@@ -677,6 +715,7 @@ mod tests {
         let p_numa_node_id = builder.add_string("numa-node-id")?;
         let p_igvm_type = builder.add_string(IGVM_DT_IGVM_TYPE_PROPERTY)?;
         let p_openhcl_memory = builder.add_string("openhcl,memory-type")?;
+        let p_interrupts = builder.add_string("interrupts")?;
 
         let mut root_builder = builder
             .start_node("")?
@@ -738,6 +777,18 @@ mod tests {
                 .add_null(p_interrupt_controller)?
                 .add_u32(p_phandle, 1)?
                 .add_null(p_ranges)?
+                .end_node()?;
+        }
+
+        // PMU
+        if let Some(pmu_gsiv) = info.pmu_gsiv {
+            assert!((16..32).contains(&pmu_gsiv));
+            const GIC_PPI: u32 = 1;
+            const IRQ_TYPE_LEVEL_HIGH: u32 = 4;
+            root_builder = root_builder
+                .start_node("pmu")?
+                .add_str(p_compatible, "arm,armv8-pmuv3")?
+                .add_u32_array(p_interrupts, &[GIC_PPI, pmu_gsiv - 16, IRQ_TYPE_LEVEL_HIGH])?
                 .end_node()?;
         }
 
@@ -931,6 +982,7 @@ mod tests {
                 gic_distributor_base: 0x10000,
                 gic_redistributors_base: 0x20000,
             }),
+            pmu_gsiv: Some(0x17),
             accepted_ranges: vec![
                 MemoryRange::new(0x10000..0x20000),
                 MemoryRange::new(0x1000000..0x1500000),

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -221,8 +221,6 @@ pub struct ParsedDeviceTree<
     pub command_line: ArrayString<MAX_COMMAND_LINE_SIZE>,
     /// Is a com3 device present
     pub com3_serial: bool,
-    /// GIC information
-    pub gic: Option<GicInfo>,
     /// The vtl2 memory allocation mode OpenHCL should use for memory.
     pub memory_allocation_mode: MemoryAllocationMode,
     /// Entropy from the host to be used by the OpenHCL kernel
@@ -237,6 +235,11 @@ pub struct ParsedDeviceTree<
     pub nvme_keepalive: bool,
     /// The physical address of the VTL0 alias mapping, if one is configured.
     pub vtl0_alias_map: Option<u64>,
+
+    /// GIC information, on AArch64.
+    pub gic: Option<GicInfo>,
+    /// PMU GSIV, if available, on AArch64.
+    pub pmu_gsiv: Option<u32>,
 }
 
 /// The memory allocation mode provided by the host. This determines how OpenHCL
@@ -312,6 +315,7 @@ impl<
             command_line: ArrayString::new_const(),
             com3_serial: false,
             gic: None,
+            pmu_gsiv: None,
             memory_allocation_mode: MemoryAllocationMode::Host,
             entropy: None,
             device_dma_page_count: None,
@@ -659,6 +663,7 @@ impl<
                         &child,
                         &mut storage.vmbus_vtl0,
                         &mut storage.vmbus_vtl2,
+                        &mut storage.pmu_gsiv,
                         &mut storage.com3_serial,
                     )?;
                 }
@@ -735,6 +740,7 @@ impl<
             device_dma_page_count: _,
             nvme_keepalive: _,
             vtl0_alias_map: _,
+            pmu_gsiv: _,
         } = storage;
 
         *device_tree_size = parser.total_size;
@@ -748,6 +754,7 @@ fn parse_compatible<'a>(
     node: &fdt::parser::Node<'a>,
     vmbus_vtl0: &mut Option<VmbusInfo>,
     vmbus_vtl2: &mut Option<VmbusInfo>,
+    pmu_gsiv: &mut Option<u32>,
     com3_serial: &mut bool,
 ) -> Result<(), ErrorKind<'a>> {
     let compatible = node
@@ -761,6 +768,8 @@ fn parse_compatible<'a>(
         parse_simple_bus(node, vmbus_vtl0, vmbus_vtl2)?;
     } else if compatible == "x86-pio-bus" {
         parse_io_bus(node, com3_serial)?;
+    } else if compatible == "arm,armv8-pmuv3" {
+        parse_pmu_gsiv(node, pmu_gsiv)?;
     } else {
         #[cfg(feature = "tracing")]
         tracing::warn!(?compatible, ?node.name,
@@ -1012,6 +1021,56 @@ fn parse_io_bus<'a>(
             );
         }
     }
+
+    Ok(())
+}
+
+fn parse_pmu_gsiv<'a>(
+    node: &fdt::parser::Node<'a>,
+    pmu_gsiv: &mut Option<u32>,
+) -> Result<(), ErrorKind<'a>> {
+    let interrupts = node.find_property("interrupts").map_err(ErrorKind::Prop)?;
+    let interrupts = interrupts.ok_or(ErrorKind::PropMissing {
+        node_name: node.name,
+        prop_name: "interrupts",
+    })?;
+
+    if interrupts.data.len() < 3 * size_of::<u32>() {
+        return Err(ErrorKind::PropInvalidU32 {
+            node_name: node.name,
+            prop_name: "interrupts size",
+            expected: 3 * size_of::<u32>() as u32,
+            actual: interrupts.data.len() as u32,
+        });
+    }
+
+    // This parser expects the PMU GSIV to be a PPI, as all platforms that
+    // support OpenHCL should be using PPIs.
+    const GIC_PPI: u32 = 1;
+    let interrupt_type = interrupts.read_u32(0).map_err(ErrorKind::Prop)?;
+    if interrupt_type != GIC_PPI {
+        return Err(ErrorKind::PropInvalidU32 {
+            node_name: node.name,
+            prop_name: "interrupts",
+            expected: GIC_PPI,
+            actual: interrupt_type,
+        });
+    }
+    let interrupt_id = interrupts.read_u32(1).map_err(ErrorKind::Prop)?;
+
+    // Interrupt id describes the index from the PPI start of 16. It must be
+    // smaller than 16, as PPIs only exist from 16 to 31.
+    if interrupt_id >= 16 {
+        return Err(ErrorKind::PropInvalidU32 {
+            node_name: node.name,
+            prop_name: "interrupts",
+            expected: 16,
+            actual: interrupt_id,
+        });
+    }
+
+    const PPI_BASE: u32 = 16;
+    *pmu_gsiv = Some(PPI_BASE + interrupt_id);
 
     Ok(())
 }
@@ -1299,6 +1358,22 @@ mod tests {
                 .unwrap();
         }
 
+        // PMU
+        if let Some(pmu_gsiv) = context.pmu_gsiv {
+            assert!((16..32).contains(&pmu_gsiv));
+            const GIC_PPI: u32 = 1;
+            const IRQ_TYPE_LEVEL_HIGH: u32 = 4;
+            root = root
+                .start_node("pmu")
+                .unwrap()
+                .add_str(p_compatible, "arm,armv8-pmuv3")
+                .unwrap()
+                .add_u32_array(p_interrupts, &[GIC_PPI, pmu_gsiv - 16, IRQ_TYPE_LEVEL_HIGH])
+                .unwrap()
+                .end_node()
+                .unwrap();
+        }
+
         // Linux requires vmbus to be under a simple-bus node.
         let mut simple_bus = root
             .start_node("bus")
@@ -1440,6 +1515,7 @@ mod tests {
         command_line: &str,
         com3_serial: bool,
         gic: Option<GicInfo>,
+        pmu_gsiv: Option<u32>,
         memory_allocation_mode: MemoryAllocationMode,
         device_dma_page_count: Option<u64>,
     ) -> TestParsedDeviceTree {
@@ -1455,13 +1531,14 @@ mod tests {
         context.gic = gic;
         context.memory_allocation_mode = memory_allocation_mode;
         context.device_dma_page_count = device_dma_page_count;
+        context.pmu_gsiv = pmu_gsiv;
         context
     }
 
     #[test]
     fn test_basic_dt() {
         let orig = create_parsed(
-            2608,
+            2672,
             &[
                 MemoryEntry {
                     range: MemoryRange::try_new(0..(1024 * HV_PAGE_SIZE)).unwrap(),
@@ -1511,6 +1588,7 @@ mod tests {
                 gic_redistributors_size: 0x60000,
                 gic_redistributor_stride: 0x20000,
             }),
+            Some(0x17),
             MemoryAllocationMode::Host,
             Some(1234),
         );
@@ -1574,6 +1652,7 @@ mod tests {
             "",
             false,
             None,
+            None,
             MemoryAllocationMode::Vtl2 {
                 memory_size: Some(1000 * 1024 * 1024), // 1000 MB
                 mmio_size: Some(128 * 1024 * 1024),    // 128 MB
@@ -1624,6 +1703,7 @@ mod tests {
             "THIS_IS_A_BOOT_ARG=1",
             false,
             None,
+            None,
             MemoryAllocationMode::Host,
             None,
         );
@@ -1661,6 +1741,7 @@ mod tests {
             None,
             "THIS_IS_A_BOOT_ARG=1",
             false,
+            None,
             None,
             MemoryAllocationMode::Host,
             None,
@@ -1705,6 +1786,7 @@ mod tests {
             "THIS_IS_A_BOOT_ARG=1",
             false,
             None,
+            None,
             MemoryAllocationMode::Host,
             None,
         );
@@ -1747,6 +1829,7 @@ mod tests {
             }),
             "THIS_IS_A_BOOT_ARG=1",
             false,
+            None,
             None,
             MemoryAllocationMode::Host,
             None,
@@ -1807,6 +1890,7 @@ mod tests {
             }),
             "THIS_IS_A_BOOT_ARG=1",
             true,
+            None,
             None,
             MemoryAllocationMode::Host,
             None,

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -399,17 +399,19 @@ pub fn write_dt(
 
         // Add PMU.
         // FIXME: Parse this from the host dt
-        // TODO: default on hyper-v is 0x17
+        // TODO: default on hyper-v is 0x17 for PPI, so it's actually that minus 16.
         let pmu_gsiv = 0x17;
         if pmu_gsiv != 0 {
             // TODO: This assumes the GSIV is a PPI. On all platforms, that seems to
             // be the case today.
+            assert!((16..32).contains(&pmu_gsiv));
+            let ppi_index = pmu_gsiv - 16;
             let pmu = root_builder
                 .start_node("pmu")?
                 .add_str(p_compatible, "arm,armv8-pmuv3")?
                 .add_u32_array(
                     p_interrupts,
-                    &[aarch64::GIC_PPI, pmu_gsiv, aarch64::IRQ_TYPE_LEVEL_HIGH],
+                    &[aarch64::GIC_PPI, ppi_index, aarch64::IRQ_TYPE_LEVEL_HIGH],
                 )?;
             root_builder = pmu.end_node()?;
         }

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -525,6 +525,7 @@ impl PartitionInfo {
             cmdline: _,
             com3_serial_available: com3_serial,
             gic,
+            pmu_gsiv,
             memory_allocation_mode: _,
             entropy,
             vtl0_alias_map: _,
@@ -550,6 +551,7 @@ impl PartitionInfo {
         cpus.extend(parsed.cpus.iter().copied());
         *com3_serial = parsed.com3_serial;
         *gic = parsed.gic.clone();
+        *pmu_gsiv = parsed.pmu_gsiv;
         *entropy = parsed.entropy.clone();
         *nvme_keepalive = parsed.nvme_keepalive;
         *boot_options = options;

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -85,8 +85,6 @@ pub struct PartitionInfo {
     pub cmdline: ArrayString<COMMAND_LINE_SIZE>,
     /// Com3 serial device is available
     pub com3_serial_available: bool,
-    /// GIC information
-    pub gic: Option<GicInfo>,
     /// Memory allocation mode that was performed.
     pub memory_allocation_mode: MemoryAllocationMode,
     /// Entropy from the host to be used by the OpenHCL kernel
@@ -97,6 +95,11 @@ pub struct PartitionInfo {
     pub nvme_keepalive: bool,
     /// Parsed boot command line options.
     pub boot_options: BootCommandLineOptions,
+
+    /// GIC information on AArch64.
+    pub gic: Option<GicInfo>,
+    /// PMU GSIV on AArch64.
+    pub pmu_gsiv: Option<u32>,
 }
 
 impl PartitionInfo {
@@ -123,12 +126,13 @@ impl PartitionInfo {
             },
             cmdline: ArrayString::new_const(),
             com3_serial_available: false,
-            gic: None,
             memory_allocation_mode: MemoryAllocationMode::Host,
             entropy: None,
             vtl0_alias_map: None,
             nvme_keepalive: false,
             boot_options: BootCommandLineOptions::new(),
+            gic: None,
+            pmu_gsiv: None,
         }
     }
 

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -1032,6 +1032,7 @@ mod test {
             },
             com3_serial_available: false,
             gic: None,
+            pmu_gsiv: None,
             memory_allocation_mode: host_fdt_parser::MemoryAllocationMode::Host,
             entropy: None,
             vtl0_alias_map: None,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1345,19 +1345,14 @@ async fn new_underhill_vm(
 
     #[cfg(guest_arch = "aarch64")]
     let processor_topology = {
-        // TODO: Hyper-V does not yet support reporting the PMU GSIV via device
-        // tree. For now, since OpenHCL is only supported on Hyper-V on aarch64,
-        // assume the value is the Hyper-V default.
-        //
-        // This value should instead come from openhcl_boot via device tree, as
-        // we may want to even use the PMU within OpenHCL itself.
-        const HYPERV_PMU_GSIV: u32 = 0x17;
         new_aarch64_topology(
             boot_info
                 .gic
                 .context("did not get gic state from bootloader")?,
             &boot_info.cpus,
-            HYPERV_PMU_GSIV,
+            boot_info
+                .pmu_gsiv
+                .context("did not get pmu gsiv from bootloader")?,
         )
         .context("failed to construct the processor topology")?
     };

--- a/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
@@ -317,10 +317,12 @@ fn build_dt(
     if pmu_gsiv != 0 {
         // TODO: This assumes the GSIV is a PPI. On all platforms, that seems to
         // be the case today.
+        assert!((16..32).contains(&pmu_gsiv));
+        let ppi_index = pmu_gsiv - 16;
         let pmu = root_builder
             .start_node("pmu")?
             .add_str(p_compatible, "arm,armv8-pmuv3")?
-            .add_u32_array(p_interrupts, &[GIC_PPI, pmu_gsiv, IRQ_TYPE_LEVEL_HIGH])?;
+            .add_u32_array(p_interrupts, &[GIC_PPI, ppi_index, IRQ_TYPE_LEVEL_HIGH])?;
         root_builder = pmu.end_node()?;
     }
 

--- a/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
@@ -312,6 +312,18 @@ fn build_dt(
         .add_null(p_always_on)?;
     root_builder = timer.end_node()?;
 
+    // Add PMU, if the interrupt is non-zero.
+    let pmu_gsiv = processor_topology.pmu_gsiv();
+    if pmu_gsiv != 0 {
+        // TODO: This assumes the GSIV is a PPI. On all platforms, that seems to
+        // be the case today.
+        let pmu = root_builder
+            .start_node("pmu")?
+            .add_str(p_compatible, "arm,armv8-pmuv3")?
+            .add_u32_array(p_interrupts, &[GIC_PPI, pmu_gsiv, IRQ_TYPE_LEVEL_HIGH])?;
+        root_builder = pmu.end_node()?;
+    }
+
     let mut soc = root_builder
         .start_node("openvmm")?
         .add_str(p_compatible, "simple-bus")?

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -12,8 +12,12 @@ use vmm_test_macros::vmm_test;
 /// Boot Linux and verify the PMU interrupt is available.
 ///
 /// TODO: This is only supported on WHP and Hyper-V.
+///
 #[vmm_test(
-    openvmm_linux_direct_aarch64,
+    // TODO: requires aarch64 serial emulator changes, or petri changes to use
+    // something other than serial. GH issue 1790.
+    //
+    // openvmm_linux_direct_aarch64,
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -11,15 +11,12 @@ use vmm_test_macros::vmm_test;
 
 /// Boot Linux and verify the PMU interrupt is available.
 ///
-/// TODO: Linux direct support requires device tree support, which is not
-/// implemented yet.
-///
 /// TODO: This is only supported on WHP and Hyper-V.
 #[vmm_test(
-    // openvmm_linux_direct_aarch64,
+    openvmm_linux_direct_aarch64,
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
 )]
 async fn pmu_gsiv<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> Result<(), anyhow::Error> {
     let (vm, agent) = config.run().await?;


### PR DESCRIPTION
Report the PMU via device tree, and parse it from device tree in OpenHCL in both `openhcl_boot` and usermode. 

Note that the kernel reports some sampling events not supported error in OpenHCL:
```
[kmsg]: [0.011789] armv8-pmu pmu: hw perfevents: no irqs for PMU, sampling events not supported
[kmsg]: [0.011916] hw perfevents: enabled with armv8_pmuv3 PMU driver, 6 (0,8000001f) counters available
```

Tracked by #1808. Due to openhcl-diag shell not working on AArch64, it's possible `perf` doesn't actually work. However, VTL0 sees the correct value being described via ACPI. 

Fixes #1775. 