### PR TITLE
scsi_buffers: Fix overallocation of pages when going through OwnedRequestBuffers::linear

### DIFF
--- a/vm/devices/storage/scsi_buffers/src/lib.rs
+++ b/vm/devices/storage/scsi_buffers/src/lib.rs
@@ -371,7 +371,7 @@ impl OwnedRequestBuffers {
     /// `offset..offset+len`.
     pub fn linear(offset: u64, len: usize, is_write: bool) -> Self {
         let start_page = offset / PAGE_SIZE as u64;
-        let end_page = offset + (len as u64).div_ceil(PAGE_SIZE as u64);
+        let end_page = start_page + (len as u64).div_ceil(PAGE_SIZE as u64);
         let gpns: Vec<u64> = (start_page..end_page).collect();
         Self {
             gpns,


### PR DESCRIPTION
Fix a small mistake in OwnedRequestBuffers::linear that would cause it to allocate way more pages than it actually needs.

This bug, and fix, was found entirely by GPT-5.