### PR TITLE
uh_core: Also memory self-test ends of ranges

### DIFF
--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -20,6 +20,12 @@ pub struct MemoryRangeWithNode {
     pub vnode: u32,
 }
 
+impl core::fmt::Display for MemoryRangeWithNode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}({})", self.range, self.vnode)
+    }
+}
+
 /// Describes the memory layout of a guest.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "inspect", derive(inspect::Inspect))]


### PR DESCRIPTION
This should help us catch bad memory setups earlier.

Note: we're still debugging what causes failures here, but the sooner we can catch them the better.

Also includes some additional tracing.