### PR TITLE
TDX: Fix a VTL 1-only typo, but move logic to only affect VTL 0

### DIFF
--- a/vm/x86/x86defs/src/tdx.rs
+++ b/vm/x86/x86defs/src/tdx.rs
@@ -478,7 +478,7 @@ impl TdxContextCode {
 pub const TDX_FIELD_CODE_L2_CTLS_VM1: TdxExtendedFieldCode =
     TdxExtendedFieldCode(0xA020000300000051);
 pub const TDX_FIELD_CODE_L2_CTLS_VM2: TdxExtendedFieldCode =
-    TdxExtendedFieldCode(0xA020000300000051);
+    TdxExtendedFieldCode(0xA020000300000052);
 
 /// Extended field code for TDG.VP.WR and TDG.VP.RD
 #[bitfield(u64)]


### PR DESCRIPTION
Masanamuthu spotted this copy/paste typo in vm/x86/x86defs/src/tdx.rs, fix that up. However I think in the only place we set any TDX controls today we actually only want those controls to apply to VTL 0, so move that logic out of the for loop. This makes this PR a functional no-op, but it fixes the typo for when the day comes that we do want to set a control on VTL 1.