### PR TITLE
vmm_tests: storvsp: generate some IO

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -405,6 +405,13 @@ async fn storvsp(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyh
     // Account for the pipette drive too
     assert_eq!(reported_sizes.len(), 3);
 
+    let _io_to_sda = cmd!(sh, "sh -c 'dd if=/dev/urandom of=/dev/sda bs=1M count=100'")
+        .run()
+        .await?;
+    let _io_to_sdb = cmd!(sh, "sh -c 'dd if=/dev/urandom of=/dev/sdb bs=1M count=100'")
+        .run()
+        .await?;
+
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;
 


### PR DESCRIPTION
Add some marginal IO to the storvsp test. This pattern found a bug in in-development code, so I believe that this test change is generally useful.