### PR TITLE
ohcl_boot: Do not check the hw debug bit for OHCL debug configuration

### DIFF
--- a/openhcl/openhcl_boot/src/arch/x86_64/tdx.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/tdx.rs
@@ -22,8 +22,6 @@ use tdcall::tdcall_map_gpa;
 use tdcall::tdcall_wrmsr;
 use x86defs::X64_LARGE_PAGE_SIZE;
 use x86defs::tdx::RESET_VECTOR_PAGE;
-use x86defs::tdx::TdCallResult;
-use x86defs::tdx::TdReport;
 
 /// Writes a synthehtic register to tell the hypervisor the OS ID for the boot shim.
 fn report_os_id(guest_os_id: u64) {
@@ -212,9 +210,4 @@ pub fn setup_vtl2_vp(partition_info: &PartitionInfo) {
             .tdx_start_vp(cpu as u32)
             .expect("start vp should not fail");
     }
-}
-
-/// Gets the TdReport.
-pub fn get_tdreport(report: &mut TdReport) -> Result<(), TdCallResult> {
-    tdcall::tdcall_mr_report(&mut TdcallInstruction, report)
 }

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -650,8 +650,8 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
         log!("openhcl_boot: early debugging enabled");
     }
 
-    let can_trust_host =
-        p.isolation_type == IsolationType::None || static_options.confidential_debug;
+    let static_confidential_debug = static_options.confidential_debug;
+    let can_trust_host = p.isolation_type == IsolationType::None || static_confidential_debug;
 
     let boot_reftime = get_ref_time(p.isolation_type);
 
@@ -666,8 +666,8 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     // Confidential debug will show up in boot_options only if included in the
     // static command line, or if can_trust_host is true (so the dynamic command
     // line has been parsed).
-    let is_confidential_debug = (can_trust_host && p.isolation_type != IsolationType::None)
-        || partition_info.boot_options.confidential_debug;
+    let is_confidential_debug =
+        static_confidential_debug || partition_info.boot_options.confidential_debug;
 
     // Fill out the non-devicetree derived parts of PartitionInfo.
     if !p.isolation_type.is_hardware_isolated()

--- a/vm/loader/manifests/openhcl-x64-cvm-dev.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-dev.json
@@ -8,7 +8,7 @@
                 "snp": {
                     "shared_gpa_boundary_bits": 46,
                     "policy": 196639,
-                    "enable_debug": true,
+                    "enable_debug": false,
                     "injection_type": "normal"
                 }
             },
@@ -26,7 +26,7 @@
             "max_vtl": 2,
             "isolation_type": {
                 "tdx": {
-                    "enable_debug": true,
+                    "enable_debug": false,
                     "sept_ve_disable": true
                 }
             },
@@ -44,7 +44,7 @@
             "max_vtl": 2,
             "isolation_type": {
                 "vbs": {
-                    "enable_debug": true
+                    "enable_debug": false
                 }
             },
             "image": {

--- a/vm/loader/manifests/openhcl-x64-cvm-dev.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-dev.json
@@ -32,7 +32,7 @@
             },
             "image": {
                 "openhcl": {
-                    "command_line": "",
+                    "command_line": "OPENHCL_CONFIDENTIAL_DEBUG=1",
                     "memory_page_count": 163840,
                     "memory_page_base": 32768,
                     "uefi": true

--- a/vm/loader/manifests/openhcl-x64-cvm-dev.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-dev.json
@@ -8,7 +8,7 @@
                 "snp": {
                     "shared_gpa_boundary_bits": 46,
                     "policy": 196639,
-                    "enable_debug": false,
+                    "enable_debug": true,
                     "injection_type": "normal"
                 }
             },
@@ -44,7 +44,7 @@
             "max_vtl": 2,
             "isolation_type": {
                 "vbs": {
-                    "enable_debug": false
+                    "enable_debug": true
                 }
             },
             "image": {

--- a/vm/loader/manifests/uefi-x64.json
+++ b/vm/loader/manifests/uefi-x64.json
@@ -6,7 +6,7 @@
             "max_vtl": 0,
             "isolation_type": {
                 "tdx": {
-                    "enable_debug": true,
+                    "enable_debug": false,
                     "sept_ve_disable": true
                 }
             },
@@ -23,7 +23,7 @@
                 "snp": {
                     "shared_gpa_boundary_bits": 39,
                     "policy": 196639,
-                    "enable_debug": true,
+                    "enable_debug": false,
                     "injection_type": "restricted"
                 }
             },

--- a/vm/loader/manifests/uefi-x64.json
+++ b/vm/loader/manifests/uefi-x64.json
@@ -23,7 +23,7 @@
                 "snp": {
                     "shared_gpa_boundary_bits": 39,
                     "policy": 196639,
-                    "enable_debug": false,
+                    "enable_debug": true,
                     "injection_type": "restricted"
                 }
             },


### PR DESCRIPTION
As discussed in today's meeting, the hw debug bit on TDX has unfortunate side effects to being set. Stop using it entirely.