### PR TITLE
ohcl_boot: Always enable logging ASAP

### DIFF
--- a/openhcl/openhcl_boot/src/boot_logger.rs
+++ b/openhcl/openhcl_boot/src/boot_logger.rs
@@ -19,12 +19,6 @@ use core::fmt::Write;
 use minimal_rt::arch::InstrIoAccess;
 use minimal_rt::arch::Serial;
 
-/// The logging type to use.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LoggerType {
-    Serial,
-}
-
 enum Logger {
     #[cfg(target_arch = "x86_64")]
     Serial(Serial<InstrIoAccess>),
@@ -55,19 +49,16 @@ pub static BOOT_LOGGER: BootLogger = BootLogger {
 };
 
 /// Initialize the boot logger. This replaces any previous init calls.
-///
-/// If a given `logger_type` is unavailable on a given isolation type, the
-/// logger will ignore it, and no logging will be initialized.
-pub fn boot_logger_init(isolation_type: IsolationType, logger_type: LoggerType) {
+pub fn boot_logger_init(isolation_type: IsolationType) {
     let mut logger = BOOT_LOGGER.logger.borrow_mut();
 
-    *logger = match (isolation_type, logger_type) {
+    *logger = match isolation_type {
         #[cfg(target_arch = "x86_64")]
-        (IsolationType::None, LoggerType::Serial) => Logger::Serial(Serial::init(InstrIoAccess)),
+        IsolationType::None => Logger::Serial(Serial::init(InstrIoAccess)),
         #[cfg(target_arch = "aarch64")]
-        (IsolationType::None, LoggerType::Serial) => Logger::Serial(Serial::init()),
+        IsolationType::None => Logger::Serial(Serial::init()),
         #[cfg(target_arch = "x86_64")]
-        (IsolationType::Tdx, LoggerType::Serial) => Logger::TdxSerial(Serial::init(TdxIoAccess)),
+        IsolationType::Tdx => Logger::TdxSerial(Serial::init(TdxIoAccess)),
         _ => Logger::None,
     };
 }

--- a/openhcl/openhcl_boot/src/boot_logger.rs
+++ b/openhcl/openhcl_boot/src/boot_logger.rs
@@ -49,16 +49,16 @@ pub static BOOT_LOGGER: BootLogger = BootLogger {
 };
 
 /// Initialize the boot logger. This replaces any previous init calls.
-pub fn boot_logger_init(isolation_type: IsolationType) {
+pub fn boot_logger_init(isolation_type: IsolationType, com3_serial_available: bool) {
     let mut logger = BOOT_LOGGER.logger.borrow_mut();
 
-    *logger = match isolation_type {
+    *logger = match (isolation_type, com3_serial_available) {
         #[cfg(target_arch = "x86_64")]
-        IsolationType::None => Logger::Serial(Serial::init(InstrIoAccess)),
+        (IsolationType::None, true) => Logger::Serial(Serial::init(InstrIoAccess)),
         #[cfg(target_arch = "aarch64")]
-        IsolationType::None => Logger::Serial(Serial::init()),
+        (IsolationType::None, true) => Logger::Serial(Serial::init()),
         #[cfg(target_arch = "x86_64")]
-        IsolationType::Tdx => Logger::TdxSerial(Serial::init(TdxIoAccess)),
+        (IsolationType::Tdx, true) => Logger::TdxSerial(Serial::init(TdxIoAccess)),
         _ => Logger::None,
     };
 }

--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -147,7 +147,7 @@ mod tests {
         assert_eq!(
             parse_boot_command_line(&cmdline),
             BootCommandLineOptions {
-                logger: Some(LoggerType::Serial),
+                logger: None,
                 confidential_debug: true,
                 ..BootCommandLineOptions::new()
             }

--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -3,15 +3,7 @@
 
 //! Command line arguments and parsing for openhcl_boot.
 
-use crate::boot_logger::LoggerType;
 use underhill_confidentiality::OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME;
-
-/// Enable boot logging in the bootloader.
-///
-/// Format of `OPENHCL_BOOT_LOG=<logger>`, with valid loggers being:
-///     - `com3`: use the com3 serial port, available on no isolation or Tdx.
-const BOOT_LOG: &str = "OPENHCL_BOOT_LOG=";
-const SERIAL_LOGGER: &str = "com3";
 
 /// Enable the private VTL2 GPA pool for page allocations. This is only enabled
 /// via the command line, because in order to support the VTL2 GPA pool
@@ -36,7 +28,6 @@ const SIDECAR: &str = "OPENHCL_SIDECAR=";
 
 #[derive(Debug, PartialEq)]
 pub struct BootCommandLineOptions {
-    pub logger: Option<LoggerType>,
     pub confidential_debug: bool,
     pub enable_vtl2_gpa_pool: Option<u64>,
     pub sidecar: bool,
@@ -46,7 +37,6 @@ pub struct BootCommandLineOptions {
 impl BootCommandLineOptions {
     pub const fn new() -> Self {
         BootCommandLineOptions {
-            logger: None,
             confidential_debug: false,
             enable_vtl2_gpa_pool: None,
             sidecar: true, // sidecar is enabled by default
@@ -59,11 +49,7 @@ impl BootCommandLineOptions {
     /// Parse arguments from a command line.
     pub fn parse(&mut self, cmdline: &str) {
         for arg in cmdline.split_whitespace() {
-            if arg.starts_with(BOOT_LOG) {
-                if let Some(SERIAL_LOGGER) = arg.split_once('=').map(|(_, arg)| arg) {
-                    self.logger = Some(LoggerType::Serial)
-                }
-            } else if arg.starts_with(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME) {
+            if arg.starts_with(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME) {
                 let arg = arg.split_once('=').map(|(_, arg)| arg);
                 if arg.is_some_and(|a| a != "0") {
                     self.confidential_debug = true;
@@ -99,59 +85,6 @@ mod tests {
         let mut options = BootCommandLineOptions::new();
         options.parse(cmdline);
         options
-    }
-
-    #[test]
-    fn test_console_parsing() {
-        assert_eq!(
-            parse_boot_command_line("OPENHCL_BOOT_LOG=com3"),
-            BootCommandLineOptions {
-                logger: Some(LoggerType::Serial),
-                ..BootCommandLineOptions::new()
-            }
-        );
-
-        assert_eq!(
-            parse_boot_command_line("OPENHCL_BOOT_LOG=1"),
-            BootCommandLineOptions {
-                logger: None,
-                ..BootCommandLineOptions::new()
-            }
-        );
-
-        assert_eq!(
-            parse_boot_command_line("OPENHCL_BOOT_LOG=random"),
-            BootCommandLineOptions {
-                logger: None,
-                ..BootCommandLineOptions::new()
-            }
-        );
-
-        assert_eq!(
-            parse_boot_command_line("OPENHCL_BOOT_LOG==com3"),
-            BootCommandLineOptions {
-                logger: None,
-                ..BootCommandLineOptions::new()
-            }
-        );
-
-        assert_eq!(
-            parse_boot_command_line("OPENHCL_BOOT_LOGserial"),
-            BootCommandLineOptions {
-                logger: None,
-                ..BootCommandLineOptions::new()
-            }
-        );
-
-        let cmdline = format!("{OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME}=1");
-        assert_eq!(
-            parse_boot_command_line(&cmdline),
-            BootCommandLineOptions {
-                logger: None,
-                confidential_debug: true,
-                ..BootCommandLineOptions::new()
-            }
-        );
     }
 
     #[test]

--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -67,10 +67,6 @@ impl BootCommandLineOptions {
                 let arg = arg.split_once('=').map(|(_, arg)| arg);
                 if arg.is_some_and(|a| a != "0") {
                     self.confidential_debug = true;
-                    // Explicit logger specification overrides this default.
-                    if self.logger.is_none() {
-                        self.logger = Some(LoggerType::Serial);
-                    }
                 }
             } else if arg.starts_with(ENABLE_VTL2_GPA_POOL) {
                 self.enable_vtl2_gpa_pool = arg.split_once('=').and_then(|(_, arg)| {


### PR DESCRIPTION
There's no reason not to have it. This also removes the configuration of logging and the ability to disable it, since we still only have the one output backend.