### PR TITLE
Remove VMGS host tampering vulnerability

### DIFF
--- a/openhcl/underhill_attestation/src/key_protector.rs
+++ b/openhcl/underhill_attestation/src/key_protector.rs
@@ -94,7 +94,7 @@ impl KeyProtectorExt for KeyProtector {
         let found_ingress_dek = !self.dek[ingress_idx].dek_buffer.iter().all(|&x| x == 0);
         let found_egress_dek = !self.dek[egress_idx].dek_buffer.iter().all(|&x| x == 0);
         let mut ingress_key = [0u8; AES_GCM_KEY_LENGTH];
-        let mut egress_key = [0u8; AES_GCM_KEY_LENGTH];
+        let mut encrypt_egress_key = [0u8; AES_GCM_KEY_LENGTH];
         let use_des_key = wrapped_des_key.is_some(); // whether the wrapped key from DiskEncryptionSettings payload is used
         let modulus_size = ingress_kek.size() as usize;
 
@@ -201,15 +201,17 @@ impl KeyProtectorExt for KeyProtector {
             None
         };
 
-        if found_egress_dek {
+        let decrypt_egress_key = if found_egress_dek {
             tracing::info!(CVM_ALLOWED, "found egress dek");
 
-            // Key rolling did not complete successfully last time (normally egress should be empty)
+            // Key rolling did not complete successfully last time (normally egress should be empty).
+            // Any existing egress key can be used to decrypt the VMGS but must not be used to
+            // re-encrypt the VMGS, as its value can be controlled by the host.
             let dek_buffer = self.dek[egress_idx].dek_buffer;
-            let new_egress_key = if let Some(unwrapping_key) = des_key {
+            let old_egress_key = if let Some(ref unwrapping_key) = des_key {
                 // The DEK buffer should contain an AES-wrapped key.
                 crypto::aes_key_unwrap_with_padding(
-                    &unwrapping_key,
+                    unwrapping_key,
                     &dek_buffer[..AES_WRAPPED_AES_KEY_LENGTH],
                 )
                 .map_err(GetKeysFromKeyProtectorError::EgressDekAesUnwrap)?
@@ -222,48 +224,54 @@ impl KeyProtectorExt for KeyProtector {
                 )
                 .map_err(GetKeysFromKeyProtectorError::EgressDekRsaUnwrap)?
             };
-            egress_key[..new_egress_key.len()].copy_from_slice(&new_egress_key);
+            let mut key = [0u8; AES_GCM_KEY_LENGTH];
+            key[..old_egress_key.len()].copy_from_slice(&old_egress_key);
+            Some(key)
         } else {
             tracing::info!(CVM_ALLOWED, "there is no egress dek");
+            None
+        };
 
-            // There is no egress DEK, so create a new key value and encrypt it.
-            getrandom::fill(&mut egress_key).expect("rng failure");
+        // Always generate a new "encrypt egress key". This is generated randomly by
+        // OpenHCL, and so cannot be controlled by the host, and is safe to use to
+        // encrypt the VMGS.
+        getrandom::fill(&mut encrypt_egress_key).expect("rng failure");
 
-            let new_egress_key = if let Some(wrapping_key) = des_key {
-                // Create an AES wrapped key
-                crypto::aes_key_wrap_with_padding(&wrapping_key, &egress_key)
-                    .map_err(GetKeysFromKeyProtectorError::EgressKeyAesWrap)?
-            } else {
-                // Create an RSA wrapped key
-                crypto::rsa_oaep_encrypt(
-                    ingress_kek,
-                    &egress_key,
-                    crypto::RsaOaepHashAlgorithm::Sha256,
-                )
-                .map_err(GetKeysFromKeyProtectorError::EgressKeyRsaWrap)?
-            };
+        let new_egress_key = if let Some(wrapping_key) = des_key {
+            // Create an AES wrapped key
+            crypto::aes_key_wrap_with_padding(&wrapping_key, &encrypt_egress_key)
+                .map_err(GetKeysFromKeyProtectorError::EgressKeyAesWrap)?
+        } else {
+            // Create an RSA wrapped key
+            crypto::rsa_oaep_encrypt(
+                ingress_kek,
+                &encrypt_egress_key,
+                crypto::RsaOaepHashAlgorithm::Sha256,
+            )
+            .map_err(GetKeysFromKeyProtectorError::EgressKeyRsaWrap)?
+        };
 
-            if new_egress_key.len() > DEK_BUFFER_SIZE {
-                Err(GetKeysFromKeyProtectorError::InvalidWrappedEgressKeySize {
-                    key_size: new_egress_key.len(),
-                    expected_size: DEK_BUFFER_SIZE,
-                })?
-            }
-
-            self.dek[egress_idx].dek_buffer[..new_egress_key.len()]
-                .copy_from_slice(&new_egress_key);
-
-            tracing::info!(
-                CVM_CONFIDENTIAL,
-                egress_idx = egress_idx,
-                egress_key_len = new_egress_key.len(),
-                "store new egress key to dek"
-            );
+        if new_egress_key.len() > DEK_BUFFER_SIZE {
+            Err(GetKeysFromKeyProtectorError::InvalidWrappedEgressKeySize {
+                key_size: new_egress_key.len(),
+                expected_size: DEK_BUFFER_SIZE,
+            })?
         }
+
+        self.dek[egress_idx].dek_buffer[..new_egress_key.len()]
+            .copy_from_slice(&new_egress_key);
+
+        tracing::info!(
+            CVM_CONFIDENTIAL,
+            egress_idx = egress_idx,
+            egress_key_len = new_egress_key.len(),
+            "store new egress key to dek"
+        );
 
         Ok(Keys {
             ingress: ingress_key,
-            egress: egress_key,
+            decrypt_egress: decrypt_egress_key,
+            encrypt_egress: encrypt_egress_key,
         })
     }
 }
@@ -355,8 +363,8 @@ mod tests {
         );
         assert!(result.is_ok());
         let plaintext = result.unwrap();
-        assert_eq!(plaintext, keys.egress);
-        let key_egress_first_boot = keys.egress;
+        assert_eq!(plaintext, keys.encrypt_egress);
+        let key_egress_first_boot = keys.encrypt_egress;
 
         // Test key rotation for reboot
 
@@ -389,7 +397,7 @@ mod tests {
         );
         assert!(result.is_ok());
         let plaintext = result.unwrap();
-        assert_eq!(plaintext, keys.egress);
+        assert_eq!(plaintext, keys.encrypt_egress);
     }
 
     #[test]
@@ -473,8 +481,8 @@ mod tests {
         );
         assert!(result.is_ok());
         let unwrapped_key = result.unwrap();
-        assert_eq!(unwrapped_key, keys.egress);
-        let key_egress_first_boot = keys.egress;
+        assert_eq!(unwrapped_key, keys.encrypt_egress);
+        let key_egress_first_boot = keys.encrypt_egress;
 
         // Test key rotation for reboot
 
@@ -516,7 +524,7 @@ mod tests {
         );
         assert!(result.is_ok());
         let unwrapped_key = result.unwrap();
-        assert_eq!(unwrapped_key, keys.egress);
+        assert_eq!(unwrapped_key, keys.encrypt_egress);
     }
 
     #[test]

--- a/openhcl/underhill_attestation/src/key_protector.rs
+++ b/openhcl/underhill_attestation/src/key_protector.rs
@@ -208,7 +208,7 @@ impl KeyProtectorExt for KeyProtector {
             // Any existing egress key can be used to decrypt the VMGS but must not be used to
             // re-encrypt the VMGS, as its value can be controlled by the host.
             let dek_buffer = self.dek[egress_idx].dek_buffer;
-            let old_egress_key = if let Some(ref unwrapping_key) = des_key {
+            let old_egress_key = if let Some(unwrapping_key) = &des_key {
                 // The DEK buffer should contain an AES-wrapped key.
                 crypto::aes_key_unwrap_with_padding(
                     unwrapping_key,

--- a/openhcl/underhill_attestation/src/key_protector.rs
+++ b/openhcl/underhill_attestation/src/key_protector.rs
@@ -258,8 +258,7 @@ impl KeyProtectorExt for KeyProtector {
             })?
         }
 
-        self.dek[egress_idx].dek_buffer[..new_egress_key.len()]
-            .copy_from_slice(&new_egress_key);
+        self.dek[egress_idx].dek_buffer[..new_egress_key.len()].copy_from_slice(&new_egress_key);
 
         tracing::info!(
             CVM_CONFIDENTIAL,

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -439,7 +439,7 @@ async fn unlock_vmgs_data_store(
         return Ok(());
     };
 
-    if new_ingress_key != new_egress_key {
+    if !openssl::memcmp::eq(&new_ingress_key, &new_egress_key) {
         tracing::trace!(CVM_ALLOWED, "EgressKey is different than IngressKey");
         new_key = true;
     }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -926,7 +926,7 @@ async fn get_derived_keys(
                     [..gsp_response.decrypted_gsp[egress_idx].length as usize]
                     .to_vec();
                 key_protector_settings.should_write_kp = false;
-                decrypt_egress_key = Some(encrypt_egress_key.clone());
+                decrypt_egress_key = Some(encrypt_egress_key);
             }
         }
     }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -585,7 +585,7 @@ async fn get_derived_keys(
         .all(|&x| x == 0);
 
     // Handle key released via attestation process (tenant key) to get keys from KeyProtector
-    let (ingress_key, decrypt_egress_key, encrypt_egress_key, no_kek) =
+    let (ingress_key, mut decrypt_egress_key, encrypt_egress_key, no_kek) =
         if let Some(ingress_kek) = ingress_rsa_kek {
             let keys = match key_protector.unwrap_and_rotate_keys(
                 ingress_kek,
@@ -926,6 +926,7 @@ async fn get_derived_keys(
                     [..gsp_response.decrypted_gsp[egress_idx].length as usize]
                     .to_vec();
                 key_protector_settings.should_write_kp = false;
+                decrypt_egress_key = Some(encrypt_egress_key.clone());
             }
         }
     }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -921,14 +921,12 @@ async fn get_derived_keys(
             .map_err(GetDerivedKeysError::DeriveIngressKey)?;
     }
 
-    // Always derive a new egress key using best available seed
-    derived_keys.decrypt_egress = match decrypt_egress_key {
-        Some(key) => {
-            Some(crypto::derive_key(&key, &egress_seed, VMGS_KEY_DERIVE_LABEL)
-                .map_err(GetDerivedKeysError::DeriveEgressKey)?)
-        }
-        None => None,
-    };
+    derived_keys.decrypt_egress = decrypt_egress_key
+        .map(|key| {
+            crypto::derive_key(&key, &egress_seed, VMGS_KEY_DERIVE_LABEL)
+        })
+        .transpose()
+        .map_err(GetDerivedKeysError::DeriveEgressKey)?;
 
     derived_keys.encrypt_egress = crypto::derive_key(&encrypt_egress_key, &egress_seed, VMGS_KEY_DERIVE_LABEL)
         .map_err(GetDerivedKeysError::DeriveEgressKey)?;

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -921,6 +921,7 @@ async fn get_derived_keys(
             .map_err(GetDerivedKeysError::DeriveIngressKey)?;
     }
 
+    // Always derive a new egress key using best available seed
     derived_keys.decrypt_egress = decrypt_egress_key
         .map(|key| {
             crypto::derive_key(&key, &egress_seed, VMGS_KEY_DERIVE_LABEL)


### PR DESCRIPTION
There is a vulnerability in OpenHCL's VMGS key-rolling code that allows the host to cause the VMGS to be encrypted with a host-controlled key. unwrap_and_rotate_keys now returns a pair of egress keys: one that may have been used to previously encrypt the VMGS and can only be used for that purpose; and a second key, always derived anew, that can safely be used to re-encrypt the VMGS.

CVE-2025-53781