### PR TITLE
uh_mem: Properly reset permissions when unsharing pages (#1891)

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1464,7 +1464,6 @@ pub trait ProtectIsolatedMemory: Send + Sync {
     /// hardware-isolated VMs, they apply just to the given vtl.
     fn change_default_vtl_protections(
         &self,
-        calling_vtl: Vtl,
         target_vtl: GuestVtl,
         protections: HvMapGpaFlags,
         tlb_access: &mut dyn TlbFlushLockAccess,
@@ -1473,7 +1472,6 @@ pub trait ProtectIsolatedMemory: Send + Sync {
     /// Changes the vtl protections on a range of guest memory.
     fn change_vtl_protections(
         &self,
-        calling_vtl: Vtl,
         target_vtl: GuestVtl,
         gpns: &[u64],
         protections: HvMapGpaFlags,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1219,7 +1219,6 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::ModifyVtlProtectionMask
         // 1 can set the protections, the permissions should be changed for VTL
         // 0.
         protector.change_vtl_protections(
-            self.intercepted_vtl.into(),
             GuestVtl::Vtl0,
             gpa_pages,
             map_flags,
@@ -1301,7 +1300,6 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::EnablePartitionVtl
         // Grant VTL 1 access to lower VTL memory
         tracing::debug!("Granting VTL 1 access to lower VTL memory");
         protector.change_default_vtl_protections(
-            Vtl::Vtl2,
             GuestVtl::Vtl1,
             hvdef::HV_MAP_GPA_PERMISSIONS_ALL,
             &mut self.vp.tlb_flush_lock_access(),
@@ -1779,7 +1777,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         }
 
         protector.change_default_vtl_protections(
-            vtl.into(),
             targeted_vtl,
             protections,
             &mut self.tlb_flush_lock_access(),


### PR DESCRIPTION
When we are sharing a page we remove all VTL 0 permissions to that page. Later on, when we re-private the page, we were failing to reset these permissions, which led to failures when the guest tried to use pages it should have had access to. This code is a bit confusing due to conflating private/shared with VTL 1 access permissions. Add a bunch of comments, and fix the reset.

Cherry-pick of #1891 