### PR TITLE
virt: Replace generic VpHaltReasons with new CpuIo::fatal_error, add configurable policy

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3160,11 +3160,18 @@ async fn new_underhill_vm(
         );
     }
 
+    let control_send = Arc::new(Mutex::new(Some(control_send)));
+
     let (chipset, devices) = chipset_builder.build()?;
+    let (fatal_error_send, fatal_error_recv) = mesh::channel();
+    let control_send_clone = control_send.clone();
     let fatal_error_policy = if env_cfg.halt_on_guest_halt {
-        vmm_core::vmotherboard_adapter::FatalErrorPolicy::DebugBreak
+        vmm_core::vmotherboard_adapter::FatalErrorPolicy::DebugBreak(fatal_error_send)
     } else {
-        vmm_core::vmotherboard_adapter::FatalErrorPolicy::Panic
+        vmm_core::vmotherboard_adapter::FatalErrorPolicy::Panic(Arc::new(move || {
+            // TODO: Make this closure async?
+            block_on(wait_for_flush_logs(&control_send_clone));
+        }))
     };
     let chipset = vmm_core::vmotherboard_adapter::ChipsetPlusSynic::new(
         synic.clone(),
@@ -3179,13 +3186,12 @@ async fn new_underhill_vm(
             .await
             .context("failed to relay initial vpci channels")?;
     }
-
-    let control_send = Arc::new(Mutex::new(Some(control_send)));
     let (halt_notify_send, halt_notify_recv) = mesh::channel();
     let halt_task = tp.spawn(
         "halt",
         halt_task(
             halt_notify_recv,
+            fatal_error_recv,
             control_send.clone(),
             get_client.clone(),
             env_cfg.halt_on_guest_halt,
@@ -3436,6 +3442,7 @@ where
 /// host (when appropriate).
 async fn halt_task(
     mut halt_notify_recv: mesh::Receiver<HaltReason>,
+    mut _fatal_error_recv: mesh::Receiver<Box<dyn std::error::Error + Send + Sync>>,
     control_send: Arc<Mutex<Option<mesh::Sender<ControlRequest>>>>,
     get_client: GuestEmulationTransportClient,
     halt_on_guest_halt: bool,
@@ -3481,14 +3488,7 @@ async fn halt_task(
             tracing::info!(CVM_ALLOWED, ?halt_request, "guest halted");
         } else {
             // All real halts require flushing logs to the host. Wait up to 5 seconds.
-            let ctx = CancelContext::new().with_timeout(Duration::from_secs(5));
-            let call = control_send
-                .lock()
-                .as_ref()
-                .map(|send| send.call(ControlRequest::FlushLogs, ctx));
-            if let Some(call) = call {
-                call.await.ok();
-            }
+            wait_for_flush_logs(&control_send).await;
 
             // Now we can notify the host about the halt.
             match halt_request {
@@ -3500,6 +3500,17 @@ async fn halt_task(
                 }
             }
         }
+    }
+}
+
+async fn wait_for_flush_logs(control_send: &Arc<Mutex<Option<mesh::Sender<ControlRequest>>>>) {
+    let ctx = CancelContext::new().with_timeout(Duration::from_secs(5));
+    let call = control_send
+        .lock()
+        .as_ref()
+        .map(|send| send.call(ControlRequest::FlushLogs, ctx));
+    if let Some(call) = call {
+        call.await.ok();
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -26,7 +26,6 @@ use aarch64defs::Cpsr64;
 use aarch64emu::AccessCpuState;
 use aarch64emu::InterceptState;
 use hcl::GuestVtl;
-use hcl::UnsupportedGuestVtl;
 use hcl::ioctl;
 use hcl::ioctl::aarch64::MshvArm64;
 use hv1_emulator::hv::ProcessorVtlHv;

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -252,22 +252,12 @@ impl BackingPrivate for HypervisorBackedArm64 {
 }
 
 #[derive(Debug, Error)]
-#[error("invalid intercepted vtl {0:?}")]
-struct InvalidInterceptedVtl(u8);
-
-#[derive(Debug, Error)]
 #[error("guest accessed unaccepted gpa {0}")]
 struct UnacceptedMemoryAccess(u64);
 
 impl UhProcessor<'_, HypervisorBackedArm64> {
-    fn intercepted_vtl(
-        message_header: &hvdef::HvArm64InterceptMessageHeader,
-    ) -> Result<GuestVtl, InvalidInterceptedVtl> {
-        message_header
-            .execution_state
-            .vtl()
-            .try_into()
-            .map_err(|e: UnsupportedGuestVtl| InvalidInterceptedVtl(e.0))
+    fn intercepted_vtl(message_header: &hvdef::HvArm64InterceptMessageHeader) -> GuestVtl {
+        message_header.execution_state.vtl().try_into().unwrap()
     }
 
     fn handle_synic_deliverable_exit(&mut self) {
@@ -300,8 +290,7 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "hypercall");
 
-        let intercepted_vtl =
-            Self::intercepted_vtl(&message.header).map_err(|e| bus.fatal_error(e.into()))?;
+        let intercepted_vtl = Self::intercepted_vtl(&message.header);
         let guest_memory = &self.partition.gm[intercepted_vtl];
         let smccc_convention = message.immediate == 0;
 
@@ -333,8 +322,7 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
             interruption_pending: message.header.execution_state.interruption_pending(),
         };
 
-        let intercepted_vtl =
-            Self::intercepted_vtl(&message.header).map_err(|e| dev.fatal_error(e.into()))?;
+        let intercepted_vtl = Self::intercepted_vtl(&message.header);
 
         // Fast path for monitor page writes.
         if Some(message.guest_physical_address & !(hvdef::HV_PAGE_SIZE - 1))

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -168,7 +168,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
         let intercepted = this
             .runner
             .run()
-            .map_err(|e| VpHaltReason::Hypervisor(MshvRunVpError(e).into()))?;
+            .map_err(|e| dev.fatal_error(MshvRunVpError(e).into()))?;
 
         if intercepted {
             let stat = match this.runner.exit_message().header.typ {
@@ -300,8 +300,8 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "hypercall");
 
-        let intercepted_vtl = Self::intercepted_vtl(&message.header)
-            .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
+        let intercepted_vtl =
+            Self::intercepted_vtl(&message.header).map_err(|e| bus.fatal_error(e.into()))?;
         let guest_memory = &self.partition.gm[intercepted_vtl];
         let smccc_convention = message.immediate == 0;
 
@@ -333,8 +333,8 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
             interruption_pending: message.header.execution_state.interruption_pending(),
         };
 
-        let intercepted_vtl = Self::intercepted_vtl(&message.header)
-            .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
+        let intercepted_vtl =
+            Self::intercepted_vtl(&message.header).map_err(|e| dev.fatal_error(e.into()))?;
 
         // Fast path for monitor page writes.
         if Some(message.guest_physical_address & !(hvdef::HV_PAGE_SIZE - 1))
@@ -393,9 +393,7 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
             // Note: SGX memory should be included in this check, so if SGX is
             // no longer included in the lower_vtl_memory_layout, make sure the
             // appropriate changes are reflected here.
-            Err(VpHaltReason::InvalidVmState(
-                UnacceptedMemoryAccess(gpa).into(),
-            ))
+            Err(dev.fatal_error(UnacceptedMemoryAccess(gpa).into()))
         } else {
             // TODO: for hardware isolation, if the intercept is due to a guest
             // error, inject a machine check

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -2253,11 +2253,12 @@ impl InitializedVm {
         assert!(virtio_mmio_start >= mem_layout.mmio()[1].start());
 
         let (chipset, devices) = chipset_builder.build()?;
+        let (fatal_error_send, _fatal_error_recv) = mesh::channel();
         let chipset = vmm_core::vmotherboard_adapter::ChipsetPlusSynic::new(
             synic.clone(),
             chipset,
             // TODO: Support this being a cmd line option
-            vmm_core::vmotherboard_adapter::FatalErrorPolicy::DebugBreak,
+            vmm_core::vmotherboard_adapter::FatalErrorPolicy::DebugBreak(fatal_error_send),
         );
 
         // create a new channel to intercept guest resets

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -2253,7 +2253,12 @@ impl InitializedVm {
         assert!(virtio_mmio_start >= mem_layout.mmio()[1].start());
 
         let (chipset, devices) = chipset_builder.build()?;
-        let chipset = vmm_core::vmotherboard_adapter::ChipsetPlusSynic::new(synic.clone(), chipset);
+        let chipset = vmm_core::vmotherboard_adapter::ChipsetPlusSynic::new(
+            synic.clone(),
+            chipset,
+            // TODO: Support this being a cmd line option
+            vmm_core::vmotherboard_adapter::FatalErrorPolicy::DebugBreak,
+        );
 
         // create a new channel to intercept guest resets
         let (halt_send, halt_recv) = mesh::channel();

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -306,6 +306,15 @@ impl CpuIo for IoHandler<'_> {
     async fn write_io(&self, vp: VpIndex, port: u16, data: &[u8]) {
         tracing::info!(vp = vp.index(), port, data = widen(data), "write io");
     }
+
+    #[track_caller]
+    fn fatal_error(&self, error: Box<dyn std::error::Error + Send + Sync>) -> virt::VpHaltReason {
+        tracing::error!(
+            err = error.as_ref() as &dyn std::error::Error,
+            "fatal error"
+        );
+        virt::VpHaltReason::TripleFault { vtl: Vtl::Vtl0 }
+    }
 }
 
 impl IoHandler<'_> {

--- a/vmm_core/src/partition_unit/debug.rs
+++ b/vmm_core/src/partition_unit/debug.rs
@@ -55,9 +55,7 @@ impl DebuggerState {
             notify.send(match reason {
                 HaltReason::PowerOff | HaltReason::Hibernate => DebugStopReason::PowerOff,
                 HaltReason::Reset => DebugStopReason::Reset,
-                HaltReason::TripleFault { vp, .. }
-                | HaltReason::InvalidVmState { vp }
-                | HaltReason::VpError { vp } => DebugStopReason::TripleFault { vp: *vp },
+                HaltReason::TripleFault { vp, .. } => DebugStopReason::TripleFault { vp: *vp },
                 HaltReason::DebugBreak { .. } => DebugStopReason::Break,
                 HaltReason::SingleStep { vp } => DebugStopReason::SingleStep { vp: *vp },
                 HaltReason::HwBreakpoint { vp, breakpoint } => DebugStopReason::HwBreakpoint {

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -149,33 +149,6 @@ where
                     registers,
                 })
             }
-            VpHaltReason::InvalidVmState(err) => {
-                tracing::error!(
-                    err = err.as_ref() as &dyn std::error::Error,
-                    "invalid VM state"
-                );
-                Err(HaltReason::InvalidVmState {
-                    vp: self.vp_index.index(),
-                })
-            }
-            VpHaltReason::EmulationFailure(err) => {
-                tracing::error!(
-                    err = err.as_ref() as &dyn std::error::Error,
-                    "emulation failure"
-                );
-                Err(HaltReason::VpError {
-                    vp: self.vp_index.index(),
-                })
-            }
-            VpHaltReason::Hypervisor(err) => {
-                tracing::error!(
-                    err = err.as_ref() as &dyn std::error::Error,
-                    "fatal vp error"
-                );
-                Err(HaltReason::VpError {
-                    vp: self.vp_index.index(),
-                })
-            }
             VpHaltReason::SingleStep => {
                 tracing::debug!("single step");
                 Err(HaltReason::SingleStep {

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -563,12 +563,6 @@ pub enum VpHaltReason {
         // FUTURE: move VTL state into `AccessVpState``.
         vtl: Vtl,
     },
-    /// The VM's state (e.g. registers, memory) is invalid.
-    InvalidVmState(Box<dyn std::error::Error + Send + Sync>),
-    /// The underlying hypervisor failed.
-    Hypervisor(Box<dyn std::error::Error + Send + Sync>),
-    /// Emulation failed.
-    EmulationFailure(Box<dyn std::error::Error + Send + Sync>),
     /// Debugger single step.
     SingleStep,
     /// Debugger hardware breakpoint.

--- a/vmm_core/virt/src/io.rs
+++ b/vmm_core/virt/src/io.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::VpHaltReason;
 use hvdef::Vtl;
 use std::future::Future;
 use vm_topology::processor::VpIndex;
@@ -47,4 +48,8 @@ pub trait CpuIo {
     /// Programmed IO write.
     #[must_use]
     fn write_io(&self, vp: VpIndex, port: u16, data: &[u8]) -> impl Future<Output = ()>;
+
+    /// Report an internal fatal error
+    #[track_caller]
+    fn fatal_error(&self, error: Box<dyn std::error::Error + Send + Sync>) -> VpHaltReason;
 }

--- a/vmm_core/virt/src/io.rs
+++ b/vmm_core/virt/src/io.rs
@@ -49,7 +49,14 @@ pub trait CpuIo {
     #[must_use]
     fn write_io(&self, vp: VpIndex, port: u16, data: &[u8]) -> impl Future<Output = ()>;
 
-    /// Report an internal fatal error
+    /// Report an internal fatal error.
+    ///
+    /// The intention behind this method is to allow the top-level VMM
+    /// to specify an error handling policy, while still being able to capture
+    /// stacks and other context from the point of failure. We previously would
+    /// return a `VpHaltReason::Panic` here, but that meant the stack trace
+    /// would be from the point of the panic handler, which lost context.
+    /// See vmotherboard's `FatalErrorPolicy` for an example.
     #[track_caller]
     fn fatal_error(&self, error: Box<dyn std::error::Error + Send + Sync>) -> VpHaltReason;
 }

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -1061,7 +1061,7 @@ impl Processor for KvmProcessor<'_> {
                     .store(false, Ordering::Relaxed);
                 if self.runner.check_or_request_interrupt_window() {
                     self.deliver_pic_interrupt(dev)
-                        .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
+                        .map_err(|e| dev.fatal_error(e.into()))?;
                 }
             }
 
@@ -1091,8 +1091,7 @@ impl Processor for KvmProcessor<'_> {
                     self.runner.run()
                 };
 
-                let exit =
-                    exit.map_err(|err| VpHaltReason::Hypervisor(KvmRunVpError::Run(err).into()))?;
+                let exit = exit.map_err(|err| dev.fatal_error(KvmRunVpError::Run(err).into()))?;
                 pending_exit = true;
                 match exit {
                     kvm::Exit::Interrupted => {
@@ -1101,7 +1100,7 @@ impl Processor for KvmProcessor<'_> {
                     }
                     kvm::Exit::InterruptWindow => {
                         self.deliver_pic_interrupt(dev)
-                            .map_err(|e| VpHaltReason::InvalidVmState(e.into()))?;
+                            .map_err(|e| dev.fatal_error(e.into()))?;
                     }
                     kvm::Exit::IoIn { port, data, size } => {
                         for data in data.chunks_mut(size as usize) {
@@ -1191,12 +1190,10 @@ impl Processor for KvmProcessor<'_> {
                         dev.handle_eoi(irq.into());
                     }
                     kvm::Exit::InternalError { error, .. } => {
-                        return Err(VpHaltReason::InvalidVmState(
-                            KvmRunVpError::InternalError(error).into(),
-                        ));
+                        return Err(dev.fatal_error(KvmRunVpError::InternalError(error).into()));
                     }
                     kvm::Exit::EmulationFailure { instruction_bytes } => {
-                        return Err(VpHaltReason::EmulationFailure(
+                        return Err(dev.fatal_error(
                             EmulationError {
                                 instruction_bytes: instruction_bytes.to_vec(),
                             }
@@ -1207,9 +1204,7 @@ impl Processor for KvmProcessor<'_> {
                         hardware_entry_failure_reason,
                     } => {
                         tracing::error!(hardware_entry_failure_reason, "VP entry failed");
-                        return Err(VpHaltReason::InvalidVmState(
-                            KvmRunVpError::InvalidVpState.into(),
-                        ));
+                        return Err(dev.fatal_error(KvmRunVpError::InvalidVpState.into()));
                     }
                 }
             }

--- a/vmm_core/virt_support_aarch64emu/src/emulate.rs
+++ b/vmm_core/virt_support_aarch64emu/src/emulate.rs
@@ -173,7 +173,7 @@ pub async fn emulate<T: EmulatorSupport>(
 ) -> Result<(), VpHaltReason> {
     emulate_core(support, intercept_state, emu_mem, dev)
         .await
-        .map_err(|e| VpHaltReason::EmulationFailure(e.into()))
+        .map_err(|e| dev.fatal_error(e.into()))
 }
 
 async fn emulate_core<T: EmulatorSupport>(

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -295,7 +295,7 @@ pub async fn emulate<T: EmulatorSupport>(
 ) -> Result<(), VpHaltReason> {
     emulate_core(support, emu_mem, dev)
         .await
-        .map_err(|e| VpHaltReason::EmulationFailure(e.into()))
+        .map_err(|e| dev.fatal_error(e.into()))
 }
 
 async fn emulate_core<T: EmulatorSupport>(
@@ -514,7 +514,7 @@ pub async fn emulate_insn_memory_op<T: EmulatorSupport>(
             emu.write_memory(segment, gva, alignment, data).await
         }
     }
-    .map_err(|e| VpHaltReason::EmulationFailure(e.into()))
+    .map_err(|e| dev.fatal_error(e.into()))
 
     // No need to flush the cache, we have not modified any registers.
 }

--- a/vmm_core/virt_support_x86emu/tests/tests/common.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/common.rs
@@ -101,6 +101,10 @@ impl CpuIo for MockCpu {
     async fn write_io(&self, _vp: VpIndex, _port: u16, _data: &[u8]) {
         todo!()
     }
+
+    fn fatal_error(&self, _error: Box<dyn std::error::Error + Send + Sync>) -> virt::VpHaltReason {
+        todo!()
+    }
 }
 
 /// Validates the given event is indeed a gpf

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -386,7 +386,7 @@ impl<'a> WhpProcessor<'a> {
             let mut runner = self.current_whp().runner();
             let exit = runner
                 .run()
-                .map_err(|err| VpHaltReason::Hypervisor(WhpRunVpError(err).into()))?;
+                .map_err(|err| dev.fatal_error(WhpRunVpError(err).into()))?;
 
             // Clear lazy EOI before processing the exit.
             if lazy_eoi {
@@ -628,7 +628,7 @@ mod x86 {
                     &mut self.state.exits.other
                 }
                 ExitReason::InvalidVpRegisterValue => {
-                    return Err(VpHaltReason::InvalidVmState(InvalidVpState.into()));
+                    return Err(dev.fatal_error(InvalidVpState.into()));
                 }
                 ExitReason::Halt => {
                     self.handle_halt(exit);
@@ -855,7 +855,7 @@ mod x86 {
                         .vtl0_deferred_policy
                     {
                         LateMapVtl0MemoryPolicy::Halt => {
-                            return Err(VpHaltReason::InvalidVmState(DeferredRamAccess.into()));
+                            return Err(dev.fatal_error(DeferredRamAccess.into()));
                         }
                         LateMapVtl0MemoryPolicy::Log => {}
                         LateMapVtl0MemoryPolicy::InjectException => {
@@ -1809,7 +1809,7 @@ mod aarch64 {
                 ExceptionClass::DATA_ABORT_LOWER => {
                     let iss = IssDataAbort::from(syndrome.iss());
                     if !iss.isv() {
-                        return Err(VpHaltReason::EmulationFailure(
+                        return Err(dev.fatal_error(
                             anyhow::anyhow!("can't handle data abort without isv: {iss:?}").into(),
                         ));
                     }
@@ -1847,7 +1847,7 @@ mod aarch64 {
                         .unwrap();
                 }
                 ec => {
-                    return Err(VpHaltReason::EmulationFailure(
+                    return Err(dev.fatal_error(
                         anyhow::anyhow!("unknown memory access exception: {ec:?}").into(),
                     ));
                 }

--- a/vmm_core/vmm_core_defs/src/lib.rs
+++ b/vmm_core/vmm_core_defs/src/lib.rs
@@ -30,14 +30,6 @@ pub enum HaltReason {
         // Arc'ed for size and cheap clones.
         registers: Option<Arc<virt::vp::Registers>>,
     },
-    InvalidVmState {
-        #[inspect(rename = "failing_vp")]
-        vp: u32,
-    },
-    VpError {
-        #[inspect(rename = "failing_vp")]
-        vp: u32,
-    },
     SingleStep {
         #[inspect(rename = "failing_vp")]
         vp: u32,


### PR DESCRIPTION
The intention behind this change is to provide better crash stacks and dumps in crash reports. By panicking at the point of error construction, rather than after the error has bubbled up to a higher layer, we are better able to capture stack context around the cause of the failure and to provide a meaningful stack to our atomations (instead of just blaming the HaltRequest::Panic handler for all these different error sources). Essentially simulating 'unwrapping' these errors.

However the ability to keep a VM 'alive' for inspection after a failure is still useful, and we want to preserve it. Therefore this change makes this new behavior configurable.