### PR TITLE
Remove a few unneeded linux-only cfgs

### DIFF
--- a/vm/devices/hyperv_ic_guest/src/lib.rs
+++ b/vm/devices/hyperv_ic_guest/src/lib.rs
@@ -13,7 +13,6 @@
 //! * heartbeat IC for reporting guest health
 //! * KVP IC for exchanging arbitrary key/value data between the host and guest
 
-#![cfg(target_os = "linux")]
 #![forbid(unsafe_code)]
 
 pub mod shutdown;

--- a/vm/devices/hyperv_ic_guest/src/shutdown.rs
+++ b/vm/devices/hyperv_ic_guest/src/shutdown.rs
@@ -3,7 +3,6 @@
 
 //! The shutdown IC client.
 
-#![cfg(target_os = "linux")]
 #![forbid(unsafe_code)]
 
 pub use hyperv_ic_protocol::shutdown::INSTANCE_ID;

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -7,7 +7,6 @@
 //! and send any vmbus notifications for that device to the
 //! SimpleVmbusClientDeviceWrapper instance.
 
-#![cfg(target_os = "linux")]
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
These crates compile perfectly fine on Windows, might as well allow them, even if they're only used by OpenHCL currently.