### PR TITLE
TPM: Break dependency on underhill_confidentiality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7189,7 +7189,6 @@ dependencies = [
  "tpm_resources",
  "tracelimit",
  "tracing",
- "underhill_confidentiality",
  "vm_resource",
  "vmcore",
  "zerocopy 0.8.24",

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2575,6 +2575,7 @@ async fn new_underhill_vm(
                 register_layout,
                 guest_secret_key: platform_attestation_data.guest_secret_key,
                 logger: Some(GetTpmLoggerHandle.into_resource()),
+                is_confidential_vm: isolation.is_isolated(),
             }
             .into_resource(),
         });

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1018,6 +1018,7 @@ fn vm_config_from_command_line(
                 register_layout,
                 guest_secret_key: None,
                 logger: None,
+                is_confidential_vm: false,
             }
             .into_resource(),
         });

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -55,6 +55,7 @@ impl PetriVmConfigOpenVmm {
                     register_layout: TpmRegisterLayout::IoPort,
                     guest_secret_key: None,
                     logger: None,
+                    is_confidential_vm: self.firmware.isolation().is_some(),
                 }
                 .into_resource(),
             });

--- a/vm/devices/tpm/Cargo.toml
+++ b/vm/devices/tpm/Cargo.toml
@@ -19,7 +19,6 @@ chipset_device.workspace = true
 chipset_device_resources.workspace = true
 cvm_tracing.workspace = true
 guestmem.workspace = true
-underhill_confidentiality = { workspace = true, features = ["std"] }
 vmcore.workspace = true
 vm_resource.workspace = true
 

--- a/vm/devices/tpm/src/resolver.rs
+++ b/vm/devices/tpm/src/resolver.rs
@@ -117,6 +117,7 @@ impl AsyncResolveResource<ChipsetDeviceHandleKind, TpmDeviceHandle> for TpmDevic
             ak_cert_type,
             resource.guest_secret_key,
             logger,
+            resource.is_confidential_vm,
         )
         .await
         .map_err(ResolveTpmError::Tpm)?;

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -3754,6 +3754,7 @@ mod tests {
             TpmAkCertType::Trusted(Arc::new(TestRequestAkCertHelper {})),
             None,
             None,
+            false,
         )
         .await
         .unwrap();

--- a/vm/devices/tpm_resources/src/lib.rs
+++ b/vm/devices/tpm_resources/src/lib.rs
@@ -30,6 +30,8 @@ pub struct TpmDeviceHandle {
     pub guest_secret_key: Option<Vec<u8>>,
     /// Optional logger to send event to the host
     pub logger: Option<Resource<TpmLoggerKind>>,
+    /// Whether or not the TPM is in a confidential VM
+    pub is_confidential_vm: bool,
 }
 
 impl ResourceId<ChipsetDeviceHandleKind> for TpmDeviceHandle {


### PR DESCRIPTION
underhill_confidentiality is an openhcl-specific crate, and should not be depended on by a generic device. The TPM slipped this by. Fix it by passing in the needed info at construction instead.