### PR TITLE
net_mana: adding tracing of the WQE on rx errors

### DIFF
--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -804,6 +804,30 @@ impl<T: DeviceBacking> ManaQueue<T> {
             }
         }
     }
+
+    fn trace_rx_wqe_from_offset(&mut self, wqe_offset: u32) {
+        let size = size_of::<WqeHeader>();
+        let bytes = self.rx_wq.read(wqe_offset, size);
+        let wqe_header = WqeHeader::read_from_prefix(&bytes);
+        let wqe_header = match wqe_header {
+            Ok((wqe_header, _)) => wqe_header,
+            Err(_) => {
+                tracelimit::error_ratelimited!(size, wqe_offset, "failed to read rx WQE");
+                return;
+            }
+        };
+
+        tracelimit::error_ratelimited!(
+            num_sgl_entries = wqe_header.params.num_sgl_entries(),
+            inline_client_oob_size = wqe_header.params.inline_client_oob_size(),
+            reserved = wqe_header.params.reserved(),
+            gd_client_unit_data = wqe_header.params.gd_client_unit_data(),
+            reserved2 = wqe_header.params.reserved2(),
+            sgl_offset = wqe_header.sgl_offset(),
+            sgl_len = wqe_header.sgl_len(),
+            "rx wqe header"
+        );
+    }
 }
 
 #[async_trait]
@@ -932,7 +956,14 @@ impl<T: DeviceBacking + Send> Queue for ManaQueue<T> {
                         i += 1;
                     }
                     ty => {
-                        tracelimit::error_ratelimited!(ty, "invalid rx cqe type");
+                        tracelimit::error_ratelimited!(
+                            ty,
+                            vendor_err = rx_oob.cqe_hdr.vendor_err(),
+                            rx_cq_id = self.rx_cq.id(),
+                            rx_wq_id = self.rx_wq.id(),
+                            "invalid rx cqe type"
+                        );
+                        self.trace_rx_wqe_from_offset(rx_oob.rx_wqe_offset);
                         self.stats.rx_errors += 1;
                         self.avail_rx.push_back(rx.id);
                     }


### PR DESCRIPTION
Improve the tracing when net_mana sees rx errors. Hopefully logging WQE header parameters will help us determine why these packets are being rejected.

Example Errors:
```
  2025-08-14T21:59:31.234049Z ERROR net_mana: invalid rx cqe type, ty: 5, vendor_err: 0, rx_cq_id: 26, rx_wq_id: 25
    at vm/devices/net/net_mana/src/lib.rs:960

  2025-08-14T21:59:31.234093Z ERROR net_mana: rx wqe header, num_sgl_entries: 1, inline_client_oob_size: 2, reserved: 0, gd_client_unit_data: 0, reserved2: false, sgl_offset: 8, sgl_len: 16
    at vm/devices/net/net_mana/src/lib.rs:821
```