### PR TITLE
repo: update Cargo.lock to fix CI break

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,7 +5014,7 @@ dependencies = [
  "sha2",
  "sidecar_defs",
  "tdcall",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "underhill_confidentiality",
  "x86defs",
  "zerocopy 0.8.25",


### PR DESCRIPTION
The previous change #1754 had a stale green PR build that was missing a Cargo.lock update. Take this change to unbreak CI. 