### PR TITLE
vmcore/vm_topology: support pmu interrupt on aarch64 (#1776)

### DIFF
--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -448,6 +448,7 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
                     gic_distributor_base: self.gic_distributor_base(),
                     gic_redistributors_base: self.gic_redistributors_base(),
                 }),
+                pmu_gsiv: Some(self.pmu_gsiv()),
             })),
         }
     }
@@ -471,8 +472,16 @@ impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
                 gic_redistributors_base: hvlite_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE,
             }
         };
+        let pmu_gsiv = arch.pmu_gsiv.unwrap_or(0);
 
-        let mut builder = TopologyBuilder::new_aarch64(gic);
+        // TODO: When this value is supported on all platforms, we should change
+        // the arch config to not be an option. For now, warn since the ARM VBSA
+        // expects this to be available.
+        if pmu_gsiv == 0 {
+            tracing::warn!("PMU GSIV is set to 0");
+        }
+
+        let mut builder = TopologyBuilder::new_aarch64(gic, pmu_gsiv);
         if let Some(smt) = self.enable_smt {
             builder.smt_enabled(smt);
         }

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -201,6 +201,7 @@ pub enum X2ApicConfig {
 #[derive(Debug, Protobuf, Default, Clone)]
 pub struct Aarch64TopologyConfig {
     pub gic_config: Option<GicConfig>,
+    pub pmu_gsiv: Option<u32>,
 }
 
 #[derive(Debug, Protobuf, Clone)]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1146,6 +1146,16 @@ fn vm_config_from_command_line(
         hvlite_defs::config::Aarch64TopologyConfig {
             // TODO: allow this to be configured from the command line
             gic_config: None,
+            // TODO: This value is platform specific, and needs to be queried
+            // from each platform. Additionally, enabling it on HVF with the
+            // correct platform value does not work, so more investigation is
+            // needed.
+            #[cfg(not(windows))]
+            pmu_gsiv: None,
+            // TODO: On WHP, the value supported is 0x17, and is
+            // not configurable today.
+            #[cfg(windows)]
+            pmu_gsiv: Some(0x17),
         },
     );
     #[cfg(guest_arch = "x86_64")]

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -296,7 +296,22 @@ impl PetriVmConfigOpenVmm {
                 proc_count: 2,
                 vps_per_socket: None,
                 enable_smt: None,
-                arch: None,
+                arch: match arch {
+                    MachineArch::X86_64 => None,
+                    #[cfg(not(windows))]
+                    MachineArch::Aarch64 => None,
+                    #[cfg(windows)]
+                    MachineArch::Aarch64 => Some(hvlite_defs::config::ArchTopologyConfig::Aarch64(
+                        hvlite_defs::config::Aarch64TopologyConfig {
+                            // TODO: The PMU GSIV value is currently hardcoded
+                            // to be 0x17 on WHP. This shouldn't be required to
+                            // be set, but a future change will set the platform
+                            // default if None was specified.
+                            pmu_gsiv: Some(0x17),
+                            ..Default::default()
+                        },
+                    )),
+                },
             },
 
             // Base chipset

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -295,12 +295,16 @@ impl PetriVmConfigOpenVmm {
                 proc_count: 2,
                 vps_per_socket: None,
                 enable_smt: None,
-                arch: match arch {
-                    MachineArch::X86_64 => None,
+                arch: Some(match arch {
+                    MachineArch::X86_64 => hvlite_defs::config::ArchTopologyConfig::X86(
+                        hvlite_defs::config::X86TopologyConfig::default(),
+                    ),
                     #[cfg(not(windows))]
-                    MachineArch::Aarch64 => None,
+                    MachineArch::Aarch64 => hvlite_defs::config::ArchTopologyConfig::Aarch64(
+                        hvlite_defs::config::Aarch64TopologyConfig::default(),
+                    ),
                     #[cfg(windows)]
-                    MachineArch::Aarch64 => Some(hvlite_defs::config::ArchTopologyConfig::Aarch64(
+                    MachineArch::Aarch64 => hvlite_defs::config::ArchTopologyConfig::Aarch64(
                         hvlite_defs::config::Aarch64TopologyConfig {
                             // TODO: The PMU GSIV value is currently hardcoded
                             // to be 0x17 on WHP. This shouldn't be required to
@@ -309,8 +313,8 @@ impl PetriVmConfigOpenVmm {
                             pmu_gsiv: Some(0x17),
                             ..Default::default()
                         },
-                    )),
-                },
+                    ),
+                }),
             },
 
             // Base chipset

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -17,7 +17,6 @@ use crate::IsolationType;
 use crate::PcatGuest;
 use crate::PetriLogSource;
 use crate::PetriTestParams;
-use crate::ProcessorTopology;
 use crate::SIZE_1_GB;
 use crate::UefiGuest;
 use crate::linux_direct_serial_agent::LinuxDirectSerialAgent;
@@ -425,8 +424,7 @@ impl PetriVmConfigOpenVmm {
             ged,
             vtl2_settings,
             framebuffer_access,
-        }
-        .with_processor_topology(ProcessorTopology::default()))
+        })
     }
 }
 

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -60,13 +60,15 @@ impl CommonState {
             .context("failed to build processor topology")?;
 
         #[cfg(guest_arch = "aarch64")]
-        let processor_topology =
-            TopologyBuilder::new_aarch64(vm_topology::processor::arch::GicInfo {
+        let processor_topology = TopologyBuilder::new_aarch64(
+            vm_topology::processor::arch::GicInfo {
                 gic_distributor_base: 0xff000000,
                 gic_redistributors_base: 0xff020000,
-            })
-            .build(1)
-            .context("failed to build processor topology")?;
+            },
+            0,
+        )
+        .build(1)
+        .context("failed to build processor topology")?;
 
         let ram_size = 0x400000;
         let memory_layout = MemoryLayout::new(ram_size, &[], None).context("bad memory layout")?;

--- a/vm/acpi_spec/src/madt.rs
+++ b/vm/acpi_spec/src/madt.rs
@@ -237,7 +237,12 @@ pub struct MadtGicc {
 const_assert_eq!(size_of::<MadtGicc>(), 80);
 
 impl MadtGicc {
-    pub fn new(acpi_processor_uid: u32, mpidr: u64, gicr: u64) -> Self {
+    pub fn new(
+        acpi_processor_uid: u32,
+        mpidr: u64,
+        gicr: u64,
+        performance_monitoring_gsiv: u32,
+    ) -> Self {
         Self {
             typ: MadtType::GICC,
             length: size_of::<Self>() as u8,
@@ -245,6 +250,7 @@ impl MadtGicc {
             acpi_processor_uid: acpi_processor_uid.into(),
             mpidr: mpidr.into(),
             gicr_base_address: gicr.into(),
+            performance_monitoring_gsiv: performance_monitoring_gsiv.into(),
             ..Self::new_zeroed()
         }
     }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -142,7 +142,10 @@ impl AcpiTopology for Aarch64Topology {
             let mpidr = u64::from(vp.mpidr) & u64::from(aarch64defs::MpidrEl1::AFFINITY_MASK);
             let gicr = topology.gic_redistributors_base()
                 + vp.base.vp_index.index() as u64 * aarch64defs::GIC_REDISTRIBUTOR_SIZE;
-            madt.extend_from_slice(acpi_spec::madt::MadtGicc::new(uid, mpidr, gicr).as_bytes());
+            let pmu_gsiv = topology.pmu_gsiv();
+            madt.extend_from_slice(
+                acpi_spec::madt::MadtGicc::new(uid, mpidr, gicr, pmu_gsiv).as_bytes(),
+            );
         }
     }
 }

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for aarch64 guests.
+
+use petri::PetriVmBuilder;
+use petri::PetriVmmBackend;
+use petri::pipette::cmd;
+use vmm_core_defs::HaltReason;
+use vmm_test_macros::vmm_test;
+
+/// Boot Linux and verify the PMU interrupt is available.
+///
+/// TODO: Linux direct support requires device tree support, which is not
+/// implemented yet.
+///
+/// TODO: This is only supported on WHP and Hyper-V.
+#[vmm_test(
+    // openvmm_linux_direct_aarch64,
+    openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+    hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+)]
+async fn pmu_gsiv<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> Result<(), anyhow::Error> {
+    let (vm, agent) = config.run().await?;
+
+    // Check dmesg for logs about the PMU.
+    let shell = agent.unix_shell();
+    let dmesg = cmd!(shell, "dmesg").read().await?;
+
+    // There should be no lines that look like the following:
+    //  "No ACPI PMU IRQ for CPU0"
+    dmesg.lines().try_for_each(|line| {
+        if line.contains("No ACPI PMU IRQ for CPU") {
+            Err(anyhow::anyhow!("PMU IRQ not found in dmesg: {}", line))
+        } else {
+            Ok(())
+        }
+    })?;
+
+    agent.power_off().await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+
+    Ok(())
+}

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -3,8 +3,7 @@
 
 //! Integration tests for aarch64 guests.
 
-use petri::PetriVmBuilder;
-use petri::PetriVmmBackend;
+use petri::PetriVmConfig;
 use petri::pipette::cmd;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::vmm_test;
@@ -21,7 +20,7 @@ use vmm_test_macros::vmm_test;
     hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
 )]
-async fn pmu_gsiv<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> Result<(), anyhow::Error> {
+async fn pmu_gsiv(config: Box<dyn PetriVmConfig>) -> Result<(), anyhow::Error> {
     let (vm, agent) = config.run().await?;
 
     // Check dmesg for logs about the PMU.

--- a/vmm_tests/vmm_tests/tests/tests/main.rs
+++ b/vmm_tests/vmm_tests/tests/tests/main.rs
@@ -27,6 +27,8 @@ mod ttrpc;
 mod x86_64;
 // Tests that will only ever run when targeting x86-64.
 mod x86_64_exclusive;
+// Tests that will only ever run targeting Aarch64/ARM64.
+mod aarch64_exclusive;
 
 pub fn main() {
     petri::test_main(|name, requirements| {


### PR DESCRIPTION
On AArch64, the Performance Monitor Unit (PMU) is supposed to be
supported by every platform. Add this information to the vm's topology,
and correctly report a configured value in the MADT via the GICC
structure. Onboard a test to verify that Linux sees the correct
interrupts.

Hyper-V and WHP support a hardcoded value of 0x17, so for now hardcode
that value on those platforms. A follow up change will correctly report
this value via a `pmu` device tree node, but take this more minimal
change to backport to the release/2505 branch.

Although macOS also supports this interrupt with the same value of 0x17,
enabling that did not cause Linux to work as expected, so more
investigation there is needed.

This fixes xperf on Windows and perf on Linux which rely on this being
present.

#1775 

Backport of #1776 