### PR TITLE
nvme_test: Add controller delay fault

### DIFF
--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -15,6 +15,8 @@ pub enum QueueFaultBehavior<T> {
     Drop,
     /// No Fault, proceed as normal
     Default,
+    /// Delay, with value in ms
+    Delay(u64),
 }
 
 /// A buildable fault configuration

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -16,7 +16,7 @@ pub enum QueueFaultBehavior<T> {
     Drop,
     /// No Fault, proceed as normal
     Default,
-    /// Delay, with value in ms
+    /// Delay
     Delay(Duration),
 }
 

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -5,6 +5,7 @@
 
 use mesh::Cell;
 use nvme_spec::Command;
+use std::time::Duration;
 
 /// Supported fault behaviour for NVMe queues
 #[derive(Debug, Clone, Copy)]
@@ -16,7 +17,7 @@ pub enum QueueFaultBehavior<T> {
     /// No Fault, proceed as normal
     Default,
     /// Delay, with value in ms
-    Delay(u64),
+    Delay(Duration),
 }
 
 /// A buildable fault configuration

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -35,6 +35,7 @@ use nvme_resources::fault::FaultConfiguration;
 use nvme_resources::fault::QueueFaultBehavior;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
+use pal_async::timer::PolledTimer;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::collections::btree_map;
@@ -42,6 +43,8 @@ use std::future::pending;
 use std::io::Cursor;
 use std::io::Write;
 use std::sync::Arc;
+use std::task::Poll;
+use std::time::Duration;
 use task_control::AsyncRun;
 use task_control::Cancelled;
 use task_control::InspectTask;
@@ -491,6 +494,11 @@ impl AdminHandler {
                                 &command
                             );
                             return Ok(());
+                        }
+                        QueueFaultBehavior::Delay(ms) => {
+                            PolledTimer::new(&self.driver)
+                                .sleep(Duration::from_millis(ms))
+                                .await;
                         }
                         QueueFaultBehavior::Default => {}
                     }

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -43,7 +43,6 @@ use std::future::pending;
 use std::io::Cursor;
 use std::io::Write;
 use std::sync::Arc;
-use std::task::Poll;
 use std::time::Duration;
 use task_control::AsyncRun;
 use task_control::Cancelled;

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -43,7 +43,6 @@ use std::future::pending;
 use std::io::Cursor;
 use std::io::Write;
 use std::sync::Arc;
-use std::time::Duration;
 use task_control::AsyncRun;
 use task_control::Cancelled;
 use task_control::InspectTask;

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -497,8 +497,8 @@ impl AdminHandler {
                             );
                             return Ok(());
                         }
-                        QueueFaultBehavior::Delay(ms) => {
-                            self.timer.sleep(Duration::from_millis(ms)).await;
+                        QueueFaultBehavior::Delay(duration) => {
+                            self.timer.sleep(duration).await;
                         }
                         QueueFaultBehavior::Default => {}
                     }


### PR DESCRIPTION
The controller delay fault was previously being implemented by the callback function mechanism. However, since we are now using enums to specify faults, it makes a lot more sense to have a delay enum and have the fault controller execute the delay fault during processing.
This will support the first keepalive vmm test that requires admin queue delay + drop functionality. 