### PR TITLE
nvme_test: Added NvmeWorkersContext input for the NvmeWorkers struct

### DIFF
--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -17,14 +17,12 @@ pub enum QueueFaultBehavior<T> {
     Default,
 }
 
-#[derive(Clone)]
 /// A buildable fault configuration
 pub struct AdminQueueFaultConfig {
     /// A map of NVME opcodes to the fault behavior for each. (This would ideally be a `HashMap`, but `mesh` doesn't support that type. Given that this is not performance sensitive, the lookup is okay)
     pub admin_submission_queue_faults: Vec<(u8, QueueFaultBehavior<Command>)>,
 }
 
-#[derive(Clone)]
 /// A simple fault configuration with admin submission queue support
 pub struct FaultConfiguration {
     /// Fault active state

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -17,12 +17,14 @@ pub enum QueueFaultBehavior<T> {
     Default,
 }
 
+#[derive(Clone)]
 /// A buildable fault configuration
 pub struct AdminQueueFaultConfig {
     /// A map of NVME opcodes to the fault behavior for each. (This would ideally be a `HashMap`, but `mesh` doesn't support that type. Given that this is not performance sensitive, the lookup is okay)
     pub admin_submission_queue_faults: Vec<(u8, QueueFaultBehavior<Command>)>,
 }
 
+#[derive(Clone)]
 /// A simple fault configuration with admin submission queue support
 pub struct FaultConfiguration {
     /// Fault active state

--- a/vm/devices/storage/nvme_test/src/pci.rs
+++ b/vm/devices/storage/nvme_test/src/pci.rs
@@ -15,6 +15,7 @@ use crate::VENDOR_ID;
 use crate::spec;
 use crate::workers::IoQueueEntrySizes;
 use crate::workers::NvmeWorkers;
+use crate::workers::NvmeWorkersContext;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoError::InvalidRegister;
@@ -146,16 +147,16 @@ impl NvmeFaultController {
             .collect();
 
         let qe_sizes = Arc::new(Default::default());
-        let admin = NvmeWorkers::new(
+        let admin = NvmeWorkers::new(NvmeWorkersContext {
             driver_source,
-            guest_memory,
+            mem: guest_memory,
             interrupts,
-            caps.max_io_queues,
-            caps.max_io_queues,
-            Arc::clone(&qe_sizes),
-            caps.subsystem_id,
+            max_sqs: caps.max_io_queues,
+            max_cqs: caps.max_io_queues,
+            qe_sizes: Arc::clone(&qe_sizes),
+            subsystem_id: caps.subsystem_id,
             fault_configuration,
-        );
+        });
 
         Self {
             cfg_space,

--- a/vm/devices/storage/nvme_test/src/workers.rs
+++ b/vm/devices/storage/nvme_test/src/workers.rs
@@ -10,6 +10,7 @@ mod io;
 pub use admin::NsidConflict;
 pub use coordinator::NvmeFaultControllerClient;
 pub use coordinator::NvmeWorkers;
+pub use coordinator::NvmeWorkersContext;
 
 use crate::PAGE_SIZE;
 use inspect::Inspect;

--- a/vm/devices/storage/nvme_test/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme_test/src/workers/coordinator.rs
@@ -31,7 +31,7 @@ use vmcore::interrupt::Interrupt;
 use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
 
-/// An input context for the NvmeWorker
+/// An input context for the NvmeWorkers
 pub struct NvmeWorkersContext<'a> {
     pub driver_source: &'a VmTaskDriverSource,
     pub mem: GuestMemory,

--- a/vm/devices/storage/nvme_test/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme_test/src/workers/coordinator.rs
@@ -87,8 +87,8 @@ impl NvmeWorkers {
             driver.clone(),
             AdminConfig {
                 driver_source: driver_source.clone(),
-                mem: mem.clone(),
-                interrupts: interrupts.clone(),
+                mem,
+                interrupts,
                 doorbells: doorbells.clone(),
                 subsystem_id,
                 max_sqs,


### PR DESCRIPTION
This is a support PR being made to reduce size of #1858. Added `NvmeWorkersContext` that stores the input for `NvmeWorkers`. This will subsequently be used to create new `NvmeWorkers` when FLR is issued to the test controller.