### PR TITLE
vmbus_server: fix a race condition when revoking and reoffering channels

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -1806,9 +1806,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
     }
 
     /// Revokes a channel by ID.
-    pub fn revoke_channel(&mut self, offer_id: OfferId, retain_id: bool) {
+    pub fn revoke_channel(&mut self, offer_id: OfferId) {
         let channel = &mut self.inner.channels[offer_id];
-        let guest_referenced = revoke(
+        let retain = revoke(
             self.inner
                 .pending_messages
                 .sender(self.notifier, self.inner.state.is_paused()),
@@ -1816,7 +1816,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             channel,
             &mut self.inner.gpadls,
         );
-        if !guest_referenced && !retain_id {
+        if !retain {
             self.inner.channels.remove(offer_id);
         }
 
@@ -4473,9 +4473,7 @@ mod tests {
 
         assert!(notifier.messages.is_empty());
 
-        server
-            .with_notifier(&mut notifier)
-            .revoke_channel(offer_id, false);
+        server.with_notifier(&mut notifier).revoke_channel(offer_id);
 
         server
             .with_notifier(&mut notifier)
@@ -4995,13 +4993,13 @@ mod tests {
         env.complete_reset();
         env.notifier.check_reset();
 
-        env.c().revoke_channel(offer_id5, false);
-        env.c().revoke_channel(offer_id6, false);
+        env.c().revoke_channel(offer_id5);
+        env.c().revoke_channel(offer_id6);
 
         env.c().restore(state.clone()).unwrap();
 
-        env.c().revoke_channel(offer_id1, false);
-        env.c().revoke_channel(offer_id4, false);
+        env.c().revoke_channel(offer_id1);
+        env.c().revoke_channel(offer_id4);
         env.c().restore_channel(offer_id3, false).unwrap();
         let offer_id5 = env.offer_with_mnf(5);
         env.c().restore_channel(offer_id5, true).unwrap();


### PR DESCRIPTION
If a channel is explicitly revoked using `ChannelServerRequest::Revoke` (used by both the OpenHCL relay and vmbusproxy), there is a small window where the offer ID can be reused before the `ChannelServerRequest` stream is dropped, at which point the revoke is attempted again. This could end up revoking the newly offered channel, rather than the original one.

This change updates the revoke logic to check the channel's sequence number, so it will not revoke newer channels.