### PR TITLE
hv1_emu: Make local overlay page allocation lazy

### DIFF
--- a/vm/hv1/hv1_emulator/src/pages.rs
+++ b/vm/hv1/hv1_emulator/src/pages.rs
@@ -55,7 +55,7 @@ impl OverlayPage {
 
         match self {
             Self::Local(old_page) => {
-                // Avoid the Deref initialization if we don't have to.
+                // Avoid the Deref initialization, since we're about to replace it anyways.
                 if let Some(old_page) = old_page.get() {
                     new_page.atomic_write_obj(&old_page.atomic_read_obj::<[u8; 4096]>());
                 }


### PR DESCRIPTION
An analysis has flagged the addition of this OverlayPage mechanism as possibly increasing our overall memory consumption by a significant amount. Try making the allocation lazy so as to avoid it in some cases.