### PR TITLE
vmbus_client: add filter and channel driver support (#1579)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8426,9 +8426,11 @@ dependencies = [
  "thiserror 2.0.12",
  "tracelimit",
  "tracing",
+ "user_driver",
  "vmbus_async",
  "vmbus_channel",
  "vmbus_core",
+ "vmbus_ring",
  "vmcore",
  "zerocopy 0.8.24",
 ]

--- a/vm/devices/vmbus/vmbus_client/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_client/Cargo.toml
@@ -7,9 +7,11 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+user_driver.workspace = true
 vmbus_async.workspace = true
 vmbus_channel.workspace = true
 vmbus_core.workspace = true
+vmbus_ring.workspace = true
 vmcore.workspace = true
 
 guid.workspace = true

--- a/vm/devices/vmbus/vmbus_client/src/driver.rs
+++ b/vm/devices/vmbus/vmbus_client/src/driver.rs
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Support for authoring vmbus device drivers on top of the vmbus client
+//! driver.
+
+use crate::ChannelRequest;
+use crate::OfferInfo;
+use crate::OpenRequest;
+use anyhow::Context as _;
+use futures::FutureExt;
+use futures_concurrency::future::Race;
+use inspect::InspectMut;
+use mesh::rpc::RpcSend;
+use pal_async::driver::SpawnDriver;
+use std::mem::ManuallyDrop;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering::Relaxed;
+use std::task::Poll;
+use user_driver::DmaClient;
+use user_driver::memory::MemoryBlock;
+use vmbus_channel::ChannelClosed;
+use vmbus_channel::RawAsyncChannel;
+use vmbus_channel::SignalVmbusChannel;
+use vmbus_channel::bus::GpadlRequest;
+use vmbus_channel::bus::OpenData;
+use vmbus_core::protocol::GpadlId;
+use vmbus_core::protocol::UserDefinedData;
+use vmbus_ring::IncomingRing;
+use vmbus_ring::OutgoingRing;
+use vmbus_ring::SingleMappedRingMem;
+use vmcore::interrupt::Interrupt;
+use vmcore::notify::Notify;
+use vmcore::notify::PolledNotify;
+
+/// Input parameters when opening a vmbus channel.
+pub struct OpenParams {
+    /// The number of pages to use for the ring buffer.
+    pub ring_pages: u16,
+    /// The offset in pages where the downstream ring starts.
+    pub ring_offset_in_pages: u16,
+}
+
+/// The memory type used for the vmbus channel ring buffer.
+pub type MemoryBlockRingMem = SingleMappedRingMem<MemoryBlockView>;
+
+/// Opens a vmbus channel, returning the ring buffer parameters.
+pub async fn open_channel(
+    driver: impl SpawnDriver + Clone + 'static,
+    offer_info: OfferInfo,
+    params: OpenParams,
+    dma_client: &dyn DmaClient,
+) -> anyhow::Result<RawAsyncChannel<MemoryBlockRingMem>> {
+    let gpadl =
+        dma_client.allocate_dma_buffer(vmbus_ring::PAGE_SIZE * params.ring_pages as usize)?;
+
+    let (resp_send, resp_recv) = mesh::oneshot();
+    // Detach the task so that it doesn't get dropped (and thereby leak the allocation).
+    driver
+        .clone()
+        .spawn("vmbus_client", async move {
+            ChannelWorker::run(driver, offer_info, params, gpadl, resp_send).await
+        })
+        .detach();
+
+    resp_recv.await.context("no response opening channel")?
+}
+
+#[derive(InspectMut)]
+struct ChannelWorker<D> {
+    #[inspect(skip)]
+    driver: D,
+    offer: vmbus_core::protocol::OfferChannel,
+    #[inspect(skip)]
+    request_send: mesh::Sender<ChannelRequest>,
+    #[inspect(skip)]
+    gpadl: ManuallyDrop<Arc<MemoryBlock>>,
+    #[inspect(debug)]
+    ring_gpadl_id: GpadlId,
+    is_gpadl_created: bool,
+    is_open: bool,
+}
+
+impl<D: SpawnDriver> ChannelWorker<D> {
+    async fn open(
+        &mut self,
+        input: OpenParams,
+        close_send: mesh::OneshotSender<()>,
+        host_to_guest: pal_event::Event,
+        revoked: Arc<AtomicBool>,
+    ) -> anyhow::Result<RawAsyncChannel<MemoryBlockRingMem>> {
+        let gpadl_buf = [self.gpadl.len() as u64]
+            .into_iter()
+            .chain(self.gpadl.pfns().iter().copied())
+            .collect::<Vec<_>>();
+
+        self.request_send
+            .call_failable(
+                ChannelRequest::Gpadl,
+                GpadlRequest {
+                    id: self.ring_gpadl_id,
+                    count: 1,
+                    buf: gpadl_buf,
+                },
+            )
+            .await?;
+
+        self.is_gpadl_created = true;
+
+        let open = self
+            .request_send
+            .call_failable(
+                ChannelRequest::Open,
+                OpenRequest {
+                    open_data: OpenData {
+                        target_vp: 0, // TODO: improve
+                        ring_offset: input.ring_offset_in_pages.into(),
+                        ring_gpadl_id: self.ring_gpadl_id,
+                        event_flag: !0,
+                        connection_id: !0,
+                        user_data: UserDefinedData::default(),
+                    },
+                    incoming_event: Some(host_to_guest.clone()),
+                    use_vtl2_connection_id: true,
+                },
+            )
+            .await?;
+
+        self.is_open = true;
+
+        let in_ring = MemoryBlockView {
+            mem: Arc::clone(&self.gpadl),
+            offset: input.ring_offset_in_pages as usize * vmbus_ring::PAGE_SIZE,
+            len: (input.ring_pages - input.ring_offset_in_pages) as usize * vmbus_ring::PAGE_SIZE,
+        };
+
+        let out_ring = MemoryBlockView {
+            mem: Arc::clone(&self.gpadl),
+            offset: 0,
+            len: input.ring_offset_in_pages as usize * vmbus_ring::PAGE_SIZE,
+        };
+
+        let signal = ClientSignaller {
+            guest_to_host: open.guest_to_host_signal,
+            host_to_guest: Notify::from_event(host_to_guest).pollable(&self.driver)?,
+            revoked: revoked.clone(),
+            _close: close_send,
+        };
+
+        Ok(RawAsyncChannel {
+            in_ring: IncomingRing::new(SingleMappedRingMem(in_ring))?,
+            out_ring: OutgoingRing::new(SingleMappedRingMem(out_ring))?,
+            signal: Box::new(signal),
+        })
+    }
+
+    async fn shutdown(self) {
+        if self.is_open {
+            self.request_send.call(ChannelRequest::Close, ()).await.ok();
+        }
+
+        if self.is_gpadl_created {
+            self.request_send
+                .call(ChannelRequest::TeardownGpadl, self.ring_gpadl_id)
+                .await
+                .ok();
+        }
+
+        // Now it is safe to deallocate the gpadl memory.
+        ManuallyDrop::into_inner(self.gpadl);
+    }
+
+    async fn run(
+        driver: D,
+        offer_info: OfferInfo,
+        input: OpenParams,
+        gpadl_mem: MemoryBlock,
+        resp: mesh::OneshotSender<anyhow::Result<RawAsyncChannel<MemoryBlockRingMem>>>,
+    ) {
+        let instance_id = offer_info.offer.instance_id;
+        let ring_gpadl_id = GpadlId((1 << 31) | offer_info.offer.channel_id.0);
+
+        let mut worker = ChannelWorker {
+            driver,
+            offer: offer_info.offer,
+            request_send: offer_info.request_send,
+            gpadl: ManuallyDrop::new(Arc::new(gpadl_mem)),
+            ring_gpadl_id,
+            is_gpadl_created: false,
+            is_open: false,
+        };
+
+        let revoked = Arc::new(AtomicBool::new(false));
+        let (close_send, close_recv) = mesh::oneshot();
+        let host_to_guest = pal_event::Event::new();
+        match worker
+            .open(input, close_send, host_to_guest.clone(), revoked.clone())
+            .await
+        {
+            Ok(channel) => {
+                resp.send(Ok(channel));
+            }
+            Err(e) => {
+                resp.send(Err(e));
+                worker.shutdown().await;
+                return;
+            }
+        }
+
+        enum Event<T, U> {
+            Close(T),
+            Revoke(U),
+        }
+
+        let revoke = offer_info.revoke_recv.map(Event::Revoke);
+        let close = close_recv.map(Event::Close);
+        let event = (revoke, close).race().await;
+        match event {
+            Event::Close(_) => {
+                tracing::debug!(%instance_id, "channel close requested");
+            }
+            Event::Revoke(_) => {
+                tracing::debug!(%instance_id, "channel revoked");
+                revoked.store(true, Relaxed);
+                host_to_guest.signal();
+                worker.is_open = false;
+            }
+        }
+
+        worker.shutdown().await;
+    }
+}
+
+/// A view into a [`MemoryBlock`].
+pub struct MemoryBlockView {
+    mem: Arc<MemoryBlock>,
+    offset: usize,
+    len: usize,
+}
+
+impl AsRef<[AtomicU8]> for MemoryBlockView {
+    fn as_ref(&self) -> &[AtomicU8] {
+        &self.mem.as_slice()[self.offset..][..self.len]
+    }
+}
+
+struct ClientSignaller {
+    guest_to_host: Interrupt,
+    host_to_guest: PolledNotify,
+    revoked: Arc<AtomicBool>,
+    // This closes the channel on drop.
+    _close: mesh::OneshotSender<()>,
+}
+
+impl SignalVmbusChannel for ClientSignaller {
+    fn signal_remote(&self) {
+        self.guest_to_host.deliver();
+    }
+
+    fn poll_for_signal(&self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), ChannelClosed>> {
+        if self.revoked.load(Relaxed) {
+            return Poll::Ready(Err(ChannelClosed));
+        }
+        self.host_to_guest.poll_wait(cx).map(Ok)
+    }
+}

--- a/vm/devices/vmbus/vmbus_client/src/filter.rs
+++ b/vm/devices/vmbus/vmbus_client/src/filter.rs
@@ -1,0 +1,266 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Support for filtering vmbus offers. This is useful for redirecting offers to
+//! separate client drivers.
+
+use crate::ConnectResult;
+use crate::OfferInfo;
+use futures::StreamExt;
+use futures_concurrency::stream::Merge;
+use guid::Guid;
+use inspect::Inspect;
+use inspect::InspectMut;
+use pal_async::task::Spawn;
+use pal_async::task::Task;
+use std::pin::pin;
+use vmbus_core::protocol::OfferChannel;
+
+/// A filter.
+///
+/// Create using [`ClientFilterBuilder`].
+pub struct ClientFilter {
+    req: mesh::Sender<FilterRequest>,
+    task: Task<()>,
+}
+
+impl Inspect for ClientFilter {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        self.req.send(FilterRequest::Inspect(req.defer()));
+    }
+}
+
+enum FilterRequest {
+    Inspect(inspect::Deferred),
+}
+
+impl ClientFilter {
+    /// Shuts down the filter.
+    pub async fn shutdown(self) {
+        drop(self.req);
+        self.task.await;
+    }
+}
+
+/// A builder for creating a [`ClientFilter`].
+pub struct ClientFilterBuilder<'a> {
+    clients: Vec<&'a mut FilterDefinition>,
+}
+
+#[derive(InspectMut)]
+struct FilterWorker {
+    #[inspect(flatten)]
+    filters: Filters,
+    #[inspect(skip)]
+    clients: Vec<mesh::Sender<OfferInfo>>,
+}
+
+struct Filters {
+    interfaces: Vec<(Guid, usize)>,
+    instances: Vec<(Guid, Guid, usize)>,
+    rest: Option<usize>,
+    names: Vec<String>,
+}
+
+/// A single filter definition.
+pub struct FilterDefinition {
+    name: String,
+    interfaces: Vec<Guid>,
+    instances: Vec<(Guid, Guid)>,
+    rest: bool,
+    result: Option<ConnectResult>,
+}
+
+impl FilterDefinition {
+    /// Returns a new filter instance with the given name (for diagnostics).
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            interfaces: Vec::new(),
+            instances: Vec::new(),
+            rest: false,
+            result: None,
+        }
+    }
+
+    /// Adds the specified interface ID to the filter, to include offers for that interface.
+    pub fn by_interface(mut self, interface_id: Guid) -> Self {
+        self.interfaces.push(interface_id);
+        self
+    }
+
+    /// Adds the specified interface ID and instance ID to the filter, to
+    /// include offers for a specific offer instance.
+    pub fn by_instance(mut self, interface_id: Guid, instance_id: Guid) -> Self {
+        self.instances.push((interface_id, instance_id));
+        self
+    }
+
+    /// Filter all remaining offers that do not match any other filter.
+    pub fn rest(mut self) -> Self {
+        self.rest = true;
+        self
+    }
+
+    /// Takes a filtered connection result.
+    ///
+    /// This should be called only after the filter has been built and offers
+    /// have been processed, via [`ClientFilterBuilder::build`]. Panics
+    /// otherwise.
+    pub fn take(mut self) -> ConnectResult {
+        self.result
+            .take()
+            .expect("failed to call ClientFilterBuilder::build")
+    }
+}
+
+impl<'a> ClientFilterBuilder<'a> {
+    /// Creates a new filter builder.
+    pub fn new() -> Self {
+        Self {
+            clients: Vec::new(),
+        }
+    }
+
+    /// Adds a filter definition.
+    pub fn add(&mut self, client: &'a mut FilterDefinition) -> &mut Self {
+        self.clients.push(client);
+        self
+    }
+
+    /// Builds a filter instance, which applies the assigned filters to the
+    /// initial and dynamic offers in `connection`.
+    ///
+    /// Uses `driver` to spawn the filter worker task.
+    pub fn build(mut self, driver: impl Spawn, connection: ConnectResult) -> ClientFilter {
+        let mut filters = Filters {
+            interfaces: Vec::new(),
+            instances: Vec::new(),
+            rest: None,
+            names: self.clients.iter().map(|c| c.name.clone()).collect(),
+        };
+        let mut offer_send = Vec::with_capacity(self.clients.len());
+        for (i, client) in self.clients.iter_mut().enumerate() {
+            let (send, recv) = mesh::channel();
+            client.result = Some(ConnectResult {
+                version: connection.version,
+                offers: Vec::new(),
+                offer_recv: recv,
+            });
+            offer_send.push(send);
+            for &interface in &client.interfaces {
+                filters.interfaces.push((interface, i));
+            }
+            for &(interface, instance) in &client.instances {
+                filters.instances.push((interface, instance, i));
+            }
+            if client.rest {
+                assert!(filters.rest.is_none(), "multiple rest filters set");
+                filters.rest = Some(i);
+            }
+        }
+
+        for offer in connection.offers {
+            if let Some(i) = filters.find(&offer.offer) {
+                self.clients[i].result.as_mut().unwrap().offers.push(offer);
+            }
+        }
+
+        let (req_send, req_recv) = mesh::channel();
+        let mut worker = FilterWorker {
+            filters,
+            clients: offer_send,
+        };
+
+        let offer_recv = connection.offer_recv;
+        let task = driver.spawn("client_filter", async move {
+            worker.run(req_recv, offer_recv).await;
+        });
+        ClientFilter {
+            task,
+            req: req_send,
+        }
+    }
+}
+
+impl Filters {
+    fn find(&self, offer: &OfferChannel) -> Option<usize> {
+        let interface = &offer.interface_id;
+        let instance = &offer.instance_id;
+        let (&v, ty) = if let Some(v) = self.instances.iter().find_map(|(iface, inst, send)| {
+            ((iface, inst) == (interface, instance)).then_some(send)
+        }) {
+            (v, "instance")
+        } else if let Some(v) = self
+            .interfaces
+            .iter()
+            .find_map(|(iface, send)| (iface == interface).then_some(send))
+        {
+            (v, "interface")
+        } else if let Some(v) = self.rest.as_ref() {
+            (v, "rest")
+        } else {
+            tracing::warn!(%interface, %instance, "rejecting offer");
+            return None;
+        };
+        tracing::debug!(
+            %interface,
+            %instance,
+            filter_type = ty,
+            client = self.names[v],
+            "accepting offer"
+        );
+        Some(v)
+    }
+}
+
+impl Inspect for Filters {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        let mut resp = req.respond();
+        let Self {
+            interfaces,
+            instances,
+            rest,
+            names,
+        } = self;
+        for &(interface, i) in interfaces {
+            resp.field(&format!("by_interface/{}", interface), &names[i]);
+        }
+        for &(interface, instance, i) in instances {
+            resp.field(
+                &format!("by_instance/{}_{}", interface, instance),
+                &names[i],
+            );
+        }
+        if let Some(i) = rest {
+            resp.field("rest", &names[*i]);
+        }
+    }
+}
+
+impl FilterWorker {
+    async fn run(&mut self, req: mesh::Receiver<FilterRequest>, offers: mesh::Receiver<OfferInfo>) {
+        enum Event {
+            Request(FilterRequest),
+            Done,
+            Offer(OfferInfo),
+        }
+        let req = req
+            .map(Event::Request)
+            .chain(futures::stream::once(async { Event::Done }));
+        let offers = offers.map(Event::Offer);
+        let mut events = pin!((req, offers).merge());
+
+        while let Some(event) = events.next().await {
+            match event {
+                Event::Request(FilterRequest::Inspect(deferred)) => deferred.inspect(&mut *self),
+                Event::Done => break,
+                Event::Offer(offer_info) => {
+                    if let Some(i) = self.filters.find(&offer_info.offer) {
+                        self.clients[i].send(offer_info);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! Client driver for the Hyper-V Virtual Machine Bus (VmBus).
+
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
 
+pub mod driver;
+pub mod filter;
 mod hvsock;
 pub mod saved_state;
 

--- a/vm/devices/vmbus/vmbus_client/src/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_client/src/saved_state.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! Saved state support for the vmbus client.
+
 use crate::ConnectResult;
 use crate::OfferInfo;
 use crate::RestoreError;


### PR DESCRIPTION
Add infrastructure to `vmbus_client` for writing vmbus channel drivers. This includes a filter, which can be used to allow some offers to go to `vmbus_relay` and others to be set aside, and infrastructure to allocate a ring buffer and open the channel.

Cherry pick of #1579.