### PR TITLE
nvme_resources: Moving to fault builder model instead of a callback function

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -8,22 +8,21 @@ use chipset_device::pci::PciConfigSpace;
 use guid::Guid;
 use inspect::Inspect;
 use inspect::InspectMut;
+use mesh::CellUpdater;
 use nvme::NvmeControllerCaps;
+use nvme_resources::fault::AdminQueueFaultConfig;
 use nvme_resources::fault::FaultConfiguration;
-use nvme_resources::fault::QueueFault;
 use nvme_resources::fault::QueueFaultBehavior;
+use nvme_spec::AdminOpcode;
 use nvme_spec::Cap;
 use nvme_spec::Command;
-use nvme_spec::Completion;
 use nvme_spec::nvm::DsmRange;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
-use pal_async::timer::PolledTimer;
 use parking_lot::Mutex;
 use pci_core::msi::MsiInterruptSet;
 use scsi_buffers::OwnedRequestBuffers;
 use std::sync::Arc;
-use std::time::Duration;
 use test_with_tracing::test;
 use user_driver::DeviceBacking;
 use user_driver::DeviceRegisterIo;
@@ -35,50 +34,24 @@ use user_driver_emulated_mock::Mapping;
 use vmcore::vm_task::SingleDriverBackend;
 use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
+use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
-
-struct AdminQueueFault {
-    pub driver: VmTaskDriver,
-}
-
-#[async_trait::async_trait]
-impl QueueFault for AdminQueueFault {
-    async fn fault_submission_queue(&self, mut command: Command) -> QueueFaultBehavior<Command> {
-        tracing::info!("Faulting submission queue using cid sequence number mismatch");
-        let opcode = nvme_spec::AdminOpcode(command.cdw0.opcode());
-        match opcode {
-            nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE => {
-                // Overwrite the previous cid to cause a panic.
-                command.cdw0.set_cid(0);
-                QueueFaultBehavior::Update(command)
-            }
-            _ => QueueFaultBehavior::Default,
-        }
-    }
-
-    async fn fault_completion_queue(
-        &self,
-        _completion: Completion,
-    ) -> QueueFaultBehavior<Completion> {
-        tracing::info!("Faulting completion queue using delay");
-        PolledTimer::new(&self.driver)
-            .sleep(Duration::from_millis(100))
-            .await;
-        QueueFaultBehavior::Default
-    }
-}
 
 #[async_test]
 #[should_panic(expected = "assertion `left == right` failed: cid sequence number mismatch:")]
 async fn test_nvme_command_fault(driver: DefaultDriver) {
     let task_driver = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())).simple();
+    let mut output_cmd = Command::new_zeroed();
+    output_cmd.cdw0.set_cid(0);
 
     test_nvme_fault_injection(
         driver,
         FaultConfiguration {
-            admin_fault: Some(Box::new(AdminQueueFault {
-                driver: task_driver,
-            })),
+            fault_active: CellUpdater::new(true).cell(),
+            admin_fault: AdminQueueFaultConfig::new().with_submission_queue_fault(
+                AdminOpcode::IDENTIFY.0,
+                QueueFaultBehavior::Update(output_cmd),
+            ),
         },
     )
     .await;

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -3,7 +3,8 @@
 
 //! Fault definitions for NVMe fault controller.
 
-use nvme_spec as spec;
+use mesh::Cell;
+use nvme_spec::Command;
 
 /// Supported fault behaviour for NVMe queues
 #[derive(Debug, Clone, Copy)]
@@ -16,24 +17,51 @@ pub enum QueueFaultBehavior<T> {
     Default,
 }
 
-/// Provides fault logic for a pair of submission and completion queue.
-#[async_trait::async_trait]
-pub trait QueueFault {
-    /// Provided a command in the submission queue, return the appropriate fault behavior.
-    async fn fault_submission_queue(
-        &self,
-        command: spec::Command,
-    ) -> QueueFaultBehavior<spec::Command>;
-
-    /// Provided a command in the completion queue, return the appropriate fault behavior.
-    async fn fault_completion_queue(
-        &self,
-        completion: spec::Completion,
-    ) -> QueueFaultBehavior<spec::Completion>;
+/// A buildable fault configuration
+pub struct AdminQueueFaultConfig {
+    /// A mapping from the admin opcode to its fault behavior. This should ideally be using a HashMap but Encode/Decode is not yet available for that.
+    /// It should also be a mapping from OpCode -> QueueFaultBehavior<Command> but Encode/Decode is not yet available for those types.
+    pub admin_submission_queue_intercept: Vec<(u8, QueueFaultBehavior<Command>)>,
 }
 
-/// Configuration for NVMe controller faults.
+/// A simple fault configuration with admin submission queue support
 pub struct FaultConfiguration {
+    /// Fault active state
+    pub fault_active: Cell<bool>,
     /// Fault to apply to the admin queues
-    pub admin_fault: Option<Box<dyn QueueFault + Send + Sync>>,
+    pub admin_fault: AdminQueueFaultConfig,
+}
+
+impl AdminQueueFaultConfig {
+    /// Create an empty fault configuration
+    pub fn new() -> Self {
+        Self {
+            admin_submission_queue_intercept: vec![],
+        }
+    }
+
+    /// Add a simple submission queue fault based on opcodes
+    pub fn with_submission_queue_fault(
+        mut self,
+        opcode: u8,
+        behaviour: QueueFaultBehavior<Command>,
+    ) -> Self {
+        self.admin_submission_queue_intercept
+            .push((opcode, behaviour));
+        self
+    }
+
+    /// Given the opcode, return the fault behaviour for the Admin Command
+    pub fn fault_submission_queue(&self, command: Command) -> QueueFaultBehavior<Command> {
+        let opcode: u8 = nvme_spec::AdminOpcode(command.cdw0.opcode()).0;
+        if let Some(behavior) = self
+            .admin_submission_queue_intercept
+            .iter()
+            .find_map(|(op, b)| if *op == opcode { Some(b) } else { None })
+        {
+            behavior.clone()
+        } else {
+            QueueFaultBehavior::Default
+        }
+    }
 }

--- a/vm/devices/storage/nvme_test/src/resolver.rs
+++ b/vm/devices/storage/nvme_test/src/resolver.rs
@@ -8,8 +8,10 @@ use crate::NvmeFaultController;
 use crate::NvmeFaultControllerCaps;
 use async_trait::async_trait;
 use disk_backend::resolve::ResolveDiskParameters;
+use mesh::CellUpdater;
 use nvme_resources::NamespaceDefinition;
 use nvme_resources::NvmeFaultControllerHandle;
+use nvme_resources::fault::AdminQueueFaultConfig;
 use nvme_resources::fault::FaultConfiguration;
 use pci_resources::ResolvePciDeviceHandleParams;
 use pci_resources::ResolvedPciDevice;
@@ -65,7 +67,10 @@ impl AsyncResolveResource<PciDeviceHandleKind, NvmeFaultControllerHandle>
                 max_io_queues: resource.max_io_queues,
                 subsystem_id: resource.subsystem_id,
             },
-            FaultConfiguration { admin_fault: None },
+            FaultConfiguration {
+                fault_active: CellUpdater::new(false).cell(),
+                admin_fault: AdminQueueFaultConfig::new(),
+            },
         );
         for NamespaceDefinition {
             nsid,

--- a/vm/devices/storage/nvme_test/src/tests/shadow_doorbell_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/shadow_doorbell_tests.rs
@@ -12,6 +12,8 @@ use crate::tests::test_helpers::read_completion_from_queue;
 use crate::tests::test_helpers::test_memory;
 use crate::tests::test_helpers::write_command_to_queue;
 use guestmem::GuestMemory;
+use mesh::CellUpdater;
+use nvme_resources::fault::AdminQueueFaultConfig;
 use nvme_resources::fault::FaultConfiguration;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
@@ -37,8 +39,10 @@ async fn setup_shadow_doorbells(
     int_controller: &TestPciInterruptController,
     dq_bases: Option<(u64, u64)>,
 ) -> crate::NvmeFaultController {
-    let fault_configuration = FaultConfiguration { admin_fault: None };
-    // Build a controller with 64 entries in the admin queue (just so that the ASQ fits in one page).
+    let fault_configuration = FaultConfiguration {
+        fault_active: CellUpdater::new(false).cell(),
+        admin_fault: AdminQueueFaultConfig::new(),
+    }; // Build a controller with 64 entries in the admin queue (just so that the ASQ fits in one page).
     let mut nvmec = instantiate_and_build_admin_queue(
         cq_buf,
         64,


### PR DESCRIPTION
While this is less flexible of an approach, using a fault builder model will help staticly define faults for vmm tests in the future since they will need to be Mesh-Sendable. 