### PR TITLE
virt_mshv_vtl: 2505: work around the hypervisor's handling of the pre…

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3432,16 +3432,6 @@ async fn load_firmware(
         .await
         .context("failed to set initial registers")?;
 
-    // For compatibility reasons, APs' VTL0 is in the running state at startup.
-    // Send INIT to put them into startup suspend (wait for SIPI) state.
-    #[cfg(guest_arch = "x86_64")]
-    for vp in processor_topology.vps_arch().skip(1) {
-        partition.request_msi(
-            Vtl::Vtl0,
-            MsiRequest::new_x86(virt::irqcon::DeliveryMode::INIT, vp.apic_id, false, 0, true),
-        );
-    }
-
     Ok(())
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -219,6 +219,11 @@ mod private {
             vtl: GuestVtl,
         ) -> Self::StateAccess<'p, 'a>;
 
+        /// Called before the first `run_vp` call to allow the backing to
+        /// perform any pre-run tasks. Must be idempotent--may be called again
+        /// before some subsequent `run_vp` calls.
+        fn pre_run_vp(_this: &mut UhProcessor<'_, Self>) {}
+
         fn run_vp(
             this: &mut UhProcessor<'_, Self>,
             dev: &impl CpuIo,
@@ -777,6 +782,8 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
         mut stop: StopVp<'_>,
         dev: &impl CpuIo,
     ) -> Result<Infallible, VpHaltReason<UhRunVpError>> {
+        T::pre_run_vp(self);
+
         if self.runner.is_sidecar() {
             if self.force_exit_sidecar && !self.signaled_sidecar_exit {
                 self.inner

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -89,6 +89,9 @@ pub struct HypervisorBackedX86 {
     #[inspect(hex, with = "|&x| u64::from(x)")]
     pub(super) next_deliverability_notifications: HvDeliverabilityNotificationsRegister,
     stats: ProcessorStatsX86,
+    /// Send an INIT to VTL0 before running the VP, to simulate setting startup
+    /// suspend. Newer hypervisors allow setting startup suspend explicitly.
+    deferred_init: bool,
 }
 
 /// Partition-wide shared data for hypervisor backed VMs.
@@ -175,10 +178,17 @@ impl BackingPrivate for HypervisorBackedX86 {
             deliverability_notifications: Default::default(),
             next_deliverability_notifications: Default::default(),
             stats: Default::default(),
+            deferred_init: false,
         })
     }
 
-    fn init(_this: &mut UhProcessor<'_, Self>) {}
+    fn init(this: &mut UhProcessor<'_, Self>) {
+        // The hypervisor initializes startup suspend to false. Set it to the
+        // architectural default.
+        if !this.vp_index().is_bsp() {
+            this.backing.deferred_init = true;
+        }
+    }
 
     type StateAccess<'p, 'a>
         = UhVpStateAccess<'a, 'p, Self>
@@ -191,6 +201,25 @@ impl BackingPrivate for HypervisorBackedX86 {
         vtl: GuestVtl,
     ) -> Self::StateAccess<'p, 'a> {
         UhVpStateAccess::new(this, vtl)
+    }
+
+    fn pre_run_vp(this: &mut UhProcessor<'_, Self>) {
+        if std::mem::take(&mut this.backing.deferred_init) {
+            tracelimit::info_ratelimited!(
+                vp = this.vp_index().index(),
+                "sending deferred INIT to set startup suspend"
+            );
+            this.partition.request_msi(
+                GuestVtl::Vtl0,
+                virt::irqcon::MsiRequest::new_x86(
+                    virt::irqcon::DeliveryMode::INIT,
+                    this.inner.vp_info.apic_id,
+                    false,
+                    0,
+                    true,
+                ),
+            );
+        }
     }
 
     async fn run_vp(
@@ -891,6 +920,23 @@ impl UhProcessor<'_, HypervisorBackedX86> {
                 u128::from(exception_event).into(),
             )
             .expect("set_vp_register should succeed for pending event");
+    }
+
+    /// Sets the startup suspend state for VTL0 of this VP.
+    ///
+    /// If `startup_suspend` is `true`, hold the VP in the startup suspend state by setting
+    /// the internal activity register. In the opposite case, clear the startup suspend state
+    /// thus letting the VP run.
+    fn set_vtl0_startup_suspend(&mut self, startup_suspend: bool) -> Result<(), ioctl::Error> {
+        let reg = u64::from(
+            hvdef::HvInternalActivityRegister::new().with_startup_suspend(startup_suspend),
+        );
+        // Non-VTL0 VPs should never be in startup suspend, so
+        // we only need to handle VTL0.
+        self.runner.set_vp_registers(
+            GuestVtl::Vtl0,
+            [(HvX64RegisterName::InternalActivityState, reg)],
+        )
     }
 
     fn set_vsm_partition_config(
@@ -1828,7 +1874,6 @@ mod save_restore {
     use hvdef::HvX64RegisterName;
     use hvdef::Vtl;
     use virt::Processor;
-    use virt::irqcon::MsiRequest;
     use virt::vp::AccessVpState;
     use virt::vp::Mtrrs;
     use vmcore::save_restore::RestoreError;
@@ -1946,24 +1991,6 @@ mod save_restore {
                 .context("failed to get shared registers")
                 .map_err(SaveError::Other)?;
 
-            // Non-VTL0 VPs should never be in startup suspend, so we only need to check VTL0.
-            // The hypervisor handles halt and idle for us.
-            let internal_activity = self
-                .runner
-                .get_vp_register(GuestVtl::Vtl0, HvX64RegisterName::InternalActivityState)
-                .inspect_err(|e| {
-                    // The ioctl get_vp_register path does not tell us
-                    // hv_status directly, so just log if it failed for any
-                    // reason.
-                    tracing::warn!(
-                        error = e as &dyn std::error::Error,
-                        "unable to query startup suspend, unable to save VTL0 startup suspend state"
-                    );
-                })
-                .ok();
-            let startup_suspend = internal_activity
-                .map(|a| HvInternalActivityRegister::from(a.as_u64()).startup_suspend());
-
             let [
                 rax,
                 rcx,
@@ -2031,11 +2058,39 @@ mod save_restore {
                 shared: _,
                 // The runner doesn't hold anything needing saving
                 runner: _,
-                // TODO CVM Servicing: The hypervisor backing doesn't need to save anything, but CVMs will.
-                backing: _,
+                backing:
+                    HypervisorBackedX86 {
+                        deliverability_notifications: _,
+                        next_deliverability_notifications: _,
+                        stats: _,
+                        deferred_init,
+                    },
                 // Currently only meaningful for CVMs
                 exit_activities: _,
-            } = self;
+            } = *self;
+
+            // Non-VTL0 VPs should never be in startup suspend, so we only need to check VTL0.
+            // The hypervisor handles halt and idle for us.
+            let startup_suspend = if deferred_init {
+                Some(true)
+            } else {
+                let internal_activity = self
+                    .runner
+                    .get_vp_register(GuestVtl::Vtl0, HvX64RegisterName::InternalActivityState)
+                    .inspect_err(|e| {
+                        // The ioctl get_vp_register path does not tell us
+                        // hv_status directly, so just log if it failed for any
+                        // reason.
+                        tracing::warn!(
+                            error = e as &dyn std::error::Error,
+                            "unable to query startup suspend, unable to save VTL0 startup suspend state"
+                        );
+                    })
+                    .ok();
+
+                internal_activity
+                    .map(|a| HvInternalActivityRegister::from(a.as_u64()).startup_suspend())
+            };
 
             let per_vtl = [GuestVtl::Vtl0, GuestVtl::Vtl1]
                 .map(|vtl| state::ProcessorVtlSavedState {
@@ -2067,8 +2122,8 @@ mod save_restore {
                 dr3: values[3].as_u64(),
                 dr6: dr6_shared.then(|| values[4].as_u64()),
                 startup_suspend,
-                crash_reg: Some(*crash_reg),
-                crash_control: crash_control.into_bits(),
+                crash_reg: Some(crash_reg),
+                crash_control: crash_control.into(),
                 msr_mtrr_def_type,
                 fixed_mtrrs: Some(fixed_mtrrs),
                 variable_mtrrs: Some(variable_mtrrs),
@@ -2172,7 +2227,7 @@ mod save_restore {
                 self.inner.message_queues[vtl].restore(&per.message_queue);
             }
 
-            let inject_startup_suspend = match startup_suspend {
+            let startup_suspend = match startup_suspend {
                 Some(true) => {
                     // When Underhill brings up APs during a servicing update
                     // via hypercall, this clears the VTL0 startup suspend
@@ -2214,35 +2269,18 @@ mod save_restore {
                 Some(false) | None => false,
             };
 
-            if inject_startup_suspend {
-                let reg = u64::from(HvInternalActivityRegister::new().with_startup_suspend(true));
-                // Non-VTL0 VPs should never be in startup suspend, so we only need to handle VTL0.
-                let result = self.runner.set_vp_registers(
-                    GuestVtl::Vtl0,
-                    [(HvX64RegisterName::InternalActivityState, reg)],
-                );
-
-                if let Err(e) = result {
-                    // The ioctl set_vp_register path does not tell us hv_status
-                    // directly, so just log if it failed for any reason.
-                    tracing::warn!(
-                        error = &e as &dyn std::error::Error,
-                        "unable to set internal activity register, falling back to init"
-                    );
-
-                    self.partition.request_msi(
-                        GuestVtl::Vtl0,
-                        MsiRequest::new_x86(
-                            virt::irqcon::DeliveryMode::INIT,
-                            self.inner.vp_info.apic_id,
-                            false,
-                            0,
-                            true,
-                        ),
-                    );
+            self.backing.deferred_init = match self.set_vtl0_startup_suspend(startup_suspend) {
+                Ok(()) => false,
+                Err(e) => {
+                    if startup_suspend {
+                        tracing::warn!(
+                            error = &e as &dyn std::error::Error,
+                            "unable to set internal activity register, falling back to deferred init"
+                        );
+                    }
+                    startup_suspend
                 }
-            }
-
+            };
             Ok(())
         }
     }


### PR DESCRIPTION
…cise VP startup on arm64

This is a backport of 075cd7c3f84d3ed7923c999a32208b5d10af9c04 to release/2505

On arm64, the hypervisor may schedule APs in VTL0 for execution even when the partition is created with the precise VP startup flag. That leads to the AP starting executing code at `PC`=`0` in VTL0 and sooner or later:
* running into an exception and jumping to the VBAR table, then jumping around until the guest loads a good context on the AP,
* in rare cases the AP runs into a stage-2 page fault (such as jumping out of its GPA) which leads to a VM exit to VTL2. As that's a fault to fetch an instruction, VTL2 has no other choice other than crash.

Fix this by handling the startup suspend state in VTL2 on arm64.

That does not happen on x86, as handling of the startup suspend state has been historically present in the paravisor

---------