### PR TITLE
openhcl_boot: remove target arch on isolation type

### DIFF
--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -510,9 +510,7 @@ pub fn write_dt(
     let isolation_type = match partition_info.isolation {
         IsolationType::None => "none",
         IsolationType::Vbs => "vbs",
-        #[cfg(target_arch = "x86_64")]
         IsolationType::Snp => "snp",
-        #[cfg(target_arch = "x86_64")]
         IsolationType::Tdx => "tdx",
     };
     openhcl_builder = openhcl_builder.add_str(p_isolation_type, isolation_type)?;

--- a/openhcl/openhcl_boot/src/host_params/shim_params.rs
+++ b/openhcl/openhcl_boot/src/host_params/shim_params.rs
@@ -11,16 +11,12 @@ use loader_defs::shim::ShimParamsRaw;
 use memory_range::MemoryRange;
 
 /// Isolation type of the partition
-///
-/// TODO: Fix arch specific abstractions across the bootloader so we can remove
-/// target_arch here and elsewhere.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum IsolationType {
     None,
     Vbs,
-    #[cfg(target_arch = "x86_64")]
+    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     Snp,
-    #[cfg(target_arch = "x86_64")]
     Tdx,
 }
 
@@ -29,9 +25,7 @@ impl IsolationType {
         match self {
             IsolationType::None => false,
             IsolationType::Vbs => false,
-            #[cfg(target_arch = "x86_64")]
             IsolationType::Snp => true,
-            #[cfg(target_arch = "x86_64")]
             IsolationType::Tdx => true,
         }
     }

--- a/openhcl/openhcl_boot/src/host_params/shim_params.rs
+++ b/openhcl/openhcl_boot/src/host_params/shim_params.rs
@@ -17,6 +17,7 @@ pub enum IsolationType {
     Vbs,
     #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     Snp,
+    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     Tdx,
 }
 


### PR DESCRIPTION
This bound only exists in `openhcl_boot`, remove it. 