### PR TITLE
firmware_uefi: EfiDiagnostics flush on inspect_mut (#1755)

### DIFF
--- a/vm/devices/firmware/firmware_uefi/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/Cargo.toml
@@ -39,7 +39,6 @@ mesh.workspace = true
 open_enum.workspace = true
 pal_async.workspace = true
 ucs2.workspace = true
-
 async-trait.workspace = true
 bitfield-struct.workspace = true
 der = { workspace = true, features = ["derive", "alloc", "oid"], optional = true }

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -143,6 +143,7 @@ pub struct UefiRuntimeDeps<'a> {
 
 /// The Hyper-V UEFI services chipset device.
 #[derive(InspectMut)]
+#[inspect(extra = "UefiDevice::inspect_extra")]
 pub struct UefiDevice {
     // Fixed configuration
     use_mmio: bool,
@@ -270,10 +271,29 @@ impl UefiDevice {
                 self.service.diagnostics.set_gpa(data)
             }
             UefiCommand::PROCESS_EFI_DIAGNOSTICS => {
-                self.process_diagnostics(false, DEFAULT_LOGS_PER_PERIOD, "guest")
+                self.process_diagnostics(false, Some(DEFAULT_LOGS_PER_PERIOD))
             }
             _ => tracelimit::warn_ratelimited!(addr, data, "unknown uefi write"),
         }
+    }
+
+    /// Extra inspection fields for the UEFI device.
+    fn inspect_extra(&mut self, resp: &mut inspect::Response<'_>) {
+        resp.field_mut_with("process_diagnostics", |v| {
+            // NOTE: Today, the inspect source code will fail if we invoke like below
+            // `inspect -u vm/uefi/process_diagnostics`. This is true, even for other
+            // mutable paths in the inspect graph.
+            if v.is_some() {
+                self.process_diagnostics(true, None);
+                Result::<_, std::convert::Infallible>::Ok(
+                    "attempted to process diagnostics through inspect".to_string(),
+                )
+            } else {
+                Result::<_, std::convert::Infallible>::Ok(
+                    "Use: inspect -u 1 vm/uefi/process_diagnostics".to_string(),
+                )
+            }
+        });
     }
 }
 
@@ -318,7 +338,7 @@ impl PollDevice for UefiDevice {
             // NOTE: Do not allow reprocessing diagnostics here.
             // UEFI programs the watchdog's configuration, so we should assume that
             // this path could trigger multiple times.
-            self.process_diagnostics(false, DEFAULT_LOGS_PER_PERIOD, "watchdog timeout");
+            self.process_diagnostics(false, Some(DEFAULT_LOGS_PER_PERIOD));
         }
     }
 }


### PR DESCRIPTION
Backport of: https://github.com/microsoft/openvmm/pull/1755

This PR focuses on allowing EfiDiagnostics to force flush through InspectMut.

We will only print EfiDiagnostics to our tracing facilities **ONLY IF WE WRITE** to the `inspect_diagnostics` field to true in `UefiDevice`.

To trigger this, use inspect like so:
```
openvmm> inspect -u true vm/uefi/process_diagnostics
```