### PR TITLE
openhcl/vbs: correctly accept pages before changing visibility for shared pool

### DIFF
--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -655,8 +655,18 @@ impl<T: CpuIo> hv1_hypercall::ModifySparseGpaPageHostVisibility for WhpHypercall
 
         let partition = self.vp.vp.partition;
 
-        for page in gpa_pages {
+        for (index, page) in gpa_pages.iter().enumerate() {
             let range = MemoryRange::from_4k_gpn_range(*page..(*page + 1));
+
+            // On VBS, the page must be accepted in order to change visibiltiy.
+            // If the page is not accepted, the hypervisor returns operation
+            // denied.
+            let gpa = *page * HV_PAGE_SIZE;
+            if partition.vtl0.gpa_visibility(gpa).is_none() {
+                tracing::error!(page, "modify visibility called for non-accepted page");
+                return Err((HvError::OperationDenied, index));
+            }
+
             // TODO: Modifying visibility today doesn't return any kind of
             // useful error to the guest. Need to check the hypervisor and
             // determine what the right thing to do is here.

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -658,7 +658,7 @@ impl<T: CpuIo> hv1_hypercall::ModifySparseGpaPageHostVisibility for WhpHypercall
         for (index, page) in gpa_pages.iter().enumerate() {
             let range = MemoryRange::from_4k_gpn_range(*page..(*page + 1));
 
-            // On VBS, the page must be accepted in order to change visibiltiy.
+            // On VBS, the page must be accepted in order to change visibility.
             // If the page is not accepted, the hypervisor returns operation
             // denied.
             let gpa = *page * HV_PAGE_SIZE;

--- a/vmm_core/virt_whp/src/memory.rs
+++ b/vmm_core/virt_whp/src/memory.rs
@@ -444,6 +444,10 @@ impl VtlPartition {
         self.mapper.accept_range(&self.whp, range, visibility)
     }
 
+    pub fn gpa_visibility(&self, gpa: u64) -> Option<PageVisibility> {
+        self.mapper.gpa_visibility(gpa)
+    }
+
     pub fn modify_visibility(
         &self,
         range: &MemoryRange,

--- a/vmm_core/virt_whp/src/memory.rs
+++ b/vmm_core/virt_whp/src/memory.rs
@@ -160,7 +160,6 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
 
     /// The page visibility for a given page. None means this page is not
     /// accepted. Only supported on mappers that support page acceptance.
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     fn gpa_visibility(&self, gpa: u64) -> Option<PageVisibility>;
 
     /// Accept the given gpa range on behalf of the guest, with the given


### PR DESCRIPTION
On VBS, the hypervisor requires pages to be accepted first before they can be transitioned to the shared state. 

Fix virt_whp's implementation to enforce this as well. 