### PR TITLE
Disable debug mode for TDX release builds

### DIFF
--- a/vm/loader/manifests/openhcl-x64-cvm-release.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-release.json
@@ -26,7 +26,7 @@
             "max_vtl": 2,
             "isolation_type": {
                 "tdx": {
-                    "enable_debug": true,
+                    "enable_debug": false,
                     "sept_ve_disable": true
                 }
             },


### PR DESCRIPTION
This release is almost ready, time to disable debug support in the builds that will end up in prod.