### PR TITLE
Revert "Disable debug mode for TDX release builds (#1865)"

### DIFF
--- a/vm/loader/manifests/openhcl-x64-cvm-release.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-release.json
@@ -26,7 +26,7 @@
             "max_vtl": 2,
             "isolation_type": {
                 "tdx": {
-                    "enable_debug": false,
+                    "enable_debug": true,
                     "sept_ve_disable": true
                 }
             },


### PR DESCRIPTION
This reverts commit b768183d1caf86ac5533954be474db2e80d32c59. This apparently broke vmbus relay on tdx. We're not sure why yet, but revert it for now to unblock RIs.