### PR TITLE
virt_mshv_vtl: Remove some outdated comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,7 +303,7 @@ serial_pl011_resources = { path = "vm/devices/serial/serial_pl011_resources" }
 serial_socket = { path = "vm/devices/serial/serial_socket" }
 tpm = { path = "vm/devices/tpm" }
 tpm_resources = { path = "vm/devices/tpm_resources" }
-mcr_resources = { path = "vm/devices/mcr_resources" } # TODO MCR: move to closed-source
+mcr_resources = { path = "vm/devices/mcr_resources" }
 uidevices = { path = "vm/devices/uidevices" }
 uidevices_resources = { path = "vm/devices/uidevices_resources" }
 user_driver = { path = "vm/devices/user_driver" }
@@ -540,7 +540,6 @@ windows-sys = "0.59"
 xshell = "=0.2.2" # pin to 0.2.2 to work around https://github.com/matklad/xshell/issues/63
 xshell-macros = "0.2"
 # We add the derive feature here since the vast majority of our crates use it.
-#zerocopy = { version = "0.7.32", features = ["derive"]}
 zerocopy = { version = "0.8.14", features = ["derive"]}
 
 [workspace.metadata.xtask.unused-deps]

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -687,8 +687,6 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                 Err(HvError::InvalidParameter)
             }
         }
-
-        // TODO GUEST VSM: interrupt rewinding
     }
 
     fn set_vtl0_pending_event(&mut self, event: HvX64PendingExceptionEvent) -> HvResult<()> {
@@ -1977,15 +1975,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         // Currently, the only pending event that needs to be delivered on exit
         // are those that VTL 1 injects into VTL 0.
         if next_vtl == GuestVtl::Vtl0 {
-            // TODO GUEST VSM: rewind interrupts injected by the apic. This
-            // might mean keeping track of whether an event was injected by the
-            // apic, injected directly (as a result of emulation or in response
-            // to the pending event register being set), or e.g. in the case of
-            // SNP, if it came in through EXTINTINFO. The latter two should not
-            // be rewound.
-            //
-            // TODO GUEST VSM: Memory intercept handling.
-
             let pending_event = self
                 .backing
                 .cvm_state()

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1442,9 +1442,6 @@ impl UhProcessor<'_, SnpBacked> {
                     HvMessageType::HvMessageTypeUnmappedGpa
                     | HvMessageType::HvMessageTypeGpaIntercept
                     | HvMessageType::HvMessageTypeUnacceptedGpa => {
-                        // TODO GUEST VSM:
-                        // - determine whether the intercept message should be delivered to VTL 1
-                        // - determine whether emulation is appropriate for this gpa
                         let gpa_message =
                             exit_message.as_message::<hvdef::HvX64MemoryInterceptMessage>();
 


### PR DESCRIPTION
Also some in the root Cargo.toml. Interrupt rewinding we don't think we need yet, and if we find a need for it we'll implement it then. Memory intercept and emulation determination for SNP is implemented.