### PR TITLE
openvmm/aarch64: query pmu value from platform

### DIFF
--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -33,6 +33,7 @@ use hvlite_defs::config::Hypervisor;
 use hvlite_defs::config::HypervisorConfig;
 use hvlite_defs::config::LoadMode;
 use hvlite_defs::config::MemoryConfig;
+use hvlite_defs::config::PmuGsivConfig;
 use hvlite_defs::config::ProcessorTopologyConfig;
 use hvlite_defs::config::SerialPipes;
 use hvlite_defs::config::VirtioBus;
@@ -384,7 +385,7 @@ struct InitializedVm {
 }
 
 trait BuildTopology<T: ArchTopology + Inspect> {
-    fn to_topology(&self) -> anyhow::Result<ProcessorTopology<T>>;
+    fn to_topology(&self, hypervisor: Hypervisor) -> anyhow::Result<ProcessorTopology<T>>;
 }
 
 trait ExtractTopologyConfig {
@@ -412,7 +413,10 @@ impl ExtractTopologyConfig for ProcessorTopology<X86Topology> {
 }
 
 impl BuildTopology<X86Topology> for ProcessorTopologyConfig {
-    fn to_topology(&self) -> anyhow::Result<ProcessorTopology<X86Topology>> {
+    fn to_topology(
+        &self,
+        _hypervisor: Hypervisor,
+    ) -> anyhow::Result<ProcessorTopology<X86Topology>> {
         let arch = match &self.arch {
             None => Default::default(),
             Some(ArchTopologyConfig::X86(arch)) => arch.clone(),
@@ -451,14 +455,17 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
                     gic_distributor_base: self.gic_distributor_base(),
                     gic_redistributors_base: self.gic_redistributors_base(),
                 }),
-                pmu_gsiv: Some(self.pmu_gsiv()),
+                pmu_gsiv: PmuGsivConfig::Gsiv(self.pmu_gsiv()),
             })),
         }
     }
 }
 
 impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
-    fn to_topology(&self) -> anyhow::Result<ProcessorTopology<Aarch64Topology>> {
+    fn to_topology(
+        &self,
+        hypervisor: Hypervisor,
+    ) -> anyhow::Result<ProcessorTopology<Aarch64Topology>> {
         let arch = match &self.arch {
             None => Default::default(),
             Some(ArchTopologyConfig::Aarch64(arch)) => arch.clone(),
@@ -475,7 +482,10 @@ impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
                 gic_redistributors_base: hvlite_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE,
             }
         };
-        let pmu_gsiv = arch.pmu_gsiv.unwrap_or(0);
+        let pmu_gsiv = match arch.pmu_gsiv {
+            PmuGsivConfig::Gsiv(gsiv) => gsiv,
+            PmuGsivConfig::Platform => platform_gsiv(hypervisor),
+        };
 
         // TODO: When this value is supported on all platforms, we should change
         // the arch config to not be an option. For now, warn since the ARM VBSA
@@ -587,6 +597,24 @@ fn choose_hypervisor() -> anyhow::Result<Hypervisor> {
         }
     }
     anyhow::bail!("no hypervisor available");
+}
+
+fn platform_gsiv(hypervisor: Hypervisor) -> u32 {
+    let gsiv = match hypervisor {
+        #[cfg(all(target_os = "windows", guest_is_native, guest_arch = "aarch64"))]
+        Hypervisor::Whp => virt_whp::WHP_PMU_GSIV,
+        // TODO: hvf supports the PMU interrupt, but enabling it didn't seem to
+        // make it work it a Linux guest. More investigation required.
+        #[cfg(all(target_os = "macos", guest_is_native, guest_arch = "aarch64"))]
+        Hypervisor::Hvf => 0,
+        _ => 0,
+    };
+
+    if gsiv == 0 {
+        tracing::warn!("No platform GSIV available for hypervisor {:?}", hypervisor);
+    }
+
+    gsiv
 }
 
 fn convert_vtl2_config(
@@ -781,7 +809,7 @@ impl InitializedVm {
             None
         };
 
-        let processor_topology = cfg.processor_topology.to_topology()?;
+        let processor_topology = cfg.processor_topology.to_topology(hypervisor_type)?;
 
         let proto = hypervisor
             .new_partition(virt::ProtoPartitionConfig {

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -611,7 +611,7 @@ fn platform_gsiv(hypervisor: Hypervisor) -> u32 {
     };
 
     if gsiv == 0 {
-        tracing::warn!("No platform GSIV available for hypervisor {:?}", hypervisor);
+        tracing::warn!(?hypervisor, "no platform GSIV available for hypervisor");
     }
 
     gsiv

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -601,7 +601,12 @@ fn choose_hypervisor() -> anyhow::Result<Hypervisor> {
 
 fn platform_gsiv(hypervisor: Hypervisor) -> u32 {
     let gsiv = match hypervisor {
-        #[cfg(all(target_os = "windows", guest_is_native, guest_arch = "aarch64"))]
+        #[cfg(all(
+            feature = "virt_whp",
+            target_os = "windows",
+            guest_is_native,
+            guest_arch = "aarch64"
+        ))]
         Hypervisor::Whp => virt_whp::WHP_PMU_GSIV,
         // TODO: hvf supports the PMU interrupt, but enabling it didn't seem to
         // make it work it a Linux guest. More investigation required.

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -203,9 +203,18 @@ pub enum X2ApicConfig {
 }
 
 #[derive(Debug, Protobuf, Default, Clone)]
+pub enum PmuGsivConfig {
+    #[default]
+    /// Use the hypervisor's platform GSIV value for the PMU.
+    Platform,
+    /// Use the specified GSIV value for the PMU.
+    Gsiv(u32),
+}
+
+#[derive(Debug, Protobuf, Default, Clone)]
 pub struct Aarch64TopologyConfig {
     pub gic_config: Option<GicConfig>,
-    pub pmu_gsiv: Option<u32>,
+    pub pmu_gsiv: PmuGsivConfig,
 }
 
 #[derive(Debug, Protobuf, Clone)]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1157,16 +1157,7 @@ fn vm_config_from_command_line(
         hvlite_defs::config::Aarch64TopologyConfig {
             // TODO: allow this to be configured from the command line
             gic_config: None,
-            // TODO: This value is platform specific, and needs to be queried
-            // from each platform. Additionally, enabling it on HVF with the
-            // correct platform value does not work, so more investigation is
-            // needed.
-            #[cfg(not(windows))]
-            pmu_gsiv: None,
-            // TODO: On WHP, the value supported is 0x17, and is
-            // not configurable today.
-            #[cfg(windows)]
-            pmu_gsiv: Some(0x17),
+            pmu_gsiv: hvlite_defs::config::PmuGsivConfig::Platform,
         },
     );
     #[cfg(guest_arch = "x86_64")]

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -340,20 +340,8 @@ impl PetriVmConfigOpenVmm {
                             ..Default::default()
                         },
                     ),
-                    #[cfg(not(windows))]
                     MachineArch::Aarch64 => hvlite_defs::config::ArchTopologyConfig::Aarch64(
                         hvlite_defs::config::Aarch64TopologyConfig::default(),
-                    ),
-                    #[cfg(windows)]
-                    MachineArch::Aarch64 => hvlite_defs::config::ArchTopologyConfig::Aarch64(
-                        hvlite_defs::config::Aarch64TopologyConfig {
-                            // TODO: The PMU GSIV value is currently hardcoded
-                            // to be 0x17 on WHP. This shouldn't be required to
-                            // be set, but a future change will set the platform
-                            // default if None was specified.
-                            pmu_gsiv: Some(0x17),
-                            ..Default::default()
-                        },
                     ),
                 }),
             }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -74,6 +74,9 @@ use vp::WhpRunVpError;
 use vp_state::WhpVpStateAccess;
 use x86defs::cpuid::Vendor;
 
+#[cfg(guest_arch = "aarch64")]
+pub use aarch64::WHP_PMU_GSIV;
+
 #[derive(Debug)]
 pub struct Whp;
 
@@ -1675,6 +1678,9 @@ mod aarch64 {
     use hvdef::Vtl;
     use virt::VpIndex;
     use virt::irqcon::MsiRequest;
+
+    /// On aarch64, the platform configured GSIV value for the PMU.
+    pub const WHP_PMU_GSIV: u32 = 0x17;
 
     impl WhpPartitionInner {
         pub(crate) fn synic_interrupt(


### PR DESCRIPTION
Remove the hardcoded PMU GSIV value, and instead of `None` add a platform enum type. 

#1775 