### PR TITLE
[MSRC 97247] Fix Trust Fall MSRC (#1849)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7083,6 +7083,7 @@ dependencies = [
  "tpm_resources",
  "tracelimit",
  "tracing",
+ "underhill_confidentiality",
  "vm_resource",
  "vmcore",
  "zerocopy 0.8.24",

--- a/vm/devices/tpm/Cargo.toml
+++ b/vm/devices/tpm/Cargo.toml
@@ -19,6 +19,7 @@ chipset_device.workspace = true
 chipset_device_resources.workspace = true
 cvm_tracing.workspace = true
 guestmem.workspace = true
+underhill_confidentiality = { workspace = true, features = ["std"] }
 vmcore.workspace = true
 vm_resource.workspace = true
 

--- a/vm/devices/tpm/src/tpm20proto.rs
+++ b/vm/devices/tpm/src/tpm20proto.rs
@@ -1375,7 +1375,7 @@ pub mod protocol {
     pub struct TpmtPublic {
         my_type: AlgId,
         name_alg: AlgId,
-        object_attributes: TpmaObject,
+        pub object_attributes: TpmaObject,
         auth_policy: Tpm2bBuffer,
         // `TPMS_RSA_PARAMS`
         pub parameters: TpmsRsaParams,


### PR DESCRIPTION
A malicious admin can evict the AK from their VM's vTPM and replace it with their own key. At boot, Azure will load that key from the VMGS and then sign an AKCert with that key, allowing the admin to spoof KeyGuard and CVM attestation.

CVM: This change mirrors changes in the legacy HCL: Regenerate the AK at boot from the TPM seeds, instead of loading it from VMGS. This ensures that the original AKCert is always present in the vTPM.

TVM: OpenHCL currently cannot regenerate the AK for a TVM, because the original AK (provisioned by the vtpmservice) contains an auth policy; OpenHCL does not implement that policy creation. As an alternative, when OpenHCL boots, it will check the attributes on the AK that it loads from VMGS. If the attributes are wrong (indicating a possibly malicious key), it will not make any calls to renew the AKCert.

CVE-2025-49707

---------