### PR TITLE
[MSRC 97247] Fix Trust Fall MSRC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7189,6 +7189,7 @@ dependencies = [
  "tpm_resources",
  "tracelimit",
  "tracing",
+ "underhill_confidentiality",
  "vm_resource",
  "vmcore",
  "zerocopy 0.8.24",

--- a/vm/devices/tpm/Cargo.toml
+++ b/vm/devices/tpm/Cargo.toml
@@ -19,6 +19,7 @@ chipset_device.workspace = true
 chipset_device_resources.workspace = true
 cvm_tracing.workspace = true
 guestmem.workspace = true
+underhill_confidentiality = { workspace = true, features = ["std"] }
 vmcore.workspace = true
 vm_resource.workspace = true
 

--- a/vm/devices/tpm/src/tpm20proto.rs
+++ b/vm/devices/tpm/src/tpm20proto.rs
@@ -1375,7 +1375,7 @@ pub mod protocol {
     pub struct TpmtPublic {
         my_type: AlgId,
         name_alg: AlgId,
-        object_attributes: TpmaObject,
+        pub object_attributes: TpmaObject,
         auth_policy: Tpm2bBuffer,
         // `TPMS_RSA_PARAMS`
         pub parameters: TpmsRsaParams,

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -10,6 +10,7 @@ use crate::TPM_NV_INDEX_ATTESTATION_REPORT;
 use crate::TPM_NV_INDEX_MITIGATED;
 use crate::TPM_RSA_SRK_HANDLE;
 use crate::TpmRsa2kPublic;
+use crate::expected_ak_attributes;
 use crate::tpm20proto;
 use crate::tpm20proto::AlgIdEnum;
 use crate::tpm20proto::CommandCodeEnum;
@@ -302,26 +303,44 @@ impl TpmEngineHelper {
     /// # Arguments
     /// * `force_create`: Whether to remove the existing AK and re-create one.
     ///
-    /// Returns the AK public in `TpmRsa2kPublic`.
-    pub fn create_ak_pub(&mut self, force_create: bool) -> Result<TpmRsa2kPublic, TpmHelperError> {
+    /// Returns the AK public in `TpmRsa2kPublic`, and a bool indicating whether AKCert
+    /// renewal is allowed.
+    pub fn create_ak_pub(
+        &mut self,
+        force_create: bool,
+    ) -> Result<(TpmRsa2kPublic, bool), TpmHelperError> {
         if let Some(res) = self.find_object(TPM_AZURE_AIK_HANDLE)? {
             if force_create {
                 // Remove existing key before creating a new one
                 self.evict_or_persist_handle(EvictOrPersist::Evict(TPM_AZURE_AIK_HANDLE))?;
             } else {
-                // Use existing key
-                return export_rsa_public(&res.out_public).map_err(|error| {
-                    TpmHelperError::ExportRsaPublicFromAkHandle {
+                let expected_attributes = expected_ak_attributes();
+
+                // If an existing key has the wrong attributes, deny renewing the AKCert later.
+                // This prevents an attack where the VTL0 admin can replace the AK with their own
+                // and get a signed AKCert.
+                let actual_attributes = res.out_public.public_area.object_attributes;
+                if actual_attributes != expected_attributes {
+                    tracing::warn!(
+                        CVM_ALLOWED,
+                        attrs = actual_attributes.0.get(),
+                        "incorrect AK attributes; denying AKCert renewal"
+                    );
+                }
+
+                return export_rsa_public(&res.out_public)
+                    .map_err(|error| TpmHelperError::ExportRsaPublicFromAkHandle {
                         ak_handle: TPM_AZURE_AIK_HANDLE.0.get(),
                         error,
-                    }
-                });
+                    })
+                    .and_then(|ak_pub| Ok((ak_pub, actual_attributes == expected_attributes)));
             }
         }
 
         let in_public = ak_pub_template().map_err(TpmHelperError::CreateAkPubTemplateFailed)?;
 
         self.create_key_object(in_public, Some(TPM_AZURE_AIK_HANDLE))
+            .and_then(|res| Ok((res, true)))
     }
 
     /// Create Windows-style Endorsement key (EK) based on the template from the TPM specification. Note that
@@ -968,7 +987,7 @@ impl TpmEngineHelper {
     ///
     /// Returns Ok(Some(ReadPublicReply)) if the object is present.
     /// Returns Ok(None) if nv index is not present.
-    fn find_object(
+    pub fn find_object(
         &mut self,
         object_handle: ReservedHandle,
     ) -> Result<Option<ReadPublicReply>, TpmHelperError> {
@@ -2096,7 +2115,7 @@ mod tests {
     ) -> (TpmRsa2kPublic, TpmRsa2kPublic) {
         let result = tpm_engine_helper.create_ak_pub(false);
         assert!(result.is_ok());
-        let ak_pub = result.unwrap();
+        let (ak_pub, _) = result.unwrap();
 
         // Ensure `create_ak_pub` persists AK
         assert!(

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -333,7 +333,7 @@ impl TpmEngineHelper {
                         ak_handle: TPM_AZURE_AIK_HANDLE.0.get(),
                         error,
                     })
-                    .and_then(|ak_pub| Ok((ak_pub, actual_attributes == expected_attributes)));
+                    .map(|ak_pub| (ak_pub, actual_attributes == expected_attributes));
             }
         }
 

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -340,7 +340,7 @@ impl TpmEngineHelper {
         let in_public = ak_pub_template().map_err(TpmHelperError::CreateAkPubTemplateFailed)?;
 
         self.create_key_object(in_public, Some(TPM_AZURE_AIK_HANDLE))
-            .and_then(|res| Ok((res, true)))
+            .map(|res| (res, true))
     }
 
     /// Create Windows-style Endorsement key (EK) based on the template from the TPM specification. Note that


### PR DESCRIPTION
A malicious admin can evict the AK from their VM's vTPM and replace it with their own key. At boot, Azure will load that key from the VMGS and then sign an AKCert with that key, allowing the admin to spoof KeyGuard and CVM attestation.

CVM: This change mirrors changes in the legacy HCL: Regenerate the AK at boot from the TPM seeds, instead of loading it from VMGS. This ensures that the original AKCert is always present in the vTPM.

TVM: OpenHCL currently cannot regenerate the AK for a TVM, because the original AK (provisioned by the vtpmservice) contains an auth policy; OpenHCL does not implement that policy creation. As an alternative, when OpenHCL boots, it will check the attributes on the AK that it loads from VMGS. If the attributes are wrong (indicating a possibly malicious key), it will not make any calls to renew the AKCert.

CVE-2025-49707