### PR TITLE
storage: Add storvsc_manager and disk_storvsc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "disk_storvsc"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "disk_backend",
+ "futures",
+ "futures-concurrency",
+ "guestmem",
+ "guid",
+ "inspect",
+ "mesh",
+ "pal_async",
+ "scsi_buffers",
+ "scsi_defs",
+ "storvsc_driver",
+ "storvsp_protocol",
+ "task_control",
+ "test_with_tracing",
+ "thiserror 2.0.12",
+ "tracing",
+ "tracing_helpers",
+ "vm_resource",
+ "vmbus_async",
+ "vmbus_channel",
+ "vmbus_core",
+ "vmbus_relay_intercept_device",
+ "vmbus_ring",
+ "vmbus_user_channel",
+ "vmcore",
+ "zerocopy 0.8.24",
+]
+
+[[package]]
 name = "disk_striped"
 version = "0.0.0"
 dependencies = [
@@ -6636,6 +6670,7 @@ dependencies = [
  "chipset_device",
  "disk_backend",
  "disk_nvme",
+ "disk_storvsc",
  "disklayer_ram",
  "guestmem",
  "guid",
@@ -6664,10 +6699,12 @@ dependencies = [
 name = "storvsc_driver"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "futures",
  "futures-concurrency",
  "guestmem",
  "inspect",
+ "mesh",
  "mesh_channel",
  "pal_async",
  "scsi_buffers",
@@ -6679,6 +6716,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "tracing_helpers",
+ "user_driver",
  "vmbus_async",
  "vmbus_channel",
  "vmbus_ring",
@@ -6734,6 +6772,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "guid",
+ "inspect",
  "open_enum",
  "scsi_defs",
  "zerocopy 0.8.24",
@@ -7507,6 +7546,7 @@ dependencies = [
  "disk_blockdevice",
  "disk_get_vmgs",
  "disk_nvme",
+ "disk_storvsc",
  "firmware_pcat",
  "firmware_uefi",
  "firmware_uefi_custom_vars",
@@ -7573,7 +7613,9 @@ dependencies = [
  "sparse_mmap",
  "state_unit",
  "storage_string",
+ "storvsc_driver",
  "storvsp",
+ "storvsp_protocol",
  "storvsp_resources",
  "tee_call",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,7 @@ disk_layered = { path = "vm/devices/storage/disk_layered" }
 disk_nvme = { path = "vm/devices/storage/disk_nvme" }
 disk_delay = { path = "vm/devices/storage/disk_delay" }
 disk_prwrap = { path = "vm/devices/storage/disk_prwrap" }
+disk_storvsc = { path = "vm/devices/storage/disk_storvsc" }
 disk_striped = { path = "vm/devices/storage/disk_striped" }
 disk_vhd1 = { path = "vm/devices/storage/disk_vhd1" }
 disk_vhdmp = { path = "vm/devices/storage/disk_vhdmp" }

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -159,7 +159,9 @@ fn build_kernel_command_line(
         "rdinit=/underhill-init",
         // Default to user-mode NVMe driver.
         "OPENHCL_NVME_VFIO=1",
-        // The next three items reduce the memory overhead of the storvsc driver.
+        // Default to user-mode storvsc driver.
+        "OPENHCL_STORVSC_USERMODE=1",
+        // The next three items reduce the memory overhead of the kernel storvsc driver.
         // Since it is only used for DVD, performance is not critical.
         "hv_storvsc.storvsc_vcpus_per_sub_channel=2048",
         // Fix number of hardware queues at 2.

--- a/openhcl/rootfs.config
+++ b/openhcl/rootfs.config
@@ -35,7 +35,7 @@ file /lib/modules/001/pci-hyperv.ko         ${OPENHCL_KERNEL_PATH}/build/native/
 
 # Storvsc is last because it sometimes takes a long time to load and should not
 # block other device startup.
-file /lib/modules/999/hv_storvsc.ko         ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/scsi/hv_storvsc.ko      0644 0 0
+#file /lib/modules/999/hv_storvsc.ko         ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/scsi/hv_storvsc.ko      0644 0 0
 
 # These nodes are needed for early logging before devfs is mounted.
 nod /dev/null      0666 0 0 c 1  3

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -48,6 +48,7 @@ disk_backend_resources.workspace = true
 disk_blockdevice.workspace = true
 disk_get_vmgs.workspace = true
 disk_nvme.workspace = true
+disk_storvsc.workspace = true
 firmware_uefi.workspace = true
 firmware_uefi_custom_vars.workspace = true
 hyperv_ic_guest.workspace = true
@@ -79,7 +80,9 @@ scsidisk.workspace = true
 scsidisk_resources.workspace = true
 serial_16550_resources.workspace = true
 storage_string.workspace = true
+storvsc_driver.workspace = true
 storvsp.workspace = true
+storvsp_protocol.workspace = true
 storvsp_resources.workspace = true
 tpm_resources.workspace = true
 tpm = { workspace = true, features = ["tpm"] }

--- a/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
+++ b/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
@@ -5,6 +5,7 @@
 
 use super::LoadedVm;
 use crate::nvme_manager::NvmeDiskConfig;
+use crate::storvsc_manager::StorvscDiskConfig;
 use crate::worker::NicConfig;
 use anyhow::Context;
 use cvm_tracing::CVM_ALLOWED;
@@ -243,6 +244,7 @@ pub struct DeviceInterfaces {
     scsi_dvds: HashMap<StorageDevicePath, mesh::Sender<SimpleScsiDvdRequest>>,
     scsi_request: HashMap<Guid, mesh::Sender<ScsiControllerRequest>>,
     use_nvme_vfio: bool,
+    use_storvsc_usermode: bool,
 }
 
 impl Vtl2SettingsWorker {
@@ -376,6 +378,7 @@ impl Vtl2SettingsWorker {
                         &StorageContext {
                             uevent_listener,
                             use_nvme_vfio: self.interfaces.use_nvme_vfio,
+                            use_storvsc_usermode: self.interfaces.use_storvsc_usermode,
                         },
                         &disk,
                         false,
@@ -394,6 +397,7 @@ impl Vtl2SettingsWorker {
                         &StorageContext {
                             uevent_listener,
                             use_nvme_vfio: self.interfaces.use_nvme_vfio,
+                            use_storvsc_usermode: self.interfaces.use_storvsc_usermode,
                         },
                         &disk,
                         false,
@@ -957,6 +961,7 @@ async fn make_disk_type_from_physical_devices(
 struct StorageContext<'a> {
     uevent_listener: &'a UeventListener,
     use_nvme_vfio: bool,
+    use_storvsc_usermode: bool,
 }
 
 #[instrument(skip_all, fields(CVM_ALLOWED))]
@@ -997,6 +1002,36 @@ async fn make_disk_type_from_physical_device(
         return Ok(Resource::new(NvmeDiskConfig {
             pci_id,
             nsid: sub_device_path,
+        }));
+    }
+
+    // Special case for VScsi when using usermode storvsc.
+    if storage_context.use_storvsc_usermode
+        && matches!(
+            single_device.device_type,
+            underhill_config::DeviceType::VScsi
+        )
+    {
+        // Wait for the SCSI controller to arrive.
+        let devpath = uio_path(&controller_instance_id);
+        async {
+            ctx.until_cancelled(storage_context.uevent_listener.wait_for_devpath(&devpath))
+                .await??;
+            Ok(())
+        }
+        .await
+        .map_err(|err| Error::StorageCannotFindVtl2Device {
+            device_type: single_device.device_type,
+            instance_id: controller_instance_id,
+            sub_device_path,
+            source: err,
+        })?;
+
+        // Cannot validate device actually exists yet. Check this later
+        // TODO: Is this true?
+        return Ok(Resource::new(StorvscDiskConfig {
+            instance_guid: controller_instance_id,
+            lun: sub_device_path as u8,
         }));
     }
 
@@ -1428,6 +1463,7 @@ pub async fn create_storage_controllers_from_vtl2_settings(
     ctx: &mut CancelContext,
     uevent_listener: &UeventListener,
     use_nvme_vfio: bool,
+    use_storvsc_usermode: bool,
     settings: &Vtl2SettingsDynamic,
     sub_channels: u16,
     is_restoring: bool,
@@ -1443,6 +1479,7 @@ pub async fn create_storage_controllers_from_vtl2_settings(
     let storage_context = StorageContext {
         uevent_listener,
         use_nvme_vfio,
+        use_storvsc_usermode,
     };
     let ide_controller =
         make_ide_controller_config(ctx, &storage_context, settings, is_restoring).await?;
@@ -1643,6 +1680,11 @@ fn vpci_path(instance_id: &Guid) -> (String, PathBuf) {
     (pci_id, devpath)
 }
 
+fn uio_path(instance_id: &Guid) -> PathBuf {
+    // TODO: Is this enough?
+    PathBuf::from(format!("/sys/bus/vmbus/devices/{instance_id}/uio"))
+}
+
 /// Waits for the PCI path to get populated. The PCI path is just a symlink to the actual
 /// device path. This should be called once the device path is available.
 pub async fn wait_for_pci_path(pci_id: &String) {
@@ -1782,6 +1824,7 @@ impl InitialControllers {
         uevent_listener: &UeventListener,
         dps: &DevicePlatformSettings,
         use_nvme_vfio: bool,
+        use_storvsc_usermode: bool,
         is_restoring: bool,
         default_io_queue_depth: u32,
     ) -> anyhow::Result<Self> {
@@ -1801,6 +1844,7 @@ impl InitialControllers {
                 &mut context,
                 uevent_listener,
                 use_nvme_vfio,
+                use_storvsc_usermode,
                 dynamic,
                 fixed.scsi_sub_channels,
                 is_restoring,
@@ -1851,6 +1895,7 @@ impl InitialControllers {
                 scsi_dvds,
                 scsi_request,
                 use_nvme_vfio,
+                use_storvsc_usermode,
             },
         };
 

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -20,6 +20,7 @@ mod nvme_manager;
 mod options;
 mod reference_time;
 mod servicing;
+mod storvsc_manager;
 mod threadpool_vm_task_backend;
 mod vmbus_relay_unit;
 mod vmgs_logger;
@@ -325,6 +326,7 @@ async fn launch_workers(
         nvme_keep_alive: opt.nvme_keep_alive,
         test_configuration: opt.test_configuration,
         disable_uefi_frontpage: opt.disable_uefi_frontpage,
+        storvsc_usermode: opt.storvsc_usermode,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -147,6 +147,10 @@ pub struct Options {
     /// will result in UEFI terminating, shutting down the guest instead of
     /// showing the frontpage.
     pub disable_uefi_frontpage: bool,
+
+    /// (OPENHCL_STORVSC_USERMODE=1)
+    /// Use the user-mode storvsc driver instead of the Linux driver.
+    pub storvsc_usermode: bool,
 }
 
 impl Options {
@@ -246,6 +250,7 @@ impl Options {
         });
         let disable_uefi_frontpage = parse_env_bool("OPENHCL_DISABLE_UEFI_FRONTPAGE");
         let signal_vtl0_started = parse_env_bool("OPENHCL_SIGNAL_VTL0_STARTED");
+        let storvsc_usermode = parse_env_bool("OPENHCL_STORVSC_USERMODE");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -301,6 +306,7 @@ impl Options {
             nvme_keep_alive,
             test_configuration,
             disable_uefi_frontpage,
+            storvsc_usermode,
         })
     }
 

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -47,6 +47,14 @@ mod state {
         pub nvme_state: crate::nvme_manager::save_restore::NvmeManagerSavedState,
     }
 
+    #[derive(Protobuf)]
+    #[mesh(package = "underhill")]
+    pub struct StorvscSavedState {
+        /// Storvsc manager (worker) saved state.
+        #[mesh(1)]
+        pub storvsc_state: crate::storvsc_manager::save_restore::StorvscManagerSavedState,
+    }
+
     /// Servicing state needed to create the LoadedVm object.
     #[derive(Protobuf)]
     #[mesh(package = "underhill")]
@@ -84,6 +92,8 @@ mod state {
         pub dma_manager_state: Option<OpenhclDmaManagerState>,
         #[mesh(10002)]
         pub vmbus_client: Option<vmbus_client::SavedState>,
+        #[mesh(10003)]
+        pub storvsc_state: Option<StorvscSavedState>,
     }
 
     #[derive(Protobuf)]
@@ -202,6 +212,7 @@ pub mod transposed {
         pub nvme_state: Option<Option<NvmeSavedState>>,
         pub dma_manager_state: Option<Option<OpenhclDmaManagerState>>,
         pub vmbus_client: Option<Option<vmbus_client::SavedState>>,
+        pub storvsc_state: Option<Option<StorvscSavedState>>,
     }
 
     /// A transposed `Option<EmuplatSavedState>`, where each field of
@@ -232,6 +243,7 @@ pub mod transposed {
                     nvme_state,
                     dma_manager_state,
                     vmbus_client,
+                    storvsc_state,
                 } = state;
 
                 OptionServicingInitState {
@@ -248,6 +260,7 @@ pub mod transposed {
                     nvme_state: Some(nvme_state),
                     dma_manager_state: Some(dma_manager_state),
                     vmbus_client: Some(vmbus_client),
+                    storvsc_state: Some(storvsc_state),
                 }
             } else {
                 OptionServicingInitState::default()

--- a/openhcl/underhill_core/src/storvsc_manager.rs
+++ b/openhcl/underhill_core/src/storvsc_manager.rs
@@ -1,0 +1,421 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Provides access to storvsc driver instances shared between disks on each vStor controller.
+
+use crate::servicing::StorvscSavedState;
+use crate::storvsc_manager::save_restore::StorvscManagerSavedState;
+use crate::storvsc_manager::save_restore::StorvscSavedDriverConfig;
+use anyhow::Context;
+use async_trait::async_trait;
+use disk_backend::resolve::ResolveDiskParameters;
+use disk_backend::resolve::ResolvedDisk;
+use futures::StreamExt;
+use futures::TryFutureExt;
+use futures::future::join_all;
+use inspect::Inspect;
+use mesh::MeshPayload;
+use mesh::rpc::Rpc;
+use mesh::rpc::RpcSend;
+use openhcl_dma_manager::AllocationVisibility;
+use openhcl_dma_manager::DmaClientParameters;
+use openhcl_dma_manager::DmaClientSpawner;
+use openhcl_dma_manager::LowerVtlPermissionPolicy;
+use pal_async::task::Spawn;
+use pal_async::task::Task;
+use std::collections::HashMap;
+use std::collections::hash_map;
+use std::sync::Arc;
+use storvsc_driver::StorvscDriver;
+use thiserror::Error;
+use tracing::Instrument;
+use vm_resource::AsyncResolveResource;
+use vm_resource::ResourceId;
+use vm_resource::ResourceResolver;
+use vm_resource::kind::DiskHandleKind;
+use vmbus_user_channel::MappedRingMem;
+use vmcore::vm_task::VmTaskDriverSource;
+
+#[derive(Debug, Error)]
+#[error("storvsc driver {instance_guid} error")]
+pub struct DriverError {
+    instance_guid: guid::Guid,
+    #[source]
+    source: InnerError,
+}
+
+#[derive(Debug, Error)]
+enum InnerError {
+    #[error("failed to initialize vmbus channel")]
+    Vmbus(#[source] vmbus_user_channel::Error),
+    #[error("failed to initialize storvsc driver")]
+    DriverInitFailed(#[source] storvsc_driver::StorvscError),
+    #[error("failed to create dma client for device")]
+    DmaClient(#[source] anyhow::Error),
+}
+
+#[derive(Debug)]
+pub struct StorvscManager {
+    task: Task<()>,
+    client: StorvscManagerClient,
+    /// Running environment (memory layout) supports save/restore.
+    save_restore_supported: bool,
+}
+
+impl Inspect for StorvscManager {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        let mut resp = req.respond();
+        resp.merge(inspect::adhoc(|req| {
+            self.client.sender.send(Request::Inspect(req.defer()))
+        }));
+    }
+}
+
+impl StorvscManager {
+    pub fn new(
+        driver_source: &VmTaskDriverSource,
+        save_restore_supported: bool,
+        is_isolated: bool,
+        saved_state: Option<StorvscSavedState>,
+        dma_client_spawner: DmaClientSpawner,
+    ) -> Self {
+        let (send, recv) = mesh::channel();
+        let driver = driver_source.simple();
+        let mut worker = StorvscManagerWorker {
+            driver_source: driver_source.clone(),
+            drivers: HashMap::new(),
+            save_restore_supported,
+            is_isolated,
+            dma_client_spawner,
+        };
+        let task = driver.spawn("storvsc-manager", async move {
+            // Restore saved data (if present) before async worker thread runs.
+            if let Some(s) = saved_state.as_ref() {
+                if let Err(e) = StorvscManager::restore(&mut worker, s)
+                    .instrument(tracing::info_span!("storvsc_manager_restore"))
+                    .await
+                {
+                    tracing::error!(
+                        error = e.as_ref() as &dyn std::error::Error,
+                        "failed to restore storvsc manager"
+                    );
+                }
+            };
+            worker.run(recv).await
+        });
+        Self {
+            task,
+            client: StorvscManagerClient { sender: send },
+            save_restore_supported,
+        }
+    }
+
+    pub fn client(&self) -> &StorvscManagerClient {
+        &self.client
+    }
+
+    pub async fn shutdown(self) {
+        self.client.sender.send(Request::Shutdown {
+            span: tracing::info_span!("shutdown_storvsc_manager"),
+        });
+        self.task.await;
+    }
+
+    /// Save storvsc manager's state during servicing.
+    pub async fn save(&self) -> Option<StorvscManagerSavedState> {
+        // The manager has no data to save, so everything will be done in the Worker task which can
+        // be contacted through the Client.
+        if self.save_restore_supported {
+            Some(self.client().save().await?)
+        } else {
+            None
+        }
+    }
+
+    /// Restore the storvsc manager's state after servicing.
+    async fn restore(
+        worker: &mut StorvscManagerWorker,
+        saved_state: &StorvscSavedState,
+    ) -> anyhow::Result<()> {
+        worker
+            .restore(&saved_state.storvsc_state)
+            .instrument(tracing::info_span!("storvsc_worker_restore"))
+            .await?;
+
+        Ok(())
+    }
+}
+
+enum Request {
+    Inspect(inspect::Deferred),
+    GetDriver(Rpc<guid::Guid, Result<Arc<StorvscDriver<MappedRingMem>>, DriverError>>),
+    Save(Rpc<(), Result<StorvscManagerSavedState, anyhow::Error>>),
+    Shutdown { span: tracing::Span },
+}
+
+#[derive(Debug, Clone)]
+pub struct StorvscManagerClient {
+    sender: mesh::Sender<Request>,
+}
+
+impl StorvscManagerClient {
+    pub async fn get_driver(
+        &self,
+        instance_guid: guid::Guid,
+    ) -> anyhow::Result<Arc<StorvscDriver<MappedRingMem>>> {
+        Ok(self
+            .sender
+            .call(Request::GetDriver, instance_guid)
+            .instrument(tracing::info_span!(
+                "storvsc_get_driver",
+                instance_guid = instance_guid.to_string()
+            ))
+            .await
+            .context("storvsc manager is shutdown")??)
+    }
+
+    pub async fn save(&self) -> Option<StorvscManagerSavedState> {
+        match self.sender.call(Request::Save, ()).await {
+            Ok(s) => s.ok(),
+            Err(_) => None,
+        }
+    }
+}
+
+#[derive(Inspect)]
+struct StorvscManagerWorker {
+    #[inspect(skip)]
+    driver_source: VmTaskDriverSource,
+    #[inspect(iter_by_key)]
+    drivers: HashMap<guid::Guid, Arc<StorvscDriver<MappedRingMem>>>,
+    /// Running environment (memory layout) allows save/restore.
+    save_restore_supported: bool,
+    /// If this VM is isolated or not. This influences DMA client allocations.
+    is_isolated: bool,
+    #[inspect(skip)]
+    dma_client_spawner: DmaClientSpawner,
+}
+
+impl StorvscManagerWorker {
+    async fn run(&mut self, mut recv: mesh::Receiver<Request>) {
+        let join_span = loop {
+            let Some(req) = recv.next().await else {
+                break tracing::Span::none();
+            };
+            match req {
+                Request::Inspect(deferred) => deferred.inspect(&self),
+                Request::GetDriver(rpc) => {
+                    rpc.handle(async |instance_guid| {
+                        self.get_driver(instance_guid)
+                            .map_err(|source| DriverError {
+                                instance_guid,
+                                source,
+                            })
+                            .await
+                    })
+                    .await
+                }
+                Request::Save(rpc) => {
+                    rpc.handle(async |_| self.save().await)
+                        .instrument(tracing::info_span!("storvsc_save_state"))
+                        .await
+                }
+                Request::Shutdown { span } => {
+                    break span;
+                }
+            }
+        };
+
+        if !self.save_restore_supported {
+            async {
+                join_all(self.drivers.drain().map(|(guid, driver)| {
+                    let guid_str = guid.to_string();
+                    async move {
+                        driver
+                            .stop()
+                            .instrument(tracing::info_span!(
+                                "shutdown_storvsc_driver",
+                                guid = guid_str
+                            ))
+                            .await
+                    }
+                }))
+                .await
+            }
+            .instrument(join_span)
+            .await;
+        }
+    }
+
+    async fn get_driver(
+        &mut self,
+        instance_guid: guid::Guid,
+    ) -> Result<Arc<StorvscDriver<MappedRingMem>>, InnerError> {
+        let storvsc = match self.drivers.entry(instance_guid) {
+            hash_map::Entry::Occupied(entry) => entry.get().clone(),
+            hash_map::Entry::Vacant(entry) => {
+                let file = vmbus_user_channel::open_uio_device(&instance_guid)
+                    .map_err(InnerError::Vmbus)?;
+                let channel = vmbus_user_channel::channel(&self.driver_source.simple(), file)
+                    .map_err(InnerError::Vmbus)?;
+
+                let dma_client = self
+                    .dma_client_spawner
+                    .new_client(DmaClientParameters {
+                        device_name: format!("storvsc_{}", instance_guid),
+                        lower_vtl_policy: LowerVtlPermissionPolicy::Any,
+                        allocation_visibility: if self.is_isolated {
+                            AllocationVisibility::Shared
+                        } else {
+                            AllocationVisibility::Private
+                        },
+                        persistent_allocations: self.save_restore_supported,
+                    })
+                    .map_err(InnerError::DmaClient)?;
+
+                let mut driver = Arc::new(StorvscDriver::new(dma_client));
+
+                Arc::get_mut(&mut driver)
+                    .unwrap()
+                    .run(
+                        &self.driver_source,
+                        channel,
+                        storvsp_protocol::ProtocolVersion {
+                            major_minor: storvsp_protocol::VERSION_BLUE,
+                            reserved: 0,
+                        },
+                        0, // TODO: Pick right VP
+                    )
+                    .map_err(InnerError::DriverInitFailed)
+                    .await?;
+
+                entry.insert(driver).clone()
+            }
+        };
+        Ok(storvsc)
+    }
+
+    /// Saves storvsc driver states into buffer during servicing.
+    pub async fn save(&mut self) -> anyhow::Result<StorvscManagerSavedState> {
+        let mut storvsc_drivers: Vec<StorvscSavedDriverConfig> = Vec::new();
+        for (guid, driver) in self.drivers.iter_mut() {
+            storvsc_drivers.push(StorvscSavedDriverConfig {
+                instance_guid: *guid,
+                driver_state: driver
+                    .save()
+                    .instrument(tracing::info_span!(
+                        "storvsc_driver_save",
+                        instance_guid = guid.to_string()
+                    ))
+                    .await?,
+            });
+        }
+
+        Ok(StorvscManagerSavedState { storvsc_drivers })
+    }
+
+    /// Restores storvsc manager and driver states from the buffer after servicing.
+    pub async fn restore(&mut self, saved_state: &StorvscManagerSavedState) -> anyhow::Result<()> {
+        self.drivers = HashMap::new();
+        for driver_state in &saved_state.storvsc_drivers {
+            let file = vmbus_user_channel::open_uio_device(&driver_state.instance_guid)
+                .map_err(InnerError::Vmbus)?;
+            let channel = vmbus_user_channel::channel(&self.driver_source.simple(), file)
+                .map_err(InnerError::Vmbus)?;
+
+            let dma_client = self
+                .dma_client_spawner
+                .new_client(DmaClientParameters {
+                    device_name: format!("storvsc_{}", driver_state.instance_guid),
+                    lower_vtl_policy: LowerVtlPermissionPolicy::Any,
+                    allocation_visibility: if self.is_isolated {
+                        AllocationVisibility::Shared
+                    } else {
+                        AllocationVisibility::Private
+                    },
+                    persistent_allocations: self.save_restore_supported,
+                })
+                .map_err(InnerError::DmaClient)?;
+
+            self.drivers.insert(
+                driver_state.instance_guid,
+                Arc::new(
+                    StorvscDriver::restore(
+                        &driver_state.driver_state,
+                        &self.driver_source,
+                        channel,
+                        0,
+                        dma_client,
+                    )
+                    .await?,
+                ), // TODO: Pick right VP
+            );
+        }
+        Ok(())
+    }
+}
+
+pub struct StorvscDiskResolver {
+    manager: StorvscManagerClient,
+}
+
+impl StorvscDiskResolver {
+    pub fn new(manager: StorvscManagerClient) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl AsyncResolveResource<DiskHandleKind, StorvscDiskConfig> for StorvscDiskResolver {
+    type Output = ResolvedDisk;
+    type Error = anyhow::Error;
+
+    async fn resolve(
+        &self,
+        _resolver: &ResourceResolver,
+        rsrc: StorvscDiskConfig,
+        _input: ResolveDiskParameters<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        let disk = self
+            .manager
+            .get_driver(rsrc.instance_guid)
+            .await
+            .context("could not open storvsc disk")?;
+
+        Ok(
+            ResolvedDisk::new(disk_storvsc::StorvscDisk::new(disk, rsrc.lun))
+                .context("invalid disk")?,
+        )
+    }
+}
+
+#[derive(MeshPayload, Default)]
+pub struct StorvscDiskConfig {
+    pub instance_guid: guid::Guid,
+    pub lun: u8,
+}
+
+impl ResourceId<DiskHandleKind> for StorvscDiskConfig {
+    const ID: &'static str = "storvsc";
+}
+
+pub mod save_restore {
+    use mesh::payload::Protobuf;
+    use vmcore::save_restore::SavedStateRoot;
+
+    #[derive(Protobuf, SavedStateRoot)]
+    #[mesh(package = "underhill")]
+    pub struct StorvscManagerSavedState {
+        #[mesh(1)]
+        pub storvsc_drivers: Vec<StorvscSavedDriverConfig>,
+    }
+
+    #[derive(Protobuf, Clone)]
+    #[mesh(package = "underhill")]
+    pub struct StorvscSavedDriverConfig {
+        #[mesh(1)]
+        pub instance_guid: guid::Guid,
+        #[mesh(2)]
+        pub driver_state: storvsc_driver::save_restore::StorvscDriverSavedState,
+    }
+}

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -49,6 +49,9 @@ use crate::reference_time::ReferenceTime;
 use crate::servicing;
 use crate::servicing::ServicingState;
 use crate::servicing::transposed::OptionServicingInitState;
+use crate::storvsc_manager::StorvscDiskConfig;
+use crate::storvsc_manager::StorvscDiskResolver;
+use crate::storvsc_manager::StorvscManager;
 use crate::threadpool_vm_task_backend::ThreadpoolBackend;
 use crate::vmbus_relay_unit::VmbusRelayHandle;
 use crate::vmgs_logger::GetVmgsLogger;
@@ -286,6 +289,8 @@ pub struct UnderhillEnvCfg {
     pub test_configuration: Option<TestScenarioConfig>,
     /// Disable the UEFI front page.
     pub disable_uefi_frontpage: bool,
+    /// Use the user-mode storvsc driver.
+    pub storvsc_usermode: bool,
 }
 
 /// Bundle of config + runtime objects for hooking into the underhill remote
@@ -1805,6 +1810,7 @@ async fn new_underhill_vm(
         &uevent_listener,
         &dps,
         env_cfg.nvme_vfio,
+        env_cfg.storvsc_usermode,
         is_restoring,
         default_io_queue_depth,
     )
@@ -1889,6 +1895,27 @@ async fn new_underhill_vm(
         resolver.add_async_resolver::<DiskHandleKind, _, NvmeDiskConfig, _>(NvmeDiskResolver::new(
             manager.client().clone(),
         ));
+
+        Some(manager)
+    } else {
+        None
+    };
+
+    let storvsc_manager = if env_cfg.storvsc_usermode {
+        let private_pool_available = !runtime_params.private_pool_ranges().is_empty();
+        let save_restore_supported = private_pool_available;
+
+        let manager = StorvscManager::new(
+            &driver_source,
+            save_restore_supported,
+            isolation.is_isolated(),
+            servicing_state.storvsc_state.unwrap_or(None),
+            dma_manager.client_spawner(),
+        );
+
+        resolver.add_async_resolver::<DiskHandleKind, _, StorvscDiskConfig, _>(
+            StorvscDiskResolver::new(manager.client().clone()),
+        );
 
         Some(manager)
     } else {
@@ -3070,6 +3097,7 @@ async fn new_underhill_vm(
         uevent_listener,
         resolver,
         nvme_manager,
+        storvsc_manager,
         emuplat_servicing: EmuplatServicing {
             get_backed_adjust_gpa_range: emuplat_adjust_gpa_range,
             rtc_local_clock: rtc_time_source.0,

--- a/openhcl/underhill_init/src/lib.rs
+++ b/openhcl/underhill_init/src/lib.rs
@@ -485,6 +485,11 @@ fn do_main() -> anyhow::Result<()> {
             "427b03e7-4ceb-4286-b5fc-486f4a1dd439",
         ),
         (
+            "/sys/bus/vmbus/drivers/uio_hv_generic/new_id",
+            // SCSI
+            "ba6163d9-04a1-4d29-b605-72e2ffb1dc7f",
+        ),
+        (
             "/proc/sys/kernel/core_pattern",
             if underhill_confidentiality::confidential_filtering_enabled() {
                 // Disable the processing of dumps for CVMs.

--- a/vm/devices/storage/disk_storvsc/Cargo.toml
+++ b/vm/devices/storage/disk_storvsc/Cargo.toml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 [package]
-name = "storvsc_driver"
+name = "disk_storvsc"
 edition.workspace = true
 rust-version.workspace = true
 
@@ -10,28 +10,34 @@ rust-version.workspace = true
 test = []
 
 [dependencies]
+disk_backend.workspace = true
+storvsc_driver.workspace = true
+
 scsi_buffers.workspace = true
 scsi_defs.workspace = true
 
 vmbus_async.workspace = true
 vmbus_channel.workspace = true
+vmbus_core.workspace = true
+vmbus_relay_intercept_device.workspace = true
 vmbus_ring.workspace = true
+vmbus_user_channel.workspace = true
 
 storvsp_protocol.workspace = true
 
 guestmem.workspace = true
+guid.workspace = true
 inspect.workspace = true
 mesh.workspace = true
-mesh_channel.workspace = true
 pal_async.workspace = true
 task_control.workspace = true
-user_driver.workspace = true
 vmcore.workspace = true
+vm_resource.workspace = true
 
 anyhow.workspace = true
+async-trait.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
-slab.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing_helpers.workspace = true

--- a/vm/devices/storage/disk_storvsc/src/lib.rs
+++ b/vm/devices/storage/disk_storvsc/src/lib.rs
@@ -1,0 +1,532 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Disk backend implementation that uses a user-mode storvsc driver.
+
+#![forbid(unsafe_code)]
+
+use disk_backend::DiskError;
+use disk_backend::DiskIo;
+use disk_backend::UnmapBehavior;
+use inspect::Inspect;
+use scsi_defs::ScsiOp;
+use scsi_defs::ScsiStatus;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use storvsc_driver::StorvscDriver;
+use storvsc_driver::StorvscErrorKind;
+use vmbus_user_channel::MappedRingMem;
+use zerocopy::FromZeros;
+use zerocopy::IntoBytes;
+
+/// Maximum number of retries when a retryable failure occurs, which should really only happen
+/// during servicing. Servicing shouldn't happen frequently enough to make more than one retry
+/// necessary, but provide some buffer room.
+const MAX_RETRIES: usize = 5;
+
+/// Disk backend using a storvsc driver to the host.
+#[derive(Inspect)]
+pub struct StorvscDisk {
+    #[inspect(skip)]
+    driver: Arc<StorvscDriver<MappedRingMem>>,
+    lun: u8,
+    num_sectors: u64,
+    sector_size: u32,
+    disk_id: Option<[u8; 16]>,
+    optimal_unmap_sectors: u32,
+    read_only: bool,
+}
+
+impl StorvscDisk {
+    /// Creates a new storvsc-backed disk that uses the provided storvsc driver.
+    pub fn new(driver: Arc<StorvscDriver<MappedRingMem>>, lun: u8) -> Self {
+        let mut disk = Self {
+            driver,
+            lun,
+            num_sectors: 0,
+            sector_size: 0,
+            disk_id: None,
+            optimal_unmap_sectors: 0,
+            read_only: false,
+        };
+        disk.scan_metadata();
+        disk
+    }
+}
+
+impl StorvscDisk {
+    fn scan_metadata(&mut self) {
+        // Allocate region for data in for READ_CAPACITY(16), MODE_SENSE(10), and INQUIRY (Block Limits VPD)
+        let data_in_size = size_of::<scsi_defs::ReadCapacity16Data>()
+            .max(size_of::<scsi_defs::ModeControlPage>())
+            .max(size_of::<scsi_defs::VpdBlockLimitsDescriptor>());
+        let data_in = match self.driver.allocate_dma_buffer(data_in_size) {
+            Ok(buf) => buf,
+            Err(err) => {
+                tracing::error!(
+                    error = err.to_string(),
+                    "Unable to allocate DMA buffer to read disk metadata"
+                );
+                return;
+            }
+        };
+
+        // READ_CAPACITY(16) returns number of sectors and sector size in bytes.
+        let read_capacity16_cdb = scsi_defs::Cdb16 {
+            operation_code: ScsiOp::READ_CAPACITY16,
+            ..FromZeros::new_zeroed()
+        };
+        match futures::executor::block_on(self.send_scsi_request(
+            read_capacity16_cdb.as_bytes(),
+            ScsiOp::READ_CAPACITY16,
+            data_in.base() as u64,
+            data_in_size,
+            true,
+        )) {
+            Ok(resp) => {
+                match resp.scsi_status {
+                    ScsiStatus::GOOD => {
+                        let capacity = data_in.read_obj::<scsi_defs::ReadCapacity16Data>(0);
+                        self.num_sectors = capacity.ex.logical_block_address.into();
+                        self.num_sectors += 1; // Add one to include the last sector
+                        self.sector_size = capacity.ex.bytes_per_block.into();
+                    }
+                    _ => {
+                        tracing::error!(
+                            scsi_status = ?resp.scsi_status,
+                            "READ_CAPACITY16 failed"
+                        );
+                        return;
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "READ_CAPACITY16 failed"
+                );
+            }
+        }
+
+        // MODE_SENSE10 to get whether read-only.
+        let mode_sense10_cdb = scsi_defs::ModeSense10 {
+            operation_code: ScsiOp::MODE_SENSE10,
+            flags2: scsi_defs::ModeSenseFlags::new().with_page_code(scsi_defs::MODE_PAGE_CONTROL),
+            sub_page_code: 0,
+            allocation_length: (data_in_size as u16).into(),
+            ..FromZeros::new_zeroed()
+        };
+
+        match futures::executor::block_on(self.send_scsi_request(
+            mode_sense10_cdb.as_bytes(),
+            mode_sense10_cdb.operation_code,
+            0,
+            0,
+            false,
+        )) {
+            Ok(resp) => match resp.scsi_status {
+                ScsiStatus::GOOD => {
+                    let mode_page = data_in.read_obj::<scsi_defs::ModeControlPage>(0);
+                    self.read_only = mode_page.flags3.swp();
+                }
+                _ => {
+                    tracing::error!(
+                        scsi_status = ?resp.scsi_status,
+                        "MODE_SENSE10 failed"
+                    );
+                }
+            },
+            Err(err) => {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "MODE_SENSE10 failed"
+                );
+            }
+        }
+
+        // INQUIRY for the Block Limits VPD page returns the optimal unmap sectors.
+        let inquiry_block_limits_cdb = scsi_defs::CdbInquiry {
+            operation_code: ScsiOp::INQUIRY.0,
+            flags: scsi_defs::InquiryFlags::new().with_vpd(true),
+            page_code: scsi_defs::VPD_BLOCK_LIMITS,
+            allocation_length: (data_in_size as u16).into(),
+            ..FromZeros::new_zeroed()
+        };
+
+        match futures::executor::block_on(self.send_scsi_request(
+            inquiry_block_limits_cdb.as_bytes(),
+            ScsiOp::INQUIRY,
+            data_in.base() as u64,
+            data_in_size,
+            true,
+        )) {
+            Ok(resp) => match resp.scsi_status {
+                ScsiStatus::GOOD => {
+                    let block_limits_vpd =
+                        data_in.read_obj::<scsi_defs::VpdBlockLimitsDescriptor>(0);
+                    self.optimal_unmap_sectors = block_limits_vpd.optimal_unmap_granularity.into();
+                }
+                _ => {
+                    tracing::error!(
+                        scsi_status = ?resp.scsi_status,
+                        "INQUIRY for Block Limits VPD failed"
+                    );
+                }
+            },
+            Err(err) => {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "INQUIRY for Block Limits VPD failed"
+                );
+            }
+        }
+
+        // INQUIRY for the Device Identification VPD page returns the designator (disk ID).
+        self.disk_id = None;
+        let inquiry_device_identification_cdb = scsi_defs::CdbInquiry {
+            operation_code: ScsiOp::INQUIRY.0,
+            flags: scsi_defs::InquiryFlags::new().with_vpd(true),
+            page_code: scsi_defs::VPD_DEVICE_IDENTIFIERS,
+            allocation_length: (data_in_size as u16).into(),
+            ..FromZeros::new_zeroed()
+        };
+
+        match futures::executor::block_on(self.send_scsi_request(
+            inquiry_device_identification_cdb.as_bytes(),
+            ScsiOp::INQUIRY,
+            data_in.base() as u64,
+            data_in_size,
+            true,
+        )) {
+            Ok(resp) => match resp.scsi_status {
+                ScsiStatus::GOOD => {
+                    let mut buf_pos = 0;
+                    let vpd_header = data_in.read_obj::<scsi_defs::VpdPageHeader>(0);
+                    buf_pos += size_of::<scsi_defs::VpdPageHeader>();
+                    while buf_pos < vpd_header.page_length as usize + 4 {
+                        let designator_header =
+                            data_in.read_obj::<scsi_defs::VpdIdentificationDescriptor>(buf_pos);
+                        buf_pos += size_of::<scsi_defs::VpdIdentificationDescriptor>();
+                        match designator_header.identifiertype {
+                            scsi_defs::VPD_IDENTIFIER_TYPE_FCPH_NAME => {
+                                // Reinterpret as NAA ID designator.
+                                let designator_naa =
+                                    data_in.read_obj::<scsi_defs::VpdNaaId>(buf_pos);
+                                let mut disk_id = [0u8; 16];
+                                disk_id[0] = designator_naa.ouid_msb;
+                                disk_id[1..3]
+                                    .copy_from_slice(designator_naa.ouid_middle.as_slice());
+                                disk_id[3] = designator_naa.ouid_lsb;
+                                disk_id[4..]
+                                    .copy_from_slice(designator_naa.vendor_specific_id.as_slice());
+                                self.disk_id = Some(disk_id);
+                                break;
+                            }
+                            _ => {
+                                buf_pos += size_of::<scsi_defs::VpdIdentificationDescriptor>()
+                                    + designator_header.identifier_length as usize;
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    tracing::error!(
+                        scsi_status = ?resp.scsi_status,
+                        "INQUIRY for Device Identification VPD failed"
+                    );
+                }
+            },
+            Err(err) => {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "INQUIRY for Block Limits VPD failed"
+                );
+            }
+        }
+    }
+
+    fn generate_scsi_request(
+        &self,
+        data_transfer_length: u32,
+        payload: &[u8],
+        is_read: bool,
+    ) -> storvsp_protocol::ScsiRequest {
+        assert!(payload.len() <= storvsp_protocol::MAX_DATA_BUFFER_LENGTH_WITH_PADDING);
+        let data_in: u8 = if is_read { 1 } else { 0 };
+        let mut request = storvsp_protocol::ScsiRequest {
+            target_id: 0,
+            path_id: 0,
+            lun: self.lun,
+            length: storvsp_protocol::SCSI_REQUEST_LEN_V2 as u16,
+            cdb_length: payload.len() as u8,
+            data_transfer_length,
+            data_in,
+            ..FromZeros::new_zeroed()
+        };
+        request.payload[0..payload.len()].copy_from_slice(payload);
+        request
+    }
+
+    async fn send_scsi_request(
+        &self,
+        cdb: &[u8],
+        op: ScsiOp,
+        buf_gpa: u64,
+        byte_len: usize,
+        is_read: bool,
+    ) -> Result<storvsp_protocol::ScsiRequest, DiskError> {
+        let request = self.generate_scsi_request(byte_len as u32, cdb, is_read);
+
+        let mut num_tries = 0;
+        loop {
+            match self.driver.send_request(&request, buf_gpa, byte_len).await {
+                Ok(resp) => match resp.scsi_status {
+                    ScsiStatus::GOOD => break Ok(resp), // Request succeeded, break out of loop
+                    _ => {
+                        tracing::error!(?op, scsi_status = ?resp.scsi_status, "SCSI request failed");
+                        Err(DiskError::Io(std::io::Error::other(format!(
+                            "SCSI request failed, op={:?}, scsi_status={:?}",
+                            op, resp.scsi_status
+                        ))))
+                    }
+                },
+                Err(err) => {
+                    tracing::error!(
+                        error = &err as &dyn std::error::Error,
+                        "SCSI request failed"
+                    );
+                    match err.kind() {
+                        StorvscErrorKind::CompletionError => Err(DiskError::Io(
+                            std::io::Error::new(std::io::ErrorKind::Interrupted, err),
+                        )),
+                        StorvscErrorKind::Cancelled => Err(DiskError::Io(std::io::Error::new(
+                            std::io::ErrorKind::Interrupted,
+                            err,
+                        ))),
+                        StorvscErrorKind::CancelledRetry => {
+                            if num_tries < MAX_RETRIES {
+                                Ok(())
+                            } else {
+                                break Err(DiskError::Io(std::io::Error::new(
+                                    std::io::ErrorKind::Interrupted,
+                                    err,
+                                )));
+                            }
+                        }
+                        _ => Err(DiskError::Io(std::io::Error::other(err))),
+                    }
+                }
+            }?;
+            num_tries += 1;
+        }
+    }
+}
+
+impl DiskIo for StorvscDisk {
+    fn disk_type(&self) -> &str {
+        "storvsc"
+    }
+
+    fn sector_count(&self) -> u64 {
+        self.num_sectors
+    }
+
+    fn sector_size(&self) -> u32 {
+        self.sector_size
+    }
+
+    fn disk_id(&self) -> Option<[u8; 16]> {
+        self.disk_id
+    }
+
+    fn physical_sector_size(&self) -> u32 {
+        self.sector_size
+    }
+
+    fn is_fua_respected(&self) -> bool {
+        true
+    }
+
+    fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+
+    async fn read_vectored(
+        &self,
+        buffers: &scsi_buffers::RequestBuffers<'_>,
+        sector: u64,
+    ) -> Result<(), DiskError> {
+        if self.sector_size == 0 {
+            // Disk failed to initialize.
+            return Err(DiskError::IllegalBlock);
+        }
+
+        if buffers.len() % self.sector_size as usize != 0 {
+            // Buffer length must be a multiple of sector size.
+            return Err(DiskError::InvalidInput);
+        }
+
+        // Get LockedPages for the buffers to pass to the storvsc client.
+        let locked_buffers = buffers
+            .guest_memory()
+            .lock_gpns(false, buffers.range().gpns())
+            .map_err(|_| DiskError::ReservationConflict)?;
+
+        let cdb = scsi_defs::Cdb16 {
+            operation_code: ScsiOp::READ16,
+            logical_block: sector.into(),
+            transfer_blocks: (buffers.len() as u32 / self.sector_size).into(),
+            ..FromZeros::new_zeroed()
+        };
+
+        self.send_scsi_request(
+            cdb.as_bytes(),
+            cdb.operation_code,
+            locked_buffers.va(),
+            buffers.len(),
+            false,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn write_vectored(
+        &self,
+        buffers: &scsi_buffers::RequestBuffers<'_>,
+        sector: u64,
+        fua: bool,
+    ) -> Result<(), DiskError> {
+        if self.sector_size == 0 {
+            // Disk failed to initialize.
+            return Err(DiskError::IllegalBlock);
+        }
+
+        if buffers.len() % self.sector_size as usize != 0 {
+            // Buffer length must be a multiple of sector size.
+            return Err(DiskError::InvalidInput);
+        }
+
+        // Get LockedPages for the buffers to pass to the storvsc client.
+        let locked_buffers = buffers
+            .guest_memory()
+            .lock_gpns(false, buffers.range().gpns())
+            .map_err(|_| DiskError::ReservationConflict)?;
+
+        let cdb = scsi_defs::Cdb16 {
+            operation_code: ScsiOp::WRITE16,
+            flags: scsi_defs::Cdb16Flags::new().with_fua(fua),
+            logical_block: sector.into(),
+            transfer_blocks: (buffers.len() as u32 / self.sector_size).into(),
+            ..FromZeros::new_zeroed()
+        };
+
+        self.send_scsi_request(
+            cdb.as_bytes(),
+            cdb.operation_code,
+            locked_buffers.va(),
+            buffers.len(),
+            true,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn sync_cache(&self) -> Result<(), DiskError> {
+        if self.sector_size == 0 {
+            // Disk failed to initialize.
+            return Err(DiskError::IllegalBlock);
+        }
+
+        let cdb = scsi_defs::Cdb16 {
+            operation_code: ScsiOp::SYNCHRONIZE_CACHE16,
+            logical_block: 0.into(),
+            transfer_blocks: 0.into(), // 0 indicates to sync all sectors
+            ..FromZeros::new_zeroed()
+        };
+
+        self.send_scsi_request(cdb.as_bytes(), cdb.operation_code, 0, 0, false)
+            .await
+            .map(|_| ())
+    }
+
+    async fn eject(&self) -> Result<(), DiskError> {
+        let cdb = scsi_defs::StartStop {
+            operation_code: ScsiOp::START_STOP_UNIT,
+            flag: scsi_defs::StartStopFlags::new().with_load_eject(true),
+            ..FromZeros::new_zeroed()
+        };
+
+        self.send_scsi_request(cdb.as_bytes(), cdb.operation_code, 0, 0, false)
+            .await
+            .map(|_| ())
+    }
+
+    async fn unmap(
+        &self,
+        sector: u64,
+        count: u64,
+        _block_level_only: bool,
+    ) -> Result<(), DiskError> {
+        let cdb = scsi_defs::Unmap {
+            operation_code: ScsiOp::UNMAP,
+            allocation_length: (size_of::<scsi_defs::UnmapBlockDescriptor>() as u16).into(),
+            ..FromZeros::new_zeroed()
+        };
+
+        let unmap_param_list = scsi_defs::UnmapListHeader {
+            data_length: ((size_of::<scsi_defs::UnmapListHeader>() - 2
+                + size_of::<scsi_defs::UnmapBlockDescriptor>()) as u16)
+                .into(),
+            block_descriptor_data_length: (size_of::<scsi_defs::UnmapBlockDescriptor>() as u16)
+                .into(),
+            ..FromZeros::new_zeroed()
+        };
+
+        let unmap_descriptor = scsi_defs::UnmapBlockDescriptor {
+            start_lba: sector.into(),
+            lba_count: (count as u32).into(), // TODO: what if more than 2^32?
+            ..FromZeros::new_zeroed()
+        };
+
+        let data_out_size =
+            size_of::<scsi_defs::UnmapListHeader>() + size_of::<scsi_defs::UnmapBlockDescriptor>();
+        let data_out = match self.driver.allocate_dma_buffer(data_out_size) {
+            Ok(buf) => buf,
+            Err(err) => {
+                tracing::error!(
+                    error = err.to_string(),
+                    "Unable to allocate DMA buffer for UNMAP"
+                );
+                return Err(DiskError::Io(std::io::Error::other(err)));
+            }
+        };
+        data_out.write_at(0, unmap_param_list.as_bytes());
+        data_out.write_at(
+            size_of::<scsi_defs::UnmapListHeader>(),
+            unmap_descriptor.as_bytes(),
+        );
+
+        self.send_scsi_request(
+            cdb.as_bytes(),
+            cdb.operation_code,
+            data_out.base() as u64,
+            data_out_size,
+            false,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    fn unmap_behavior(&self) -> UnmapBehavior {
+        UnmapBehavior::Unspecified
+    }
+
+    fn optimal_unmap_sectors(&self) -> u32 {
+        self.optimal_unmap_sectors
+    }
+
+    async fn wait_resize(&self, sector_count: u64) -> u64 {
+        // This is difficult because it cannot update the stored sector count
+        todo!()
+    }
+}

--- a/vm/devices/storage/scsi_defs/src/lib.rs
+++ b/vm/devices/storage/scsi_defs/src/lib.rs
@@ -771,6 +771,60 @@ pub struct ModeSenseFlags {
 
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct ModeControlPage {
+    /*
+        UCHAR PageCode : 6;
+        UCHAR SPFBit : 1;
+        UCHAR PSBit : 1;
+    */
+    pub page_code: u8,
+    pub page_length: u8,
+    /*
+        UCHAR RLECBit : 1;
+        UCHAR GLTSDBit : 1;
+        UCHAR D_SENSEBit : 1;
+        UCHAR Reserved1 : 1;
+        UCHAR TMF_ONLYBit : 1;
+        UCHAR TST : 3;
+    */
+    pub flags1: u8,
+    /*
+        UCHAR Reserved2 : 1;
+        UCHAR QERR : 2;
+        UCHAR Reserved3 : 1;
+        UCHAR QueueAlgorithmModifier : 4;
+    */
+    pub flags2: u8,
+    pub flags3: ModeControlPageFlags3,
+    /*
+        UCHAR AutoloadMode : 3;
+        UCHAR Reserved5 : 3;
+        UCHAR TASBit : 1;
+        UCHAR ATOBit : 1;
+    */
+    pub flags4: u8,
+    pub reserved6: [u8; 2],
+    pub busy_timeout_period: [u8; 2],
+    pub extended_self_test_completion_time: [u8; 2],
+}
+
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct ModeControlPageFlags3 {
+    #[bits(3)]
+    pub reserved: u8,
+    #[bits(1)]
+    pub swp: bool,
+    #[bits(2)]
+    pub ua_intlck_ctrl: u8,
+    #[bits(1)]
+    pub rac: bool,
+    #[bits(1)]
+    pub vs: bool,
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct ModeReadWriteRecoveryPage {
     /*
         UCHAR PageCode : 6;

--- a/vm/devices/storage/storage_tests/Cargo.toml
+++ b/vm/devices/storage/storage_tests/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 chipset_device.workspace = true
 disk_backend.workspace = true
 disk_nvme.workspace = true
+disk_storvsc.workspace = true
 disklayer_ram.workspace = true
 guestmem.workspace = true
 guid = { workspace = true, features = ["mesh", "inspect"] }

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -1660,6 +1660,7 @@ impl VmbusDevice for StorageDevice {
                 interface_name: "scsi".to_owned(),
                 instance_id: self.instance_id,
                 interface_id: storvsp_protocol::SCSI_INTERFACE_ID,
+                channel_type: ChannelType::Pipe { message_mode: true },
                 ..Default::default()
             }
         }

--- a/vm/devices/storage/storvsp_protocol/Cargo.toml
+++ b/vm/devices/storage/storvsp_protocol/Cargo.toml
@@ -15,6 +15,7 @@ arbitrary = { workspace = true, optional = true, features = ["derive"] }
 scsi_defs.workspace = true
 
 guid.workspace = true
+inspect.workspace = true
 open_enum.workspace = true
 zerocopy.workspace = true
 [dev-dependencies]

--- a/vm/devices/storage/storvsp_protocol/src/lib.rs
+++ b/vm/devices/storage/storvsp_protocol/src/lib.rs
@@ -5,6 +5,7 @@
 #![forbid(unsafe_code)]
 
 use guid::Guid;
+use inspect::Inspect;
 use open_enum::open_enum;
 use scsi_defs::ScsiStatus;
 use scsi_defs::srb::SrbStatusAndFlags;
@@ -155,7 +156,7 @@ pub struct ChannelProperties {
 pub const STORAGE_CHANNEL_SUPPORTS_MULTI_CHANNEL: u32 = 0x1;
 
 #[repr(C)]
-#[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
 pub struct ProtocolVersion {
     // Major (MSB) and minor (LSB) version numbers.
     pub major_minor: u16,

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -2194,8 +2194,7 @@ impl Debug for LockedPages {
 }
 
 #[derive(Copy, Clone, Debug)]
-// Field is read via slice transmute and pointer casts, not actually dead.
-struct PagePtr(#[expect(dead_code)] *const AtomicU8);
+struct PagePtr(*const AtomicU8);
 
 // SAFETY: PagePtr is just a pointer with no methods and has no inherent safety
 // constraints.
@@ -2212,6 +2211,10 @@ impl LockedPages {
         // the reference in _mem, and the lifetimes here ensure the LockedPages outlives
         // the slice.
         unsafe { std::slice::from_raw_parts(self.pages.as_ptr().cast::<&Page>(), self.pages.len()) }
+    }
+
+    pub fn va(&self) -> u64 {
+        self.pages.first().unwrap().0 as u64
     }
 }
 


### PR DESCRIPTION
This fully replaces the hv_storvsc kernel module with a user-mode storvsc implementation for communicating from OpenHCL to the host.