### PR TITLE
netvsp: handle RNDIS packet filter OID for stopping Rx

### DIFF
--- a/vm/devices/net/netvsp/src/rndisprot.rs
+++ b/vm/devices/net/netvsp/src/rndisprot.rs
@@ -751,6 +751,7 @@ open_enum! {
         DEFAULT = 0x80,
         RSS_CAPABILITIES = 0x88,
         RSS_PARAMETERS = 0x89,
+        OID_REQUEST = 0x96,
         OFFLOAD = 0xA7,
         OFFLOAD_ENCAPSULATION = 0xA8,
     }
@@ -1082,3 +1083,5 @@ open_enum! {
         BINARY = 4,
     }
 }
+
+pub type RndisPacketFilterOidValue = u32;

--- a/vm/devices/net/netvsp/src/saved_state.rs
+++ b/vm/devices/net/netvsp/src/saved_state.rs
@@ -120,6 +120,8 @@ pub struct ReadyPrimary {
     pub guest_link_down: bool,
     #[mesh(15)]
     pub pending_link_action: Option<bool>,
+    #[mesh(16)]
+    pub stop_rx: bool,
 }
 
 #[derive(Debug, Protobuf)]


### PR DESCRIPTION
Linux netvsc sends an OID to stop receiving packets on vmbus channel close. Example scenarios: hibernation and MTU change. Prior to opening a new channel and processing the packets, netvsc checks that there are no pending packets. If there are, netvsc logs and error and is unable to recover. We observe the error: `hv_netvsc eth0: Ring buffer not empty after closing rndis` in the guest syslog.

Modifying netvsp to handle the OID and stop processing RX traffic. This will allow for netvsc to successfully close and re-open the vmbus channel, even under heavy incoming traffic.