### PR TITLE
ci: add ubuntu 2404 cvm tests

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -901,7 +901,10 @@ impl IntoPipeline for CheckinGatesCli {
         ];
 
         let cvm_filter = |arch| format!("test({arch}) + (test(vbs) & test(hyperv))");
-        let cvm_x64_test_artifacts = vec![KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd];
+        let cvm_x64_test_artifacts = vec![
+            KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd,
+            KnownTestArtifacts::Ubuntu2404ServerX64Vhd,
+        ];
 
         for VmmTestJobParams {
             platform,

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -306,6 +306,9 @@ impl SimpleFlowNode for Node {
                         if windows && (tdx || snp || hyperv_vbs) {
                             artifacts.push(KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd);
                         }
+                        if windows && (tdx || snp || hyperv_vbs) {
+                            artifacts.push(KnownTestArtifacts::Ubuntu2404ServerX64Vhd);
+                        }
                         if ubuntu {
                             artifacts.push(KnownTestArtifacts::Ubuntu2204ServerX64Vhd);
                         }

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -67,6 +67,7 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64 => get_test_artifact_path(KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd),
             _ if id == test_vhd::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Vhd),
             _ if id == test_vhd::UBUNTU_2204_SERVER_X64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2204ServerX64Vhd),
+            _ if id == test_vhd::UBUNTU_2404_SERVER_X64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2404ServerX64Vhd),
             _ if id == test_vhd::UBUNTU_2404_SERVER_AARCH64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd),
             _ if id == test_vhd::WINDOWS_11_ENTERPRISE_AARCH64 => get_test_artifact_path(KnownTestArtifacts::Windows11EnterpriseAarch64Vhdx),
 

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -333,6 +333,29 @@ pub mod artifacts {
         }
 
         declare_artifacts! {
+            /// Ubuntu 24.04 Server X64
+            UBUNTU_2404_SERVER_X64
+        }
+
+        impl IsTestVhd for UBUNTU_2404_SERVER_X64 {
+            const OS_FLAVOR: OsFlavor = OsFlavor::Linux;
+            const ARCH: MachineArch = MachineArch::X86_64;
+            fn quirks() -> GuestQuirks {
+                let mut quirks = GuestQuirks::for_all_backends(GuestQuirksInner {
+                    hyperv_shutdown_ic_sleep: Some(std::time::Duration::from_secs(20)),
+                    ..Default::default()
+                });
+                quirks.hyperv.initial_reboot = Some(InitialRebootCondition::WithOpenHclUefi);
+                quirks
+            }
+        }
+
+        impl IsHostedOnHvliteAzureBlobStore for UBUNTU_2404_SERVER_X64 {
+            const FILENAME: &'static str = "ubuntu-24.04-server-cloudimg-amd64.vhd";
+            const SIZE: u64 = 3758211584;
+        }
+
+        declare_artifacts! {
             /// Ubuntu 24.04 Server Aarch64
             UBUNTU_2404_SERVER_AARCH64
         }

--- a/vmm_tests/vmm_test_images/src/lib.rs
+++ b/vmm_tests/vmm_test_images/src/lib.rs
@@ -30,6 +30,7 @@ pub enum KnownTestArtifacts {
     FreeBsd13_2X64Vhd,
     FreeBsd13_2X64Iso,
     Ubuntu2204ServerX64Vhd,
+    Ubuntu2404ServerX64Vhd,
     Ubuntu2404ServerAarch64Vhd,
     Windows11EnterpriseAarch64Vhdx,
     VmgsWithBootEntry,
@@ -82,6 +83,11 @@ const KNOWN_TEST_ARTIFACT_METADATA: &[KnownTestArtifactMeta] = &[
         KnownTestArtifacts::Ubuntu2204ServerX64Vhd,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2204_SERVER_X64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2204_SERVER_X64::SIZE,
+    ),
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::Ubuntu2404ServerX64Vhd,
+        petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_X64::FILENAME,
+        petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_X64::SIZE,
     ),
     KnownTestArtifactMeta::new(
         KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -405,6 +405,9 @@ fn parse_vhd(input: ParseStream<'_>, generation: Generation) -> syn::Result<Imag
         "ubuntu_2204_server_x64" => Ok(image_info!(
             ::petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2204_SERVER_X64
         )),
+        "ubuntu_2404_server_x64" => Ok(image_info!(
+            ::petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_X64
+        )),
         "ubuntu_2404_server_aarch64" => Ok(image_info!(
             ::petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64
         )),
@@ -555,6 +558,7 @@ fn parse_extra_deps(input: ParseStream<'_>) -> syn::Result<Vec<Path>> {
 ///
 /// Valid x64 VHD options are:
 /// - `ubuntu_2204_server_x64`: Ubuntu Linux 22.04 cloudimg from Canonical
+/// - `ubuntu_2404_server_x64`: Ubuntu Linux 24.04 cloudimg from Canonical
 /// - `windows_datacenter_core_2022_x64`: Windows Server Datacenter Core 2022 from the Azure Marketplace
 /// - `windows_datacenter_core_2025_x64`: Windows Server Datacenter Core 2025 from the Azure Marketplace
 /// - `freebsd_13_2_x64`: FreeBSD 13.2 from the FreeBSD Project

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -376,8 +376,11 @@ async fn reboot<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> Result<(), any
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2404_server_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64)),
-    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64))
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2404_server_x64)),
+    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2404_server_x64))
 )]
 async fn boot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let mut vm = config.run_without_agent().await?;
@@ -391,8 +394,11 @@ async fn boot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow:
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2404_server_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64)),
-    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64))
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2404_server_x64)),
+    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2404_server_x64))
 )]
 async fn boot_no_agent_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let mut vm = config
@@ -495,8 +501,11 @@ async fn vmbus_relay_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> any
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2404_server_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64)),
-    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64))
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2404_server_x64)),
+    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2404_server_x64))
 )]
 async fn boot_no_agent_single_proc<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
@@ -529,8 +538,11 @@ async fn boot_no_agent_single_proc<T: PetriVmmBackend>(
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2404_server_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64)),
-    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64))
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2404_server_x64)),
+    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2404_server_x64))
 )]
 async fn reboot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let mut vm = config.run_without_agent().await?;


### PR DESCRIPTION
Adds Ubuntu 24.04 CVM tests. These tests use 24.04 since our 22.04 image doesn't boot properly in Hyper-V CVMs, and our 24.04 images doesn't boot properly in OpenVMM VBS VMs. 