### PR TITLE
nvme_test: Added panic fault for admin commands

### DIFF
--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -9,7 +9,7 @@ use nvme_spec::Command;
 use std::time::Duration;
 
 /// Supported fault behaviour for NVMe queues
-#[derive(Debug, Clone, Copy, MeshPayload)]
+#[derive(Debug, Clone, MeshPayload)]
 pub enum QueueFaultBehavior<T> {
     /// Update the queue entry with the returned data
     Update(T),
@@ -19,6 +19,8 @@ pub enum QueueFaultBehavior<T> {
     Default,
     /// Delay
     Delay(Duration),
+    /// Panic
+    Panic(String),
 }
 
 #[derive(MeshPayload, Clone)]

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -477,7 +477,7 @@ impl AdminHandler {
                         .admin_submission_queue_faults
                         .iter()
                         .find(|(op, _)| *op == opcode.0)
-                        .map(|(_, behavior)| *behavior)
+                        .map(|(_, behavior)| behavior.clone())
                         .unwrap_or_else(|| QueueFaultBehavior::Default);
 
                     match fault {
@@ -498,6 +498,12 @@ impl AdminHandler {
                         }
                         QueueFaultBehavior::Delay(duration) => {
                             self.timer.sleep(duration).await;
+                        }
+                        QueueFaultBehavior::Panic(message) => {
+                            panic!(
+                                "configured fault: admin command panic with command: {:?} and message: {}",
+                                &command, &message
+                            );
                         }
                         QueueFaultBehavior::Default => {}
                     }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -256,7 +256,7 @@ async fn keepalive_with_nvme_fault(
         fault_active: fault_start_updater.cell(),
         admin_fault: AdminQueueFaultConfig::new().with_submission_queue_fault(
             nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0,
-            QueueFaultBehavior::Drop,
+            QueueFaultBehavior::Panic("Received a CREATE_IO_COMPLETION_QUEUE command during servicing with keepalive enabled. This should never happen.".to_string()),
         ),
     };
 


### PR DESCRIPTION
Previously the openhcl test was using the `QueueFaultBehaviour::Drop` fault in order to block `CREATE_IO_COMPLETION_QUEUE` commands. In the test failure case this relied on the test timing out and failing. In order to fail fast we can instead panic if such a command is seen.  This should reduce test run time in the failure case.