### PR TITLE
uh_mem: Don't remove permissions when sharing pages

### DIFF
--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -27,7 +27,6 @@ use hcl::ioctl::MshvVtl;
 use hcl::ioctl::snp::SnpPageError;
 use hv1_structs::VtlArray;
 use hvdef::HV_MAP_GPA_PERMISSIONS_ALL;
-use hvdef::HV_MAP_GPA_PERMISSIONS_NONE;
 use hvdef::HV_PAGE_SIZE;
 use hvdef::HvError;
 use hvdef::HvMapGpaFlags;
@@ -588,13 +587,6 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         };
 
         for &range in &ranges {
-            if shared && vtl == GuestVtl::Vtl0 {
-                // Accessing these pages through the encrypted mapping is now
-                // invalid. Make sure the VTL bitmaps reflect this.
-                self.vtl0
-                    .update_permission_bitmaps(range, HV_MAP_GPA_PERMISSIONS_NONE);
-            }
-
             clear_bitmap.update_valid(range, false);
         }
 


### PR DESCRIPTION
When we are sharing a page we previously were removing all VTL 0 permissions to that page. There is no need to do this, as the encrypted/shared bitmaps already track access to these pages for us. Later on, when we re-private the page, we were failing to reset these permissions, which led to failures when the guest tried to use pages it should have had access to. I think the later resetting code is correct, and the code here is wrong, but a read-through of the full function is probably warranted to review this.