### PR TITLE
vmbus_server: revert to creating interrupts before channel open

### DIFF
--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -57,7 +57,6 @@ use vmbus_channel::bus::OfferInput;
 use vmbus_channel::bus::OfferResources;
 use vmbus_channel::bus::OpenData;
 use vmbus_channel::bus::OpenRequest;
-use vmbus_channel::bus::OpenResult;
 use vmbus_channel::bus::ParentBus;
 use vmbus_channel::channel::ChannelHandle;
 use vmbus_channel::channel::VmbusDevice;
@@ -87,7 +86,7 @@ use zerocopy::KnownLayout;
 const VMNIC_CHANNEL_TYPE_GUID: Guid = guid::guid!("f8615163-df3e-46c5-913f-f2d2f965ed0e");
 
 enum ChannelResponse {
-    Open(Option<OpenResult>),
+    Open(bool),
     Close,
     Gpadl(bool),
     // TeardownGpadl(GpadlId),
@@ -576,18 +575,19 @@ impl TestNicDevice {
             .await
             .expect("open successful");
 
-        let ChannelResponse::Open(Some(result)) = open_response else {
+        let ChannelResponse::Open(true) = open_response else {
             panic!("Unexpected return value");
         };
 
         let mem = self.mock_vmbus.memory.clone();
+        let guest_to_host_interrupt = self.offer_input.event.clone();
         TestNicChannel::new(
             self,
             &mem,
             gpadl_map,
             ring_gpadl_id,
             host_to_guest_event,
-            result.guest_to_host_interrupt,
+            guest_to_host_interrupt,
         )
     }
 
@@ -631,16 +631,17 @@ impl TestNicDevice {
             .await
             .expect("open successful");
 
-        let ChannelResponse::Open(Some(result)) = open_response else {
+        let ChannelResponse::Open(true) = open_response else {
             panic!("Unexpected return value");
         };
 
+        let guest_to_host_interrupt = self.offer_input.event.clone();
         TestNicSubchannel::new(
             &self.mock_vmbus.memory,
             gpadl_map,
             ring_gpadl_id,
             host_to_guest_event,
-            result.guest_to_host_interrupt,
+            guest_to_host_interrupt,
         )
     }
 
@@ -690,7 +691,7 @@ impl TestNicDevice {
         next_avail_guest_page: usize,
         next_avail_gpadl_id: u32,
         host_to_guest_interrupt: Interrupt,
-    ) -> anyhow::Result<Option<Interrupt>> {
+    ) -> anyhow::Result<()> {
         // Restore the previous memory settings
         assert_eq!(self.next_avail_gpadl_id, 1);
         self.next_avail_gpadl_id = next_avail_gpadl_id;
@@ -709,7 +710,6 @@ impl TestNicDevice {
             })
             .collect::<Vec<(GpadlId, MultiPagedRangeBuf<Vec<u64>>)>>();
 
-        let mut guest_to_host_interrupt = None;
         mesh::CancelContext::new()
             .with_timeout(Duration::from_millis(1000))
             .until_cancelled(async {
@@ -732,8 +732,7 @@ impl TestNicDevice {
                                             accepted: true,
                                         }
                                     }).collect::<Vec<vmbus_channel::bus::RestoredGpadl>>();
-                                    rpc.handle_sync(|open| {
-                                        guest_to_host_interrupt = open.map(|open| open.guest_to_host_interrupt);
+                                    rpc.handle_sync(|_open| {
                                         Ok(vmbus_channel::bus::RestoreResult {
                                             open_request: Some(OpenRequest {
                                                 open_data: OpenData {
@@ -761,7 +760,7 @@ impl TestNicDevice {
             .await
             .unwrap()?;
 
-        Ok(guest_to_host_interrupt)
+        Ok(())
     }
 }
 
@@ -1275,6 +1274,7 @@ impl<'a> TestNicChannel<'a> {
         buffer: SavedStateBlob,
     ) -> anyhow::Result<TestNicChannel<'_>> {
         let mem = self.nic.mock_vmbus.memory.clone();
+        let guest_to_host_interrupt = nic.offer_input.event.clone();
         let host_to_guest_interrupt = {
             let event = self.host_to_guest_event.clone();
             Interrupt::from_fn(move || event.signal())
@@ -1285,17 +1285,15 @@ impl<'a> TestNicChannel<'a> {
         let next_avail_guest_page = self.nic.next_avail_guest_page;
         let next_avail_gpadl_id = self.nic.next_avail_gpadl_id;
 
-        let guest_to_host_interrupt = nic
-            .restore(
-                buffer,
-                gpadl_map.clone(),
-                channel_id,
-                next_avail_guest_page,
-                next_avail_gpadl_id,
-                host_to_guest_interrupt,
-            )
-            .await?
-            .expect("should be open");
+        nic.restore(
+            buffer,
+            gpadl_map.clone(),
+            channel_id,
+            next_avail_guest_page,
+            next_avail_gpadl_id,
+            host_to_guest_interrupt,
+        )
+        .await?;
 
         Ok(TestNicChannel::new(
             nic,

--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -122,7 +122,7 @@ pub enum ModifyRequest {
 pub enum ChannelServerRequest {
     /// A request to restore the channel.
     ///
-    /// The input parameter provides the open result if the channel was saved open.
+    /// The input parameter indicates if the channel was saved open.
     Restore(FailableRpc<bool, RestoreResult>),
     /// A request to revoke the channel.
     ///

--- a/vm/devices/vmbus/vmbus_channel/src/channel.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/channel.rs
@@ -10,7 +10,6 @@ use crate::bus::OfferInput;
 use crate::bus::OfferParams;
 use crate::bus::OfferResources;
 use crate::bus::OpenRequest;
-use crate::bus::OpenResult;
 use crate::bus::ParentBus;
 use crate::gpadl::GpadlMap;
 use crate::gpadl::GpadlMapView;
@@ -334,6 +333,7 @@ async fn offer_generic(
 
     let request = OfferInput {
         params: offer,
+        event: events[0].clone().interrupt(),
         request_send,
         server_request_recv,
     };
@@ -592,7 +592,7 @@ impl Device {
         channel: &mut dyn VmbusDevice,
         channel_idx: usize,
         open_request: OpenRequest,
-    ) -> Option<OpenResult> {
+    ) -> bool {
         assert!(!self.open[channel_idx]);
         // N.B. Any asynchronous GPADL requests will block while in
         //      open(). This should be fine for all known devices.
@@ -601,13 +601,11 @@ impl Device {
                 error = error.as_ref() as &dyn std::error::Error,
                 "failed to open channel"
             );
-            None
+            true
         } else {
-            Some(OpenResult {
-                guest_to_host_interrupt: self.events[channel_idx].clone().interrupt(),
-            })
+            false
         };
-        self.open[channel_idx] = opened.is_some();
+        self.open[channel_idx] = opened;
         opened
     }
 
@@ -764,6 +762,7 @@ impl Device {
                     subchannel_index: subchannel_idx as u16,
                     ..offer.clone()
                 },
+                event: self.events[subchannel_idx].clone().interrupt(),
                 request_send,
                 server_request_recv,
             };
@@ -800,12 +799,9 @@ impl Device {
             .map_err(ChannelRestoreError::EnablingSubchannels)?;
 
         let mut results = Vec::with_capacity(states.len());
-        for (channel_idx, (open, event)) in states.iter().copied().zip(&self.events).enumerate() {
-            let open_result = open.then(|| OpenResult {
-                guest_to_host_interrupt: event.clone().interrupt(),
-            });
+        for (channel_idx, open) in states.iter().copied().enumerate() {
             let result = self.server_requests[channel_idx]
-                .call_failable(ChannelServerRequest::Restore, open_result)
+                .call_failable(ChannelServerRequest::Restore, open)
                 .await
                 .map_err(|err| ChannelRestoreError::RestoreError(err.into()))?;
 

--- a/vm/devices/vmbus/vmbus_client/src/filter.rs
+++ b/vm/devices/vmbus/vmbus_client/src/filter.rs
@@ -240,6 +240,7 @@ impl Inspect for Filters {
 
 impl FilterWorker {
     async fn run(&mut self, req: mesh::Receiver<FilterRequest>, offers: mesh::Receiver<OfferInfo>) {
+        #[allow(clippy::large_enum_variant)]
         enum Event {
             Request(FilterRequest),
             Done,

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -296,14 +296,14 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
             .reserve_memory(state, &offer.request_send, 4)
             .await
             .context("reserve memory")?;
+        let guest_to_host_interrupt = offer.guest_to_host_interrupt.clone();
         state.offer = Some(offer);
         let offer = state.offer.as_ref().unwrap();
-        let opened = self
-            .open_channel(&offer.request_send, ring_gpadl_id, &interrupt_event)
+        self.open_channel(&offer.request_send, ring_gpadl_id, &interrupt_event)
             .await
             .context("open channel")?;
         let channel = self
-            .create_vmbus_channel(&memory, &interrupt_event, opened.guest_to_host_signal)
+            .create_vmbus_channel(&memory, &interrupt_event, guest_to_host_interrupt)
             .context("create vmbus queue")?;
 
         let save_restore = self.device.task_mut().0.supports_save_restore();

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -72,7 +72,6 @@ use vmbus_channel::bus::OfferKey;
 use vmbus_channel::bus::OfferResources;
 use vmbus_channel::bus::OpenData;
 use vmbus_channel::bus::OpenRequest;
-use vmbus_channel::bus::OpenResult;
 use vmbus_channel::bus::ParentBus;
 use vmbus_channel::bus::RestoreResult;
 use vmbus_channel::gpadl::GpadlMap;
@@ -225,6 +224,7 @@ enum VmbusRequest {
 #[derive(mesh::MeshPayload, Debug)]
 pub struct OfferInfo {
     pub params: OfferParamsInternal,
+    pub event: Interrupt,
     pub request_send: mesh::Sender<ChannelRequest>,
     pub server_request_recv: mesh::Receiver<ChannelServerRequest>,
 }
@@ -702,7 +702,7 @@ struct ServerTaskInner {
 
 #[derive(Debug)]
 enum ChannelResponse {
-    Open(Option<OpenResult>),
+    Open(bool),
     Close,
     Gpadl(GpadlId, bool),
     TeardownGpadl(GpadlId),
@@ -722,6 +722,7 @@ struct Channel {
     seq: u64,
     state: ChannelState,
     gpadls: Arc<GpadlMap>,
+    guest_to_host_event: Arc<ChannelEvent>,
     flags: protocol::OfferFlags,
     // A channel can be reserved no matter what state it is in. This allows the message port for a
     // reserved channel to remain available even if the channel is closed, so the guest can read the
@@ -736,22 +737,17 @@ struct ReservedState {
     target: ConnectionTarget,
 }
 
+struct ChannelOpenState {
+    open_params: OpenParams,
+    _event_port: Box<dyn Send>,
+    guest_event_port: Box<dyn GuestEventPort>,
+    host_to_guest_interrupt: Interrupt,
+}
+
 enum ChannelState {
     Closed,
-    Opening {
-        open_params: OpenParams,
-        guest_event_port: Box<dyn GuestEventPort>,
-        host_to_guest_interrupt: Interrupt,
-    },
-    Open {
-        open_params: OpenParams,
-        _event_port: Box<dyn Send>,
-        guest_event_port: Box<dyn GuestEventPort>,
-        host_to_guest_interrupt: Interrupt,
-        guest_to_host_event: Arc<ChannelEvent>,
-    },
+    Open(Box<ChannelOpenState>),
     Closing,
-    FailedOpen,
 }
 
 impl ServerTask {
@@ -792,6 +788,7 @@ impl ServerTask {
                 send: info.request_send,
                 state: ChannelState::Closed,
                 gpadls: GpadlMap::new(),
+                guest_to_host_event: Arc::new(ChannelEvent(info.event)),
                 seq,
                 flags,
                 reserved_state: ReservedState {
@@ -863,46 +860,38 @@ impl ServerTask {
         }
     }
 
-    fn handle_open(&mut self, offer_id: OfferId, result: Option<OpenResult>) {
-        let status = if result.is_some() {
+    fn handle_open(&mut self, offer_id: OfferId, success: bool) {
+        let status = if success {
+            let channel = self
+                .inner
+                .channels
+                .get_mut(&offer_id)
+                .expect("channel exists");
+
+            // Some guests ignore interrupts before they receive the OpenResult message. To avoid
+            // a potential hang, signal the channel after a delay if needed.
+            if let Some(delay) = self.channel_unstick_delay {
+                if channel.unstick_state == ChannelUnstickState::None {
+                    channel.unstick_state = ChannelUnstickState::Queued;
+                    let seq = channel.seq;
+                    let mut timer = PolledTimer::new(&self.driver);
+                    self.channel_unstickers.push(Box::pin(async move {
+                        timer.sleep(delay).await;
+                        OfferInstanceId { offer_id, seq }
+                    }));
+                } else {
+                    channel.unstick_state = ChannelUnstickState::NeedsRequeue;
+                }
+            }
+
             0
         } else {
             protocol::STATUS_UNSUCCESSFUL
         };
 
-        match self.inner.complete_open(offer_id, result) {
-            Ok(channel) => {
-                // Some guests ignore interrupts before they receive the OpenResult message. To avoid
-                // a potential hang, signal the channel after a delay if needed.
-                if let Some(delay) = self.channel_unstick_delay {
-                    if channel.unstick_state == ChannelUnstickState::None {
-                        channel.unstick_state = ChannelUnstickState::Queued;
-                        let seq = channel.seq;
-                        let mut timer = PolledTimer::new(&self.driver);
-                        self.channel_unstickers.push(Box::pin(async move {
-                            timer.sleep(delay).await;
-                            OfferInstanceId { offer_id, seq }
-                        }));
-                    } else {
-                        channel.unstick_state = ChannelUnstickState::NeedsRequeue;
-                    }
-                }
-
-                self.server
-                    .with_notifier(&mut self.inner)
-                    .open_complete(offer_id, status);
-            }
-            Err(err) => {
-                tracelimit::error_ratelimited!(
-                    error = err.as_ref() as &dyn std::error::Error,
-                    "failed to complete open"
-                );
-                // If complete_open failed, the channel is now in FailedOpen state and the device needs
-                // to notified to close it. Calling open_complete is postponed until the device responds
-                // to the close request.
-                self.inner.notify(offer_id, channels::Action::Close);
-            }
-        }
+        self.server
+            .with_notifier(&mut self.inner)
+            .open_complete(offer_id, status);
     }
 
     fn handle_close(&mut self, offer_id: OfferId) {
@@ -918,14 +907,6 @@ impl ServerTask {
                 self.server
                     .with_notifier(&mut self.inner)
                     .close_complete(offer_id);
-            }
-            ChannelState::FailedOpen => {
-                // Now that the device has processed the close request after open failed, we can
-                // finish handling the failed open and send an open result to the guest.
-                channel.state = ChannelState::Closed;
-                self.server
-                    .with_notifier(&mut self.inner)
-                    .open_complete(offer_id, protocol::STATUS_UNSUCCESSFUL);
             }
             _ => {
                 tracing::error!(?offer_id, "invalid close channel response");
@@ -955,17 +936,16 @@ impl ServerTask {
     fn handle_restore_channel(
         &mut self,
         offer_id: OfferId,
-        open: Option<OpenResult>,
+        open: bool,
     ) -> anyhow::Result<RestoreResult> {
         let gpadls = self.server.channel_gpadls(offer_id);
 
         // If the channel is opened, handle that before calling into channels so that failure can
         // be handled before the channel is marked restored.
         let open_request = open
-            .map(|result| -> anyhow::Result<_> {
+            .then(|| -> anyhow::Result<_> {
                 let params = self.server.get_restore_open_params(offer_id)?;
-                let (_, interrupt) = self.inner.open_channel(offer_id, &params)?;
-                let channel = self.inner.complete_open(offer_id, Some(result))?;
+                let (channel, interrupt) = self.inner.open_channel(offer_id, &params)?;
                 Ok(OpenRequest::new(
                     params.open_data,
                     interrupt,
@@ -1329,19 +1309,13 @@ impl ServerTask {
         force: bool,
         unstick_host: bool,
     ) -> anyhow::Result<()> {
-        if let ChannelState::Open {
-            open_params,
-            host_to_guest_interrupt,
-            guest_to_host_event,
-            ..
-        } = &channel.state
-        {
+        if let ChannelState::Open(state) = &channel.state {
             if force {
                 tracing::info!(channel = %channel.key, "waking host and guest");
                 if unstick_host {
-                    guest_to_host_event.0.deliver();
+                    channel.guest_to_host_event.0.deliver();
                 }
-                host_to_guest_interrupt.deliver();
+                state.host_to_guest_interrupt.deliver();
                 return Ok(());
             }
 
@@ -1349,14 +1323,14 @@ impl ServerTask {
                 .gpadls
                 .clone()
                 .view()
-                .map(open_params.open_data.ring_gpadl_id)
+                .map(state.open_params.open_data.ring_gpadl_id)
                 .context("couldn't find ring gpadl")?;
 
             let aligned = AlignedGpadlView::new(gpadl)
                 .ok()
                 .context("ring not aligned")?;
             let (in_gpadl, out_gpadl) = aligned
-                .split(open_params.open_data.ring_offset)
+                .split(state.open_params.open_data.ring_offset)
                 .ok()
                 .context("couldn't split ring")?;
 
@@ -1364,8 +1338,8 @@ impl ServerTask {
                 gm,
                 channel,
                 in_gpadl,
-                unstick_host.then_some(guest_to_host_event),
-                host_to_guest_interrupt,
+                unstick_host.then_some(channel.guest_to_host_event.as_ref()),
+                &state.host_to_guest_interrupt,
             ) {
                 tracelimit::warn_ratelimited!(
                     channel = %channel.key,
@@ -1377,8 +1351,8 @@ impl ServerTask {
                 gm,
                 channel,
                 out_gpadl,
-                unstick_host.then_some(guest_to_host_event),
-                host_to_guest_interrupt,
+                unstick_host.then_some(channel.guest_to_host_event.as_ref()),
+                &state.host_to_guest_interrupt,
             ) {
                 tracelimit::warn_ratelimited!(
                     channel = %channel.key,
@@ -1485,15 +1459,15 @@ impl Notifier for ServerTaskInner {
                         Box::pin(future::ready((
                             offer_id,
                             seq,
-                            Ok(ChannelResponse::Open(None)),
+                            Ok(ChannelResponse::Open(false)),
                         )))
                     }
                 }
             }
             channels::Action::Close => {
                 if let Some(channel_bitmap) = self.channel_bitmap.as_ref() {
-                    if let ChannelState::Open { open_params, .. } = channel.state {
-                        channel_bitmap.unregister_channel(open_params.event_flag);
+                    if let ChannelState::Open(ref state) = channel.state {
+                        channel_bitmap.unregister_channel(state.open_params.event_flag);
                     }
                 }
 
@@ -1536,11 +1510,8 @@ impl Notifier for ServerTaskInner {
                 )
             }
             channels::Action::Modify { target_vp } => {
-                if let ChannelState::Open {
-                    guest_event_port, ..
-                } = &mut channel.state
-                {
-                    if let Err(err) = guest_event_port.set_target_vp(target_vp) {
+                if let ChannelState::Open(state) = &mut channel.state {
+                    if let Err(err) = state.guest_event_port.set_target_vp(target_vp) {
                         tracelimit::error_ratelimited!(
                             error = &err as &dyn std::error::Error,
                             channel = %channel.key,
@@ -1608,13 +1579,13 @@ impl Notifier for ServerTaskInner {
     fn inspect(&self, version: Option<VersionInfo>, offer_id: OfferId, req: inspect::Request<'_>) {
         let channel = self.channels.get(&offer_id).expect("should exist");
         let mut resp = req.respond();
-        if let ChannelState::Open { open_params, .. } = &channel.state {
+        if let ChannelState::Open(state) = &channel.state {
             let mem = self.get_gm_for_channel(version.expect("must be connected"), channel);
             inspect_rings(
                 &mut resp,
                 mem,
                 channel.gpadls.clone(),
-                &open_params.open_data,
+                &state.open_params.open_data,
             );
         }
     }
@@ -1719,6 +1690,24 @@ impl ServerTaskInner {
             .get_mut(&offer_id)
             .expect("channel does not exist");
 
+        // Always register with the channel bitmap; if Win7, this may be unnecessary.
+        if let Some(channel_bitmap) = self.channel_bitmap.as_ref() {
+            channel_bitmap.register_channel(
+                open_params.event_flag,
+                channel.guest_to_host_event.0.clone(),
+            );
+        }
+        // Always set up an event port; if V1, this will be unused.
+        let event_port = self
+            .synic
+            .add_event_port(
+                open_params.connection_id,
+                self.vtl,
+                channel.guest_to_host_event.clone(),
+                open_params.monitor_info,
+            )
+            .expect("connection ID should not be in use");
+
         // For pre-Win8 guests, the host-to-guest event always targets vp 0 and the channel
         // bitmap is used instead of the event flag.
         let (target_vp, event_flag) = if self.channel_bitmap.is_some() {
@@ -1761,77 +1750,78 @@ impl ServerTaskInner {
             channel.reserved_state.target = target;
         }
 
-        channel.state = ChannelState::Opening {
+        channel.state = ChannelState::Open(Box::new(ChannelOpenState {
             open_params: *open_params,
+            _event_port: event_port,
             guest_event_port,
             host_to_guest_interrupt: interrupt.clone(),
-        };
+        }));
         Ok((channel, interrupt))
     }
 
-    fn complete_open(
-        &mut self,
-        offer_id: OfferId,
-        result: Option<OpenResult>,
-    ) -> anyhow::Result<&mut Channel> {
-        let channel = self
-            .channels
-            .get_mut(&offer_id)
-            .expect("channel does not exist");
+    // fn complete_open(
+    //     &mut self,
+    //     offer_id: OfferId,
+    //     result: Option<OpenResult>,
+    // ) -> anyhow::Result<&mut Channel> {
+    //     let channel = self
+    //         .channels
+    //         .get_mut(&offer_id)
+    //         .expect("channel does not exist");
 
-        channel.state = if let Some(result) = result {
-            // The channel will be left in the FailedOpen state only if an error occurs in the match
-            // arm.
-            match std::mem::replace(&mut channel.state, ChannelState::FailedOpen) {
-                ChannelState::Opening {
-                    open_params,
-                    guest_event_port,
-                    host_to_guest_interrupt,
-                } => {
-                    let guest_to_host_event =
-                        Arc::new(ChannelEvent(result.guest_to_host_interrupt));
-                    // Always register with the channel bitmap; if Win7, this may be unnecessary.
-                    if let Some(channel_bitmap) = self.channel_bitmap.as_ref() {
-                        channel_bitmap.register_channel(
-                            open_params.event_flag,
-                            guest_to_host_event.0.clone(),
-                        );
-                    }
-                    // Always set up an event port; if V1, this will be unused.
-                    let event_port = self
-                        .synic
-                        .add_event_port(
-                            open_params.connection_id,
-                            self.vtl,
-                            guest_to_host_event.clone(),
-                            open_params.monitor_info,
-                        )
-                        .with_context(|| {
-                            format!(
-                                "failed to create event port for VTL {:?}, connection ID {:#x}",
-                                self.vtl, open_params.connection_id
-                            )
-                        })?;
+    //     channel.state = if let Some(result) = result {
+    //         // The channel will be left in the FailedOpen state only if an error occurs in the match
+    //         // arm.
+    //         match std::mem::replace(&mut channel.state, ChannelState::FailedOpen) {
+    //             ChannelState::Opening {
+    //                 open_params,
+    //                 guest_event_port,
+    //                 host_to_guest_interrupt,
+    //             } => {
+    //                 let guest_to_host_event =
+    //                     Arc::new(ChannelEvent(result.guest_to_host_interrupt));
+    //                 // Always register with the channel bitmap; if Win7, this may be unnecessary.
+    //                 if let Some(channel_bitmap) = self.channel_bitmap.as_ref() {
+    //                     channel_bitmap.register_channel(
+    //                         open_params.event_flag,
+    //                         guest_to_host_event.0.clone(),
+    //                     );
+    //                 }
+    //                 // Always set up an event port; if V1, this will be unused.
+    //                 let event_port = self
+    //                     .synic
+    //                     .add_event_port(
+    //                         open_params.connection_id,
+    //                         self.vtl,
+    //                         guest_to_host_event.clone(),
+    //                         open_params.monitor_info,
+    //                     )
+    //                     .with_context(|| {
+    //                         format!(
+    //                             "failed to create event port for VTL {:?}, connection ID {:#x}",
+    //                             self.vtl, open_params.connection_id
+    //                         )
+    //                     })?;
 
-                    ChannelState::Open {
-                        open_params,
-                        _event_port: event_port,
-                        guest_event_port,
-                        host_to_guest_interrupt,
-                        guest_to_host_event,
-                    }
-                }
-                s => {
-                    tracing::error!("attempting to complete open of open or closed channel");
-                    // Restore the original state
-                    s
-                }
-            }
-        } else {
-            ChannelState::Closed
-        };
-        Ok(channel)
-    }
+    //                 ChannelState::Open {
+    //                     open_params,
+    //                     _event_port: event_port,
+    //                     guest_event_port,
+    //                     host_to_guest_interrupt,
+    //                     guest_to_host_event,
+    //                 }
+    //             }
+    //             s => {
+    //                 tracing::error!("attempting to complete open of open or closed channel");
+    //                 // Restore the original state
+    //                 s
+    //             }
+    //         }
+    //     } else {
+    //         ChannelState::Closed
+    //     };
+    //     Ok(channel)
+    // }
 
     /// If the client specified an interrupt page, map it into host memory and
     /// set up the shared event port.
@@ -1884,13 +1874,7 @@ impl ServerTaskInner {
         if self.channels.iter().any(|(_, c)| {
             matches!(
                 &c.state,
-                ChannelState::Open {
-                    open_params,
-                    ..
-                } | ChannelState::Opening {
-                    open_params,
-                    ..
-                } if open_params.monitor_info.is_some()
+                ChannelState::Open(state) if state.open_params.monitor_info.is_some()
             )
         }) {
             anyhow::bail!("attempt to change monitor page while open channels using mnf");
@@ -2034,6 +2018,7 @@ impl VmbusServerControl {
     async fn offer(&self, request: OfferInput) -> anyhow::Result<OfferResources> {
         let mut offer_info = OfferInfo {
             params: request.params.into(),
+            event: request.event,
             request_send: request.request_send,
             server_request_recv: request.server_request_recv,
         };
@@ -2365,9 +2350,7 @@ mod tests {
             };
 
             f(rpc.input());
-            rpc.complete(Some(OpenResult {
-                guest_to_host_interrupt: Interrupt::null(),
-            }));
+            rpc.complete(true);
         }
 
         async fn handle_gpadl_teardown(&mut self) {
@@ -2385,7 +2368,7 @@ mod tests {
 
         async fn restore(&self) {
             self.server_request_send
-                .call(ChannelServerRequest::Restore, None)
+                .call(ChannelServerRequest::Restore, false)
                 .await
                 .unwrap()
                 .unwrap();
@@ -2424,6 +2407,7 @@ mod tests {
             let (request_send, request_recv) = mesh::channel();
             let (server_request_send, server_request_recv) = mesh::channel();
             let offer = OfferInput {
+                event: Interrupt::from_fn(|| {}),
                 request_send,
                 server_request_recv,
                 params: OfferParams {
@@ -2881,6 +2865,7 @@ mod tests {
                     flags: protocol::OfferFlags::new().with_enumerate_device_interface(true),
                     ..Default::default()
                 },
+                event: Interrupt::from_fn(|| {}),
                 request_send,
                 server_request_recv,
             })

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -657,15 +657,15 @@ impl ProxyTask {
         match request {
             ChannelRequest::Open(rpc) => {
                 rpc.handle(async |open_request| {
-                    if let Err(err) = self.handle_open(proxy_id, &open_request).await {
-                        tracing::error!(
-                            error = err.as_ref() as &dyn std::error::Error,
-                            "failed to open channel"
-                        );
-                        false
-                    } else {
-                        true
-                    }
+                    self.handle_open(proxy_id, &open_request)
+                        .await
+                        .inspect_err(|err| {
+                            tracing::error!(
+                                error = err.as_ref() as &dyn std::error::Error,
+                                "failed to open channel"
+                            );
+                        })
+                        .is_ok()
                 })
                 .await
             }

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -53,7 +53,6 @@ use vmbus_channel::bus::ChannelType;
 use vmbus_channel::bus::OfferKey;
 use vmbus_channel::bus::OfferParams;
 use vmbus_channel::bus::OpenRequest;
-use vmbus_channel::bus::OpenResult;
 use vmbus_channel::gpadl::GpadlId;
 use vmbus_core::HvsockConnectRequest;
 use vmbus_core::HvsockConnectResult;
@@ -149,7 +148,6 @@ impl ProxyIntegration {
 
 struct Channel {
     server_request_send: Option<mesh::Sender<ChannelServerRequest>>,
-    incoming_event: Event,
     worker_result: Option<mesh::OneshotReceiver<()>>,
     wrapped_event: Option<WrappedEvent>,
 }
@@ -227,11 +225,7 @@ impl ProxyTask {
         recv
     }
 
-    async fn handle_open(
-        &self,
-        proxy_id: u64,
-        open_request: &OpenRequest,
-    ) -> anyhow::Result<Event> {
+    async fn handle_open(&self, proxy_id: u64, open_request: &OpenRequest) -> anyhow::Result<()> {
         let maybe_wrapped =
             MaybeWrappedEvent::new(&TpPool::system(), open_request.interrupt.clone())?;
 
@@ -255,7 +249,7 @@ impl ProxyTask {
         let channel = channels.get_mut(&proxy_id).unwrap();
         channel.worker_result = Some(recv);
         channel.wrapped_event = maybe_wrapped.into_wrapped();
-        Ok(channel.incoming_event.clone())
+        Ok(())
     }
 
     async fn handle_close(&self, proxy_id: u64) {
@@ -319,7 +313,6 @@ impl ProxyTask {
         offer_key: OfferKey,
         vtl: u8,
         server_request_send: Option<mesh::Sender<ChannelServerRequest>>,
-        incoming_event: Event,
     ) -> Option<(Option<WrappedEvent>, mesh::OneshotReceiver<()>)> {
         // A channel is considered saved in the "open" state if it is in any state that has an open
         // request. This is because the server will not notify the channel for the open in any of
@@ -342,12 +335,7 @@ impl ProxyTask {
             "restoring channel after offer");
 
         let restore_result = send
-            .call_failable(
-                ChannelServerRequest::Restore,
-                channel_saved_open.then(|| OpenResult {
-                    guest_to_host_interrupt: Interrupt::from_event(incoming_event.clone()),
-                }),
-            )
+            .call_failable(ChannelServerRequest::Restore, channel_saved_open)
             .await
             .inspect_err(|err| {
                 tracing::warn!(
@@ -458,6 +446,7 @@ impl ProxyTask {
             OfferRequest::Offer,
             OfferInfo {
                 params: new_offer.into(),
+                event: Interrupt::from_event(incoming_event),
                 request_send,
                 server_request_recv,
             },
@@ -489,7 +478,6 @@ impl ProxyTask {
                 },
                 offer.TargetVtl,
                 server_request_send.clone(),
-                incoming_event.clone(),
             )
             .await
         } else {
@@ -508,7 +496,6 @@ impl ProxyTask {
                     proxy_id,
                     Channel {
                         server_request_send,
-                        incoming_event,
                         worker_result,
                         wrapped_event,
                     },
@@ -670,18 +657,14 @@ impl ProxyTask {
         match request {
             ChannelRequest::Open(rpc) => {
                 rpc.handle(async |open_request| {
-                    let result = self.handle_open(proxy_id, &open_request).await;
-                    match result {
-                        Ok(event) => Some(OpenResult {
-                            guest_to_host_interrupt: Interrupt::from_event(event),
-                        }),
-                        Err(err) => {
-                            tracing::error!(
-                                error = err.as_ref() as &dyn std::error::Error,
-                                "failed to open proxy channel"
-                            );
-                            None
-                        }
+                    if let Err(err) = self.handle_open(proxy_id, &open_request).await {
+                        tracing::error!(
+                            error = err.as_ref() as &dyn std::error::Error,
+                            "failed to open channel"
+                        );
+                        false
+                    } else {
+                        true
                     }
                 })
                 .await


### PR DESCRIPTION
This change reverts the changes made by #649. While the model used by that change was better, it was discovered that some channels, notably some IC channels, being communicating as soon as the device is notified of the open. This leads to the possibility of the guest attempting to send an interrupt before the synic event port was created, so the interrupt would be lost.

This change therefore moves the creation of the guest-to-host event port back to when the open request is received.

Note that this is not a straight-forward revert of the original commit, as the code had diverged too much, particularly because the synic handling for vmbus_relay was moved into vmbus_client. This is therefore essentially a new change that reverts to the same functionality as before.