### PR TITLE
openhcl_boot: refactor address space init to a builder pattern

### DIFF
--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -827,6 +827,7 @@ mod test {
     use crate::host_params::PartitionInfo;
     use crate::host_params::shim_params::IsolationType;
     use crate::memory::AddressSpaceManager;
+    use crate::memory::AddressSpaceManagerBuilder;
     use arrayvec::ArrayString;
     use arrayvec::ArrayVec;
     use core::ops::Range;
@@ -1039,16 +1040,14 @@ mod test {
             })
             .collect::<Vec<_>>();
         let mut address_space = AddressSpaceManager::new_const();
-        address_space
-            .init(
-                &ram,
-                bootshim_used,
-                subtract_ranges([parameter_range], reclaim),
-                None,
-                None,
-                None,
-            )
-            .unwrap();
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            &ram,
+            bootshim_used,
+            subtract_ranges([parameter_range], reclaim),
+        )
+        .init()
+        .unwrap();
         address_space
     }
 
@@ -1228,16 +1227,14 @@ mod test {
                 })
                 .collect::<Vec<_>>();
             let mut address_space = AddressSpaceManager::new_const();
-            address_space
-                .init(
-                    &ram,
-                    bootshim_used,
-                    subtract_ranges([parameter_range], None),
-                    None,
-                    None,
-                    None,
-                )
-                .unwrap();
+            AddressSpaceManagerBuilder::new(
+                &mut address_space,
+                &ram,
+                bootshim_used,
+                core::iter::once(parameter_range),
+            )
+            .init()
+            .unwrap();
             address_space
         };
 


### PR DESCRIPTION
An upcoming change has more range types to be reported in the init call, so make this a builder in preperation for that. This makes it cleaner as otherwise the function becomes very unwieldy. 