### PR TITLE
Repo: Explicitly specify static crt for musl targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -89,6 +89,8 @@ rustflags = [
 rustflags = [
   # Use the musl from the sysroot, not from the Rust distribution.
   "-Clink-self-contained=n",
+  # Force musl to be statically linked in
+  "-Ctarget-feature=+crt-static",
   # Use RELR relocation format, which is considerably smaller.
   "-Clink-arg=-Wl,-z,pack-relative-relocs",
 ]


### PR DESCRIPTION
This is currently Rust's default behavior, but it will be changing at some point in the future (https://github.com/rust-lang/rust/pull/144513). Just specifying it explicitly now doesn't hurt, and avoids the warning noise whenever it shows up.