### PR TITLE
virt_*: The big error cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,6 +3961,7 @@ dependencies = [
 name = "membacking"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "futures",
  "getrandom 0.3.2",
  "guestmem",
@@ -8039,6 +8040,7 @@ name = "virt_kvm"
 version = "0.0.0"
 dependencies = [
  "aarch64defs",
+ "anyhow",
  "bitfield-struct 0.10.1",
  "build_rs_guest_arch",
  "cfg-if",
@@ -8069,6 +8071,7 @@ dependencies = [
 name = "virt_mshv"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "arrayvec",
  "build_rs_guest_arch",
  "guestmem",

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -89,6 +89,7 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
+// TODO: Chunk this up into smaller per-interface errors.
 /// Error returned by HCL operations.
 #[derive(Error, Debug)]
 #[expect(missing_docs)]
@@ -136,8 +137,6 @@ pub enum Error {
     NumSignalEvent(#[source] io::Error),
     #[error("failed to create vtl")]
     CreateVTL(#[source] nix::Error),
-    #[error("Gva to gpa translation failed")]
-    TranslateGvaToGpa(#[source] TranslateGvaToGpaError),
     #[error("gpa failed vtl access check")]
     CheckVtlAccess(#[source] HvError),
     #[error("failed to set registers using set_vp_registers hypercall")]

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -8,7 +8,6 @@ pub mod tlb_lock;
 
 use super::UhEmulationState;
 use super::UhProcessor;
-use super::UhRunVpError;
 use crate::CvmVtl1State;
 use crate::GuestVsmState;
 use crate::GuestVtl;
@@ -33,6 +32,7 @@ use hvdef::HvInterruptType;
 use hvdef::HvMapGpaFlags;
 use hvdef::HvMessage;
 use hvdef::HvMessageType;
+use hvdef::HvRegisterValue;
 use hvdef::HvRegisterVsmPartitionConfig;
 use hvdef::HvRegisterVsmVpSecureVtlConfig;
 use hvdef::HvResult;
@@ -50,7 +50,6 @@ use hvdef::hypercall::HvFlushFlags;
 use hvdef::hypercall::TranslateGvaResultCode;
 use std::iter::zip;
 use virt::Processor;
-use virt::VpHaltReason;
 use virt::io::CpuIo;
 use virt::irqcon::MsiRequest;
 use virt::vp::AccessVpState;
@@ -174,7 +173,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         &mut self,
         vtl: GuestVtl,
         name: hvdef::HvRegisterName,
-    ) -> HvResult<hvdef::HvRegisterValue> {
+    ) -> HvResult<HvRegisterValue> {
         self.validate_register_access(vtl, name)?;
         // TODO: when get vp register i.e. in access vp state gets refactored,
         // clean this up.
@@ -918,7 +917,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::GetVpRegisters
         vp_index: u32,
         vtl: Option<Vtl>,
         registers: &[hvdef::HvRegisterName],
-        output: &mut [hvdef::HvRegisterValue],
+        output: &mut [HvRegisterValue],
     ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
@@ -1809,12 +1808,12 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Handle checking for cross-VTL interrupts, preempting VTL 0, and setting
     /// VINA when appropriate. Returns true if interrupt reprocessing is required.
-    fn cvm_handle_cross_vtl_interrupts(&mut self, dev: &impl CpuIo) -> Result<bool, UhRunVpError> {
+    fn cvm_handle_cross_vtl_interrupts(&mut self, dev: &impl CpuIo) -> bool {
         let cvm_state = self.backing.cvm_state();
 
         // If VTL1 is not yet enabled, there is nothing to do.
         if cvm_state.vtl1.is_none() {
-            return Ok(false);
+            return false;
         }
 
         // Check for VTL preemption - which ignores RFLAGS.IF
@@ -1842,13 +1841,10 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             }
         }
 
-        Ok(reprocessing_required)
+        reprocessing_required
     }
 
-    pub(crate) fn hcvm_handle_vp_start_enable_vtl(
-        &mut self,
-        vtl: GuestVtl,
-    ) -> Result<(), UhRunVpError> {
+    pub(crate) fn hcvm_handle_vp_start_enable_vtl(&mut self, vtl: GuestVtl) {
         let context = {
             self.cvm_vp_inner().hv_start_enable_vtl_vp[vtl]
                 .lock()
@@ -1870,16 +1866,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             );
 
             if vtl == GuestVtl::Vtl0 {
-                let is_protected_register = |reg, value| -> Result<(), UhRunVpError> {
-                    if self.cvm_is_protected_register_write(vtl, reg, value) {
-                        // In this case, it doesn't matter what VTL the calling
-                        // VP was in, just fail the startup. No need to send an
-                        // intercept message.
-                        return Err(UhRunVpError::StateAccessDenied);
-                    }
-                    Ok(())
-                };
-
                 let hvdef::hypercall::InitialVpContextX64 {
                     rip: _,
                     rsp: _,
@@ -1901,31 +1887,41 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     msr_cr_pat: _,
                 } = start_enable_vtl_state.context;
 
-                is_protected_register(HvX64RegisterName::Cr0, cr0)?;
-                is_protected_register(HvX64RegisterName::Cr4, cr4)?;
-                is_protected_register(
-                    HvX64RegisterName::Gdtr,
-                    hvdef::HvRegisterValue::from(gdtr).as_u64(),
-                )?;
-                is_protected_register(
-                    HvX64RegisterName::Idtr,
-                    hvdef::HvRegisterValue::from(idtr).as_u64(),
-                )?;
-                is_protected_register(
-                    HvX64RegisterName::Ldtr,
-                    hvdef::HvRegisterValue::from(ldtr).as_u64(),
-                )?;
-                is_protected_register(
-                    HvX64RegisterName::Tr,
-                    hvdef::HvRegisterValue::from(tr).as_u64(),
-                )?;
+                for (reg, value) in [
+                    (HvX64RegisterName::Cr0, cr0),
+                    (HvX64RegisterName::Cr4, cr4),
+                    (
+                        HvX64RegisterName::Gdtr,
+                        HvRegisterValue::from(gdtr).as_u64(),
+                    ),
+                    (
+                        HvX64RegisterName::Idtr,
+                        HvRegisterValue::from(idtr).as_u64(),
+                    ),
+                    (
+                        HvX64RegisterName::Ldtr,
+                        HvRegisterValue::from(ldtr).as_u64(),
+                    ),
+                    (HvX64RegisterName::Tr, HvRegisterValue::from(tr).as_u64()),
+                ] {
+                    if self.cvm_is_protected_register_write(vtl, reg, value) {
+                        // In this case, it doesn't matter what VTL the calling
+                        // VP was in, just fail the startup. No need to send an
+                        // intercept message.
+                        tracelimit::error_ratelimited!(
+                            ?reg,
+                            "Attempted to write to protected register during VTL 0 startup",
+                        );
+                        return;
+                    }
+                }
             }
 
             hv1_emulator::hypercall::set_x86_vp_context(
                 &mut self.access_state(vtl.into()),
                 &(start_enable_vtl_state.context),
             )
-            .map_err(UhRunVpError::State)?;
+            .unwrap();
 
             if let InitialVpContextOperation::StartVp = start_enable_vtl_state.operation {
                 match vtl {
@@ -1956,8 +1952,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                 }
             }
         }
-
-        Ok(())
     }
 
     fn cvm_handle_exit_activity(&mut self) {
@@ -2375,7 +2369,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         scan_irr: VtlArray<bool, 2>,
         first_scan_irr: &mut bool,
         dev: &impl CpuIo,
-    ) -> Result<bool, VpHaltReason<UhRunVpError>> {
+    ) -> bool {
         self.cvm_handle_exit_activity();
 
         if self.backing.untrusted_synic_mut().is_some() {
@@ -2386,13 +2380,11 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             // Process interrupts.
             self.update_synic(vtl, false);
 
-            B::poll_apic(self, vtl, scan_irr[vtl] || *first_scan_irr)
-                .map_err(VpHaltReason::Hypervisor)?;
+            B::poll_apic(self, vtl, scan_irr[vtl] || *first_scan_irr);
         }
         *first_scan_irr = false;
 
         self.cvm_handle_cross_vtl_interrupts(dev)
-            .map_err(VpHaltReason::InvalidVmState)
     }
 
     fn update_synic(&mut self, vtl: GuestVtl, untrusted_synic: bool) {
@@ -2662,8 +2654,6 @@ pub(crate) fn validate_xsetbv_exit(input: XsetbvExitInput) -> Option<u64> {
 }
 
 impl<T: CpuIo, B: HardwareIsolatedBacking> TranslateGvaSupport for UhEmulationState<'_, '_, T, B> {
-    type Error = UhRunVpError;
-
     fn guest_memory(&self) -> &GuestMemory {
         &self.vp.partition.gm[self.vtl]
     }
@@ -2672,8 +2662,8 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> TranslateGvaSupport for UhEmulationSt
         self.vp.set_tlb_lock(Vtl::Vtl2, self.vtl)
     }
 
-    fn registers(&mut self) -> Result<TranslationRegisters, Self::Error> {
-        Ok(self.vp.backing.translation_registers(self.vp, self.vtl))
+    fn registers(&mut self) -> TranslationRegisters {
+        self.vp.backing.translation_registers(self.vp, self.vtl)
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1865,58 +1865,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                 "setting up vp with initial registers"
             );
 
-            if vtl == GuestVtl::Vtl0 {
-                let hvdef::hypercall::InitialVpContextX64 {
-                    rip: _,
-                    rsp: _,
-                    rflags: _,
-                    cs: _,
-                    ds: _,
-                    es: _,
-                    fs: _,
-                    gs: _,
-                    ss: _,
-                    tr,
-                    ldtr,
-                    idtr,
-                    gdtr,
-                    efer: _,
-                    cr0,
-                    cr3: _,
-                    cr4,
-                    msr_cr_pat: _,
-                } = start_enable_vtl_state.context;
-
-                for (reg, value) in [
-                    (HvX64RegisterName::Cr0, cr0),
-                    (HvX64RegisterName::Cr4, cr4),
-                    (
-                        HvX64RegisterName::Gdtr,
-                        HvRegisterValue::from(gdtr).as_u64(),
-                    ),
-                    (
-                        HvX64RegisterName::Idtr,
-                        HvRegisterValue::from(idtr).as_u64(),
-                    ),
-                    (
-                        HvX64RegisterName::Ldtr,
-                        HvRegisterValue::from(ldtr).as_u64(),
-                    ),
-                    (HvX64RegisterName::Tr, HvRegisterValue::from(tr).as_u64()),
-                ] {
-                    if self.cvm_is_protected_register_write(vtl, reg, value) {
-                        // In this case, it doesn't matter what VTL the calling
-                        // VP was in, just fail the startup. No need to send an
-                        // intercept message.
-                        tracelimit::error_ratelimited!(
-                            ?reg,
-                            "Attempted to write to protected register during VTL 0 startup",
-                        );
-                        return;
-                    }
-                }
-            }
-
             hv1_emulator::hypercall::set_x86_vp_context(
                 &mut self.access_state(vtl.into()),
                 &(start_enable_vtl_state.context),

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -632,6 +632,7 @@ impl<T: Backing> UhProcessor<'_, T> {
     }
 }
 
+#[cfg(guest_arch = "x86_64")]
 #[derive(Debug, Error)]
 #[error("unexpected debug exception with dr6 value {dr6:#x}")]
 struct UnexpectedDebugException {
@@ -649,8 +650,8 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
         &mut self,
         _vtl: Vtl,
         _state: Option<&virt::x86::DebugState>,
-    ) -> Result<(), Self::Error> {
-        anyhow::bail!("not supported")
+    ) -> Result<(), <T::StateAccess<'p, '_> as virt::vp::AccessVpState>::Error> {
+        unimplemented!()
     }
 
     #[cfg(guest_arch = "x86_64")]
@@ -1081,7 +1082,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         intercept_state: &aarch64emu::InterceptState,
         vtl: GuestVtl,
         cache: T::EmulationCache,
-    ) -> Result<(), VpHaltReason<UhRunVpError>>
+    ) -> Result<(), VpHaltReason>
     where
         for<'b> UhEmulationState<'b, 'a, D, T>: virt_support_aarch64emu::emulate::EmulatorSupport,
     {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -180,7 +180,6 @@ struct BackingParams<'a, 'b, T: Backing> {
 
 mod private {
     use super::BackingParams;
-    use super::UhRunVpError;
     use super::vp_state;
     use crate::BackingShared;
     use crate::Error;
@@ -221,7 +220,7 @@ mod private {
             this: &mut UhProcessor<'_, Self>,
             dev: &impl CpuIo,
             stop: &mut StopVp<'_>,
-        ) -> impl Future<Output = Result<(), VpHaltReason<UhRunVpError>>>;
+        ) -> impl Future<Output = Result<(), VpHaltReason>>;
 
         /// Process any pending interrupts. Returns true if reprocessing is required.
         fn process_interrupts(
@@ -229,14 +228,10 @@ mod private {
             scan_irr: VtlArray<bool, 2>,
             first_scan_irr: &mut bool,
             dev: &impl CpuIo,
-        ) -> Result<bool, VpHaltReason<UhRunVpError>>;
+        ) -> bool;
 
         /// Process any pending APIC work.
-        fn poll_apic(
-            this: &mut UhProcessor<'_, Self>,
-            vtl: GuestVtl,
-            scan_irr: bool,
-        ) -> Result<(), UhRunVpError>;
+        fn poll_apic(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl, scan_irr: bool);
 
         /// Requests the VP to exit when an external interrupt is ready to be
         /// delivered.
@@ -250,10 +245,7 @@ mod private {
         /// This is used for hypervisor-managed and untrusted SINTs.
         fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
 
-        fn handle_vp_start_enable_vtl_wake(
-            _this: &mut UhProcessor<'_, Self>,
-            _vtl: GuestVtl,
-        ) -> Result<(), UhRunVpError>;
+        fn handle_vp_start_enable_vtl_wake(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl);
 
         fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}
 
@@ -570,69 +562,6 @@ impl UhVpInner {
     }
 }
 
-/// Underhill-specific run VP error
-#[derive(Debug, Error)]
-pub enum UhRunVpError {
-    /// Failed to run
-    #[error("failed to run")]
-    Run(#[source] hcl::ioctl::Error),
-    #[error("sidecar run error")]
-    Sidecar(#[source] sidecar_client::SidecarError),
-    /// Failed to access state for emulation
-    #[error("failed to access state for emulation")]
-    EmulationState(#[source] hcl::ioctl::Error),
-    /// Failed to translate GVA
-    #[error("failed to translate GVA")]
-    TranslateGva(#[source] hcl::ioctl::Error),
-    /// Failed VTL access check
-    #[error("failed VTL access check")]
-    VtlAccess(#[source] hcl::ioctl::Error),
-    /// Failed to advance rip
-    #[error("failed to advance rip")]
-    AdvanceRip(#[source] hcl::ioctl::Error),
-    /// Failed to set pending event
-    #[error("failed to set pending event")]
-    Event(#[source] hcl::ioctl::Error),
-    /// Guest accessed unaccepted gpa
-    #[error("guest accessed unaccepted gpa {0}")]
-    UnacceptedMemoryAccess(u64),
-    /// State access error
-    #[error("state access error")]
-    State(#[source] vp_state::Error),
-    /// Invalid vmcb
-    #[error("invalid vmcb")]
-    InvalidVmcb,
-    #[error("unknown exit {0:#x?}")]
-    UnknownVmxExit(x86defs::vmx::VmxExit),
-    #[error("bad guest state on VP.ENTER")]
-    VmxBadGuestState,
-    #[error("failed to read hypercall parameters")]
-    HypercallParameters(#[source] guestmem::GuestMemoryError),
-    #[error("failed to write hypercall result")]
-    HypercallResult(#[source] guestmem::GuestMemoryError),
-    #[error("unexpected debug exception with dr6 value {0:#x}")]
-    UnexpectedDebugException(u64),
-    /// Handling an intercept on behalf of an invalid Lower VTL
-    #[error("invalid intercepted vtl {0:?}")]
-    InvalidInterceptedVtl(u8),
-    #[error("access to state blocked by another vtl")]
-    StateAccessDenied,
-}
-
-/// Underhill processor run error
-#[derive(Debug, Error)]
-pub enum ProcessorError {
-    /// IOCTL error
-    #[error("hcl error")]
-    Ioctl(#[from] hcl::ioctl::Error),
-    /// State access error
-    #[error("state access error")]
-    State(#[from] vp_state::Error),
-    /// Not supported
-    #[error("operation not supported")]
-    NotSupported,
-}
-
 impl<T: Backing> UhProcessor<'_, T> {
     fn inspect_extra(&mut self, resp: &mut inspect::Response<'_>) {
         resp.child("stats", |req| {
@@ -663,7 +592,7 @@ impl<T: Backing> UhProcessor<'_, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn handle_debug_exception(&mut self, vtl: GuestVtl) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_debug_exception(&mut self, vtl: GuestVtl) -> Result<(), VpHaltReason> {
         // FUTURE: Underhill does not yet support VTL1 so this is only tested with VTL0.
         if vtl == GuestVtl::Vtl0 {
             let debug_regs: virt::x86::vp::DebugRegisters = self
@@ -688,7 +617,10 @@ impl<T: Backing> UhProcessor<'_, T> {
             if i >= BREAKPOINT_INDEX_OFFSET {
                 // Received a debug exception not triggered by a breakpoint or single step.
                 return Err(VpHaltReason::InvalidVmState(
-                    UhRunVpError::UnexpectedDebugException(debug_regs.dr6),
+                    UnexpectedDebugException {
+                        dr6: debug_regs.dr6,
+                    }
+                    .into(),
                 ));
             }
             let bp = virt::x86::HardwareBreakpoint::from_dr7(debug_regs.dr7, dr[i], i);
@@ -700,9 +632,13 @@ impl<T: Backing> UhProcessor<'_, T> {
     }
 }
 
+#[derive(Debug, Error)]
+#[error("unexpected debug exception with dr6 value {dr6:#x}")]
+struct UnexpectedDebugException {
+    dr6: u64,
+}
+
 impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
-    type Error = ProcessorError;
-    type RunVpError = UhRunVpError;
     type StateAccess<'a>
         = T::StateAccess<'p, 'a>
     where
@@ -714,7 +650,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
         _vtl: Vtl,
         _state: Option<&virt::x86::DebugState>,
     ) -> Result<(), Self::Error> {
-        Err(ProcessorError::NotSupported)
+        anyhow::bail!("not supported")
     }
 
     #[cfg(guest_arch = "x86_64")]
@@ -722,12 +658,13 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
         &mut self,
         vtl: Vtl,
         state: Option<&virt::x86::DebugState>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <T::StateAccess<'p, '_> as AccessVpState>::Error> {
         // FUTURE: Underhill does not yet support VTL1 so this is only tested with VTL0.
         if vtl == Vtl::Vtl0 {
             let mut db: [u64; 4] = [0; 4];
-            let mut rflags =
-                x86defs::RFlags::from(self.access_state(Vtl::Vtl0).registers().unwrap().rflags);
+            let mut access_state = self.access_state(vtl);
+            let mut registers = access_state.registers()?;
+            let mut rflags = x86defs::RFlags::from(registers.rflags);
             let mut dr7: u64 = 0;
 
             if let Some(state) = state {
@@ -748,18 +685,10 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                 dr6: 0,
                 dr7,
             };
-
-            let mut access_state = self.access_state(vtl);
-
             access_state.set_debug_regs(&debug_registers)?;
 
-            let registers = {
-                let mut registers = access_state.registers().unwrap();
-                registers.rflags = rflags.into();
-                registers
-            };
+            registers.rflags = rflags.into();
             access_state.set_registers(&registers)?;
-
             return Ok(());
         }
 
@@ -770,7 +699,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
         &mut self,
         mut stop: StopVp<'_>,
         dev: &impl CpuIo,
-    ) -> Result<Infallible, VpHaltReason<UhRunVpError>> {
+    ) -> Result<Infallible, VpHaltReason> {
         if self.runner.is_sidecar() {
             if self.force_exit_sidecar && !self.signaled_sidecar_exit {
                 self.inner
@@ -825,12 +754,12 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
 
                     // Process wakes.
                     let scan_irr = if self.inner.wake_reasons.load(Ordering::Relaxed) != 0 {
-                        self.handle_wake().map_err(VpHaltReason::Hypervisor)?
+                        self.handle_wake()
                     } else {
                         [false, false].into()
                     };
 
-                    if T::process_interrupts(self, scan_irr, &mut first_scan_irr, dev)? {
+                    if T::process_interrupts(self, scan_irr, &mut first_scan_irr, dev) {
                         continue;
                     }
 
@@ -842,7 +771,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                         }
                     }
 
-                    return <Result<_, VpHaltReason<_>>>::Ok(()).into();
+                    return <Result<_, VpHaltReason>>::Ok(()).into();
                 }
             })
             .await?;
@@ -872,17 +801,16 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
         }
     }
 
-    fn flush_async_requests(&mut self) -> Result<(), Self::RunVpError> {
+    fn flush_async_requests(&mut self) {
         if self.inner.wake_reasons.load(Ordering::Relaxed) != 0 {
-            let scan_irr = self.handle_wake()?;
+            let scan_irr = self.handle_wake();
             for vtl in [GuestVtl::Vtl1, GuestVtl::Vtl0] {
                 if scan_irr[vtl] {
-                    T::poll_apic(self, vtl, true)?;
+                    T::poll_apic(self, vtl, true);
                 }
             }
         }
         self.runner.flush_deferred_state();
-        Ok(())
     }
 
     fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
@@ -951,7 +879,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     /// Returns true if the interrupt controller has work to do.
-    fn handle_wake(&mut self) -> Result<VtlArray<bool, 2>, UhRunVpError> {
+    fn handle_wake(&mut self) -> VtlArray<bool, 2> {
         let wake_reasons_raw = self.inner.wake_reasons.swap(0, Ordering::SeqCst);
         let wake_reasons_vtl: [WakeReason; 2] = zerocopy::transmute!(wake_reasons_raw);
         for (vtl, wake_reasons) in [
@@ -999,7 +927,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 
             #[cfg(guest_arch = "x86_64")]
             if wake_reasons.hv_start_enable_vtl_vp() {
-                T::handle_vp_start_enable_vtl_wake(self, vtl)?;
+                T::handle_vp_start_enable_vtl_wake(self, vtl);
             }
 
             #[cfg(guest_arch = "x86_64")]
@@ -1010,7 +938,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             }
         }
 
-        Ok(wake_reasons_vtl.map(|w| w.intcon()).into())
+        wake_reasons_vtl.map(|w| w.intcon()).into()
     }
 
     fn request_sint_notifications(&mut self, vtl: GuestVtl, sints: u16) {
@@ -1117,10 +1045,9 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         interruption_pending: bool,
         vtl: GuestVtl,
         cache: T::EmulationCache,
-    ) -> Result<(), VpHaltReason<UhRunVpError>>
+    ) -> Result<(), VpHaltReason>
     where
-        for<'b> UhEmulationState<'b, 'a, D, T>:
-            virt_support_x86emu::emulate::EmulatorSupport<Error = UhRunVpError>,
+        for<'b> UhEmulationState<'b, 'a, D, T>: virt_support_x86emu::emulate::EmulatorSupport,
     {
         let guest_memory = &self.partition.gm[vtl];
         let (kx_guest_memory, ux_guest_memory) = match vtl {
@@ -1156,8 +1083,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         cache: T::EmulationCache,
     ) -> Result<(), VpHaltReason<UhRunVpError>>
     where
-        for<'b> UhEmulationState<'b, 'a, D, T>:
-            virt_support_aarch64emu::emulate::EmulatorSupport<Error = UhRunVpError>,
+        for<'b> UhEmulationState<'b, 'a, D, T>: virt_support_aarch64emu::emulate::EmulatorSupport,
     {
         let guest_memory = &self.partition.gm[vtl];
         virt_support_aarch64emu::emulate::emulate(

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -157,7 +157,10 @@ impl BackingPrivate for HypervisorBackedArm64 {
         }
 
         this.unlock_tlb_lock(Vtl::Vtl2);
-        let intercepted = this.runner.run().unwrap();
+        let intercepted = this
+            .runner
+            .run()
+            .map_err(|e| VpHaltReason::Hypervisor(MshvRunVpError(e).into()))?;
 
         if intercepted {
             let stat = match this.runner.exit_message().header.typ {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -12,6 +12,7 @@ use super::super::BackingPrivate;
 use super::super::signal_mnf;
 use super::super::vp_state;
 use super::super::vp_state::UhVpStateAccess;
+use super::MshvRunVpError;
 use super::VbsIsolatedVtl1State;
 use crate::BackingShared;
 use crate::Error;

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -9,7 +9,6 @@ type VpRegisterName = HvArm64RegisterName;
 
 use super::super::BackingParams;
 use super::super::BackingPrivate;
-use super::super::UhRunVpError;
 use super::super::signal_mnf;
 use super::super::vp_state;
 use super::super::vp_state::UhVpStateAccess;
@@ -139,7 +138,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         if this.backing.deliverability_notifications
             != this.backing.next_deliverability_notifications
         {
@@ -158,10 +157,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
         }
 
         this.unlock_tlb_lock(Vtl::Vtl2);
-        let intercepted = this
-            .runner
-            .run()
-            .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Run(e)))?;
+        let intercepted = this.runner.run().unwrap();
 
         if intercepted {
             let stat = match this.runner.exit_message().header.typ {
@@ -200,21 +196,15 @@ impl BackingPrivate for HypervisorBackedArm64 {
         Ok(())
     }
 
-    fn poll_apic(
-        _this: &mut UhProcessor<'_, Self>,
-        _vtl: GuestVtl,
-        _scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
-        Ok(())
-    }
+    fn poll_apic(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl, _scan_irr: bool) {}
 
     fn process_interrupts(
         _this: &mut UhProcessor<'_, Self>,
         _scan_irr: hv1_structs::VtlArray<bool, 2>,
         _first_scan_irr: &mut bool,
         _dev: &impl CpuIo,
-    ) -> Result<bool, VpHaltReason<UhRunVpError>> {
-        Ok(false)
+    ) -> bool {
+        false
     }
 
     fn request_extint_readiness(this: &mut UhProcessor<'_, Self>) {
@@ -239,10 +229,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
         None
     }
 
-    fn handle_vp_start_enable_vtl_wake(
-        _this: &mut UhProcessor<'_, Self>,
-        _vtl: GuestVtl,
-    ) -> Result<(), UhRunVpError> {
+    fn handle_vp_start_enable_vtl_wake(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl) {
         unimplemented!()
     }
 
@@ -253,11 +240,23 @@ impl BackingPrivate for HypervisorBackedArm64 {
     }
 }
 
+#[derive(Debug, Error)]
+#[error("invalid intercepted vtl {0:?}")]
+struct InvalidInterceptedVtl(u8);
+
+#[derive(Debug, Error)]
+#[error("guest accessed unaccepted gpa {0}")]
+struct UnacceptedMemoryAccess(u64);
+
 impl UhProcessor<'_, HypervisorBackedArm64> {
     fn intercepted_vtl(
         message_header: &hvdef::HvArm64InterceptMessageHeader,
-    ) -> Result<GuestVtl, UnsupportedGuestVtl> {
-        message_header.execution_state.vtl().try_into()
+    ) -> Result<GuestVtl, InvalidInterceptedVtl> {
+        message_header
+            .execution_state
+            .vtl()
+            .try_into()
+            .map_err(|e: UnsupportedGuestVtl| InvalidInterceptedVtl(e.0))
     }
 
     fn handle_synic_deliverable_exit(&mut self) {
@@ -282,10 +281,7 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
         self.deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
     }
 
-    fn handle_hypercall_exit(
-        &mut self,
-        bus: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_hypercall_exit(&mut self, bus: &impl CpuIo) -> Result<(), VpHaltReason> {
         let message = self
             .runner
             .exit_message()
@@ -293,10 +289,8 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "hypercall");
 
-        let intercepted_vtl =
-            Self::intercepted_vtl(&message.header).map_err(|UnsupportedGuestVtl(vtl)| {
-                VpHaltReason::InvalidVmState(UhRunVpError::InvalidInterceptedVtl(vtl))
-            })?;
+        let intercepted_vtl = Self::intercepted_vtl(&message.header)
+            .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
         let guest_memory = &self.partition.gm[intercepted_vtl];
         let smccc_convention = message.immediate == 0;
 
@@ -310,14 +304,10 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
             guest_memory,
             hv1_hypercall::Arm64RegisterIo::new(handler, false, smccc_convention),
         );
-
         Ok(())
     }
 
-    async fn handle_mmio_exit(
-        &mut self,
-        dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    async fn handle_mmio_exit(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason> {
         let message = self
             .runner
             .exit_message()
@@ -332,10 +322,8 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
             interruption_pending: message.header.execution_state.interruption_pending(),
         };
 
-        let intercepted_vtl =
-            Self::intercepted_vtl(&message.header).map_err(|UnsupportedGuestVtl(vtl)| {
-                VpHaltReason::InvalidVmState(UhRunVpError::InvalidInterceptedVtl(vtl))
-            })?;
+        let intercepted_vtl = Self::intercepted_vtl(&message.header)
+            .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
 
         // Fast path for monitor page writes.
         if Some(message.guest_physical_address & !(hvdef::HV_PAGE_SIZE - 1))
@@ -373,14 +361,13 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
 
         let cache = UhCpuStateCache::default();
         self.emulate(dev, &intercept_state, intercepted_vtl, cache)
-            .await?;
-        Ok(())
+            .await
     }
 
     async fn handle_unaccepted_gpa_intercept(
         &mut self,
         dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         let gpa = self
             .runner
             .exit_message()
@@ -396,13 +383,12 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
             // no longer included in the lower_vtl_memory_layout, make sure the
             // appropriate changes are reflected here.
             Err(VpHaltReason::InvalidVmState(
-                UhRunVpError::UnacceptedMemoryAccess(gpa),
+                UnacceptedMemoryAccess(gpa).into(),
             ))
         } else {
             // TODO: for hardware isolation, if the intercept is due to a guest
             // error, inject a machine check
-            self.handle_mmio_exit(dev).await?;
-            Ok(())
+            self.handle_mmio_exit(dev).await
         }
     }
 }
@@ -574,8 +560,6 @@ impl<T: CpuIo> AccessCpuState for UhEmulationState<'_, '_, T, HypervisorBackedAr
 }
 
 impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedArm64> {
-    type Error = UhRunVpError;
-
     fn vp_index(&self) -> VpIndex {
         self.vp.vp_index()
     }
@@ -641,7 +625,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
         &mut self,
         gpa: u64,
         mode: emulate::TranslateMode,
-    ) -> Result<(), EmuCheckVtlAccessError<Self::Error>> {
+    ) -> Result<(), EmuCheckVtlAccessError> {
         // Underhill currently doesn't set VTL 2 protections against execute exclusively, it removes
         // all permissions from a page. So for VTL 1, no need to check the permissions; if VTL 1
         // doesn't have permissions to a page, Underhill should appropriately fail when it tries
@@ -668,7 +652,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
                 .vp
                 .runner
                 .get_vp_register(self.vtl, HvArm64RegisterName::SpsrEl2)
-                .map_err(UhRunVpError::EmulationState)?
+                .unwrap()
                 .as_u64()
                 .into();
 
@@ -683,7 +667,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
                 .partition
                 .hcl
                 .check_vtl_access(gpa, self.vtl, flags)
-                .map_err(|e| EmuCheckVtlAccessError::Hypervisor(UhRunVpError::VtlAccess(e)))?;
+                .unwrap();
 
             if let Some(ioctl::CheckVtlAccessResult { vtl, denied_flags }) = access_result {
                 return Err(EmuCheckVtlAccessError::AccessDenied { vtl, denied_flags });
@@ -697,7 +681,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
         &mut self,
         gva: u64,
         mode: emulate::TranslateMode,
-    ) -> Result<Result<EmuTranslateResult, EmuTranslateError>, Self::Error> {
+    ) -> Result<EmuTranslateResult, EmuTranslateError> {
         let mut control_flags = hypercall::TranslateGvaControlFlagsArm64::new();
         match mode {
             emulate::TranslateMode::Read => control_flags.set_validate_read(true),
@@ -732,22 +716,22 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
             .partition
             .hcl
             .translate_gva_to_gpa(gva, control_flags)
-            .map_err(|e| UhRunVpError::TranslateGva(ioctl::Error::TranslateGvaToGpa(e)))?
+            .unwrap()
         {
             Ok(ioctl::TranslateResult {
                 gpa_page,
                 overlay_page,
             }) => {
                 self.vp.mark_tlb_locked(Vtl::Vtl2, self.vtl);
-                Ok(Ok(EmuTranslateResult {
+                Ok(EmuTranslateResult {
                     gpa: (gpa_page << hvdef::HV_PAGE_SHIFT) + (gva & (hvdef::HV_PAGE_SIZE - 1)),
                     overlay_page: Some(overlay_page),
-                }))
+                })
             }
-            Err(ioctl::aarch64::TranslateErrorAarch64 { code }) => Ok(Err(EmuTranslateError {
+            Err(ioctl::aarch64::TranslateErrorAarch64 { code }) => Err(EmuTranslateError {
                 code: hypercall::TranslateGvaResultCode(code),
                 event_info: None,
-            })),
+            }),
         }
     }
 
@@ -928,8 +912,7 @@ mod save_restore {
 
         fn save(&mut self) -> Result<Self::SavedState, SaveError> {
             // Ensure all async requests are reflected in the saved state.
-            self.flush_async_requests()
-                .map_err(|err| SaveError::Other(err.into()))?;
+            self.flush_async_requests();
 
             let internal_activity = self
                 .runner

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/mod.rs
@@ -6,10 +6,15 @@
 use crate::HypervisorBacked;
 use crate::UhProcessor;
 use hcl::GuestVtl;
+use thiserror::Error;
 
 pub mod arm64;
 mod tlb_lock;
 pub mod x64;
+
+#[derive(Debug, Error)]
+#[error("failed to run")]
+struct MshvRunVpError(#[source] hcl::ioctl::Error);
 
 #[derive(Default, inspect::Inspect)]
 pub(crate) struct VbsIsolatedVtl1State {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -10,7 +10,6 @@ type VpRegisterName = HvX64RegisterName;
 use super::super::BackingParams;
 use super::super::BackingPrivate;
 use super::super::UhEmulationState;
-use super::super::UhRunVpError;
 use super::super::signal_mnf;
 use super::super::vp_state;
 use super::super::vp_state::UhVpStateAccess;
@@ -196,7 +195,7 @@ impl BackingPrivate for HypervisorBackedX86 {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         stop: &mut StopVp<'_>,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         if this.backing.deliverability_notifications
             != this.backing.next_deliverability_notifications
         {
@@ -218,7 +217,7 @@ impl BackingPrivate for HypervisorBackedX86 {
             let mut run = this
                 .runner
                 .run_sidecar()
-                .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Run(e)))?;
+                .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
             match stop.until_stop(run.wait()).await {
                 Ok(r) => r,
                 Err(stop) => {
@@ -231,19 +230,17 @@ impl BackingPrivate for HypervisorBackedX86 {
                     r
                 }
             }
-            .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Sidecar(e)))?
+            .map_err(|e| VpHaltReason::InvalidVmState(ioctl::Error::Sidecar(e).into()))?
         } else {
             this.unlock_tlb_lock(Vtl::Vtl2);
-            this.runner
-                .run()
-                .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Run(e)))?
+            this.runner.run().unwrap()
         };
 
         if intercepted {
             let message_type = this.runner.exit_message().header.typ;
 
             let mut intercept_handler =
-                InterceptHandler::new(this).map_err(VpHaltReason::InvalidVmState)?;
+                InterceptHandler::new(this).map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
 
             let stat = match message_type {
                 HvMessageType::HvMessageTypeX64IoPortIntercept => {
@@ -262,7 +259,7 @@ impl BackingPrivate for HypervisorBackedX86 {
                     &mut this.backing.stats.unaccepted_gpa
                 }
                 HvMessageType::HvMessageTypeHypercallIntercept => {
-                    intercept_handler.handle_hypercall_exit(dev)?;
+                    intercept_handler.handle_hypercall_exit(dev);
                     &mut this.backing.stats.hypercall
                 }
                 HvMessageType::HvMessageTypeSynicSintDeliverable => {
@@ -274,15 +271,15 @@ impl BackingPrivate for HypervisorBackedX86 {
                     &mut this.backing.stats.interrupt_deliverable
                 }
                 HvMessageType::HvMessageTypeX64CpuidIntercept => {
-                    intercept_handler.handle_cpuid_intercept()?;
+                    intercept_handler.handle_cpuid_intercept();
                     &mut this.backing.stats.cpuid
                 }
                 HvMessageType::HvMessageTypeMsrIntercept => {
-                    intercept_handler.handle_msr_intercept()?;
+                    intercept_handler.handle_msr_intercept();
                     &mut this.backing.stats.msr
                 }
                 HvMessageType::HvMessageTypeX64ApicEoi => {
-                    intercept_handler.handle_eoi(dev)?;
+                    intercept_handler.handle_eoi(dev);
                     &mut this.backing.stats.eoi
                 }
                 HvMessageType::HvMessageTypeUnrecoverableException => {
@@ -319,21 +316,15 @@ impl BackingPrivate for HypervisorBackedX86 {
         Ok(())
     }
 
-    fn poll_apic(
-        _this: &mut UhProcessor<'_, Self>,
-        _vtl: GuestVtl,
-        _scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
-        Ok(())
-    }
+    fn poll_apic(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl, _scan_irr: bool) {}
 
     fn process_interrupts(
         _this: &mut UhProcessor<'_, Self>,
         _scan_irr: hv1_structs::VtlArray<bool, 2>,
         _first_scan_irr: &mut bool,
         _dev: &impl CpuIo,
-    ) -> Result<bool, VpHaltReason<UhRunVpError>> {
-        Ok(false)
+    ) -> bool {
+        false
     }
 
     fn request_extint_readiness(this: &mut UhProcessor<'_, Self>) {
@@ -356,10 +347,7 @@ impl BackingPrivate for HypervisorBackedX86 {
         None
     }
 
-    fn handle_vp_start_enable_vtl_wake(
-        _this: &mut UhProcessor<'_, Self>,
-        _vtl: GuestVtl,
-    ) -> Result<(), UhRunVpError> {
+    fn handle_vp_start_enable_vtl_wake(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl) {
         unimplemented!()
     }
 
@@ -427,14 +415,24 @@ struct InterceptHandler<'a, 'b> {
     intercepted_vtl: GuestVtl,
 }
 
+#[derive(Debug, Error)]
+#[error("invalid intercepted vtl {0:?}")]
+struct InvalidInterceptedVtl(u8);
+
+#[derive(Debug, Error)]
+#[error("guest accessed unaccepted gpa {0}")]
+struct UnacceptedMemoryAccess(u64);
+
 impl<'a, 'b> InterceptHandler<'a, 'b> {
-    fn new(vp: &'a mut UhProcessor<'b, HypervisorBackedX86>) -> Result<Self, UhRunVpError> {
+    fn new(
+        vp: &'a mut UhProcessor<'b, HypervisorBackedX86>,
+    ) -> Result<Self, InvalidInterceptedVtl> {
         let message_type = vp.runner.exit_message().header.typ;
 
         let intercepted_vtl = match vp.runner.reg_page_vtl() {
             Ok(vtl) => vtl,
             Err(ioctl::x64::RegisterPageVtlError::InvalidVtl(vtl)) => {
-                return Err(UhRunVpError::InvalidInterceptedVtl(vtl));
+                return Err(InvalidInterceptedVtl(vtl));
             }
             Err(ioctl::x64::RegisterPageVtlError::NoRegisterPage) => {
                 if matches!(&message_type, &HvMessageType::HvMessageTypeX64ApicEoi) {
@@ -513,9 +511,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
                         reason => unreachable!("unknown exit reason: {:#x?}", reason),
                     };
 
-                    message_header.execution_state.vtl().try_into().map_err(
-                        |hcl::UnsupportedGuestVtl(vtl)| UhRunVpError::InvalidInterceptedVtl(vtl),
-                    )?
+                    message_header
+                        .execution_state
+                        .vtl()
+                        .try_into()
+                        .map_err(|hcl::UnsupportedGuestVtl(vtl)| InvalidInterceptedVtl(vtl))?
                 }
             }
         };
@@ -526,10 +526,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         })
     }
 
-    fn handle_interrupt_deliverable_exit(
-        &mut self,
-        bus: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_interrupt_deliverable_exit(&mut self, bus: &impl CpuIo) -> Result<(), VpHaltReason> {
         let message = self
             .vp
             .runner
@@ -564,7 +561,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
                     HvX64RegisterName::PendingEvent0,
                     u128::from(event).into(),
                 )
-                .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Event(e)))?;
+                .unwrap();
         }
 
         Ok(())
@@ -597,10 +594,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
             .deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
     }
 
-    fn handle_hypercall_exit(
-        &mut self,
-        bus: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_hypercall_exit(&mut self, bus: &impl CpuIo) {
         let message = self
             .vp
             .runner
@@ -623,14 +617,9 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
             guest_memory,
             hv1_hypercall::X64RegisterIo::new(handler, is_64bit),
         );
-
-        Ok(())
     }
 
-    async fn handle_mmio_exit(
-        &mut self,
-        dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    async fn handle_mmio_exit(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason> {
         let message = self
             .vp
             .runner
@@ -663,7 +652,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
                 dev,
                 interruption_pending,
                 tlb_lock_held,
-            )? {
+            ) {
                 if let Some(connection_id) = self.vp.partition.monitor_page.write_bit(bit) {
                     signal_mnf(dev, connection_id);
                 }
@@ -674,14 +663,10 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         let cache = self.vp.emulation_cache(self.intercepted_vtl);
         self.vp
             .emulate(dev, interruption_pending, self.intercepted_vtl, cache)
-            .await?;
-        Ok(())
+            .await
     }
 
-    async fn handle_io_port_exit(
-        &mut self,
-        dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    async fn handle_io_port_exit(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason> {
         let message = self
             .vp
             .runner
@@ -711,14 +696,15 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
                 dev,
             )
             .await;
-            self.vp.set_rip(self.intercepted_vtl, next_rip)
+            self.vp.set_rip(self.intercepted_vtl, next_rip);
+            Ok(())
         }
     }
 
     async fn handle_unaccepted_gpa_intercept(
         &mut self,
         dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         let gpa = self
             .vp
             .runner
@@ -735,17 +721,14 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
             // no longer included in the lower_vtl_memory_layout, make sure the
             // appropriate changes are reflected here.
             Err(VpHaltReason::InvalidVmState(
-                UhRunVpError::UnacceptedMemoryAccess(gpa),
+                UnacceptedMemoryAccess(gpa).into(),
             ))
         } else {
-            // TODO SNP: for hardware isolation, if the intercept is due to a guest
-            // error, inject a machine check
-            self.handle_mmio_exit(dev).await?;
-            Ok(())
+            self.handle_mmio_exit(dev).await
         }
     }
 
-    fn handle_cpuid_intercept(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_cpuid_intercept(&mut self) {
         let message = self
             .vp
             .runner
@@ -772,10 +755,10 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         self.vp.runner.cpu_context_mut().gps[protocol::RCX] = ecx.into();
         self.vp.runner.cpu_context_mut().gps[protocol::RDX] = edx.into();
 
-        self.vp.set_rip(self.intercepted_vtl, next_rip)
+        self.vp.set_rip(self.intercepted_vtl, next_rip);
     }
 
-    fn handle_msr_intercept(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_msr_intercept(&mut self) {
         let message = self
             .vp
             .runner
@@ -798,7 +781,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
                     Err(MsrError::InvalidAccess) => {
                         self.vp.inject_gpf(self.intercepted_vtl);
                         // Do not advance RIP.
-                        return Ok(());
+                        return;
                     }
                 };
 
@@ -816,17 +799,17 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
                     Err(MsrError::InvalidAccess) => {
                         self.vp.inject_gpf(self.intercepted_vtl);
                         // Do not advance RIP.
-                        return Ok(());
+                        return;
                     }
                 }
             }
             _ => unreachable!(),
         }
 
-        self.vp.set_rip(self.intercepted_vtl, rip)
+        self.vp.set_rip(self.intercepted_vtl, rip);
     }
 
-    fn handle_eoi(&self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_eoi(&self, dev: &impl CpuIo) {
         let message = self
             .vp
             .runner
@@ -836,16 +819,15 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         tracing::trace!(msg = %format_args!("{:x?}", message), "eoi");
 
         dev.handle_eoi(message.interrupt_vector);
-        Ok(())
     }
 
-    fn handle_unrecoverable_exception(&self) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_unrecoverable_exception(&self) -> Result<(), VpHaltReason> {
         Err(VpHaltReason::TripleFault {
             vtl: self.intercepted_vtl.into(),
         })
     }
 
-    fn handle_exception(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_exception(&mut self) -> Result<(), VpHaltReason> {
         let message = self
             .vp
             .runner
@@ -863,12 +845,10 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
 }
 
 impl UhProcessor<'_, HypervisorBackedX86> {
-    fn set_rip(&mut self, vtl: GuestVtl, rip: u64) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn set_rip(&mut self, vtl: GuestVtl, rip: u64) {
         self.runner
             .set_vp_register(vtl, HvX64RegisterName::Rip, rip.into())
-            .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::AdvanceRip(e)))?;
-
-        Ok(())
+            .unwrap();
     }
 
     fn inject_gpf(&mut self, vtl: GuestVtl) {
@@ -1047,9 +1027,7 @@ fn from_seg(reg: hvdef::HvX64SegmentRegister) -> SegmentRegister {
 }
 
 impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX86> {
-    type Error = UhRunVpError;
-
-    fn flush(&mut self) -> Result<(), Self::Error> {
+    fn flush(&mut self) {
         self.vp
             .runner
             .set_vp_registers(
@@ -1061,7 +1039,6 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
                 ],
             )
             .unwrap();
-        Ok(())
     }
 
     fn vp_index(&self) -> VpIndex {
@@ -1090,9 +1067,8 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
         u128::from_le_bytes(self.vp.runner.cpu_context().fx_state.xmm[index])
     }
 
-    fn set_xmm(&mut self, index: usize, v: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, index: usize, v: u128) {
         self.vp.runner.cpu_context_mut().fx_state.xmm[index] = v.to_le_bytes();
-        Ok(())
     }
 
     fn rip(&mut self) -> u64 {
@@ -1218,7 +1194,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
         &mut self,
         gpa: u64,
         mode: virt_support_x86emu::emulate::TranslateMode,
-    ) -> Result<(), EmuCheckVtlAccessError<Self::Error>> {
+    ) -> Result<(), EmuCheckVtlAccessError> {
         // Underhill currently doesn't set VTL 2 protections against execute exclusively, it removes
         // all permissions from a page. So for VTL 1, no need to check the permissions; if VTL 1
         // doesn't have permissions to a page, Underhill should appropriately fail when it tries
@@ -1245,7 +1221,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
                 .vp
                 .runner
                 .get_vp_register(self.vtl, HvX64RegisterName::InstructionEmulationHints)
-                .map_err(UhRunVpError::EmulationState)?;
+                .unwrap();
 
             let flags =
                 if hvdef::HvInstructionEmulatorHintsRegister::from(mbec_user_execute.as_u64())
@@ -1261,7 +1237,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
                 .partition
                 .hcl
                 .check_vtl_access(gpa, self.vtl, flags)
-                .map_err(|e| EmuCheckVtlAccessError::Hypervisor(UhRunVpError::VtlAccess(e)))?;
+                .unwrap();
 
             if let Some(ioctl::CheckVtlAccessResult { vtl, denied_flags }) = access_result {
                 return Err(EmuCheckVtlAccessError::AccessDenied { vtl, denied_flags });
@@ -1275,7 +1251,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
         &mut self,
         gva: u64,
         mode: virt_support_x86emu::emulate::TranslateMode,
-    ) -> Result<Result<EmuTranslateResult, EmuTranslateError>, Self::Error> {
+    ) -> Result<EmuTranslateResult, EmuTranslateError> {
         let mut control_flags = hypercall::TranslateGvaControlFlagsX64::new();
         match mode {
             virt_support_x86emu::emulate::TranslateMode::Read => {
@@ -1313,22 +1289,22 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             .vp
             .runner
             .translate_gva_to_gpa(gva, control_flags)
-            .map_err(|e| UhRunVpError::TranslateGva(ioctl::Error::TranslateGvaToGpa(e)))?
+            .unwrap()
         {
             Ok(ioctl::TranslateResult {
                 gpa_page,
                 overlay_page,
             }) => {
                 self.vp.mark_tlb_locked(Vtl::Vtl2, self.vtl);
-                Ok(Ok(EmuTranslateResult {
+                Ok(EmuTranslateResult {
                     gpa: (gpa_page << hvdef::HV_PAGE_SHIFT) + (gva & (HV_PAGE_SIZE - 1)),
                     overlay_page: Some(overlay_page),
-                }))
+                })
             }
-            Err(ioctl::x64::TranslateErrorX64 { code, event_info }) => Ok(Err(EmuTranslateError {
+            Err(ioctl::x64::TranslateErrorX64 { code, event_info }) => Err(EmuTranslateError {
                 code: hypercall::TranslateGvaResultCode(code),
                 event_info: Some(event_info),
-            })),
+            }),
         }
     }
 
@@ -1400,7 +1376,7 @@ impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, Hyperv
     }
 
     fn set_rip(&mut self, rip: u64) {
-        self.vp.set_rip(self.intercepted_vtl, rip).unwrap()
+        self.vp.set_rip(self.intercepted_vtl, rip)
     }
 
     fn gp(&mut self, n: hv1_hypercall::X64HypercallRegister) -> u64 {
@@ -1942,9 +1918,7 @@ mod save_restore {
 
         fn save(&mut self) -> Result<Self::SavedState, SaveError> {
             // Ensure all async requests are reflected in the saved state.
-            self.flush_async_requests()
-                .context("failed to flush async requests")
-                .map_err(SaveError::Other)?;
+            self.flush_async_requests();
 
             let dr6_shared = self.partition.hcl.dr6_shared();
             let mut values = [FromZeros::new_zeroed(); SHARED_REGISTERS.len()];

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -13,6 +13,7 @@ use super::super::UhEmulationState;
 use super::super::signal_mnf;
 use super::super::vp_state;
 use super::super::vp_state::UhVpStateAccess;
+use super::MshvRunVpError;
 use super::VbsIsolatedVtl1State;
 use crate::BackingShared;
 use crate::Error;
@@ -233,7 +234,9 @@ impl BackingPrivate for HypervisorBackedX86 {
             .map_err(|e| VpHaltReason::InvalidVmState(ioctl::Error::Sidecar(e).into()))?
         } else {
             this.unlock_tlb_lock(Vtl::Vtl2);
-            this.runner.run().unwrap()
+            this.runner
+                .run()
+                .map_err(|e| VpHaltReason::Hypervisor(MshvRunVpError(e).into()))?
         };
 
         if intercepted {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -83,16 +83,20 @@ use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
 
 #[derive(Debug, Error)]
-enum SnpError {
-    #[error("invalid vmcb")]
-    InvalidVmcb,
+#[error("invalid vmcb")]
+struct InvalidVmcb;
+
+#[derive(Debug, Error)]
+enum SnpGhcbError {
     #[error("failed to access GHCB page")]
     GhcbPageAccess(#[source] guestmem::GuestMemoryError),
     #[error("ghcb page used for vmgexit does not match overlay page")]
     GhcbMisconfiguration,
-    #[error("failed to run")]
-    Run(#[source] hcl::ioctl::Error),
 }
+
+#[derive(Debug, Error)]
+#[error("failed to run")]
+struct SnpRunVpError(#[source] hcl::ioctl::Error);
 
 /// A backing for SNP partitions.
 #[derive(InspectMut)]
@@ -924,7 +928,7 @@ impl UhProcessor<'_, SnpBacked> {
         &mut self,
         dev: &impl CpuIo,
         intercepted_vtl: GuestVtl,
-    ) -> Result<(), SnpError> {
+    ) -> Result<(), SnpGhcbError> {
         let message = self
             .runner
             .exit_message()
@@ -950,7 +954,7 @@ impl UhProcessor<'_, SnpBacked> {
                         "ghcb page used for vmgexit does not match overlay page"
                     );
 
-                    return Err(SnpError::GhcbMisconfiguration);
+                    return Err(SnpGhcbError::GhcbMisconfiguration);
                 }
 
                 match x86defs::snp::GhcbUsage(message.ghcb_page.ghcb_usage) {
@@ -967,7 +971,7 @@ impl UhProcessor<'_, SnpBacked> {
                                 overlay_base
                                     + x86defs::snp::GHCB_PAGE_HYPERCALL_PARAMETERS_OFFSET as u64,
                             )
-                            .map_err(SnpError::GhcbPageAccess)?;
+                            .map_err(SnpGhcbError::GhcbPageAccess)?;
 
                         let mut handler = GhcbEnlightenedHypercall {
                             handler: UhHypercallHandler {
@@ -998,7 +1002,7 @@ impl UhProcessor<'_, SnpBacked> {
                                     + x86defs::snp::GHCB_PAGE_HYPERCALL_OUTPUT_OFFSET as u64,
                                 handler.result.as_bytes(),
                             )
-                            .map_err(SnpError::GhcbPageAccess)?;
+                            .map_err(SnpGhcbError::GhcbPageAccess)?;
                     }
                     usage => unimplemented!("ghcb usage {usage:?}"),
                 }
@@ -1213,7 +1217,7 @@ impl UhProcessor<'_, SnpBacked> {
         let mut has_intercept = self
             .runner
             .run()
-            .map_err(|e| VpHaltReason::Hypervisor(SnpError::Run(e).into()))?;
+            .map_err(|e| VpHaltReason::Hypervisor(SnpRunVpError(e).into()))?;
 
         let entered_from_vtl = next_vtl;
         let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
@@ -1473,7 +1477,7 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::INVALID_VMCB => {
-                return Err(VpHaltReason::InvalidVmState(SnpError::InvalidVmcb.into()));
+                return Err(VpHaltReason::InvalidVmState(InvalidVmcb.into()));
             }
 
             SevExitCode::INVLPGB | SevExitCode::ILLEGAL_INVLPGB => {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -10,7 +10,6 @@ use super::HardwareIsolatedBacking;
 use super::InterceptMessageOptionalState;
 use super::InterceptMessageState;
 use super::UhEmulationState;
-use super::UhRunVpError;
 use super::hardware_cvm;
 use super::vp_state;
 use super::vp_state::UhVpStateAccess;
@@ -82,6 +81,16 @@ use x86defs::snp::SevVmsa;
 use x86defs::snp::Vmpl;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
+
+#[derive(Debug, Error)]
+enum SnpError {
+    #[error("invalid vmcb")]
+    InvalidVmcb,
+    #[error("failed to access GHCB page")]
+    GhcbPageAccess(#[source] guestmem::GuestMemoryError),
+    #[error("ghcb page used for vmgexit does not match overlay page")]
+    GhcbMisconfiguration,
+}
 
 /// A backing for SNP partitions.
 #[derive(InspectMut)]
@@ -531,15 +540,11 @@ impl BackingPrivate for SnpBacked {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         this.run_vp_snp(dev).await
     }
 
-    fn poll_apic(
-        this: &mut UhProcessor<'_, Self>,
-        vtl: GuestVtl,
-        scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
+    fn poll_apic(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl, scan_irr: bool) {
         // Clear any pending interrupt.
         this.runner.vmsa_mut(vtl).v_intr_cntrl_mut().set_irq(false);
 
@@ -603,10 +608,7 @@ impl BackingPrivate for SnpBacked {
         Some(&mut self.cvm.hv[vtl])
     }
 
-    fn handle_vp_start_enable_vtl_wake(
-        this: &mut UhProcessor<'_, Self>,
-        vtl: GuestVtl,
-    ) -> Result<(), UhRunVpError> {
+    fn handle_vp_start_enable_vtl_wake(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) {
         this.hcvm_handle_vp_start_enable_vtl(vtl)
     }
 
@@ -619,7 +621,7 @@ impl BackingPrivate for SnpBacked {
         scan_irr: VtlArray<bool, 2>,
         first_scan_irr: &mut bool,
         dev: &impl CpuIo,
-    ) -> Result<bool, VpHaltReason<UhRunVpError>> {
+    ) -> bool {
         this.cvm_process_interrupts(scan_irr, first_scan_irr, dev)
     }
 }
@@ -862,17 +864,16 @@ impl<'b> ApicBacking<'b, SnpBacked> for UhProcessor<'b, SnpBacked> {
         self
     }
 
-    fn handle_interrupt(&mut self, vtl: GuestVtl, vector: u8) -> Result<(), UhRunVpError> {
+    fn handle_interrupt(&mut self, vtl: GuestVtl, vector: u8) {
         let mut vmsa = self.runner.vmsa_mut(vtl);
         vmsa.v_intr_cntrl_mut().set_vector(vector);
         vmsa.v_intr_cntrl_mut().set_priority((vector >> 4).into());
         vmsa.v_intr_cntrl_mut().set_ignore_tpr(false);
         vmsa.v_intr_cntrl_mut().set_irq(true);
         self.backing.cvm.lapics[vtl].activity = MpState::Running;
-        Ok(())
     }
 
-    fn handle_nmi(&mut self, vtl: GuestVtl) -> Result<(), UhRunVpError> {
+    fn handle_nmi(&mut self, vtl: GuestVtl) {
         // TODO SNP: support virtual NMI injection
         // For now, just inject an NMI and hope for the best.
         // Don't forget to update handle_cross_vtl_interrupts if this code changes.
@@ -889,16 +890,13 @@ impl<'b> ApicBacking<'b, SnpBacked> for UhProcessor<'b, SnpBacked> {
         );
         self.backing.cvm.lapics[vtl].nmi_pending = false;
         self.backing.cvm.lapics[vtl].activity = MpState::Running;
-        Ok(())
     }
 
-    fn handle_sipi(&mut self, vtl: GuestVtl, cs: SegmentRegister) -> Result<(), UhRunVpError> {
+    fn handle_sipi(&mut self, vtl: GuestVtl, cs: SegmentRegister) {
         let mut vmsa = self.runner.vmsa_mut(vtl);
         vmsa.set_cs(virt_seg_to_snp(cs));
         vmsa.set_rip(0);
         self.backing.cvm.lapics[vtl].activity = MpState::Running;
-
-        Ok(())
     }
 }
 
@@ -924,7 +922,7 @@ impl UhProcessor<'_, SnpBacked> {
         &mut self,
         dev: &impl CpuIo,
         intercepted_vtl: GuestVtl,
-    ) -> Result<(), UhRunVpError> {
+    ) -> Result<(), SnpError> {
         let message = self
             .runner
             .exit_message()
@@ -950,9 +948,7 @@ impl UhProcessor<'_, SnpBacked> {
                         "ghcb page used for vmgexit does not match overlay page"
                     );
 
-                    return Err(UhRunVpError::EmulationState(
-                        hcl::ioctl::Error::InvalidRegisterValue,
-                    ));
+                    return Err(SnpError::GhcbMisconfiguration);
                 }
 
                 match x86defs::snp::GhcbUsage(message.ghcb_page.ghcb_usage) {
@@ -969,7 +965,7 @@ impl UhProcessor<'_, SnpBacked> {
                                 overlay_base
                                     + x86defs::snp::GHCB_PAGE_HYPERCALL_PARAMETERS_OFFSET as u64,
                             )
-                            .map_err(UhRunVpError::HypercallParameters)?;
+                            .map_err(SnpError::GhcbPageAccess)?;
 
                         let mut handler = GhcbEnlightenedHypercall {
                             handler: UhHypercallHandler {
@@ -1000,7 +996,7 @@ impl UhProcessor<'_, SnpBacked> {
                                     + x86defs::snp::GHCB_PAGE_HYPERCALL_OUTPUT_OFFSET as u64,
                                 handler.result.as_bytes(),
                             )
-                            .map_err(UhRunVpError::HypercallResult)?;
+                            .map_err(SnpError::GhcbPageAccess)?;
                     }
                     usage => unimplemented!("ghcb usage {usage:?}"),
                 }
@@ -1186,7 +1182,7 @@ impl UhProcessor<'_, SnpBacked> {
         false
     }
 
-    async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
+    async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason> {
         let next_vtl = self.backing.cvm.exit_vtl;
 
         let mut vmsa = self.runner.vmsa_mut(next_vtl);
@@ -1212,10 +1208,7 @@ impl UhProcessor<'_, SnpBacked> {
         // Set the lazy EOI bit just before running.
         let lazy_eoi = self.sync_lazy_eoi(next_vtl);
 
-        let mut has_intercept = self
-            .runner
-            .run()
-            .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::Run(err)))?;
+        let mut has_intercept = self.runner.run().unwrap();
 
         let entered_from_vtl = next_vtl;
         let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
@@ -1475,7 +1468,7 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::INVALID_VMCB => {
-                return Err(VpHaltReason::InvalidVmState(UhRunVpError::InvalidVmcb));
+                return Err(VpHaltReason::InvalidVmState(SnpError::InvalidVmcb.into()));
             }
 
             SevExitCode::INVLPGB | SevExitCode::ILLEGAL_INVLPGB => {
@@ -1515,7 +1508,7 @@ impl UhProcessor<'_, SnpBacked> {
                 match self.runner.exit_message().header.typ {
                     HvMessageType::HvMessageTypeX64SevVmgexitIntercept => {
                         self.handle_vmgexit(dev, entered_from_vtl)
-                            .map_err(VpHaltReason::InvalidVmState)?;
+                            .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
                     }
                     _ => has_intercept = true,
                 }
@@ -1669,10 +1662,7 @@ impl UhProcessor<'_, SnpBacked> {
 }
 
 impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
-    type Error = UhRunVpError;
-
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
+    fn flush(&mut self) {
         //AMD SNP does not require an emulation cache
     }
 
@@ -1732,12 +1722,11 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
         self.vp.runner.vmsa_mut(self.vtl).xmm_registers(index)
     }
 
-    fn set_xmm(&mut self, index: usize, v: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, index: usize, v: u128) {
         self.vp
             .runner
             .vmsa_mut(self.vtl)
             .set_xmm_registers(index, v);
-        Ok(())
     }
 
     fn rip(&mut self) -> u64 {
@@ -1805,7 +1794,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
         &mut self,
         _gpa: u64,
         _mode: virt_support_x86emu::emulate::TranslateMode,
-    ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError<Self::Error>> {
+    ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError> {
         // Nothing to do here, the guest memory object will handle the check.
         Ok(())
     }
@@ -1815,11 +1804,8 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
         gva: u64,
         mode: virt_support_x86emu::emulate::TranslateMode,
     ) -> Result<
-        Result<
-            virt_support_x86emu::emulate::EmuTranslateResult,
-            virt_support_x86emu::emulate::EmuTranslateError,
-        >,
-        Self::Error,
+        virt_support_x86emu::emulate::EmuTranslateResult,
+        virt_support_x86emu::emulate::EmuTranslateError,
     > {
         emulate_translate_gva(self, gva, mode)
     }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -10,7 +10,6 @@ use super::BackingSharedParams;
 use super::HardwareIsolatedBacking;
 use super::UhEmulationState;
 use super::UhHypercallHandler;
-use super::UhRunVpError;
 use super::hardware_cvm;
 use super::vp_state;
 use super::vp_state::UhVpStateAccess;
@@ -52,6 +51,7 @@ use inspect::InspectMut;
 use inspect_counters::Counter;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
+use thiserror::Error;
 use tlb_flush::FLUSH_GVA_LIST_SIZE;
 use tlb_flush::TdxFlushState;
 use tlb_flush::TdxPartitionFlushState;
@@ -157,6 +157,14 @@ const MSR_ALLOWED_READ_WRITE: &[u32] = &[
     x86defs::X86X_IA32_MSR_XFD,
     x86defs::X86X_IA32_MSR_XFD_ERR,
 ];
+
+#[derive(Debug, Error)]
+enum TdxError {
+    #[error("unknown exit {0:#x?}")]
+    UnknownVmxExit(VmxExit),
+    #[error("bad guest state on VP.ENTER")]
+    VmxBadGuestState,
+}
 
 #[derive(Debug)]
 struct TdxExit<'a>(&'a tdx_tdg_vp_enter_exit_info);
@@ -1091,16 +1099,12 @@ impl BackingPrivate for TdxBacked {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         this.run_vp_tdx(dev).await
     }
 
-    fn poll_apic(
-        this: &mut UhProcessor<'_, Self>,
-        vtl: GuestVtl,
-        scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
-        if !this.try_poll_apic(vtl, scan_irr)? {
+    fn poll_apic(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl, scan_irr: bool) {
+        if !this.try_poll_apic(vtl, scan_irr) {
             tracing::info!(CVM_ALLOWED, "disabling APIC offload due to auto EOI");
             let page = this.runner.tdx_apic_page_mut(vtl);
             let (irr, isr) = pull_apic_offload(page);
@@ -1109,10 +1113,8 @@ impl BackingPrivate for TdxBacked {
                 .lapic
                 .disable_offload(&irr, &isr);
             this.set_apic_offload(vtl, false);
-            this.try_poll_apic(vtl, false)?;
+            this.try_poll_apic(vtl, false);
         }
-
-        Ok(())
     }
 
     fn request_extint_readiness(_this: &mut UhProcessor<'_, Self>) {
@@ -1135,10 +1137,7 @@ impl BackingPrivate for TdxBacked {
         Some(&mut self.cvm.hv[vtl])
     }
 
-    fn handle_vp_start_enable_vtl_wake(
-        this: &mut UhProcessor<'_, Self>,
-        vtl: GuestVtl,
-    ) -> Result<(), UhRunVpError> {
+    fn handle_vp_start_enable_vtl_wake(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) {
         this.hcvm_handle_vp_start_enable_vtl(vtl)
     }
 
@@ -1151,7 +1150,7 @@ impl BackingPrivate for TdxBacked {
         scan_irr: VtlArray<bool, 2>,
         first_scan_irr: &mut bool,
         dev: &impl CpuIo,
-    ) -> Result<bool, VpHaltReason<UhRunVpError>> {
+    ) -> bool {
         this.cvm_process_interrupts(scan_irr, first_scan_irr, dev)
     }
 }
@@ -1159,7 +1158,7 @@ impl BackingPrivate for TdxBacked {
 impl UhProcessor<'_, TdxBacked> {
     /// Returns `Ok(false)` if the APIC offload needs to be disabled and the
     /// poll retried.
-    fn try_poll_apic(&mut self, vtl: GuestVtl, scan_irr: bool) -> Result<bool, UhRunVpError> {
+    fn try_poll_apic(&mut self, vtl: GuestVtl, scan_irr: bool) -> bool {
         let mut scan = TdxApicScanner {
             processor_controls: self.backing.vtls[vtl]
                 .processor_controls
@@ -1170,7 +1169,7 @@ impl UhProcessor<'_, TdxBacked> {
         };
 
         // TODO TDX: filter proxy IRRs by setting the `proxy_irr_blocked` field of the run page
-        hardware_cvm::apic::poll_apic_core(&mut scan, vtl, scan_irr)?;
+        hardware_cvm::apic::poll_apic_core(&mut scan, vtl, scan_irr);
 
         let TdxApicScanner {
             vp: _,
@@ -1256,7 +1255,7 @@ impl UhProcessor<'_, TdxBacked> {
             if let Err(OffloadNotSupported) = r {
                 // APIC needs offloading to be disabled to support auto-EOI. The caller
                 // will disable offload and try again.
-                return Ok(false);
+                return false;
             }
 
             if update_rvi {
@@ -1286,7 +1285,7 @@ impl UhProcessor<'_, TdxBacked> {
             self.backing.cvm.lapics[vtl].activity = MpState::Running;
         }
 
-        Ok(true)
+        true
     }
 
     fn access_apic_without_offload<R>(
@@ -1360,7 +1359,7 @@ impl<'b> hardware_cvm::apic::ApicBacking<'b, TdxBacked> for TdxApicScanner<'_, '
         self.vp
     }
 
-    fn handle_interrupt(&mut self, vtl: GuestVtl, vector: u8) -> Result<(), UhRunVpError> {
+    fn handle_interrupt(&mut self, vtl: GuestVtl, vector: u8) {
         // Exit idle when an interrupt is received, regardless of IF
         if self.vp.backing.cvm.lapics[vtl].activity == MpState::Idle {
             self.vp.backing.cvm.lapics[vtl].activity = MpState::Running;
@@ -1375,7 +1374,7 @@ impl<'b> hardware_cvm::apic::ApicBacking<'b, TdxBacked> for TdxApicScanner<'_, '
                 != INTERRUPT_TYPE_EXTERNAL
         {
             self.processor_controls.set_interrupt_window_exiting(true);
-            return Ok(());
+            return;
         }
 
         // Ensure the interrupt is not blocked by RFLAGS.IF or interrupt shadow.
@@ -1391,14 +1390,14 @@ impl<'b> hardware_cvm::apic::ApicBacking<'b, TdxBacked> for TdxApicScanner<'_, '
             || interruptibility.blocked_by_movss()
         {
             self.processor_controls.set_interrupt_window_exiting(true);
-            return Ok(());
+            return;
         }
 
         let priority = vector >> 4;
         let apic = self.vp.runner.tdx_apic_page(vtl);
         if (apic.tpr.value as u8 >> 4) >= priority {
             self.tpr_threshold = priority;
-            return Ok(());
+            return;
         }
 
         self.vp.backing.vtls[vtl].interruption_information = InterruptionInformation::new()
@@ -1407,10 +1406,9 @@ impl<'b> hardware_cvm::apic::ApicBacking<'b, TdxBacked> for TdxApicScanner<'_, '
             .with_interruption_type(INTERRUPT_TYPE_EXTERNAL);
 
         self.vp.backing.cvm.lapics[vtl].activity = MpState::Running;
-        Ok(())
     }
 
-    fn handle_nmi(&mut self, vtl: GuestVtl) -> Result<(), UhRunVpError> {
+    fn handle_nmi(&mut self, vtl: GuestVtl) {
         // Exit idle when an interrupt is received, regardless of IF
         // TODO: Investigate lifting more activity management into poll_apic_core
         if self.vp.backing.cvm.lapics[vtl].activity == MpState::Idle {
@@ -1426,7 +1424,7 @@ impl<'b> hardware_cvm::apic::ApicBacking<'b, TdxBacked> for TdxApicScanner<'_, '
                 != INTERRUPT_TYPE_EXTERNAL
         {
             self.processor_controls.set_nmi_window_exiting(true);
-            return Ok(());
+            return;
         }
 
         let interruptibility: Interruptibility = self
@@ -1440,7 +1438,7 @@ impl<'b> hardware_cvm::apic::ApicBacking<'b, TdxBacked> for TdxApicScanner<'_, '
             || interruptibility.blocked_by_movss()
         {
             self.processor_controls.set_nmi_window_exiting(true);
-            return Ok(());
+            return;
         }
 
         self.vp.backing.vtls[vtl].interruption_information = InterruptionInformation::new()
@@ -1449,20 +1447,17 @@ impl<'b> hardware_cvm::apic::ApicBacking<'b, TdxBacked> for TdxApicScanner<'_, '
             .with_interruption_type(INTERRUPT_TYPE_NMI);
 
         self.vp.backing.cvm.lapics[vtl].activity = MpState::Running;
-        Ok(())
     }
 
-    fn handle_sipi(&mut self, vtl: GuestVtl, cs: SegmentRegister) -> Result<(), UhRunVpError> {
+    fn handle_sipi(&mut self, vtl: GuestVtl, cs: SegmentRegister) {
         self.vp.write_segment(vtl, TdxSegmentReg::Cs, cs).unwrap();
         self.vp.backing.vtls[vtl].private_regs.rip = 0;
         self.vp.backing.cvm.lapics[vtl].activity = MpState::Running;
-
-        Ok(())
     }
 }
 
 impl UhProcessor<'_, TdxBacked> {
-    async fn run_vp_tdx(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
+    async fn run_vp_tdx(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason> {
         let next_vtl = self.backing.cvm.exit_vtl;
 
         if self.backing.vtls[next_vtl].interruption_information.valid() {
@@ -1562,10 +1557,7 @@ impl UhProcessor<'_, TdxBacked> {
         self.runner
             .write_private_regs(&self.backing.vtls[next_vtl].private_regs);
 
-        let has_intercept = self
-            .runner
-            .run()
-            .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Run(e)))?;
+        let has_intercept = self.runner.run().unwrap();
 
         // TLB flushes can only target lower VTLs, so it is fine to use a relaxed
         // ordering here. The worst that can happen is some spurious wakes, due
@@ -1657,7 +1649,7 @@ impl UhProcessor<'_, TdxBacked> {
         &mut self,
         dev: &impl CpuIo,
         intercepted_vtl: GuestVtl,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         let exit_info = TdxExit(self.runner.tdx_vp_enter_exit_info());
 
         // First, check that the VM entry was even successful.
@@ -2019,9 +2011,7 @@ impl UhProcessor<'_, TdxBacked> {
                     ) {
                         self.runner
                             .set_vp_register(intercepted_vtl, HvX64RegisterName::Xfem, value.into())
-                            .map_err(|err| {
-                                VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err))
-                            })?;
+                            .unwrap();
                         self.advance_to_next_instruction(intercepted_vtl);
                     }
                 } else {
@@ -2183,9 +2173,9 @@ impl UhProcessor<'_, TdxBacked> {
                     .descriptor_table
             }
             _ => {
-                return Err(VpHaltReason::Hypervisor(UhRunVpError::UnknownVmxExit(
-                    exit_info.code().vmx_exit(),
-                )));
+                return Err(VpHaltReason::InvalidVmState(
+                    TdxError::UnknownVmxExit(exit_info.code().vmx_exit()).into(),
+                ));
             }
         };
         stat.increment();
@@ -2407,11 +2397,7 @@ impl UhProcessor<'_, TdxBacked> {
         tracing::error!(CVM_CONFIDENTIAL, vmcs_pat, "guest PAT");
     }
 
-    fn handle_vm_enter_failed(
-        &self,
-        vtl: GuestVtl,
-        vmx_exit: VmxExit,
-    ) -> VpHaltReason<UhRunVpError> {
+    fn handle_vm_enter_failed(&self, vtl: GuestVtl, vmx_exit: VmxExit) -> VpHaltReason {
         assert!(vmx_exit.vm_enter_failed());
         match vmx_exit.basic_reason() {
             VmxExitBasic::BAD_GUEST_STATE => {
@@ -2420,10 +2406,9 @@ impl UhProcessor<'_, TdxBacked> {
                 tracing::error!(CVM_ALLOWED, "VP.ENTER failed with bad guest state");
                 self.trace_processor_state(vtl);
 
-                // TODO: panic instead?
-                VpHaltReason::Hypervisor(UhRunVpError::VmxBadGuestState)
+                VpHaltReason::InvalidVmState(TdxError::VmxBadGuestState.into())
             }
-            _ => VpHaltReason::Hypervisor(UhRunVpError::UnknownVmxExit(vmx_exit)),
+            _ => VpHaltReason::InvalidVmState(TdxError::UnknownVmxExit(vmx_exit).into()),
         }
     }
 
@@ -2789,15 +2774,12 @@ impl UhProcessor<'_, TdxBacked> {
 }
 
 impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, TdxBacked> {
-    type Error = UhRunVpError;
-
     fn vp_index(&self) -> VpIndex {
         self.vp.vp_index()
     }
 
-    fn flush(&mut self) -> Result<(), Self::Error> {
+    fn flush(&mut self) {
         // no cached registers are modifiable by the emulator for TDX
-        Ok(())
     }
 
     fn vendor(&self) -> x86defs::cpuid::Vendor {
@@ -2816,9 +2798,8 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, TdxBacked> {
         u128::from_ne_bytes(self.vp.runner.fx_state().xmm[index])
     }
 
-    fn set_xmm(&mut self, index: usize, v: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, index: usize, v: u128) {
         self.vp.runner.fx_state_mut().xmm[index] = v.to_ne_bytes();
-        Ok(())
     }
 
     fn rip(&mut self) -> u64 {
@@ -2919,7 +2900,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, TdxBacked> {
         &mut self,
         _gpa: u64,
         _mode: TranslateMode,
-    ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError<Self::Error>> {
+    ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError> {
         // Nothing to do here, the guest memory object will handle the check.
         Ok(())
     }
@@ -2929,11 +2910,8 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, TdxBacked> {
         gva: u64,
         mode: TranslateMode,
     ) -> Result<
-        Result<
-            virt_support_x86emu::emulate::EmuTranslateResult,
-            virt_support_x86emu::emulate::EmuTranslateError,
-        >,
-        Self::Error,
+        virt_support_x86emu::emulate::EmuTranslateResult,
+        virt_support_x86emu::emulate::EmuTranslateError,
     > {
         emulate_translate_gva(self, gva, mode)
     }
@@ -3184,7 +3162,7 @@ impl UhProcessor<'_, TdxBacked> {
         &mut self,
         vtl: GuestVtl,
         dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         let exit_info = TdxExit(self.runner.tdx_vp_enter_exit_info());
         assert_eq!(
             exit_info.code().vmx_exit().basic_reason(),
@@ -3290,7 +3268,7 @@ impl UhProcessor<'_, TdxBacked> {
         &mut self,
         vtl: GuestVtl,
         dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+    ) -> Result<(), VpHaltReason> {
         let exit_info = TdxExit(self.runner.tdx_vp_enter_exit_info());
         assert_eq!(
             exit_info.code().vmx_exit().basic_reason(),

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -164,6 +164,8 @@ enum TdxError {
     UnknownVmxExit(VmxExit),
     #[error("bad guest state on VP.ENTER")]
     VmxBadGuestState,
+    #[error("failed to run")]
+    Run(#[source] hcl::ioctl::Error),
 }
 
 #[derive(Debug)]
@@ -1557,7 +1559,10 @@ impl UhProcessor<'_, TdxBacked> {
         self.runner
             .write_private_regs(&self.backing.vtls[next_vtl].private_regs);
 
-        let has_intercept = self.runner.run().unwrap();
+        let has_intercept = self
+            .runner
+            .run()
+            .map_err(|e| VpHaltReason::Hypervisor(TdxError::Run(e).into()))?;
 
         // TLB flushes can only target lower VTLs, so it is fine to use a relaxed
         // ordering here. The worst that can happen is some spurious wakes, due

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -159,14 +159,16 @@ const MSR_ALLOWED_READ_WRITE: &[u32] = &[
 ];
 
 #[derive(Debug, Error)]
-enum TdxError {
-    #[error("unknown exit {0:#x?}")]
-    UnknownVmxExit(VmxExit),
-    #[error("bad guest state on VP.ENTER")]
-    VmxBadGuestState,
-    #[error("failed to run")]
-    Run(#[source] hcl::ioctl::Error),
-}
+#[error("unknown exit {0:#x?}")]
+struct UnknownVmxExit(VmxExit);
+
+#[derive(Debug, Error)]
+#[error("bad guest state on VP.ENTER")]
+struct VmxBadGuestState;
+
+#[derive(Debug, Error)]
+#[error("failed to run")]
+struct TdxRunVpError(#[source] hcl::ioctl::Error);
 
 #[derive(Debug)]
 struct TdxExit<'a>(&'a tdx_tdg_vp_enter_exit_info);
@@ -1562,7 +1564,7 @@ impl UhProcessor<'_, TdxBacked> {
         let has_intercept = self
             .runner
             .run()
-            .map_err(|e| VpHaltReason::Hypervisor(TdxError::Run(e).into()))?;
+            .map_err(|e| VpHaltReason::Hypervisor(TdxRunVpError(e).into()))?;
 
         // TLB flushes can only target lower VTLs, so it is fine to use a relaxed
         // ordering here. The worst that can happen is some spurious wakes, due
@@ -2179,7 +2181,7 @@ impl UhProcessor<'_, TdxBacked> {
             }
             _ => {
                 return Err(VpHaltReason::InvalidVmState(
-                    TdxError::UnknownVmxExit(exit_info.code().vmx_exit()).into(),
+                    UnknownVmxExit(exit_info.code().vmx_exit()).into(),
                 ));
             }
         };
@@ -2411,9 +2413,9 @@ impl UhProcessor<'_, TdxBacked> {
                 tracing::error!(CVM_ALLOWED, "VP.ENTER failed with bad guest state");
                 self.trace_processor_state(vtl);
 
-                VpHaltReason::InvalidVmState(TdxError::VmxBadGuestState.into())
+                VpHaltReason::InvalidVmState(VmxBadGuestState.into())
             }
-            _ => VpHaltReason::InvalidVmState(TdxError::UnknownVmxExit(vmx_exit).into()),
+            _ => VpHaltReason::InvalidVmState(UnknownVmxExit(vmx_exit).into()),
         }
     }
 

--- a/openvmm/membacking/Cargo.toml
+++ b/openvmm/membacking/Cargo.toml
@@ -19,6 +19,7 @@ mesh.workspace = true
 pal_async.workspace = true
 sparse_mmap.workspace = true
 
+anyhow.workspace = true
 futures.workspace = true
 getrandom.workspace = true
 parking_lot.workspace = true

--- a/openvmm/membacking/src/partition_mapper.rs
+++ b/openvmm/membacking/src/partition_mapper.rs
@@ -28,9 +28,9 @@ pub struct PartitionMapper {
 #[derive(Debug, Error)]
 pub enum PartitionMapperError {
     #[error("failed to map range to partition")]
-    Map(#[source] virt::Error),
+    Map(#[source] anyhow::Error),
     #[error("failed to pin range to partition")]
-    Pin(#[source] virt::Error),
+    Pin(#[source] anyhow::Error),
 }
 
 impl PartitionMapper {

--- a/vm/x86/x86emu/fuzz/cpu.rs
+++ b/vm/x86/x86emu/fuzz/cpu.rs
@@ -118,9 +118,7 @@ impl Cpu for FuzzerCpu {
     }
 
     /// Sets the value of an XMM* register.
-    fn set_xmm(&mut self, _reg: usize, _value: u128) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    fn set_xmm(&mut self, _reg: usize, _value: u128) {}
 }
 
 #[derive(Debug)]

--- a/vm/x86/x86emu/fuzz/fuzz_x86emu.rs
+++ b/vm/x86/x86emu/fuzz/fuzz_x86emu.rs
@@ -39,7 +39,7 @@ fn do_fuzz(static_params: StaticParams) -> arbitrary::Result<()> {
             Error::NotEnoughBytes => unreachable!(),
 
             // Should be impossible given our simple cpu implementation
-            Error::MemoryAccess(_, _, _) | Error::IoPort(_, _, _) | Error::XmmRegister(_, _, _) => {
+            Error::MemoryAccess(_, _, _) | Error::IoPort(_, _, _) => {
                 unreachable!()
             }
         }

--- a/vm/x86/x86emu/src/cpu.rs
+++ b/vm/x86/x86emu/src/cpu.rs
@@ -64,7 +64,7 @@ pub trait Cpu {
     fn gp_sign_extend(&mut self, reg: RegisterIndex) -> i64;
     fn set_gp(&mut self, reg: RegisterIndex, v: u64);
     fn xmm(&mut self, index: usize) -> u128;
-    fn set_xmm(&mut self, index: usize, v: u128) -> Result<(), Self::Error>;
+    fn set_xmm(&mut self, index: usize, v: u128);
     fn rip(&mut self) -> u64;
     fn set_rip(&mut self, v: u64);
     fn segment(&mut self, index: Segment) -> SegmentRegister;
@@ -137,7 +137,7 @@ impl<T: Cpu + ?Sized> Cpu for &mut T {
         (*self).xmm(index)
     }
 
-    fn set_xmm(&mut self, index: usize, v: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, index: usize, v: u128) {
         (*self).set_xmm(index, v)
     }
 

--- a/vm/x86/x86emu/src/emulator.rs
+++ b/vm/x86/x86emu/src/emulator.rs
@@ -141,8 +141,6 @@ pub enum Error<E> {
     MemoryAccess(u64, OperationKind, #[source] E),
     #[error("io port access error - {1:?} @ {0:#x}")]
     IoPort(u16, OperationKind, #[source] E),
-    #[error("XMM register access error - {1:?} @ {0:#x}")]
-    XmmRegister(usize, OperationKind, #[source] E),
     #[error("executing instruction caused exception due to {2:?} - {0:?}({1:?})")]
     InstructionException(Exception, Option<u32>, ExceptionCause),
     #[error("decode failure")]

--- a/vm/x86/x86emu/src/emulator/mov.rs
+++ b/vm/x86/x86emu/src/emulator/mov.rs
@@ -3,7 +3,6 @@
 
 use super::AlignmentMode;
 use super::Emulator;
-use super::Error;
 use super::InternalError;
 use crate::Cpu;
 use crate::Segment;
@@ -47,9 +46,7 @@ impl<T: Cpu> Emulator<'_, T> {
                 let reg = instr.op0_register();
                 assert!(reg.is_xmm());
                 let xmm_index = reg.number();
-                self.cpu.set_xmm(xmm_index, value).map_err(|err| {
-                    Error::XmmRegister(xmm_index, super::OperationKind::Write, err)
-                })?
+                self.cpu.set_xmm(xmm_index, value)
             }
             _ => Err(self.unsupported_instruction(instr))?,
         };

--- a/vm/x86/x86emu/tests/tests/common.rs
+++ b/vm/x86/x86emu/tests/tests/common.rs
@@ -409,9 +409,8 @@ impl<T: TestRegister> Cpu for SingleCellCpu<T> {
         self.xmm[reg]
     }
 
-    fn set_xmm(&mut self, reg: usize, value: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, reg: usize, value: u128) {
         self.xmm[reg] = value;
-        Ok(())
     }
 }
 
@@ -539,7 +538,7 @@ impl Cpu for MultipleCellCpu {
         self.state.rflags = v
     }
 
-    fn set_xmm(&mut self, _reg: usize, _value: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, _reg: usize, _value: u128) {
         todo!()
     }
 

--- a/vm/x86/x86emu/tests/tests/mov/sse.rs
+++ b/vm/x86/x86emu/tests/tests/mov/sse.rs
@@ -30,7 +30,7 @@ fn mov_regvalue_to_memory_sse() {
             |asm| instr(asm, xmmword_ptr(0x200), xmm15),
             |cpu| {
                 cpu.valid_gva = 0x200;
-                let _ = cpu.set_xmm(15, 0x1234567890abcdef13579ace24680bdf);
+                cpu.set_xmm(15, 0x1234567890abcdef13579ace24680bdf);
             },
         );
 
@@ -75,7 +75,7 @@ fn movaps_unaligned() {
         |asm| asm.movaps(xmmword_ptr(0x205), xmm15),
         |cpu| {
             cpu.valid_gva = 0x205;
-            let _ = cpu.set_xmm(15, 0x1234567890abcdef13579ace24680bdf);
+            cpu.set_xmm(15, 0x1234567890abcdef13579ace24680bdf);
         },
     );
 }
@@ -88,7 +88,7 @@ fn movapd_unaligned() {
         |asm| asm.movapd(xmmword_ptr(0x205), xmm15),
         |cpu| {
             cpu.valid_gva = 0x205;
-            let _ = cpu.set_xmm(15, 0x1234567890abcdef13579ace24680bdf);
+            cpu.set_xmm(15, 0x1234567890abcdef13579ace24680bdf);
         },
     );
 }
@@ -101,7 +101,7 @@ fn movdqa_unaligned() {
         |asm| asm.movdqa(xmmword_ptr(0x205), xmm15),
         |cpu| {
             cpu.valid_gva = 0x205;
-            let _ = cpu.set_xmm(15, 0x1234567890abcdef13579ace24680bdf);
+            cpu.set_xmm(15, 0x1234567890abcdef13579ace24680bdf);
         },
     );
 }

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -150,19 +150,13 @@ where
                 })
             }
             VpHaltReason::InvalidVmState(err) => {
-                tracing::error!(err = &err as &dyn std::error::Error, "invalid vm state");
+                tracing::error!(err, "invalid VM state");
                 Err(HaltReason::InvalidVmState {
                     vp: self.vp_index.index(),
                 })
             }
-            VpHaltReason::EmulationFailure(error) => {
-                tracing::error!(error, "emulation failure");
-                Err(HaltReason::VpError {
-                    vp: self.vp_index.index(),
-                })
-            }
-            VpHaltReason::Hypervisor(err) => {
-                tracing::error!(err = &err as &dyn std::error::Error, "fatal vp error");
+            VpHaltReason::EmulationFailure(err) => {
+                tracing::error!(err, "emulation failure");
                 Err(HaltReason::VpError {
                     vp: self.vp_index.index(),
                 })

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -150,13 +150,19 @@ where
                 })
             }
             VpHaltReason::InvalidVmState(err) => {
-                tracing::error!(err, "invalid VM state");
+                tracing::error!(
+                    err = err.as_ref() as &dyn std::error::Error,
+                    "invalid VM state"
+                );
                 Err(HaltReason::InvalidVmState {
                     vp: self.vp_index.index(),
                 })
             }
             VpHaltReason::EmulationFailure(err) => {
-                tracing::error!(err, "emulation failure");
+                tracing::error!(
+                    err = err.as_ref() as &dyn std::error::Error,
+                    "emulation failure"
+                );
                 Err(HaltReason::VpError {
                     vp: self.vp_index.index(),
                 })

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -167,6 +167,15 @@ where
                     vp: self.vp_index.index(),
                 })
             }
+            VpHaltReason::Hypervisor(err) => {
+                tracing::error!(
+                    err = err.as_ref() as &dyn std::error::Error,
+                    "fatal vp error"
+                );
+                Err(HaltReason::VpError {
+                    vp: self.vp_index.index(),
+                })
+            }
             VpHaltReason::SingleStep => {
                 tracing::debug!("single step");
                 Err(HaltReason::SingleStep {

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -1383,7 +1383,7 @@ mod vp_state {
         vtl: Vtl,
         gva: u64,
         buf: &mut [u8],
-    ) -> Result<(), anyhow::Error> {
+    ) -> anyhow::Result<()> {
         let mut offset = 0;
         while offset < buf.len() {
             let gpa = translate_gva(guest_memory, debug, vtl, gva + offset as u64)
@@ -1401,7 +1401,7 @@ mod vp_state {
         vtl: Vtl,
         gva: u64,
         buf: &[u8],
-    ) -> Result<(), anyhow::Error> {
+    ) -> anyhow::Result<()> {
         let mut offset = 0;
         while offset < buf.len() {
             let gpa = translate_gva(guest_memory, debug, vtl, gva + offset as u64)

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -43,8 +43,6 @@ use vmcore::vpci_msi::MsiAddressData;
 use vmcore::vpci_msi::RegisterInterruptError;
 use vmcore::vpci_msi::VpciInterruptParameters;
 
-pub type Error = anyhow::Error;
-
 pub trait Hypervisor: 'static {
     /// The prototype partition type.
     type ProtoPartition<'a>: ProtoPartition<Partition = Self::Partition>;

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -565,6 +565,8 @@ pub enum VpHaltReason {
     },
     /// The VM's state (e.g. registers, memory) is invalid.
     InvalidVmState(Box<dyn std::error::Error + Send + Sync>),
+    /// The underlying hypervisor failed.
+    Hypervisor(Box<dyn std::error::Error + Send + Sync>),
     /// Emulation failed.
     EmulationFailure(Box<dyn std::error::Error + Send + Sync>),
     /// Debugger single step.

--- a/vmm_core/virt/src/generic/partition_memory_map.rs
+++ b/vmm_core/virt/src/generic/partition_memory_map.rs
@@ -14,7 +14,7 @@ pub trait PartitionMemoryMap: Send + Sync {
     ///
     /// The hypervisor must ensure that this operation does not fail as long as
     /// the preconditions are satisfied.
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), anyhow::Error>;
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()>;
 
     /// Maps a range from process memory into the VM.
     ///
@@ -30,16 +30,16 @@ pub trait PartitionMemoryMap: Send + Sync {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), anyhow::Error>;
+    ) -> anyhow::Result<()>;
 
     /// Prefetches any memory in the given range so that it can be accessed
     /// quickly by the partition without exits.
-    fn prefetch_range(&self, _addr: u64, _size: u64) -> Result<(), anyhow::Error> {
+    fn prefetch_range(&self, _addr: u64, _size: u64) -> anyhow::Result<()> {
         Ok(())
     }
 
     /// Pins a range in memory so that it can be accessed by assigned devices.
-    fn pin_range(&self, _addr: u64, _size: u64) -> Result<(), anyhow::Error> {
+    fn pin_range(&self, _addr: u64, _size: u64) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -59,5 +59,5 @@ pub trait PartitionMemoryMap: Send + Sync {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), anyhow::Error>;
+    ) -> anyhow::Result<()>;
 }

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -935,7 +935,9 @@ impl<'p> Processor for HvfProcessor<'p> {
             }
 
             // SAFETY: we are not concurrently accessing `exit`.
-            unsafe { abi::hv_vcpu_run(self.vcpu.vcpu) }.chk().unwrap();
+            unsafe { abi::hv_vcpu_run(self.vcpu.vcpu) }
+                .chk()
+                .map_err(|err| VpHaltReason::Hypervisor(err.into()))?;
 
             match self.vcpu.exit.reason {
                 abi::HvExitReason::CANCELED => {

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -369,7 +369,7 @@ impl virt::PartitionMemoryMapper for HvfPartition {
 }
 
 impl virt::PartitionMemoryMap for HvfPartitionInner {
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), virt::Error> {
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
         let range = MemoryRange::new(addr..addr + size);
         self.mappings.lock().retain(|mapping| {
             if !range.overlaps(mapping) {
@@ -392,7 +392,7 @@ impl virt::PartitionMemoryMap for HvfPartitionInner {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         let mut mappings = self.mappings.lock();
         let mut flags = abi::HvMemoryFlags::READ.0;
         if writable {

--- a/vmm_core/virt_kvm/Cargo.toml
+++ b/vmm_core/virt_kvm/Cargo.toml
@@ -28,6 +28,7 @@ safe_intrinsics.workspace = true
 inspect.workspace = true
 pal_event.workspace = true
 
+anyhow.workspace = true
 jiff.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -419,7 +419,8 @@ impl virt::Processor for KvmProcessor<'_> {
                     self.runner.run()
                 };
 
-                let exit = exit.unwrap();
+                let exit =
+                    exit.map_err(|err| VpHaltReason::Hypervisor(KvmRunVpError::Run(err).into()))?;
                 pending_exit = true;
                 match exit {
                     kvm::Exit::Interrupted => {

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -377,8 +377,6 @@ impl virt::vm::AccessVmState for &KvmPartition {
 }
 
 impl virt::Processor for KvmProcessor<'_> {
-    type Error = KvmError;
-    type RunVpError = KvmRunVpError;
     type StateAccess<'a>
         = &'a mut Self
     where
@@ -388,7 +386,7 @@ impl virt::Processor for KvmProcessor<'_> {
         &mut self,
         _vtl: Vtl,
         _state: Option<&DebugState>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <&mut Self as virt::vp::AccessVpState>::Error> {
         unimplemented!()
     }
 
@@ -396,7 +394,7 @@ impl virt::Processor for KvmProcessor<'_> {
         &mut self,
         stop: StopVp<'_>,
         dev: &impl CpuIo,
-    ) -> Result<Infallible, VpHaltReason<Self::RunVpError>> {
+    ) -> Result<Infallible, VpHaltReason> {
         loop {
             self.inner.needs_yield.maybe_yield().await;
             stop.check()?;
@@ -421,7 +419,7 @@ impl virt::Processor for KvmProcessor<'_> {
                     self.runner.run()
                 };
 
-                let exit = exit.map_err(|err| VpHaltReason::Hypervisor(KvmRunVpError::Run(err)))?;
+                let exit = exit.unwrap();
                 pending_exit = true;
                 match exit {
                     kvm::Exit::Interrupted => {
@@ -440,15 +438,17 @@ impl virt::Processor for KvmProcessor<'_> {
                         dev.handle_eoi(irq.into());
                     }
                     kvm::Exit::InternalError { error, .. } => {
-                        return Err(VpHaltReason::Hypervisor(KvmRunVpError::InternalError(
-                            error,
-                        )));
+                        return Err(VpHaltReason::InvalidVmState(
+                            KvmRunVpError::InternalError(error).into(),
+                        ));
                     }
                     kvm::Exit::FailEntry {
                         hardware_entry_failure_reason,
                     } => {
                         tracing::error!(hardware_entry_failure_reason, "VP entry failed");
-                        return Err(VpHaltReason::InvalidVmState(KvmRunVpError::InvalidVpState));
+                        return Err(VpHaltReason::InvalidVmState(
+                            KvmRunVpError::InvalidVpState.into(),
+                        ));
                     }
                     _ => panic!("unhandled exit: {:?}", exit),
                 }
@@ -456,9 +456,7 @@ impl virt::Processor for KvmProcessor<'_> {
         }
     }
 
-    fn flush_async_requests(&mut self) -> Result<(), Self::RunVpError> {
-        Ok(())
-    }
+    fn flush_async_requests(&mut self) {}
 
     fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
         debug_assert_eq!(vtl, Vtl::Vtl0);

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -999,8 +999,6 @@ impl<T: CpuIo> hv1_hypercall::SignalEvent for KvmHypercallExit<'_, T> {
 }
 
 impl Processor for KvmProcessor<'_> {
-    type Error = KvmError;
-    type RunVpError = KvmRunVpError;
     type StateAccess<'a>
         = KvmVpStateAccess<'a>
     where
@@ -1010,7 +1008,7 @@ impl Processor for KvmProcessor<'_> {
         &mut self,
         _vtl: Vtl,
         state: Option<&virt::x86::DebugState>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <KvmVpStateAccess<'_> as AccessVpState>::Error> {
         let mut control = 0;
         let mut db = [0; 4];
         let mut dr7 = 0;
@@ -1037,7 +1035,7 @@ impl Processor for KvmProcessor<'_> {
         &mut self,
         stop: StopVp<'_>,
         dev: &impl CpuIo,
-    ) -> Result<Infallible, VpHaltReason<KvmRunVpError>> {
+    ) -> Result<Infallible, VpHaltReason> {
         loop {
             self.inner.needs_yield.maybe_yield().await;
             stop.check()?;
@@ -1063,7 +1061,7 @@ impl Processor for KvmProcessor<'_> {
                     .store(false, Ordering::Relaxed);
                 if self.runner.check_or_request_interrupt_window() {
                     self.deliver_pic_interrupt(dev)
-                        .map_err(VpHaltReason::Hypervisor)?;
+                        .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
                 }
             }
 
@@ -1093,7 +1091,7 @@ impl Processor for KvmProcessor<'_> {
                     self.runner.run()
                 };
 
-                let exit = exit.map_err(|err| VpHaltReason::Hypervisor(KvmRunVpError::Run(err)))?;
+                let exit = exit.unwrap();
                 pending_exit = true;
                 match exit {
                     kvm::Exit::Interrupted => {
@@ -1102,7 +1100,7 @@ impl Processor for KvmProcessor<'_> {
                     }
                     kvm::Exit::InterruptWindow => {
                         self.deliver_pic_interrupt(dev)
-                            .map_err(VpHaltReason::Hypervisor)?;
+                            .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
                     }
                     kvm::Exit::IoIn { port, data, size } => {
                         for data in data.chunks_mut(size as usize) {
@@ -1192,9 +1190,9 @@ impl Processor for KvmProcessor<'_> {
                         dev.handle_eoi(irq.into());
                     }
                     kvm::Exit::InternalError { error, .. } => {
-                        return Err(VpHaltReason::Hypervisor(KvmRunVpError::InternalError(
-                            error,
-                        )));
+                        return Err(VpHaltReason::InvalidVmState(
+                            KvmRunVpError::InternalError(error).into(),
+                        ));
                     }
                     kvm::Exit::EmulationFailure { instruction_bytes } => {
                         return Err(VpHaltReason::EmulationFailure(
@@ -1208,16 +1206,16 @@ impl Processor for KvmProcessor<'_> {
                         hardware_entry_failure_reason,
                     } => {
                         tracing::error!(hardware_entry_failure_reason, "VP entry failed");
-                        return Err(VpHaltReason::InvalidVmState(KvmRunVpError::InvalidVpState));
+                        return Err(VpHaltReason::InvalidVmState(
+                            KvmRunVpError::InvalidVpState.into(),
+                        ));
                     }
                 }
             }
         }
     }
 
-    fn flush_async_requests(&mut self) -> Result<(), Self::RunVpError> {
-        Ok(())
-    }
+    fn flush_async_requests(&mut self) {}
 
     fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
         assert_eq!(vtl, Vtl::Vtl0);

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -1091,7 +1091,8 @@ impl Processor for KvmProcessor<'_> {
                     self.runner.run()
                 };
 
-                let exit = exit.unwrap();
+                let exit =
+                    exit.map_err(|err| VpHaltReason::Hypervisor(KvmRunVpError::Run(err).into()))?;
                 pending_exit = true;
                 match exit {
                     kvm::Exit::Interrupted => {

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -90,13 +90,11 @@ struct KvmPartitionInner {
 }
 
 #[derive(Debug, Error)]
-pub enum KvmRunVpError {
+enum KvmRunVpError {
     #[error("KVM internal error: {0:#x}")]
     InternalError(u32),
     #[error("invalid vp state")]
     InvalidVpState,
-    #[error("failed to run VP")]
-    Run(#[source] kvm::Error),
     #[error("failed to inject an extint interrupt")]
     ExtintInterrupt(#[source] kvm::Error),
 }

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -89,12 +89,14 @@ struct KvmPartitionInner {
     cpuid: virt::CpuidLeafSet,
 }
 
+// TODO: Chunk this up into smaller types.
 #[derive(Debug, Error)]
 enum KvmRunVpError {
     #[error("KVM internal error: {0:#x}")]
     InternalError(u32),
     #[error("invalid vp state")]
     InvalidVpState,
+    #[cfg(guest_arch = "x86_64")]
     #[error("failed to inject an extint interrupt")]
     ExtintInterrupt(#[source] kvm::Error),
 }

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -137,7 +137,7 @@ impl KvmPartitionInner {
         size: usize,
         addr: u64,
         readonly: bool,
-    ) -> Result<(), anyhow::Error> {
+    ) -> anyhow::Result<()> {
         let mut state = self.memory.lock();
 
         // Memory slots cannot be resized but can be moved within the guest
@@ -186,12 +186,12 @@ impl virt::PartitionMemoryMap for KvmPartitionInner {
         addr: u64,
         writable: bool,
         _exec: bool,
-    ) -> Result<(), anyhow::Error> {
+    ) -> anyhow::Result<()> {
         // SAFETY: guaranteed by caller.
         unsafe { self.map_region(data, size, addr, !writable) }
     }
 
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), anyhow::Error> {
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
         let range = MemoryRange::new(addr..addr + size);
         let mut state = self.memory.lock();
         for (slot, entry) in state.ranges.iter_mut().enumerate() {

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -96,6 +96,8 @@ enum KvmRunVpError {
     InternalError(u32),
     #[error("invalid vp state")]
     InvalidVpState,
+    #[error("failed to run VP")]
+    Run(#[source] kvm::Error),
     #[cfg(guest_arch = "x86_64")]
     #[error("failed to inject an extint interrupt")]
     ExtintInterrupt(#[source] kvm::Error),

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -137,7 +137,7 @@ impl KvmPartitionInner {
         size: usize,
         addr: u64,
         readonly: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> Result<(), anyhow::Error> {
         let mut state = self.memory.lock();
 
         // Memory slots cannot be resized but can be moved within the guest
@@ -186,12 +186,12 @@ impl virt::PartitionMemoryMap for KvmPartitionInner {
         addr: u64,
         writable: bool,
         _exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> Result<(), anyhow::Error> {
         // SAFETY: guaranteed by caller.
         unsafe { self.map_region(data, size, addr, !writable) }
     }
 
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), virt::Error> {
+    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), anyhow::Error> {
         let range = MemoryRange::new(addr..addr + size);
         let mut state = self.memory.lock();
         for (slot, entry) in state.ranges.iter_mut().enumerate() {

--- a/vmm_core/virt_mshv/Cargo.toml
+++ b/vmm_core/virt_mshv/Cargo.toml
@@ -22,6 +22,7 @@ pal_event.workspace = true
 inspect.workspace = true
 tracelimit.workspace = true
 
+anyhow.workspace = true
 mshv-bindings = { workspace = true, features = ["with-serde", "fam-wrappers"] }
 mshv-ioctls.workspace = true
 arrayvec.workspace = true

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -1067,6 +1067,7 @@ impl TranslateGvaSupport for MshvEmulationState<'_> {
     }
 }
 
+// TODO: Chunk this up into smaller types.
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("operation not supported")]
@@ -1075,8 +1076,6 @@ pub enum Error {
     CreateVMFailed,
     #[error("failed to create VCPU")]
     CreateVcpu(#[source] MshvError),
-    #[error("emulator GPA translation error")]
-    EmulatorTranslateGPA,
     #[error("vtl2 not supported")]
     Vtl2NotSupported,
     #[error("isolation not supported")]
@@ -1087,8 +1086,6 @@ pub enum Error {
     OpenMshv(#[source] MshvError),
     #[error("register access error")]
     Register(#[source] MshvError),
-    #[error("interrupt assertion failed")]
-    AssertInterrupt(#[source] MshvError),
     #[error("install instercept failed")]
     InstallIntercept(#[source] MshvError),
 }

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -1146,7 +1146,7 @@ impl virt::PartitionMemoryMap for MshvPartitionInner {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> Result<(), anyhow::Error> {
         let mut state = self.memory.lock();
 
         // Memory slots cannot be resized but can be moved within the guest
@@ -1189,7 +1189,7 @@ impl virt::PartitionMemoryMap for MshvPartitionInner {
         Ok(())
     }
 
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), virt::Error> {
+    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), anyhow::Error> {
         let mut state = self.memory.lock();
         let (slot, range) = state
             .ranges

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -1146,7 +1146,7 @@ impl virt::PartitionMemoryMap for MshvPartitionInner {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), anyhow::Error> {
+    ) -> anyhow::Result<()> {
         let mut state = self.memory.lock();
 
         // Memory slots cannot be resized but can be moved within the guest
@@ -1189,7 +1189,7 @@ impl virt::PartitionMemoryMap for MshvPartitionInner {
         Ok(())
     }
 
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), anyhow::Error> {
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
         let mut state = self.memory.lock();
         let (slot, range) = state
             .ranges

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -453,8 +453,8 @@ impl MshvProcessor<'_> {
         message: &hv_message,
         devices: &impl CpuIo,
         interruption_pending: bool,
-    ) -> Result<(), VpHaltReason<MshvError>> {
-        let cache = self.emulation_cache().map_err(VpHaltReason::Hypervisor)?;
+    ) -> Result<(), VpHaltReason> {
+        let cache = self.emulation_cache();
         let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
             gm: &self.partition.gm,
             kx_gm: &self.partition.gm,
@@ -476,7 +476,7 @@ impl MshvProcessor<'_> {
         &self,
         message: &hv_message,
         devices: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<MshvError>> {
+    ) -> Result<(), VpHaltReason> {
         let info = message.to_ioport_info().unwrap();
         let access_info = info.access_info;
         // SAFETY: This union only contains one field.
@@ -512,8 +512,7 @@ impl MshvProcessor<'_> {
                 (mshv_bindings::hv_register_name_HV_X64_REGISTER_RAX, ret_rax),
             ];
 
-            set_registers_64!(self.inner.vcpufd, arr_reg_name_value)
-                .map_err(VpHaltReason::Hypervisor)?;
+            set_registers_64!(self.inner.vcpufd, arr_reg_name_value).unwrap();
         }
 
         Ok(())
@@ -523,33 +522,21 @@ impl MshvProcessor<'_> {
         &self,
         message: &hv_message,
         devices: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<MshvError>> {
+    ) -> Result<(), VpHaltReason> {
         let execution_state = message.to_memory_info().unwrap().header.execution_state;
         // SAFETY: This union only contains one field.
         let mmio_execution_state = unsafe { execution_state.__bindgen_anon_1 };
         let interruption_pending = mmio_execution_state.interruption_pending() != 0;
 
-        self.emulate(message, devices, interruption_pending).await?;
-
-        Ok(())
+        self.emulate(message, devices, interruption_pending).await
     }
 
-    fn handle_synic_deliverable_exit(
-        &self,
-        message: &hv_message,
-        _devices: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<MshvError>> {
+    fn handle_synic_deliverable_exit(&self, message: &hv_message, _devices: &impl CpuIo) {
         let info = message.to_sint_deliverable_info().unwrap();
-
         self.flush_messages(info.deliverable_sints);
-        Ok(())
     }
 
-    fn handle_hypercall_intercept(
-        &self,
-        message: &hv_message,
-        devices: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<MshvError>> {
+    fn handle_hypercall_intercept(&self, message: &hv_message, devices: &impl CpuIo) {
         let info = message.to_hypercall_intercept_info().unwrap();
         let execution_state = info.header.execution_state;
         // SAFETY: Accessing the raw field of this union is always safe.
@@ -659,8 +646,6 @@ impl MshvProcessor<'_> {
                 .set_reg(&dirty_regs)
                 .expect("RIP setting is not a fallable operation");
         }
-
-        Ok(())
     }
 
     fn flush_messages(&self, deliverable_sints: u16) {
@@ -698,8 +683,8 @@ impl MshvProcessor<'_> {
         }
     }
 
-    fn emulation_cache(&self) -> Result<MshvEmuCache, MshvError> {
-        let regs = self.inner.vcpufd.get_regs()?;
+    fn emulation_cache(&self) -> MshvEmuCache {
+        let regs = self.inner.vcpufd.get_regs().unwrap();
         let gps = [
             regs.rax, regs.rcx, regs.rdx, regs.rbx, regs.rsp, regs.rbp, regs.rsi, regs.rdi,
             regs.r8, regs.r9, regs.r10, regs.r11, regs.r12, regs.r13, regs.r14, regs.r15,
@@ -719,14 +704,14 @@ impl MshvProcessor<'_> {
         let cr0 = sregs.cr0;
         let efer = sregs.efer;
 
-        Ok(MshvEmuCache {
+        MshvEmuCache {
             gps,
             segs,
             rip,
             rflags: rflags.into(),
             cr0,
             efer,
-        })
+        }
     }
 }
 
@@ -740,8 +725,6 @@ struct MshvEmulationState<'a> {
 }
 
 impl EmulatorSupport for MshvEmulationState<'_> {
-    type Error = MshvError;
-
     fn vp_index(&self) -> VpIndex {
         self.vp_index
     }
@@ -800,7 +783,7 @@ impl EmulatorSupport for MshvEmulationState<'_> {
         hvu128_to_u128(unsafe { &reg.value.reg128 })
     }
 
-    fn set_xmm(&mut self, reg: usize, value: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, reg: usize, value: u128) {
         assert!(reg < 16);
         let name = HvX64RegisterName(HvX64RegisterName::Xmm0.0 + reg as u32);
         // SAFETY: `HvRegisterAssoc` and `hv_register_assoc` have the same layout.
@@ -809,11 +792,10 @@ impl EmulatorSupport for MshvEmulationState<'_> {
                 name, value,
             )))
         };
-        self.processor.vcpufd.set_reg(&[reg])?;
-        Ok(())
+        self.processor.vcpufd.set_reg(&[reg]).unwrap();
     }
 
-    fn flush(&mut self) -> Result<(), Self::Error> {
+    fn flush(&mut self) {
         let arr_reg_name_value = [
             (
                 mshv_bindings::hv_register_name_HV_X64_REGISTER_RIP,
@@ -889,8 +871,7 @@ impl EmulatorSupport for MshvEmulationState<'_> {
             ),
         ];
 
-        set_registers_64!(self.processor.vcpufd, arr_reg_name_value)?;
-        Ok(())
+        set_registers_64!(self.processor.vcpufd, arr_reg_name_value).unwrap();
     }
 
     fn instruction_bytes(&self) -> &[u8] {
@@ -983,7 +964,7 @@ impl EmulatorSupport for MshvEmulationState<'_> {
         &mut self,
         _gpa: u64,
         _mode: TranslateMode,
-    ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError<Self::Error>> {
+    ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError> {
         // TODO: No VTL2 supported so always return Ok.
         Ok(())
     }
@@ -992,7 +973,7 @@ impl EmulatorSupport for MshvEmulationState<'_> {
         &mut self,
         gva: u64,
         mode: TranslateMode,
-    ) -> Result<Result<EmuTranslateResult, EmuTranslateError>, Self::Error> {
+    ) -> Result<EmuTranslateResult, EmuTranslateError> {
         emulate_translate_gva(self, gva, mode)
     }
 
@@ -1042,8 +1023,6 @@ impl EmulatorSupport for MshvEmulationState<'_> {
 }
 
 impl TranslateGvaSupport for MshvEmulationState<'_> {
-    type Error = MshvError;
-
     fn guest_memory(&self) -> &GuestMemory {
         &self.partition.gm
     }
@@ -1052,7 +1031,7 @@ impl TranslateGvaSupport for MshvEmulationState<'_> {
         // The hypervisor automatically acquires the TLB lock for exo partitions.
     }
 
-    fn registers(&mut self) -> Result<TranslationRegisters, Self::Error> {
+    fn registers(&mut self) -> TranslationRegisters {
         let mut reg = [
             HvX64RegisterName::Cr0,
             HvX64RegisterName::Cr4,
@@ -1065,15 +1044,18 @@ impl TranslateGvaSupport for MshvEmulationState<'_> {
 
         // SAFETY: `HvRegisterAssoc` and `hv_register_assoc` have the same size.
         unsafe {
-            self.processor.vcpufd.get_reg(std::mem::transmute::<
-                &mut [HvRegisterAssoc],
-                &mut [hv_register_assoc],
-            >(&mut reg[..]))?;
+            self.processor
+                .vcpufd
+                .get_reg(std::mem::transmute::<
+                    &mut [HvRegisterAssoc],
+                    &mut [hv_register_assoc],
+                >(&mut reg[..]))
+                .unwrap();
         }
 
         let [cr0, cr4, efer, cr3, rflags, ss] = reg.map(|v| v.value);
 
-        Ok(TranslationRegisters {
+        TranslationRegisters {
             cr0: cr0.as_u64(),
             cr4: cr4.as_u64(),
             efer: efer.as_u64(),
@@ -1081,7 +1063,7 @@ impl TranslateGvaSupport for MshvEmulationState<'_> {
             rflags: rflags.as_u64(),
             ss: from_seg(ss.as_segment()),
             encryption_mode: virt_support_x86emu::translate::EncryptionMode::None,
-        })
+        }
     }
 }
 
@@ -1382,8 +1364,6 @@ impl InspectMut for MshvProcessor<'_> {
 }
 
 impl virt::Processor for MshvProcessor<'_> {
-    type Error = Error;
-    type RunVpError = MshvError;
     type StateAccess<'a>
         = &'a mut Self
     where
@@ -1393,7 +1373,7 @@ impl virt::Processor for MshvProcessor<'_> {
         &mut self,
         _vtl: Vtl,
         _state: Option<&virt::x86::DebugState>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <&mut Self as virt::vp::AccessVpState>::Error> {
         Err(Error::NotSupported)
     }
 
@@ -1401,7 +1381,7 @@ impl virt::Processor for MshvProcessor<'_> {
         &mut self,
         stop: StopVp<'_>,
         dev: &impl CpuIo,
-    ) -> Result<Infallible, VpHaltReason<MshvError>> {
+    ) -> Result<Infallible, VpHaltReason> {
         let vpinner = self.inner;
         let _cleaner = MshvVpInnerCleaner { vpinner };
         let vcpufd = &vpinner.vcpufd;
@@ -1428,11 +1408,11 @@ impl virt::Processor for MshvProcessor<'_> {
                     }
                     HvMessageType::HvMessageTypeSynicSintDeliverable => {
                         tracing::trace!("SYNIC_SINT_DELIVERABLE");
-                        self.handle_synic_deliverable_exit(&exit, dev)?;
+                        self.handle_synic_deliverable_exit(&exit, dev);
                     }
                     HvMessageType::HvMessageTypeHypercallIntercept => {
                         tracing::trace!("HYPERCALL_INTERCEPT");
-                        self.handle_hypercall_intercept(&exit, dev)?;
+                        self.handle_hypercall_intercept(&exit, dev);
                     }
                     exit => {
                         panic!("Unhandled vcpu exit code {exit:?}");
@@ -1450,9 +1430,7 @@ impl virt::Processor for MshvProcessor<'_> {
         }
     }
 
-    fn flush_async_requests(&mut self) -> Result<(), Self::RunVpError> {
-        Ok(())
-    }
+    fn flush_async_requests(&mut self) {}
 
     fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
         assert_eq!(vtl, Vtl::Vtl0);

--- a/vmm_core/virt_support_aarch64emu/src/emulate.rs
+++ b/vmm_core/virt_support_aarch64emu/src/emulate.rs
@@ -25,9 +25,6 @@ use zerocopy::IntoBytes;
 
 /// Support routines for the emulator.
 pub trait EmulatorSupport: AccessCpuState {
-    /// The hypervisor error type.
-    type Error: 'static + std::error::Error + Send + Sync;
-
     /// The current VP index.
     fn vp_index(&self) -> VpIndex;
 
@@ -46,14 +43,14 @@ pub trait EmulatorSupport: AccessCpuState {
         &mut self,
         gpa: u64,
         mode: TranslateMode,
-    ) -> Result<(), EmuCheckVtlAccessError<Self::Error>>;
+    ) -> Result<(), EmuCheckVtlAccessError>;
 
     /// Translates a GVA to a GPA.
     fn translate_gva(
         &mut self,
         gva: u64,
         mode: TranslateMode,
-    ) -> Result<Result<EmuTranslateResult, EmuTranslateError>, Self::Error>;
+    ) -> Result<EmuTranslateResult, EmuTranslateError>;
 
     /// Generates an event (exception, guest nested page fault, etc.) in the guest.
     fn inject_pending_event(&mut self, event_info: HvAarch64PendingEvent);
@@ -109,9 +106,7 @@ pub struct InitialTranslation {
 }
 
 #[derive(Error, Debug)]
-pub enum EmuCheckVtlAccessError<E> {
-    #[error(transparent)]
-    Hypervisor(#[from] E),
+pub enum EmuCheckVtlAccessError {
     #[error("failed vtl permissions access for vtl {vtl:?} and access flags {denied_flags:?}")]
     AccessDenied {
         vtl: hvdef::Vtl,
@@ -159,14 +154,14 @@ impl TryFrom<HvInterceptAccessType> for TranslateMode {
 }
 
 #[derive(Debug, Error)]
-enum EmulationError<E> {
+enum EmulationError {
     #[error("an interrupt caused the memory access exit")]
     InterruptionPending,
     #[error("emulator error (instruction {bytes:02x?})")]
     Emulator {
         bytes: Vec<u8>,
         #[source]
-        error: aarch64emu::Error<Error<E>>,
+        error: aarch64emu::Error<Error>,
     },
 }
 
@@ -187,7 +182,7 @@ async fn emulate_core<T: EmulatorSupport>(
     intercept_state: &InterceptState,
     gm: &GuestMemory,
     dev: &impl CpuIo,
-) -> Result<(), EmulationError<T::Error>> {
+) -> Result<(), EmulationError> {
     tracing::trace!(physical_address = support.physical_address(), "emulating");
 
     if support.interruption_pending() {
@@ -276,9 +271,7 @@ struct EmulatorCpu<'a, T, U> {
 }
 
 #[derive(Debug, Error)]
-enum Error<E> {
-    #[error(transparent)]
-    Hypervisor(#[from] E),
+enum Error {
     #[error("translation error")]
     Translate(#[source] TranslateGvaError, Option<EsrEl2>),
     #[error("vtl permissions denied access for gpa {gpa}")]
@@ -341,7 +334,7 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
         }
     }
 
-    pub fn translate_gva(&mut self, gva: u64, mode: TranslateMode) -> Result<u64, Error<T::Error>> {
+    pub fn translate_gva(&mut self, gva: u64, mode: TranslateMode) -> Result<u64, Error> {
         type TranslateCode = hvdef::hypercall::TranslateGvaResultCode;
 
         // Note about invalid accesses at user mode: the exception code will
@@ -369,7 +362,7 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
         };
 
         match self.support.translate_gva(gva, mode) {
-            Ok(Ok(EmuTranslateResult { gpa, overlay_page })) => {
+            Ok(EmuTranslateResult { gpa, overlay_page }) => {
                 if overlay_page.is_some()
                     && overlay_page
                         .expect("should've already checked that the overlay page has value")
@@ -386,7 +379,7 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
                 self.cached_translation = Some(new_cache_entry);
                 Ok(gpa)
             }
-            Ok(Err(EmuTranslateError { code, event_info })) => match code {
+            Err(EmuTranslateError { code, event_info }) => match code {
                 TranslateCode::INTERCEPT => {
                     tracing::trace!("translate gva to gpa returned an intercept event");
                     Err(Error::Translate(TranslateGvaError::Intercept, event_info))
@@ -421,22 +414,13 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
                     Err(Error::Translate(TranslateGvaError::UnknownCode(code), None))
                 }
             },
-            Err(e) => {
-                tracing::trace!("translate error {:?}", e);
-                Err(Error::Hypervisor(e))
-            }
         }
     }
 
-    pub fn check_vtl_access(
-        &mut self,
-        gpa: u64,
-        mode: TranslateMode,
-    ) -> Result<(), Error<T::Error>> {
+    pub fn check_vtl_access(&mut self, gpa: u64, mode: TranslateMode) -> Result<(), Error> {
         self.support
             .check_vtl_access(gpa, mode)
             .map_err(|e| match e {
-                EmuCheckVtlAccessError::Hypervisor(hv_err) => Error::Hypervisor(hv_err),
                 EmuCheckVtlAccessError::AccessDenied { vtl, denied_flags } => Error::NoVtlAccess {
                     gpa,
                     intercepting_vtl: vtl,
@@ -447,7 +431,7 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
 }
 
 impl<T: EmulatorSupport, U: CpuIo> aarch64emu::Cpu for EmulatorCpu<'_, T, U> {
-    type Error = Error<T::Error>;
+    type Error = Error;
 
     async fn read_instruction(&mut self, gva: u64, bytes: &mut [u8]) -> Result<(), Self::Error> {
         let gpa = match self.translate_gva(gva, TranslateMode::Execute) {
@@ -632,7 +616,7 @@ pub fn make_exception_event(syndrome: EsrEl2, fault_address: u64) -> HvAarch64Pe
 #[must_use]
 fn inject_memory_access_fault<T: EmulatorSupport>(
     gva: u64,
-    result: &Error<T::Error>,
+    result: &Error,
     support: &mut T,
     syndrome: EsrEl2,
 ) -> bool {
@@ -667,7 +651,7 @@ fn inject_memory_access_fault<T: EmulatorSupport>(
             support.inject_pending_event(event);
             true
         }
-        Error::Hypervisor(_) | Error::Memory(_) => false,
+        Error::Memory(_) => false,
     }
 }
 

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -27,9 +27,6 @@ use zerocopy::IntoBytes;
 
 /// Support routines for the emulator.
 pub trait EmulatorSupport {
-    /// The hypervisor error type.
-    type Error: 'static + std::error::Error + Send + Sync;
-
     /// The current VP index.
     fn vp_index(&self) -> VpIndex;
 
@@ -67,10 +64,10 @@ pub trait EmulatorSupport {
     fn xmm(&mut self, reg: usize) -> u128;
 
     /// Sets the value of an XMM* register.
-    fn set_xmm(&mut self, reg: usize, value: u128) -> Result<(), Self::Error>;
+    fn set_xmm(&mut self, reg: usize, value: u128);
 
     /// Flush registers in the emulation cache to the backing
-    fn flush(&mut self) -> Result<(), Self::Error>;
+    fn flush(&mut self);
 
     /// The instruction bytes, if available.
     fn instruction_bytes(&self) -> &[u8];
@@ -90,14 +87,14 @@ pub trait EmulatorSupport {
         &mut self,
         gpa: u64,
         mode: TranslateMode,
-    ) -> Result<(), EmuCheckVtlAccessError<Self::Error>>;
+    ) -> Result<(), EmuCheckVtlAccessError>;
 
     /// Translates a GVA to a GPA.
     fn translate_gva(
         &mut self,
         gva: u64,
         mode: TranslateMode,
-    ) -> Result<Result<EmuTranslateResult, EmuTranslateError>, Self::Error>;
+    ) -> Result<EmuTranslateResult, EmuTranslateError>;
 
     /// Generates an event (exception, guest nested page fault, etc.) in the guest.
     fn inject_pending_event(&mut self, event_info: hvdef::HvX64PendingEvent);
@@ -136,8 +133,6 @@ pub trait EmulatorSupport {
 }
 
 pub trait TranslateGvaSupport {
-    type Error;
-
     /// Gets the object used to access the guest memory.
     fn guest_memory(&self) -> &GuestMemory;
 
@@ -145,7 +140,7 @@ pub trait TranslateGvaSupport {
     fn acquire_tlb_lock(&mut self);
 
     /// Returns the registers used to walk the page table.
-    fn registers(&mut self) -> Result<crate::translate::TranslationRegisters, Self::Error>;
+    fn registers(&mut self) -> crate::translate::TranslationRegisters;
 }
 
 /// Emulates a page table walk.
@@ -155,7 +150,7 @@ pub fn emulate_translate_gva<T: TranslateGvaSupport>(
     support: &mut T,
     gva: u64,
     mode: TranslateMode,
-) -> Result<Result<EmuTranslateResult, EmuTranslateError>, T::Error> {
+) -> Result<EmuTranslateResult, EmuTranslateError> {
     // Always acquire the TLB lock for this path.
     support.acquire_tlb_lock();
 
@@ -169,9 +164,9 @@ pub fn emulate_translate_gva<T: TranslateGvaSupport>(
         set_page_table_bits: true,
     };
 
-    let registers = support.registers()?;
+    let registers = support.registers();
 
-    let r = match translate_gva_to_gpa(support.guest_memory(), gva, &registers, flags) {
+    match translate_gva_to_gpa(support.guest_memory(), gva, &registers, flags) {
         Ok(crate::translate::TranslateResult { gpa, cache_info: _ }) => Ok(EmuTranslateResult {
             gpa,
             overlay_page: None,
@@ -180,8 +175,7 @@ pub fn emulate_translate_gva<T: TranslateGvaSupport>(
             code: err.into(),
             event_info: None,
         }),
-    };
-    Ok(r)
+    }
 }
 
 /// The result of translate_gva on [`EmulatorSupport`].
@@ -205,9 +199,7 @@ pub struct InitialTranslation {
 }
 
 #[derive(Error, Debug)]
-pub enum EmuCheckVtlAccessError<E> {
-    #[error(transparent)]
-    Hypervisor(#[from] E),
+pub enum EmuCheckVtlAccessError {
     #[error("failed vtl permissions access for vtl {vtl:?} and access flags {denied_flags:?}")]
     AccessDenied {
         vtl: hvdef::Vtl,
@@ -255,20 +247,18 @@ impl TryFrom<HvInterceptAccessType> for TranslateMode {
 }
 
 #[derive(Debug, Error)]
-enum EmulationError<E> {
+enum EmulationError {
     #[error("an interrupt caused the memory access exit")]
     InterruptionPending,
     #[error("linear IP was not within CS segment limit")]
     LinearIpPastCsLimit,
-    #[error("failed to flush the emulator cache")]
-    CacheFlushFailed(#[source] E),
     #[error("failed to read instruction stream")]
-    InstructionRead(#[source] E),
+    InstructionRead(#[source] Error),
     #[error("emulator error (instruction {bytes:02x?})")]
     Emulator {
         bytes: Vec<u8>,
         #[source]
-        error: x86emu::Error<E>,
+        error: x86emu::Error<Error>,
     },
 }
 
@@ -303,7 +293,17 @@ pub async fn emulate<T: EmulatorSupport>(
     support: &mut T,
     emu_mem: &EmulatorMemoryAccess<'_>,
     dev: &impl CpuIo,
-) -> Result<(), VpHaltReason<T::Error>> {
+) -> Result<(), VpHaltReason> {
+    emulate_core(support, emu_mem, dev)
+        .await
+        .map_err(|e| VpHaltReason::EmulationFailure(e.into()))
+}
+
+async fn emulate_core<T: EmulatorSupport>(
+    support: &mut T,
+    emu_mem: &EmulatorMemoryAccess<'_>,
+    dev: &impl CpuIo,
+) -> Result<(), EmulationError> {
     let vendor = support.vendor();
 
     let mut bytes = [0; 16];
@@ -335,9 +335,7 @@ pub async fn emulate<T: EmulatorSupport>(
         // cause an infinite loop (as the processor tries to get the trap
         // vector out of the mmio-ed vector table).  Just give up.
 
-        return Err(VpHaltReason::EmulationFailure(
-            EmulationError::<T::Error>::InterruptionPending.into(),
-        ));
+        return Err(EmulationError::InterruptionPending);
     }
 
     let initial_alignment_check = support.rflags().alignment_check();
@@ -357,11 +355,9 @@ pub async fn emulate<T: EmulatorSupport>(
                 assert!(valid_bytes < bytes.len());
 
                 // TODO: inject #GP due to segmentation fault.
-                let linear_ip =
-                    emu.linear_ip(valid_bytes as u64)
-                        .ok_or(VpHaltReason::EmulationFailure(
-                            EmulationError::<T::Error>::LinearIpPastCsLimit.into(),
-                        ))?;
+                let linear_ip = emu
+                    .linear_ip(valid_bytes as u64)
+                    .ok_or(EmulationError::LinearIpPastCsLimit)?;
 
                 let is_user_mode = emu.is_user_mode();
 
@@ -374,9 +370,7 @@ pub async fn emulate<T: EmulatorSupport>(
                         if inject_memory_access_fault(linear_ip, &translate_error, support) {
                             return Ok(());
                         } else {
-                            return Err(VpHaltReason::EmulationFailure(
-                                EmulationError::InstructionRead(translate_error).into(),
-                            ));
+                            return Err(EmulationError::InstructionRead(translate_error));
                         }
                     }
                 };
@@ -387,9 +381,7 @@ pub async fn emulate<T: EmulatorSupport>(
                     if inject_memory_access_fault(linear_ip, &err, support) {
                         return Ok(());
                     } else {
-                        return Err(VpHaltReason::EmulationFailure(
-                            EmulationError::InstructionRead(err).into(),
-                        ));
+                        return Err(EmulationError::InstructionRead(err));
                     };
                 }
 
@@ -417,9 +409,7 @@ pub async fn emulate<T: EmulatorSupport>(
         break res;
     };
 
-    cpu.support.flush().map_err(|err| {
-        VpHaltReason::EmulationFailure(EmulationError::<T::Error>::CacheFlushFailed(err).into())
-    })?;
+    cpu.support.flush();
 
     // If the alignment check flag is not in sync with the hypervisor because the instruction emulator
     // modifies internally, then the appropriate SMAP enforcement flags need to be passed to the hypervisor
@@ -463,13 +453,10 @@ pub async fn emulate<T: EmulatorSupport>(
                     "given an instruction that we shouldn't have been asked to emulate - likely a bug in the caller"
                 );
 
-                return Err(VpHaltReason::EmulationFailure(
-                    EmulationError::Emulator {
-                        bytes: instruction_bytes.to_vec(),
-                        error: err,
-                    }
-                    .into(),
-                ));
+                return Err(EmulationError::Emulator {
+                    bytes: instruction_bytes.to_vec(),
+                    error: err,
+                });
             }
             x86emu::Error::InstructionException(exception, error_code, cause) => {
                 tracing::trace!(
@@ -483,23 +470,17 @@ pub async fn emulate<T: EmulatorSupport>(
             }
             x86emu::Error::MemoryAccess(addr, kind, err) => {
                 if !inject_memory_access_fault(addr, &err, support) {
-                    return Err(VpHaltReason::EmulationFailure(
-                        EmulationError::Emulator {
-                            bytes: instruction_bytes.to_vec(),
-                            error: x86emu::Error::MemoryAccess(addr, kind, err),
-                        }
-                        .into(),
-                    ));
+                    return Err(EmulationError::Emulator {
+                        bytes: instruction_bytes.to_vec(),
+                        error: x86emu::Error::MemoryAccess(addr, kind, err),
+                    });
                 }
             }
-            err @ (x86emu::Error::IoPort { .. } | x86emu::Error::XmmRegister { .. }) => {
-                return Err(VpHaltReason::EmulationFailure(
-                    EmulationError::Emulator {
-                        bytes: instruction_bytes.to_vec(),
-                        error: err,
-                    }
-                    .into(),
-                ));
+            err @ x86emu::Error::IoPort { .. } => {
+                return Err(EmulationError::Emulator {
+                    bytes: instruction_bytes.to_vec(),
+                    error: err,
+                });
             }
             x86emu::Error::NotEnoughBytes => unreachable!(),
         }
@@ -521,7 +502,7 @@ pub async fn emulate_insn_memory_op<T: EmulatorSupport>(
     segment: Segment,
     alignment: AlignmentMode,
     op: EmulatedMemoryOperation<'_>,
-) -> Result<(), VpHaltReason<T::Error>> {
+) -> Result<(), VpHaltReason> {
     assert!(!support.interruption_pending());
 
     let vendor = support.vendor();
@@ -571,9 +552,7 @@ struct EmulatorCpu<'a, T, U> {
 }
 
 #[derive(Debug, Error)]
-enum Error<E> {
-    #[error(transparent)]
-    Hypervisor(#[from] E),
+enum Error {
     #[error("translation error")]
     Translate(
         #[source] TranslateGvaError,
@@ -638,7 +617,7 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
         gva: u64,
         mode: TranslateMode,
         is_user_mode: bool,
-    ) -> Result<u64, Error<T::Error>> {
+    ) -> Result<u64, Error> {
         type TranslateCode = hvdef::hypercall::TranslateGvaResultCode;
 
         if let Some(GvaGpaCacheEntry {
@@ -660,7 +639,7 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
         };
 
         match self.support.translate_gva(gva, mode) {
-            Ok(Ok(EmuTranslateResult { gpa, overlay_page })) => {
+            Ok(EmuTranslateResult { gpa, overlay_page }) => {
                 if overlay_page.is_some()
                     && overlay_page
                         .expect("should've already checked that the overlay page has value")
@@ -691,7 +670,7 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
                 self.cached_translation = Some(new_cache_entry);
                 Ok(gpa)
             }
-            Ok(Err(EmuTranslateError { code, event_info })) => {
+            Err(EmuTranslateError { code, event_info }) => {
                 match code {
                     TranslateCode::INTERCEPT => {
                         tracing::trace!("translate gva to gpa returned an intercept event");
@@ -778,22 +757,13 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
                     }
                 }
             }
-            Err(e) => {
-                tracing::trace!("translate error {:?}", e);
-                Err(Error::Hypervisor(e))
-            }
         }
     }
 
-    pub fn check_vtl_access(
-        &mut self,
-        gpa: u64,
-        mode: TranslateMode,
-    ) -> Result<(), Error<T::Error>> {
+    pub fn check_vtl_access(&mut self, gpa: u64, mode: TranslateMode) -> Result<(), Error> {
         self.support
             .check_vtl_access(gpa, mode)
             .map_err(|e| match e {
-                EmuCheckVtlAccessError::Hypervisor(hv_err) => Error::Hypervisor(hv_err),
                 EmuCheckVtlAccessError::AccessDenied { vtl, denied_flags } => Error::NoVtlAccess {
                     gpa,
                     intercepting_vtl: vtl,
@@ -804,7 +774,7 @@ impl<T: EmulatorSupport, U> EmulatorCpu<'_, T, U> {
 }
 
 impl<T: EmulatorSupport, U: CpuIo> x86emu::Cpu for EmulatorCpu<'_, T, U> {
-    type Error = Error<T::Error>;
+    type Error = Error;
 
     async fn read_memory(
         &mut self,
@@ -947,8 +917,8 @@ impl<T: EmulatorSupport, U: CpuIo> x86emu::Cpu for EmulatorCpu<'_, T, U> {
     }
 
     /// Sets the value of an XMM* register.
-    fn set_xmm(&mut self, reg: usize, value: u128) -> Result<(), Self::Error> {
-        self.support.set_xmm(reg, value).map_err(Error::Hypervisor)
+    fn set_xmm(&mut self, reg: usize, value: u128) {
+        self.support.set_xmm(reg, value)
     }
 }
 
@@ -988,7 +958,7 @@ pub async fn emulate_io(
 #[must_use]
 fn inject_memory_access_fault<T: EmulatorSupport>(
     gva: u64,
-    result: &Error<T::Error>,
+    result: &Error,
     support: &mut T,
 ) -> bool {
     match result {
@@ -1022,7 +992,7 @@ fn inject_memory_access_fault<T: EmulatorSupport>(
             support.inject_pending_event(event);
             true
         }
-        Error::Hypervisor(_) | Error::Memory(_) => false,
+        Error::Memory(_) => false,
     }
 }
 
@@ -1103,11 +1073,11 @@ pub fn emulate_mnf_write_fast_path<T: EmulatorSupport>(
     dev: &impl CpuIo,
     interruption_pending: bool,
     tlb_lock_held: bool,
-) -> Result<Option<u32>, VpHaltReason<T::Error>> {
+) -> Option<u32> {
     let mut cpu = EmulatorCpu::new(gm, dev, support);
     let instruction_bytes = cpu.support.instruction_bytes();
     if interruption_pending || !tlb_lock_held || instruction_bytes.is_empty() {
-        return Ok(None);
+        return None;
     }
     let mut bytes = [0; 16];
     let valid_bytes;
@@ -1118,8 +1088,6 @@ pub fn emulate_mnf_write_fast_path<T: EmulatorSupport>(
     }
     let instruction_bytes = &bytes[..valid_bytes];
     let bit = x86emu::fast_path::emulate_fast_path_set_bit(instruction_bytes, &mut cpu);
-    support.flush().map_err(|err| {
-        VpHaltReason::EmulationFailure(EmulationError::<T::Error>::CacheFlushFailed(err).into())
-    })?;
-    Ok(bit)
+    support.flush();
+    bit
 }

--- a/vmm_core/virt_support_x86emu/tests/tests/checkvtlaccess.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/checkvtlaccess.rs
@@ -26,8 +26,6 @@ struct MockSupport {
 }
 
 impl EmulatorSupport for MockSupport {
-    type Error = std::convert::Infallible;
-
     fn vp_index(&self) -> VpIndex {
         VpIndex::BSP
     }
@@ -68,12 +66,10 @@ impl EmulatorSupport for MockSupport {
     fn xmm(&mut self, _reg: usize) -> u128 {
         todo!()
     }
-    fn set_xmm(&mut self, _reg: usize, _v: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, _reg: usize, _v: u128) {
         todo!()
     }
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    fn flush(&mut self) {}
 
     fn instruction_bytes(&self) -> &[u8] {
         &self.instruction_bytes
@@ -83,7 +79,7 @@ impl EmulatorSupport for MockSupport {
         &mut self,
         _gpa: u64,
         mode: TranslateMode,
-    ) -> Result<(), EmuCheckVtlAccessError<Self::Error>> {
+    ) -> Result<(), EmuCheckVtlAccessError> {
         if let Some(vtl) = self.fail_vtl_access {
             let flags = match mode {
                 TranslateMode::Read => hvdef::HvMapGpaFlags::new().with_readable(true),
@@ -106,11 +102,11 @@ impl EmulatorSupport for MockSupport {
         &mut self,
         gva: u64,
         _mode: TranslateMode,
-    ) -> Result<Result<EmuTranslateResult, EmuTranslateError>, Self::Error> {
-        Ok(Ok(EmuTranslateResult {
+    ) -> Result<EmuTranslateResult, EmuTranslateError> {
+        Ok(EmuTranslateResult {
             gpa: gva,
             overlay_page: None,
-        }))
+        })
     }
 
     fn physical_address(&self) -> Option<u64> {

--- a/vmm_core/virt_support_x86emu/tests/tests/emulate.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/emulate.rs
@@ -22,8 +22,6 @@ struct MockSupport {
 }
 
 impl EmulatorSupport for MockSupport {
-    type Error = std::convert::Infallible;
-
     fn vp_index(&self) -> VpIndex {
         VpIndex::BSP
     }
@@ -64,12 +62,10 @@ impl EmulatorSupport for MockSupport {
     fn xmm(&mut self, _reg: usize) -> u128 {
         todo!()
     }
-    fn set_xmm(&mut self, _reg: usize, _v: u128) -> Result<(), Self::Error> {
+    fn set_xmm(&mut self, _reg: usize, _v: u128) {
         todo!()
     }
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    fn flush(&mut self) {}
 
     fn instruction_bytes(&self) -> &[u8] {
         &self.instruction_bytes
@@ -79,7 +75,7 @@ impl EmulatorSupport for MockSupport {
         &mut self,
         _gpa: u64,
         _mode: virt_support_x86emu::emulate::TranslateMode,
-    ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError<Self::Error>> {
+    ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError> {
         Ok(())
     }
 
@@ -87,11 +83,11 @@ impl EmulatorSupport for MockSupport {
         &mut self,
         gva: u64,
         _mode: virt_support_x86emu::emulate::TranslateMode,
-    ) -> Result<Result<EmuTranslateResult, EmuTranslateError>, Self::Error> {
-        Ok(Ok(EmuTranslateResult {
+    ) -> Result<EmuTranslateResult, EmuTranslateError> {
+        Ok(EmuTranslateResult {
             gpa: gva,
             overlay_page: None,
-        }))
+        })
     }
 
     fn physical_address(&self) -> Option<u64> {

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -693,7 +693,6 @@ impl<T: CpuIo> hv1_hypercall::ModifySparseGpaPageHostVisibility for WhpHypercall
 mod x86 {
     use super::WhpHypercallExit;
     use crate::WhpProcessor;
-    use crate::WhpRunVpError;
     use crate::regs;
     use crate::vtl2;
     use arrayvec::ArrayVec;
@@ -819,7 +818,7 @@ mod x86 {
             bus: &'a T,
             info: &whp::abi::WHV_HYPERCALL_CONTEXT,
             exit_context: &'a whp::abi::WHV_VP_EXIT_CONTEXT,
-        ) -> Result<(), WhpRunVpError> {
+        ) {
             let vpref = vp.vp;
 
             let is_64bit =
@@ -842,7 +841,7 @@ mod x86 {
             this.flush()
         }
 
-        fn flush(&mut self) -> Result<(), WhpRunVpError> {
+        fn flush(&mut self) {
             let registers = &mut self.registers;
             let mut pairs = (
                 ArrayVec::<_, 14>::new(),
@@ -878,10 +877,7 @@ mod x86 {
 
             let (names, values) = &pairs;
             if !names.is_empty() {
-                self.vp
-                    .current_whp()
-                    .set_registers(names, values)
-                    .map_err(WhpRunVpError::Event)?;
+                self.vp.current_whp().set_registers(names, values).unwrap();
 
                 registers.gp_dirty = false;
                 registers.rip_dirty = false;
@@ -900,12 +896,10 @@ mod x86 {
                 self.vp
                     .current_whp()
                     .set_register(whp::Register128::PendingEvent, exception_event.into())
-                    .map_err(WhpRunVpError::Event)?;
+                    .unwrap();
 
                 self.registers.invalid_opcode = false;
             }
-
-            Ok(())
         }
     }
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -70,7 +70,6 @@ use vmcore::reference_time::ReferenceTimeResult;
 use vmcore::reference_time::ReferenceTimeSource;
 use vmcore::vmtime::VmTimeAccess;
 use vmcore::vmtime::VmTimeSource;
-use vp::WhpRunVpError;
 use vp_state::WhpVpStateAccess;
 use x86defs::cpuid::Vendor;
 
@@ -685,6 +684,7 @@ struct WhpVpRef<'a> {
     index: VpIndex,
 }
 
+// TODO: Chunk this up into smaller types.
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("whp error, failed to {operation}")]
@@ -693,8 +693,6 @@ pub enum Error {
         #[source]
         source: whp::WHvError,
     },
-    #[error("vtl2 memory process creation")]
-    Vtl2MemoryProcess(#[source] std::io::Error),
     #[error("guest debugging not supported")]
     GuestDebuggingNotSupported,
     #[error(transparent)]
@@ -1491,8 +1489,6 @@ impl Drop for WhpProcessor<'_> {
 }
 
 impl<'p> virt::Processor for WhpProcessor<'p> {
-    type Error = Error;
-    type RunVpError = WhpRunVpError;
     type StateAccess<'a>
         = WhpVpStateAccess<'a, 'p>
     where
@@ -1502,7 +1498,7 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
         &mut self,
         _vtl: Vtl,
         _state: Option<&virt::x86::DebugState>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <WhpVpStateAccess<'_, 'p> as virt::vp::AccessVpState>::Error> {
         Err(Error::GuestDebuggingNotSupported)
     }
 
@@ -1516,17 +1512,16 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
         &mut self,
         stop: StopVp<'_>,
         dev: &impl CpuIo,
-    ) -> Result<Infallible, VpHaltReason<WhpRunVpError>> {
+    ) -> Result<Infallible, VpHaltReason> {
         self.run_vp(stop, dev).await
     }
 
-    fn flush_async_requests(&mut self) -> Result<(), Self::RunVpError> {
+    fn flush_async_requests(&mut self) {
         // TODO: flush more (e.g. HvStartVp context)
-        self.flush_apic(Vtl::Vtl0)?;
+        self.flush_apic(Vtl::Vtl0);
         if self.state.vtls.vtl2.is_some() {
-            self.flush_apic(Vtl::Vtl2)?;
+            self.flush_apic(Vtl::Vtl2);
         }
-        Ok(())
     }
 
     fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -702,9 +702,9 @@ pub enum Error {
     #[error("failed to create virtual device")]
     NewDevice(#[source] virt::x86::apic_software_device::DeviceIdInUse),
     #[error("resetting memory mappings failed")]
-    ResetMemoryMapping(#[source] virt::Error),
+    ResetMemoryMapping(#[source] anyhow::Error),
     #[error("accepting pages failed")]
-    AcceptPages(#[source] virt::Error),
+    AcceptPages(#[source] anyhow::Error),
     #[error("invalid apic base")]
     InvalidApicBase(#[source] virt_support_apic::InvalidApicBase),
 }

--- a/vmm_core/virt_whp/src/memory.rs
+++ b/vmm_core/virt_whp/src/memory.rs
@@ -35,9 +35,9 @@ pub trait SimpleMemoryMap: Send + Sync {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error>;
+    ) -> anyhow::Result<()>;
 
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), virt::Error>;
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()>;
 }
 
 impl SimpleMemoryMap for whp::Partition {
@@ -49,7 +49,7 @@ impl SimpleMemoryMap for whp::Partition {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         tracing::debug!(addr, size, ?data, writable, exec, "map range");
         let mut flags = whp::abi::WHvMapGpaRangeFlagRead;
         if writable {
@@ -66,7 +66,7 @@ impl SimpleMemoryMap for whp::Partition {
         }
     }
 
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), virt::Error> {
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
         tracing::debug!(addr, size, "unmap range");
         whp::Partition::unmap_range(self, addr, size).context("whp unmap_range failed")
     }
@@ -88,7 +88,7 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error>;
+    ) -> anyhow::Result<()>;
 
     /// Unmap a given range from the partition.
     ///
@@ -100,7 +100,7 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
         partition: &dyn SimpleMemoryMap,
         addr: u64,
         size: u64,
-    ) -> Result<(), virt::Error>;
+    ) -> anyhow::Result<()>;
 
     /// If overlays are supported in this partition mapper or not.
     fn overlays_supported(&self) -> bool;
@@ -134,7 +134,7 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
 
     /// Map all deferred ranges and put the mapper into a mapped state, where
     /// future map calls are no longer deferred.
-    fn map_deferred(&self, partition: &dyn SimpleMemoryMap) -> Result<(), virt::Error>;
+    fn map_deferred(&self, partition: &dyn SimpleMemoryMap) -> anyhow::Result<()>;
 
     /// Apply the specified VTL protection to the specified `addr`, `size`.
     ///
@@ -145,14 +145,14 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
         addr: u64,
         size: u64,
         access: VtlAccess,
-    ) -> Result<(), virt::Error>;
+    ) -> anyhow::Result<()>;
 
     /// Return this partition to the reset state. If this partition was
     /// previously in a deferred mapping state at start, each range will become
     /// unmapped and deferred until mapped again, unless previously allowed.
     ///
     /// Additionally, VTL protections are removed.
-    fn reset_mappings(&self, partition: &dyn SimpleMemoryMap) -> Result<(), virt::Error>;
+    fn reset_mappings(&self, partition: &dyn SimpleMemoryMap) -> anyhow::Result<()>;
 
     /// If page acceptance and visibility is supported by this mapper.
     #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
@@ -176,7 +176,7 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
         partition: &dyn SimpleMemoryMap,
         range: &MemoryRange,
         visibility: PageVisibility,
-    ) -> Result<(), virt::Error>;
+    ) -> anyhow::Result<()>;
 
     /// Modify the visibility of an accepted range.
     ///
@@ -187,7 +187,7 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
         partition: &dyn SimpleMemoryMap,
         range: &MemoryRange,
         visibility: PageVisibility,
-    ) -> Result<(), virt::Error>;
+    ) -> anyhow::Result<()>;
 }
 
 /// Memory mapper implementation that does not support VTLs, but does support
@@ -219,7 +219,7 @@ impl MemoryMapper for WhpMemoryMapper {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         if let Some(overlays) = self.overlays.as_ref() {
             if process.is_some() {
                 todo!();
@@ -245,7 +245,7 @@ impl MemoryMapper for WhpMemoryMapper {
         partition: &dyn SimpleMemoryMap,
         addr: u64,
         size: u64,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         if let Some(overlays) = self.overlays.as_ref() {
             overlays.lock().unmap_range(partition, addr, size);
             Ok(())
@@ -295,7 +295,7 @@ impl MemoryMapper for WhpMemoryMapper {
         false
     }
 
-    fn map_deferred(&self, _partition: &dyn SimpleMemoryMap) -> Result<(), virt::Error> {
+    fn map_deferred(&self, _partition: &dyn SimpleMemoryMap) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -305,11 +305,11 @@ impl MemoryMapper for WhpMemoryMapper {
         _addr: u64,
         _size: u64,
         _access: VtlAccess,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         unimplemented!()
     }
 
-    fn reset_mappings(&self, _partition: &dyn SimpleMemoryMap) -> Result<(), virt::Error> {
+    fn reset_mappings(&self, _partition: &dyn SimpleMemoryMap) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -326,7 +326,7 @@ impl MemoryMapper for WhpMemoryMapper {
         _partition: &dyn SimpleMemoryMap,
         _range: &MemoryRange,
         _visibility: PageVisibility,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         unimplemented!()
     }
 
@@ -335,7 +335,7 @@ impl MemoryMapper for WhpMemoryMapper {
         _partition: &dyn SimpleMemoryMap,
         _range: &MemoryRange,
         _visibility: PageVisibility,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         unimplemented!()
     }
 }
@@ -381,7 +381,7 @@ impl VtlPartition {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         let range = MemoryRange::new(addr..addr + size as u64);
         let mut ranges = self.ranges.write();
         assert!(
@@ -405,11 +405,11 @@ impl VtlPartition {
         Ok(())
     }
 
-    pub fn map_deferred(&self) -> Result<(), virt::Error> {
+    pub fn map_deferred(&self) -> anyhow::Result<()> {
         self.mapper.map_deferred(&self.whp)
     }
 
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), virt::Error> {
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
         let range = MemoryRange::new(addr..addr + size);
         let mut ranges = self.ranges.write();
 
@@ -426,12 +426,12 @@ impl VtlPartition {
         addr: u64,
         size: u64,
         access: VtlAccess,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         self.mapper
             .apply_vtl_protection(&self.whp, addr, size, access)
     }
 
-    pub fn reset_mappings(&self) -> Result<(), virt::Error> {
+    pub fn reset_mappings(&self) -> anyhow::Result<()> {
         self.mapper.reset_mappings(&self.whp)
     }
 
@@ -439,7 +439,7 @@ impl VtlPartition {
         &self,
         range: &MemoryRange,
         visibility: PageVisibility,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         self.mapper.accept_range(&self.whp, range, visibility)
     }
 
@@ -451,7 +451,7 @@ impl VtlPartition {
         &self,
         range: &MemoryRange,
         visibility: PageVisibility,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         self.mapper.modify_visibility(&self.whp, range, visibility)
     }
 }
@@ -463,7 +463,7 @@ impl virt::PartitionMemoryMapper for WhpPartition {
 }
 
 impl virt::PartitionMemoryMap for WhpPartitionAndVtl {
-    fn unmap_range(&self, addr: u64, size: u64) -> Result<(), virt::Error> {
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
         self.vtlp().unmap_range(addr, size)
     }
 
@@ -474,7 +474,7 @@ impl virt::PartitionMemoryMap for WhpPartitionAndVtl {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         // SAFETY: guaranteed by caller
         unsafe {
             self.vtlp()
@@ -490,7 +490,7 @@ impl virt::PartitionMemoryMap for WhpPartitionAndVtl {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         // SAFETY: guaranteed by caller
         unsafe {
             self.vtlp()
@@ -498,7 +498,7 @@ impl virt::PartitionMemoryMap for WhpPartitionAndVtl {
         }
     }
 
-    fn prefetch_range(&self, addr: u64, size: u64) -> Result<(), virt::Error> {
+    fn prefetch_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
         self.vtlp().whp.populate_ranges(
             &[whp::abi::WHV_MEMORY_RANGE_ENTRY {
                 GuestAddress: addr,
@@ -510,7 +510,7 @@ impl virt::PartitionMemoryMap for WhpPartitionAndVtl {
         Ok(())
     }
 
-    fn pin_range(&self, addr: u64, size: u64) -> Result<(), virt::Error> {
+    fn pin_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
         self.vtlp()
             .whp
             .pin_ranges(&[whp::abi::WHV_MEMORY_RANGE_ENTRY {

--- a/vmm_core/virt_whp/src/memory/vtl2_mapper.rs
+++ b/vmm_core/virt_whp/src/memory/vtl2_mapper.rs
@@ -133,7 +133,7 @@ impl VtlMemoryMapper {
         &self,
         partition: &dyn SimpleMemoryMap,
         mapping: &DeferredMapping,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         let DeferredMapping {
             process,
             data,
@@ -170,7 +170,7 @@ fn map_subset(
     writable: bool,
     exec: bool,
     allowed_ranges: impl Iterator<Item = RangeInclusive<u64>>,
-) -> Result<RangeMap<u64, ()>, virt::Error> {
+) -> anyhow::Result<RangeMap<u64, ()>> {
     let total_range_inclusive = addr..=(addr + size as u64 - 1);
     let mut unmapped_ranges: RangeMap<u64, ()> = RangeMap::new();
     unmapped_ranges.insert(total_range_inclusive, ());
@@ -227,7 +227,7 @@ impl MemoryMapper for VtlMemoryMapper {
         addr: u64,
         writable: bool,
         exec: bool,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         let mut state = self.mapping_state.lock();
         let total_range_inclusive = addr..=(addr + size as u64 - 1);
 
@@ -396,7 +396,7 @@ impl MemoryMapper for VtlMemoryMapper {
         partition: &dyn SimpleMemoryMap,
         addr: u64,
         size: u64,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         let mut state = self.mapping_state.lock();
         let mapped_ranges = match state.deref_mut() {
             MappingState::Deferred { .. } => {
@@ -511,7 +511,7 @@ impl MemoryMapper for VtlMemoryMapper {
         }
     }
 
-    fn map_deferred(&self, partition: &dyn SimpleMemoryMap) -> Result<(), virt::Error> {
+    fn map_deferred(&self, partition: &dyn SimpleMemoryMap) -> anyhow::Result<()> {
         let mut state = self.mapping_state.lock();
         let prev_state = std::mem::replace(state.deref_mut(), MappingState::StateChanging);
 
@@ -562,7 +562,7 @@ impl MemoryMapper for VtlMemoryMapper {
         addr: u64,
         size: u64,
         access: VtlAccess,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         let mut state = self.mapping_state.lock();
 
         let mapped_ranges = match state.deref_mut() {
@@ -668,7 +668,7 @@ impl MemoryMapper for VtlMemoryMapper {
         Ok(())
     }
 
-    fn reset_mappings(&self, partition: &dyn SimpleMemoryMap) -> Result<(), virt::Error> {
+    fn reset_mappings(&self, partition: &dyn SimpleMemoryMap) -> anyhow::Result<()> {
         let mut state = self.mapping_state.lock();
         let prev_state = std::mem::replace(state.deref_mut(), MappingState::StateChanging);
 
@@ -803,7 +803,7 @@ impl MemoryMapper for VtlMemoryMapper {
         partition: &dyn SimpleMemoryMap,
         range: &MemoryRange,
         visibility: PageVisibility,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         match self.mapping_state.lock().deref_mut() {
             MappingState::Deferred { .. } | MappingState::Mapped { .. } => unimplemented!(),
             MappingState::StateChanging => unreachable!(),
@@ -889,7 +889,7 @@ impl MemoryMapper for VtlMemoryMapper {
         _partition: &dyn SimpleMemoryMap,
         range: &MemoryRange,
         visibility: PageVisibility,
-    ) -> Result<(), virt::Error> {
+    ) -> anyhow::Result<()> {
         match self.mapping_state.lock().deref_mut() {
             MappingState::Deferred { .. } | MappingState::Mapped { .. } => unimplemented!(),
             MappingState::StateChanging => unreachable!(),

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -19,37 +19,12 @@ use std::future::poll_fn;
 use std::mem::offset_of;
 use std::sync::atomic::Ordering;
 use std::task::Poll;
-use thiserror::Error;
 use tracing_helpers::ErrorValueExt;
 use virt::StopVp;
 use virt::VpHaltReason;
 use virt::io::CpuIo;
 use virt::vp::AccessVpState;
 use zerocopy::IntoBytes;
-
-#[derive(Debug, Error)]
-pub enum WhpRunVpError {
-    #[error("failed to run")]
-    Run(#[source] whp::WHvError),
-    #[error("failed to access state for emulation")]
-    EmulationState(#[source] whp::WHvError),
-    #[error("failed to set VP activity")]
-    Activity(#[source] whp::WHvError),
-    #[error("failed to set pending event")]
-    Event(#[source] whp::WHvError),
-    #[error("failed to translate GVA")]
-    TranslateGva(#[source] whp::WHvError),
-    #[error("failed to set pending interruption")]
-    Interruption(#[source] whp::WHvError),
-    #[error("vp state is invalid")]
-    InvalidVpState,
-    #[error("accessing deferred ram by VTL 2")]
-    DeferredRamAccess,
-    #[error("state access error")]
-    State(#[source] crate::Error),
-    #[error("exit reason {0:?} not supported")]
-    UnknownExit(HvMessageType),
-}
 
 #[derive(Debug, Default, Inspect)]
 pub(crate) struct ExitStats {
@@ -250,9 +225,8 @@ impl<'a> WhpProcessor<'a> {
         &mut self,
         stop: StopVp<'_>,
         dev: &impl CpuIo,
-    ) -> Result<Infallible, VpHaltReason<WhpRunVpError>> {
-        self.reset_if_requested()
-            .map_err(VpHaltReason::Hypervisor)?;
+    ) -> Result<Infallible, VpHaltReason> {
+        self.reset_if_requested();
 
         tracing::trace!(vtl = ?self.state.active_vtl, "current vtl");
         let mut last_waker = None;
@@ -288,9 +262,7 @@ impl<'a> WhpProcessor<'a> {
                         } else {
                             self.current_whp()
                                 .set_register(whp::Register64::InternalActivityState, 0)
-                                .map_err(|err| {
-                                    VpHaltReason::Hypervisor(WhpRunVpError::Activity(err))
-                                })?;
+                                .unwrap();
                         }
                     }
                 }
@@ -367,7 +339,7 @@ impl<'a> WhpProcessor<'a> {
                 }
 
                 // Process the user-mode APIC, waiting for interrupts if halted.
-                let ready = self.process_apic(dev).map_err(VpHaltReason::Hypervisor)?;
+                let ready = self.process_apic(dev);
 
                 // Arm the timer.
                 if self.state.vmtime.poll_timeout(cx).is_ready() {
@@ -378,7 +350,7 @@ impl<'a> WhpProcessor<'a> {
                 }
 
                 if ready {
-                    <Result<_, VpHaltReason<_>>>::Ok(()).into()
+                    <Result<_, VpHaltReason>>::Ok(()).into()
                 } else {
                     Poll::Pending
                 }
@@ -407,9 +379,7 @@ impl<'a> WhpProcessor<'a> {
             let lazy_eoi = self.sync_lazy_eoi();
 
             let mut runner = self.current_whp().runner();
-            let exit = runner
-                .run()
-                .map_err(|err| VpHaltReason::Hypervisor(WhpRunVpError::Run(err)))?;
+            let exit = runner.run().unwrap();
 
             // Clear lazy EOI before processing the exit.
             if lazy_eoi {
@@ -422,7 +392,7 @@ impl<'a> WhpProcessor<'a> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn handle_triple_fault(&mut self) -> Result<(), VpHaltReason<WhpRunVpError>> {
+    fn handle_triple_fault(&mut self) -> Result<(), VpHaltReason> {
         let reinject_into_vtl2 = self
             .vp
             .partition
@@ -485,7 +455,7 @@ impl<'a> WhpProcessor<'a> {
     }
 
     /// Flushes pending register changes.
-    pub(crate) fn reset_if_requested(&mut self) -> Result<(), WhpRunVpError> {
+    pub(crate) fn reset_if_requested(&mut self) {
         if self.inner.reset_next.swap(false, Ordering::SeqCst) {
             self.state.reset(false, self.inner.vp_info.base.is_bsp());
         }
@@ -503,8 +473,6 @@ impl<'a> WhpProcessor<'a> {
             self.state.finish_reset_vtl2 = false;
             self.finish_reset(Vtl::Vtl2);
         }
-
-        Ok(())
     }
 
     fn finish_reset(&mut self, vtl: Vtl) {
@@ -562,7 +530,6 @@ impl<'a> WhpProcessor<'a> {
 
 #[cfg(guest_arch = "x86_64")]
 mod x86 {
-    use super::WhpRunVpError;
     use crate::Hv1State;
     use crate::WhpProcessor;
     use crate::emu;
@@ -576,6 +543,7 @@ mod x86 {
     use hvdef::HvX64VpExecutionState;
     use hvdef::Vtl;
     use hvdef::hypercall::InitialVpContextX64;
+    use thiserror::Error;
     use virt::LateMapVtl0MemoryPolicy;
     use virt::VpHaltReason;
     use virt::io::CpuIo;
@@ -591,6 +559,14 @@ mod x86 {
     use zerocopy::FromZeros;
     use zerocopy::IntoBytes;
 
+    #[derive(Debug, Error)]
+    #[error("vp state is invalid")]
+    struct InvalidVpState;
+
+    #[derive(Debug, Error)]
+    #[error("accessing deferred ram by VTL 2")]
+    struct DeferredRamAccess;
+
     // HACK: on certain machines, Windows booting from the PCAT BIOS spams these
     // MSRs during boot.
     //
@@ -603,7 +579,7 @@ mod x86 {
             &mut self,
             dev: &impl CpuIo,
             exit: whp::Exit<'_>,
-        ) -> Result<(), VpHaltReason<WhpRunVpError>> {
+        ) -> Result<(), VpHaltReason> {
             use whp::ExitReason;
 
             let stat = match exit.reason {
@@ -612,7 +588,7 @@ mod x86 {
                     &mut self.state.exits.io
                 }
                 ExitReason::Cpuid(info) => {
-                    self.handle_cpuid(info, exit)?;
+                    self.handle_cpuid(info, exit);
                     &mut self.state.exits.cpuid
                 }
                 ExitReason::ApicEoi(info) => {
@@ -620,17 +596,15 @@ mod x86 {
                     &mut self.state.exits.apic_eoi
                 }
                 ExitReason::MsrAccess(info) => {
-                    self.handle_msr(dev, info, exit)
-                        .map_err(VpHaltReason::Hypervisor)?;
+                    self.handle_msr(dev, info, exit);
                     &mut self.state.exits.msr
                 }
                 ExitReason::InterruptWindow(info) => {
-                    self.handle_interrupt_window(info)?;
+                    self.handle_interrupt_window(info);
                     &mut self.state.exits.interrupt_window
                 }
                 ExitReason::Hypercall(info) => {
-                    crate::hypercalls::WhpHypercallExit::handle(self, dev, info, exit.vp_context)
-                        .map_err(VpHaltReason::Hypervisor)?;
+                    crate::hypercalls::WhpHypercallExit::handle(self, dev, info, exit.vp_context);
                     &mut self.state.exits.hypercall
                 }
                 ExitReason::MemoryAccess(access) => {
@@ -647,15 +621,14 @@ mod x86 {
                     &mut self.state.exits.other
                 }
                 ExitReason::InvalidVpRegisterValue => {
-                    return Err(VpHaltReason::InvalidVmState(WhpRunVpError::InvalidVpState));
+                    return Err(VpHaltReason::InvalidVmState(InvalidVpState.into()));
                 }
                 ExitReason::Halt => {
                     self.handle_halt(exit);
                     &mut self.state.exits.halt
                 }
                 ExitReason::Exception(info) => {
-                    self.handle_exception(dev, info, exit)
-                        .map_err(VpHaltReason::Hypervisor)?;
+                    self.handle_exception(dev, info, exit);
                     &mut self.state.exits.exception
                 }
                 _ => {
@@ -744,7 +717,7 @@ mod x86 {
             dev: &impl CpuIo,
             access: &whp::abi::WHV_MEMORY_ACCESS_CONTEXT,
             exit: whp::Exit<'_>,
-        ) -> Result<(), VpHaltReason<WhpRunVpError>> {
+        ) -> Result<(), VpHaltReason> {
             let backing_type = self
                 .vp
                 .partition
@@ -875,9 +848,7 @@ mod x86 {
                         .vtl0_deferred_policy
                     {
                         LateMapVtl0MemoryPolicy::Halt => {
-                            return Err(VpHaltReason::InvalidVmState(
-                                WhpRunVpError::DeferredRamAccess,
-                            ));
+                            return Err(VpHaltReason::InvalidVmState(DeferredRamAccess.into()));
                         }
                         LateMapVtl0MemoryPolicy::Log => {}
                         LateMapVtl0MemoryPolicy::InjectException => {
@@ -890,9 +861,7 @@ mod x86 {
 
                             self.current_whp()
                                 .set_register(whp::Register128::PendingEvent, event.into())
-                                .map_err(|err| {
-                                    VpHaltReason::Hypervisor(WhpRunVpError::Event(err))
-                                })?;
+                                .unwrap();
 
                             return Ok(());
                         }
@@ -914,7 +883,7 @@ mod x86 {
                         dev,
                         interruption_pending,
                         gva_valid,
-                    )? {
+                    ) {
                         if let Some(connection_id) = self.vp.partition.monitor_page.write_bit(bit) {
                             self.signal_mnf(dev, connection_id);
                         }
@@ -941,7 +910,7 @@ mod x86 {
         fn handle_interrupt_window(
             &mut self,
             info: &whp::abi::WHV_X64_INTERRUPTION_DELIVERABLE_CONTEXT,
-        ) -> Result<(), VpHaltReason<WhpRunVpError>> {
+        ) {
             if self.state.enabled_vtls.is_set(Vtl::Vtl2) && self.state.active_vtl == Vtl::Vtl0 {
                 let notifications = &mut self.state.vtl2_deliverability_notifications;
                 let inject = if notifications.interrupt_notification()
@@ -974,7 +943,7 @@ mod x86 {
                     );
 
                     // If VTL2 wanted this type of notification, then the host did not.
-                    return Ok(());
+                    return;
                 }
             }
 
@@ -983,7 +952,6 @@ mod x86 {
             notifications.set_interrupt_notification(false);
             notifications.set_nmi_notification(false);
             notifications.set_interrupt_priority(0);
-            Ok(())
         }
 
         fn handle_apic_eoi(&mut self, info: &whp::abi::WHV_X64_APIC_EOI_CONTEXT, dev: &impl CpuIo) {
@@ -1009,7 +977,7 @@ mod x86 {
             dev: &impl CpuIo,
             info: &whp::abi::WHV_X64_IO_PORT_ACCESS_CONTEXT,
             exit: whp::Exit<'_>,
-        ) -> Result<(), VpHaltReason<WhpRunVpError>> {
+        ) -> Result<(), VpHaltReason> {
             // Before handling, check if we should dispatch the exit to VTL2.
             if let Some(intercept_state) = self.intercept_state() {
                 if self.state.active_vtl == Vtl::Vtl0
@@ -1076,7 +1044,7 @@ mod x86 {
                     self.current_whp(),
                     [(whp::Register64::Rax, rax), (whp::Register64::Rip, rip),]
                 )
-                .map_err(|err| VpHaltReason::Hypervisor(WhpRunVpError::EmulationState(err)))?;
+                .unwrap();
             }
             Ok(())
         }
@@ -1085,7 +1053,7 @@ mod x86 {
             &mut self,
             info: &whp::abi::WHV_X64_CPUID_ACCESS_CONTEXT,
             exit: whp::Exit<'_>,
-        ) -> Result<(), VpHaltReason<WhpRunVpError>> {
+        ) {
             let function = info.Rax as u32;
             let index = info.Rcx as u32;
             let default = [
@@ -1182,7 +1150,7 @@ mod x86 {
                         HvMessageType::HvMessageTypeX64CpuidIntercept,
                         message.as_bytes(),
                     );
-                    return Ok(());
+                    return;
                 }
             }
 
@@ -1197,9 +1165,7 @@ mod x86 {
                     (whp::Register64::Rip, rip),
                 ]
             )
-            .map_err(|err| VpHaltReason::Hypervisor(WhpRunVpError::EmulationState(err)))?;
-
-            Ok(())
+            .unwrap();
         }
 
         fn send_unknown_msrs_to_vtl2(&self) -> bool {
@@ -1235,11 +1201,11 @@ mod x86 {
             dev: &impl CpuIo,
             info: &whp::abi::WHV_X64_MSR_ACCESS_CONTEXT,
             exit: whp::Exit<'_>,
-        ) -> Result<(), WhpRunVpError> {
+        ) {
             let handled = if info.AccessInfo.IsWrite() {
-                self.msr_write(dev, exit, info.MsrNumber, info.Rax, info.Rdx)?
+                self.msr_write(dev, exit, info.MsrNumber, info.Rax, info.Rdx)
             } else {
-                self.msr_read(dev, exit, info.MsrNumber)?
+                self.msr_read(dev, exit, info.MsrNumber)
             };
             if !handled {
                 // inject a GPF
@@ -1251,9 +1217,8 @@ mod x86 {
 
                 self.current_whp()
                     .set_register(whp::Register128::PendingEvent, event.into())
-                    .map_err(WhpRunVpError::Event)?;
+                    .unwrap();
             }
-            Ok(())
         }
 
         fn msr_write(
@@ -1263,7 +1228,7 @@ mod x86 {
             msr: u32,
             rax: u64,
             rdx: u64,
-        ) -> Result<bool, WhpRunVpError> {
+        ) -> bool {
             let v = rax & 0xffffffff | rdx << 32;
             let r = self
                 .apic_msr_write(dev, msr, v)
@@ -1361,7 +1326,7 @@ mod x86 {
                         rdx,
                         rax,
                     );
-                    return Ok(true);
+                    return true;
                 }
             }
 
@@ -1384,18 +1349,13 @@ mod x86 {
                 let rip = exit.vp_context.Rip.wrapping_add(2);
                 self.current_whp()
                     .set_register(whp::Register64::Rip, rip)
-                    .map_err(WhpRunVpError::EmulationState)?;
+                    .unwrap();
             }
 
-            Ok(!gpf)
+            !gpf
         }
 
-        fn msr_read(
-            &mut self,
-            dev: &impl CpuIo,
-            exit: whp::Exit<'_>,
-            msr: u32,
-        ) -> Result<bool, WhpRunVpError> {
+        fn msr_read(&mut self, dev: &impl CpuIo, exit: whp::Exit<'_>, msr: u32) -> bool {
             let r = self
                 .apic_msr_read(dev, msr)
                 .or_else_if_unknown(|| match msr {
@@ -1455,7 +1415,7 @@ mod x86 {
                         0,
                         0,
                     );
-                    return Ok(true);
+                    return true;
                 }
             }
 
@@ -1480,10 +1440,10 @@ mod x86 {
                         (whp::Register64::Rip, rip),
                     ]
                 )
-                .map_err(WhpRunVpError::EmulationState)?;
+                .unwrap();
             }
 
-            Ok(v.is_some())
+            v.is_some()
         }
 
         /// Handles exception exits, which are only used to handle emulating
@@ -1493,7 +1453,7 @@ mod x86 {
             dev: &impl CpuIo,
             info: &whp::abi::WHV_VP_EXCEPTION_CONTEXT,
             exit: whp::Exit<'_>,
-        ) -> Result<(), WhpRunVpError> {
+        ) {
             if !info.ExceptionInfo.SoftwareException()
                 && info.ExceptionType.0 == x86defs::Exception::GENERAL_PROTECTION_FAULT.0
             {
@@ -1508,13 +1468,13 @@ mod x86 {
                                 whp::Register64::Rdx
                             ]
                         )
-                        .map_err(WhpRunVpError::EmulationState)?;
+                        .unwrap();
 
                         let mut header = self.new_intercept_header(2, HvInterceptAccessType::WRITE);
                         header.instruction_length_and_cr8 = 2;
 
-                        if self.msr_write(dev, exit, rcx as u32, rax, rdx)? {
-                            return Ok(());
+                        if self.msr_write(dev, exit, rcx as u32, rax, rdx) {
+                            return;
                         }
                     }
                     [0x0f, 0x32, ..] => {
@@ -1522,13 +1482,13 @@ mod x86 {
                         let rcx = self
                             .current_whp()
                             .get_register(whp::Register64::Rcx)
-                            .map_err(WhpRunVpError::EmulationState)?;
+                            .unwrap();
 
                         let mut header = self.new_intercept_header(2, HvInterceptAccessType::READ);
                         header.instruction_length_and_cr8 = 2;
 
-                        if self.msr_read(dev, exit, rcx as u32)? {
-                            return Ok(());
+                        if self.msr_read(dev, exit, rcx as u32) {
+                            return;
                         }
                     }
                     _ => {}
@@ -1551,9 +1511,7 @@ mod x86 {
 
             self.current_whp()
                 .set_register(whp::Register128::PendingEvent, event)
-                .map_err(WhpRunVpError::Event)?;
-
-            Ok(())
+                .unwrap();
         }
 
         /// Emulates an instruction due to a memory access exit.
@@ -1562,7 +1520,7 @@ mod x86 {
             access: &WhpVpRefEmulation<'_>,
             dev: &impl CpuIo,
             exit: &whp::Exit<'_>,
-        ) -> Result<(), VpHaltReason<WhpRunVpError>> {
+        ) -> Result<(), VpHaltReason> {
             let vp = self.vp;
             let mut state = emu::WhpEmulationState::new(access, self, exit, dev);
             let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
@@ -1726,7 +1684,6 @@ mod x86 {
 
 #[cfg(guest_arch = "aarch64")]
 mod aarch64 {
-    use super::WhpRunVpError;
     use crate::InitialVpContext;
     use crate::WhpProcessor;
     use aarch64defs::EsrEl2;
@@ -1742,8 +1699,8 @@ mod aarch64 {
     }
 
     impl WhpProcessor<'_> {
-        pub(super) fn process_apic(&mut self, _dev: &impl CpuIo) -> Result<bool, WhpRunVpError> {
-            Ok(true)
+        pub(super) fn process_apic(&mut self, _dev: &impl CpuIo) -> bool {
+            true
         }
 
         pub(super) fn sync_lazy_eoi(&mut self) -> bool {
@@ -1754,11 +1711,9 @@ mod aarch64 {
             unreachable!()
         }
 
-        pub(crate) fn flush_apic(&mut self, _vtl: Vtl) -> Result<(), WhpRunVpError> {
-            Ok(())
-        }
+        pub(crate) fn flush_apic(&mut self, _vtl: Vtl) {}
 
-        fn get_x(&self, n: u8) -> Result<u64, WhpRunVpError> {
+        fn get_x(&self, n: u8) -> u64 {
             let mut value = [Default::default()];
             self.current_whp()
                 .get_registers(
@@ -1767,11 +1722,11 @@ mod aarch64 {
                     )],
                     &mut value,
                 )
-                .map_err(WhpRunVpError::EmulationState)?;
-            Ok(u128::from(value[0].0) as u64)
+                .unwrap();
+            u128::from(value[0].0) as u64
         }
 
-        fn set_x(&self, n: u8, v: u64) -> Result<(), WhpRunVpError> {
+        fn set_x(&self, n: u8, v: u64) {
             let value = [whp::abi::WHV_REGISTER_VALUE(v.into())];
             self.current_whp()
                 .set_registers(
@@ -1780,15 +1735,14 @@ mod aarch64 {
                     )],
                     &value,
                 )
-                .map_err(WhpRunVpError::EmulationState)?;
-            Ok(())
+                .unwrap();
         }
 
         pub(super) async fn handle_exit(
             &mut self,
             dev: &impl CpuIo,
             exit: whp::Exit<'_>,
-        ) -> Result<(), VpHaltReason<WhpRunVpError>> {
+        ) -> Result<(), VpHaltReason> {
             use whp::ExitReason;
 
             let stat = match exit.reason {
@@ -1816,8 +1770,8 @@ mod aarch64 {
                     HvMessageType::HvMessageTypeArm64ResetIntercept => {
                         return Err(self.handle_reset(message_ref(message)));
                     }
-                    reason => {
-                        return Err(VpHaltReason::Hypervisor(WhpRunVpError::UnknownExit(reason)));
+                    _ => {
+                        unreachable!("unsupported exit reason: {:?}", exit);
                     }
                 },
             };
@@ -1836,7 +1790,7 @@ mod aarch64 {
             dev: &impl CpuIo,
             message: &hvdef::HvArm64MemoryInterceptMessage,
             exit: whp::Exit<'_>,
-        ) -> Result<(), VpHaltReason<WhpRunVpError>> {
+        ) -> Result<(), VpHaltReason> {
             let _ = (dev, message, exit);
             let syndrome = EsrEl2::from(message.syndrome);
             tracing::trace!(
@@ -1856,10 +1810,7 @@ mod aarch64 {
                     let sign_extend = iss.sse();
                     let reg = iss.srt();
                     if iss.wnr() {
-                        let data = self
-                            .get_x(reg)
-                            .map_err(VpHaltReason::Hypervisor)?
-                            .to_ne_bytes();
+                        let data = self.get_x(reg).to_ne_bytes();
                         dev.write_mmio(self.vp.index, message.guest_physical_address, &data[..len])
                             .await;
                     } else {
@@ -1878,7 +1829,7 @@ mod aarch64 {
                                 data &= 0xffffffff;
                             }
                         }
-                        self.set_x(reg, data).map_err(VpHaltReason::Hypervisor)?;
+                        self.set_x(reg, data);
                     }
                     let pc = message
                         .header
@@ -1886,9 +1837,7 @@ mod aarch64 {
                         .wrapping_add(if syndrome.il() { 4 } else { 2 });
                     self.current_whp()
                         .set_register(whp::Register64::Pc, pc)
-                        .map_err(|err| {
-                            VpHaltReason::Hypervisor(WhpRunVpError::EmulationState(err))
-                        })?;
+                        .unwrap();
                 }
                 ec => {
                     return Err(VpHaltReason::EmulationFailure(
@@ -1900,10 +1849,7 @@ mod aarch64 {
         }
 
         /// Handle a reset from the hypervisor-handled PSCI call.
-        fn handle_reset(
-            &mut self,
-            info: &hvdef::HvArm64ResetInterceptMessage,
-        ) -> VpHaltReason<WhpRunVpError> {
+        fn handle_reset(&mut self, info: &hvdef::HvArm64ResetInterceptMessage) -> VpHaltReason {
             match info.reset_type {
                 hvdef::HvArm64ResetType::POWER_OFF => VpHaltReason::PowerOff,
                 hvdef::HvArm64ResetType::REBOOT => VpHaltReason::Reset,

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -19,6 +19,7 @@ use std::future::poll_fn;
 use std::mem::offset_of;
 use std::sync::atomic::Ordering;
 use std::task::Poll;
+use thiserror::Error;
 use tracing_helpers::ErrorValueExt;
 use virt::StopVp;
 use virt::VpHaltReason;

--- a/vmm_core/virt_whp/src/vp_state.rs
+++ b/vmm_core/virt_whp/src/vp_state.rs
@@ -20,7 +20,7 @@ pub struct WhpVpStateAccess<'a, 'b> {
 
 impl<'a> WhpProcessor<'a> {
     pub(crate) fn access_state(&mut self, vtl: Vtl) -> WhpVpStateAccess<'_, 'a> {
-        self.reset_if_requested().unwrap();
+        self.reset_if_requested();
         WhpVpStateAccess { run: self, vtl }
     }
 }


### PR DESCRIPTION
This PR does a number of things to significantly clean up error handling through the multiple virt backends:

1. Remove the generic from virt::VpHaltReason, in favor of boxing

This allows us to chunk up our overly large error enums into much smaller structs, as they no longer need to all be under the same type.

2. Remove the vast majority of uses of VpHaltReason::Hypervisor

The reasoning being that if the hypervisor is truly at fault we can not recover and may be in a bad state. Most of these errors have been changed to unwraps, with a few being changed to InvalidVmState, and even fewer left alone.

3. Remove Result returns on functions that never fail

This significantly cleans up a number of trait definitions, and should result in more compact code.

I think more can be done along these lines, but this took me a while as it is so I decided to call it here for now. It's definitely possible we'll want to walk this back in some of these places, very open to feedback.

