### PR TITLE
local_clock: Tweak flaky test output

### DIFF
--- a/support/local_clock/src/clock_impls.rs
+++ b/support/local_clock/src/clock_impls.rs
@@ -143,8 +143,9 @@ mod tests {
 
         // cannot use assert_eq, because there is a *bit* of extra time elapsed
         // aside from the thread sleep.
-        assert!(delta >= LocalClockDelta::from_millis(1000), "{delta:?}");
-        assert!(delta < LocalClockDelta::from_millis(2000), "{delta:?}"); // sanity check
+        eprintln!("delta: {delta:?}");
+        assert!(delta >= LocalClockDelta::from_millis(1000));
+        assert!(delta < LocalClockDelta::from_millis(2000)); // sanity check
     }
 
     #[test]


### PR DESCRIPTION
Apparently the custom panic strings don't get printed by nextest. Just print it manually instead.