### PR TITLE
nvme_test: added NvmeFaultControllerResolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5133,6 +5133,7 @@ dependencies = [
  "net_tap",
  "netvsp",
  "nvme",
+ "nvme_test",
  "rusqlite",
  "scsidisk",
  "serial_16550",

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -57,6 +57,7 @@ vmcore.workspace = true
 # PCI devices
 gdma.workspace = true
 nvme.workspace = true
+nvme_test.workspace = true
 
 # SCSI
 scsidisk.workspace = true

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -61,6 +61,7 @@ vm_resource::register_static_resolvers! {
     // PCI devices
     gdma::resolver::GdmaDeviceResolver,
     nvme::resolver::NvmeControllerResolver,
+    nvme_test::resolver::NvmeFaultControllerResolver,
     virtio::resolver::VirtioPciResolver,
 
     // SCSI

--- a/vm/devices/storage/nvme_resources/src/lib.rs
+++ b/vm/devices/storage/nvme_resources/src/lib.rs
@@ -29,6 +29,23 @@ impl ResourceId<PciDeviceHandleKind> for NvmeControllerHandle {
     const ID: &'static str = "nvme";
 }
 
+/// A handle to an NVMe controller.
+#[derive(MeshPayload)]
+pub struct NvmeFaultControllerHandle {
+    /// The subsystem ID to use when responding to controller identify queries.
+    pub subsystem_id: Guid,
+    /// The number of MSI-X interrupts to support.
+    pub msix_count: u16,
+    /// The number of IO queues to support.
+    pub max_io_queues: u16,
+    /// The initial set of namespaces.
+    pub namespaces: Vec<NamespaceDefinition>,
+}
+
+impl ResourceId<PciDeviceHandleKind> for NvmeFaultControllerHandle {
+    const ID: &'static str = "nvme_fault";
+}
+
 /// A controller namespace definition.
 #[derive(MeshPayload)]
 pub struct NamespaceDefinition {

--- a/vm/devices/storage/nvme_test/src/resolver.rs
+++ b/vm/devices/storage/nvme_test/src/resolver.rs
@@ -10,7 +10,7 @@ use crate::NvmeFaultControllerCaps;
 use async_trait::async_trait;
 use disk_backend::resolve::ResolveDiskParameters;
 use nvme_resources::NamespaceDefinition;
-use nvme_resources::NvmeControllerHandle;
+use nvme_resources::NvmeFaultControllerHandle;
 use pci_resources::ResolvePciDeviceHandleParams;
 use pci_resources::ResolvedPciDevice;
 use thiserror::Error;
@@ -20,15 +20,15 @@ use vm_resource::ResourceResolver;
 use vm_resource::declare_static_async_resolver;
 use vm_resource::kind::PciDeviceHandleKind;
 
-/// Resource resolver for [`NvmeControllerHandle`].
-pub struct NvmeControllerResolver;
+/// Resource resolver for [`NvmeFaultControllerHandle`].
+pub struct NvmeFaultControllerResolver;
 
 declare_static_async_resolver! {
-    NvmeControllerResolver,
-    (PciDeviceHandleKind, NvmeControllerHandle),
+    NvmeFaultControllerResolver,
+    (PciDeviceHandleKind, NvmeFaultControllerHandle),
 }
 
-/// Error returned by [`NvmeControllerResolver`].
+/// Error returned by [`NvmeFaultControllerResolver`].
 #[derive(Debug, Error)]
 #[expect(missing_docs)]
 pub enum Error {
@@ -43,14 +43,16 @@ pub enum Error {
 }
 
 #[async_trait]
-impl AsyncResolveResource<PciDeviceHandleKind, NvmeControllerHandle> for NvmeControllerResolver {
+impl AsyncResolveResource<PciDeviceHandleKind, NvmeFaultControllerHandle>
+    for NvmeFaultControllerResolver
+{
     type Output = ResolvedPciDevice;
     type Error = Error;
 
     async fn resolve(
         &self,
         resolver: &ResourceResolver,
-        resource: NvmeControllerHandle,
+        resource: NvmeFaultControllerHandle,
         input: ResolvePciDeviceHandleParams<'_>,
     ) -> Result<Self::Output, Self::Error> {
         let controller = NvmeFaultController::new(


### PR DESCRIPTION
The resolver in the `nvme_test` crate should resolve the `NvmeFaultController` type. This was a bug during the initial push to the nvme_test crate.
For now the behavior of the NvmeFaultControllerHandler is scoped to a no-fault behavior. Support for defining faults in the vmm test will be coming in a follow up PR 