### PR TITLE
nvme: support multiple submission queues per completion queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,6 +4780,7 @@ dependencies = [
  "pci_core",
  "pci_resources",
  "scsi_buffers",
+ "slab",
  "task_control",
  "thiserror 2.0.16",
  "tracelimit",

--- a/vm/devices/storage/nvme/Cargo.toml
+++ b/vm/devices/storage/nvme/Cargo.toml
@@ -26,13 +26,15 @@ guid.workspace = true
 inspect.workspace = true
 mesh.workspace = true
 pal_async.workspace = true
+task_control.workspace = true
+tracelimit.workspace = true
+
 async-trait.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
 parking_lot.workspace = true
-task_control.workspace = true
+slab.workspace = true
 thiserror.workspace = true
-tracelimit.workspace = true
 tracing.workspace = true
 unicycle.workspace = true
 zerocopy = { workspace = true, features = ["alloc"] }

--- a/vm/devices/storage/nvme/src/queue.rs
+++ b/vm/devices/storage/nvme/src/queue.rs
@@ -252,13 +252,9 @@ pub enum QueueError {
 }
 
 impl SubmissionQueue {
-    pub fn new(
-        doorbells: Arc<RwLock<DoorbellMemory>>,
-        db_id: u16,
-        mem: GuestMemory,
-        gpa: u64,
-        len: u16,
-    ) -> Self {
+    pub fn new(cq: &CompletionQueue, db_id: u16, gpa: u64, len: u16) -> Self {
+        let doorbells = cq.head.doorbells.clone();
+        let mem = cq.mem.clone();
         doorbells.read().write(db_id, 0);
         Self {
             tail: DoorbellState::new(doorbells, db_id, len.into()),


### PR DESCRIPTION
The NVMe spec requires that multiple submission queues be able to target the same completion queue. Initially we thought no guests really rely on this, but it turns out that depending on the VM's topology, Windows expects this to work.

Support this without adding extra synchronization--have a single task own all submission queues that are tied to a single completion queue. This limits CPU parallelism, but I don't really expect that to be the bottleneck for common use cases, since this configuration implies the guest has a single CPU handling completions anyway.

This change fixes Windows NVMe boot in various configurations.