### PR TITLE
Fix lints for Rust 1.89

### DIFF
--- a/support/mesh/mesh_derive/src/lib.rs
+++ b/support/mesh/mesh_derive/src/lib.rs
@@ -178,7 +178,7 @@ impl Parse for Attr {
         } else if ident == "rename" {
             Ok(Self::Rename(parse_string_attr(input)?))
         } else {
-            return Err(syn::Error::new_spanned(ident, "unknown attribute"));
+            Err(syn::Error::new_spanned(ident, "unknown attribute"))
         }
     }
 }
@@ -254,7 +254,7 @@ impl Parse for ItemAttr {
         } else if ident == "transparent" {
             Ok(Self::Transparent)
         } else {
-            return Err(syn::Error::new_spanned(ident, "unknown attribute"));
+            Err(syn::Error::new_spanned(ident, "unknown attribute"))
         }
     }
 }

--- a/support/pal/src/windows.rs
+++ b/support/pal/src/windows.rs
@@ -1079,7 +1079,7 @@ macro_rules! delayload {
             $visibility unsafe fn $name($($params: $types,)*) -> $result {
                 match funcs::$name() {
                     Ok(fnval) => {
-                        type FnType = unsafe extern "stdcall" fn($($params: $types,)*) -> $result;
+                        type FnType = unsafe extern "system" fn($($params: $types,)*) -> $result;
                         let fnptr: FnType = ::std::mem::transmute(fnval);
                         fnptr($($params,)*)
                     },

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
@@ -28,6 +28,7 @@ pub trait NvramServicesExt {
 
     /// Get a variable identified by `name` (as a UCS-2 string) + `vendor`,
     /// returning the variable's attributes and data.
+    #[allow(dead_code)]
     async fn get_variable_ucs2(
         &mut self,
         vendor: Guid,

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -322,8 +322,8 @@ impl LxVolume {
             // Try to read the link target from the reparse data.
             let target_string = self.state.read_reparse_link(&handle)?;
             // TODO: Remove this once LxUtilSymlinkRead is implemented and re-work to just use the Option
-            if target_string.is_some() {
-                target = target_string.unwrap();
+            if let Some(target_string) = target_string {
+                target = target_string;
             }
 
             // If the function succeeded but returned a NULL buffer, this is a V1 LX symlink which must be

--- a/vm/devices/user_driver_emulated_mock/src/lib.rs
+++ b/vm/devices/user_driver_emulated_mock/src/lib.rs
@@ -25,13 +25,11 @@ use pci_core::msi::MsiControl;
 use pci_core::msi::MsiInterruptSet;
 use pci_core::msi::MsiInterruptTarget;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU8;
 use user_driver::DeviceBacking;
 use user_driver::DeviceRegisterIo;
 use user_driver::DmaClient;
 use user_driver::interrupt::DeviceInterrupt;
 use user_driver::interrupt::DeviceInterruptSource;
-use user_driver::memory::PAGE_SIZE;
 use user_driver::memory::PAGE_SIZE64;
 
 /// A wrapper around any user_driver device T. It provides device emulation by providing access to the memory shared with the device and thus
@@ -126,15 +124,6 @@ pub struct Mapping<T> {
     device: Arc<Mutex<T>>,
     addr: u64,
     len: usize,
-}
-
-#[repr(C, align(4096))]
-struct Page([AtomicU8; PAGE_SIZE]);
-
-impl Default for Page {
-    fn default() -> Self {
-        Self([0; PAGE_SIZE].map(AtomicU8::new))
-    }
 }
 
 impl<T: 'static + Send + InspectMut + MmioIntercept, U: 'static + Send + DmaClient> DeviceBacking

--- a/vm/devices/vga/src/emu.rs
+++ b/vm/devices/vga/src/emu.rs
@@ -1454,7 +1454,6 @@ impl Emulator {
         }
 
         if self.state.persistent_state.crt_regs_locked {
-            #[expect(clippy::comparison_chain)]
             if reg == CrtControlReg::OVERFLOW_REGISTER {
                 // Only update bit 4.
                 value &= 0x10;

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -517,8 +517,8 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
 
     fn handle_save(&mut self) -> SavedStateBlob {
         let saved_state = self.saved_state.take();
-        if saved_state.is_some() {
-            let blob = SavedStateBlob::new(saved_state.unwrap());
+        if let Some(saved_state) = saved_state {
+            let blob = SavedStateBlob::new(saved_state);
             self.handle_restore(&blob);
             blob
         } else {


### PR DESCRIPTION
Pretty small cleanups from this version, though there is one new warning in mesh not fixed in this PR that will take some thought to fix.