### PR TITLE
inspect: Adding Inspect support for the Duration type

### DIFF
--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -1620,7 +1620,7 @@ impl Inspect for std::fs::File {
     }
 }
 
-impl Inspect for std::time::Duration {
+impl Inspect for core::time::Duration {
     fn inspect(&self, req: Request<'_>) {
         req.value(format!("{}.{:09}s", self.as_secs(), self.subsec_nanos()));
     }

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -1620,6 +1620,12 @@ impl Inspect for std::fs::File {
     }
 }
 
+impl Inspect for std::time::Duration {
+    fn inspect(&self, req: Request<'_>) {
+        req.value(format!("{}.{:09}s", self.as_secs(), self.subsec_nanos()));
+    }
+}
+
 /// Wrapper around `T` that implements [`Inspect`] by calling
 /// [`ToString::to_string()`].
 pub struct AsDisplay<T>(pub T);

--- a/vm/devices/storage/disk_delay/src/lib.rs
+++ b/vm/devices/storage/disk_delay/src/lib.rs
@@ -23,7 +23,7 @@ use vmcore::vm_task::VmTaskDriverSource;
 /// A disk with delay on every I/O operation.
 #[derive(Inspect)]
 pub struct DelayDisk {
-    #[inspect(hex, with = "|x| inspect::AsDebug(x.get())")]
+    #[inspect(with = "|x| x.get()")]
     delay: Cell<Duration>,
     inner: Disk,
     driver: VmTaskDriver,

--- a/vm/vmcore/src/vmtime.rs
+++ b/vm/vmcore/src/vmtime.rs
@@ -895,7 +895,6 @@ enum VmTimerPeriodicInner {
     Stopped,
     Running {
         last_timeout: VmTime,
-        #[inspect(debug)]
         period: Duration,
     },
 }


### PR DESCRIPTION
Adds inspect support for the Duration type. Prints out with the format 1234.567800000s (Nanoseconds precision).
Fixes #1784 