### PR TITLE
[MSRC 97247] Fix Trust Fall MSRC (#1849)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6333,6 +6333,7 @@ dependencies = [
  "tpm_resources",
  "tracelimit",
  "tracing",
+ "underhill_confidentiality",
  "vm_resource",
  "vmcore",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6321,6 +6321,7 @@ dependencies = [
  "bitfield-struct",
  "chipset_device",
  "chipset_device_resources",
+ "cvm_tracing",
  "getrandom",
  "guestmem",
  "inspect",

--- a/vm/devices/tpm/Cargo.toml
+++ b/vm/devices/tpm/Cargo.toml
@@ -18,6 +18,7 @@ tpm_resources.workspace = true
 chipset_device.workspace = true
 chipset_device_resources.workspace = true
 guestmem.workspace = true
+underhill_confidentiality = { workspace = true, features = ["std"] }
 vmcore.workspace = true
 vm_resource.workspace = true
 

--- a/vm/devices/tpm/Cargo.toml
+++ b/vm/devices/tpm/Cargo.toml
@@ -17,6 +17,7 @@ tpm_resources.workspace = true
 
 chipset_device.workspace = true
 chipset_device_resources.workspace = true
+cvm_tracing.workspace = true
 guestmem.workspace = true
 underhill_confidentiality = { workspace = true, features = ["std"] }
 vmcore.workspace = true

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -20,6 +20,8 @@ mod tpm_helper;
 use self::io_port_interface::PpiOperation;
 use self::io_port_interface::TpmIoCommand;
 use crate::ak_cert::TpmAkCertType;
+use crate::tpm20proto::TpmaObject;
+use crate::tpm20proto::TpmaObjectBits;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::MmioIntercept;
@@ -51,6 +53,7 @@ use tpm_helper::TpmCommandError;
 use tpm_helper::TpmEngineHelper;
 use tpm_helper::TpmHelperError;
 use tpm_resources::TpmRegisterLayout;
+use underhill_confidentiality::is_confidential_vm;
 use vmcore::device_state::ChangeDeviceState;
 use vmcore::non_volatile_store::NonVolatileStore;
 use vmcore::non_volatile_store::NonVolatileStoreError;
@@ -220,6 +223,7 @@ pub struct Tpm {
     io_region: Option<(&'static str, RangeInclusive<u16>)>, // Valid only on HypervX64
     #[inspect(skip)]
     mmio_region: Vec<(&'static str, RangeInclusive<u64>)>,
+    allow_ak_cert_renewal: bool,
 
     // Runtime glue
     rt: TpmRuntime,
@@ -392,6 +396,7 @@ impl Tpm {
             refresh_tpm_seeds,
             io_region,
             mmio_region,
+            allow_ak_cert_renewal: false,
 
             rt: TpmRuntime {
                 mem,
@@ -442,6 +447,7 @@ impl Tpm {
 
     async fn on_first_boot(&mut self, guest_secret_key: Option<Vec<u8>>) -> Result<(), TpmError> {
         use ms_tpm_20_ref::NvError;
+        let mut force_ak_regen = false;
         let fixup_16k_ak_cert;
 
         // Check whether or not we need to pave-over the blank TPM with our
@@ -468,6 +474,13 @@ impl Tpm {
 
                     return Err(TpmErrorKind::ResetTpmWithState(e).into());
                 }
+
+                // If this is a confidential VM or has a vTPM blob size that indicates that it was
+                // HCL-provisioned, regenerate the AK from TPM seeds. This prevents an attack where
+                // the VTL0 admin can replace the AK and get an AKCert for it.
+                force_ak_regen = self.refresh_tpm_seeds
+                    || blob.len() != LEGACY_VTPM_SIZE
+                    || is_confidential_vm();
 
                 // If this is a small vTPM blob, potentially fixup the AK cert.
                 fixup_16k_ak_cert = blob.len() == LEGACY_VTPM_SIZE;
@@ -539,15 +552,21 @@ impl Tpm {
             // Initialize `TpmKeys`.
             // The procedure also generates randomized AK based on the TPM seed
             // and writes the AK into `TPM_AZURE_AIK_HANDLE` NV store.
-            let ak_pub = self
+            let (ak_pub, can_renew_ak) = self
                 .tpm_engine_helper
-                .create_ak_pub(self.refresh_tpm_seeds)
+                .create_ak_pub(force_ak_regen)
                 .map_err(TpmErrorKind::CreateAkPublic)?;
             let ek_pub = self
                 .tpm_engine_helper
                 .create_ek_pub()
                 .map_err(TpmErrorKind::CreateEkPublic)?;
             self.keys = Some(TpmKeys { ak_pub, ek_pub });
+            tracing::info!(
+                CVM_ALLOWED,
+                can_renew_ak = can_renew_ak,
+                "loaded existing AK from VMGS vTPM state"
+            );
+            self.allow_ak_cert_renewal = can_renew_ak;
 
             // Conditionally define nv indexes for ak cert and attestation report.
             // The Nvram size can only be defined with platform hierarchy. Otherwise
@@ -845,6 +864,12 @@ impl Tpm {
     /// This routine calls (via GET) external server to issue AK cert.
     /// This function can only be called when `ak_cert_type` is `Trusted` or `HwAttested`.
     fn renew_ak_cert(&mut self) -> Result<(), TpmError> {
+        // Silently do nothing if renewal is not allowed.
+        if !self.allow_ak_cert_renewal {
+            tracing::info!(CVM_ALLOWED, "AK cert renewal is not allowed");
+            return Ok(());
+        }
+
         // Return if the request is pending
         if self.async_ak_cert_request.is_some() {
             return Ok(());
@@ -948,6 +973,12 @@ impl Tpm {
 
     /// Renew device attestation data (i.e., attestation report and AK cert) on NV_Read if needed
     fn refresh_device_attestation_data_on_nv_read(&mut self) {
+        // Silently do nothing if renewal is not allowed.
+        if !self.allow_ak_cert_renewal {
+            tracing::info!(CVM_ALLOWED, "AK cert renewal is not allowed");
+            return;
+        }
+
         let Some(nv_read) = tpm20proto::protocol::NvReadCmd::deserialize(&self.command_buffer)
         else {
             return;
@@ -1287,6 +1318,19 @@ impl MmioIntercept for Tpm {
     }
 }
 
+/// Expected attributes for a correctly-provisioned AK.
+pub fn expected_ak_attributes() -> TpmaObject {
+    TpmaObjectBits::new()
+        .with_fixed_tpm(true)
+        .with_fixed_parent(true)
+        .with_sensitive_data_origin(true)
+        .with_user_with_auth(true)
+        .with_no_da(true)
+        .with_restricted(true)
+        .with_sign_encrypt(true)
+        .into()
+}
+
 /// The IO port interface bespoke to the Hyper-V implementation of the vTPM.
 mod io_port_interface {
     use inspect::Inspect;
@@ -1515,6 +1559,8 @@ mod save_restore {
             pub auth_value: Option<u64>,
             #[mesh(61)]
             pub keys: Option<SavedTpmKeys>,
+            #[mesh(62)]
+            pub allow_ak_cert_renewal: Option<bool>,
         }
     }
 
@@ -1612,6 +1658,7 @@ mod save_restore {
                 tpm_state_blob: self.tpm_engine_helper.tpm_engine.save_state(),
                 auth_value: self.auth_value,
                 keys,
+                allow_ak_cert_renewal: Some(self.allow_ak_cert_renewal),
             };
 
             Ok(saved_state)
@@ -1626,6 +1673,7 @@ mod save_restore {
                 tpm_state_blob,
                 auth_value,
                 keys,
+                allow_ak_cert_renewal,
             } = state;
 
             self.control_area = {
@@ -1691,6 +1739,18 @@ mod save_restore {
                     exponent: keys.ek_pub_exponent,
                 },
             });
+
+            if allow_ak_cert_renewal.is_none() {
+                // Whether AKCert renewal is allowed depends on the attributes of the AK
+                // saved in the vTPM. It may not be safe to read it here (which requires
+                // executing a readpublic command) because the vTPM may be in the middle
+                // of executing another command.
+                tracing::info!(
+                    CVM_ALLOWED,
+                    "vTPM servicing state does not include allow_ak_cert_renewal; denying renewal until reboot"
+                );
+            }
+            self.allow_ak_cert_renewal = allow_ak_cert_renewal.unwrap_or(false);
 
             Ok(())
         }

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -28,6 +28,7 @@ use chipset_device::mmio::MmioIntercept;
 use chipset_device::pio::PortIoIntercept;
 use chipset_device::poll_device::PollDevice;
 use chipset_device::ChipsetDevice;
+use cvm_tracing::CVM_ALLOWED;
 use guestmem::GuestMemory;
 use inspect::Inspect;
 use inspect::InspectMut;

--- a/vm/devices/tpm/src/tpm20proto.rs
+++ b/vm/devices/tpm/src/tpm20proto.rs
@@ -1368,7 +1368,7 @@ pub mod protocol {
     pub struct TpmtPublic {
         r#type: AlgId,
         name_alg: AlgId,
-        object_attributes: TpmaObject,
+        pub object_attributes: TpmaObject,
         auth_policy: Tpm2bBuffer,
         // `TPMS_RSA_PARAMS`
         pub parameters: TpmsRsaParams,

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -3,6 +3,7 @@
 
 //! The module includes the helper functions for sending TPM commands.
 
+use crate::expected_ak_attributes;
 use crate::tpm20proto;
 use crate::tpm20proto::protocol::common::CmdAuth;
 use crate::tpm20proto::protocol::CreatePrimaryReply;
@@ -299,26 +300,44 @@ impl TpmEngineHelper {
     /// # Arguments
     /// * `force_create`: Whether to remove the existing AK and re-create one.
     ///
-    /// Returns the AK public in `TpmRsa2kPublic`.
-    pub fn create_ak_pub(&mut self, force_create: bool) -> Result<TpmRsa2kPublic, TpmHelperError> {
+    /// Returns the AK public in `TpmRsa2kPublic`, and a bool indicating whether AKCert
+    /// renewal is allowed.
+    pub fn create_ak_pub(
+        &mut self,
+        force_create: bool,
+    ) -> Result<(TpmRsa2kPublic, bool), TpmHelperError> {
         if let Some(res) = self.find_object(TPM_AZURE_AIK_HANDLE)? {
             if force_create {
                 // Remove existing key before creating a new one
                 self.evict_or_persist_handle(EvictOrPersist::Evict(TPM_AZURE_AIK_HANDLE))?;
             } else {
-                // Use existing key
-                return export_rsa_public(&res.out_public).map_err(|error| {
-                    TpmHelperError::ExportRsaPublicFromAkHandle {
+                let expected_attributes = expected_ak_attributes();
+
+                // If an existing key has the wrong attributes, deny renewing the AKCert later.
+                // This prevents an attack where the VTL0 admin can replace the AK with their own
+                // and get a signed AKCert.
+                let actual_attributes = res.out_public.public_area.object_attributes;
+                if actual_attributes != expected_attributes {
+                    tracing::warn!(
+                        CVM_ALLOWED,
+                        attrs = actual_attributes.0.get(),
+                        "incorrect AK attributes; denying AKCert renewal"
+                    );
+                }
+
+                return export_rsa_public(&res.out_public)
+                    .map_err(|error| TpmHelperError::ExportRsaPublicFromAkHandle {
                         ak_handle: TPM_AZURE_AIK_HANDLE.0.get(),
                         error,
-                    }
-                });
+                    })
+                    .map(|ak_pub| (ak_pub, actual_attributes == expected_attributes));
             }
         }
 
         let in_public = ak_pub_template().map_err(TpmHelperError::CreateAkPubTemplateFailed)?;
 
         self.create_key_object(in_public, Some(TPM_AZURE_AIK_HANDLE))
+            .map(|res| (res, true))
     }
 
     /// Create Windows-style Endorsement key (EK) based on the template from the TPM specification. Note that
@@ -959,7 +978,7 @@ impl TpmEngineHelper {
     ///
     /// Returns Ok(Some(ReadPublicReply)) if the object is present.
     /// Returns Ok(None) if nv index is not present.
-    fn find_object(
+    pub fn find_object(
         &mut self,
         object_handle: ReservedHandle,
     ) -> Result<Option<ReadPublicReply>, TpmHelperError> {
@@ -2060,7 +2079,7 @@ mod tests {
     ) -> (TpmRsa2kPublic, TpmRsa2kPublic) {
         let result = tpm_engine_helper.create_ak_pub(false);
         assert!(result.is_ok());
-        let ak_pub = result.unwrap();
+        let (ak_pub, _) = result.unwrap();
 
         // Ensure `create_ak_pub` persists AK
         assert!(tpm_engine_helper

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -2608,7 +2608,7 @@ mod tests {
             {
                 assert_eq!(nv_index, TPM_NV_INDEX_ATTESTATION_REPORT);
                 assert_eq!(input_size, report_input_larger.len());
-                assert_eq!(allocated_size, MAX_ATTESTATION_INDEX_SIZE.into());
+                assert_eq!(allocated_size, MAX_ATTESTATION_INDEX_SIZE as usize);
             }
         }
 

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -42,6 +42,7 @@ use crate::TPM_NV_INDEX_AIK_CERT;
 use crate::TPM_NV_INDEX_ATTESTATION_REPORT;
 use crate::TPM_NV_INDEX_MITIGATED;
 use crate::TPM_RSA_SRK_HANDLE;
+use cvm_tracing::CVM_ALLOWED;
 use inspect::InspectMut;
 use ms_tpm_20_ref::MsTpm20RefPlatform;
 use thiserror::Error;

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -2516,7 +2516,7 @@ mod tests {
             {
                 assert_eq!(nv_index, TPM_NV_INDEX_AIK_CERT);
                 assert_eq!(input_size, ak_cert_input_larger.len());
-                assert_eq!(allocated_size, MAX_NV_INDEX_SIZE.into());
+                assert_eq!(allocated_size, MAX_NV_INDEX_SIZE as usize);
             } else {
                 panic!()
             }


### PR DESCRIPTION
A malicious admin can evict the AK from their VM's vTPM and replace it with their own key. At boot, Azure will load that key from the VMGS and then sign an AKCert with that key, allowing the admin to spoof KeyGuard and CVM attestation.

CVM: This change mirrors changes in the legacy HCL: Regenerate the AK at boot from the TPM seeds, instead of loading it from VMGS. This ensures that the original AKCert is always present in the vTPM.

TVM: OpenHCL currently cannot regenerate the AK for a TVM, because the original AK (provisioned by the vtpmservice) contains an auth policy; OpenHCL does not implement that policy creation. As an alternative, when OpenHCL boots, it will check the attributes on the AK that it loads from VMGS. If the attributes are wrong (indicating a possibly malicious key), it will not make any calls to renew the AKCert.

CVE-2025-49707

---------