### PR TITLE
vmgstool: recover if no space for new encryption key

### DIFF
--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -38,6 +38,7 @@ zerocopy.workspace = true
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 disklayer_ram.workspace = true
 disk_backend.workspace = true
+vmgs = { workspace = true, features = ["encryption_ossl", "test_helpers"] }
 vmgs_format.workspace = true
 
 [lints]

--- a/vm/devices/storage/disk_get_vmgs/src/lib.rs
+++ b/vm/devices/storage/disk_get_vmgs/src/lib.rs
@@ -407,7 +407,7 @@ mod tests {
         let file_id = FileId::BIOS_NVRAM;
         let encryption_key = vec![1; 32];
 
-        vmgs.add_new_encryption_key(&encryption_key, vmgs::EncryptionAlgorithm::AES_GCM)
+        vmgs.update_encryption_key(&encryption_key, vmgs::EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
 

--- a/vm/vmgs/vmgs/Cargo.toml
+++ b/vm/vmgs/vmgs/Cargo.toml
@@ -17,6 +17,8 @@ encryption_win = ["dep:windows"]
 # Use OpenSSL crypto APIs
 encryption_ossl = ["dep:openssl"]
 
+test_helpers = []
+
 [dependencies]
 disk_backend.workspace = true
 guestmem.workspace = true

--- a/vm/vmgs/vmgs/src/error.rs
+++ b/vm/vmgs/vmgs/src/error.rs
@@ -61,6 +61,12 @@ pub enum Error {
     /// Cannot read encrypted file - VMGS is locked.
     #[error("cannot read encrypted file - VMGS is locked")]
     ReadEncrypted,
+    /// Tried to add a new encryption key, but there are already two keys.
+    #[error("no space to add new encryption key")]
+    DatastoreKeysFull,
+    /// Datastore keys full, but there is no active key.
+    #[error("unable to determine inactive key for removal")]
+    NoActiveDatastoreKey,
 
     /// OpenSSL errors.
     #[cfg(feature = "encryption_ossl")]

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -1246,8 +1246,7 @@ impl Vmgs {
 
     /// Associates a new root key with the data store and removes the old
     /// encryption key, if it exists. If two keys already exist, the
-    /// inactive key is removed first. Returns the index of the newly
-    /// associated key.
+    /// inactive key is removed first.
     #[cfg(with_encryption)]
     pub async fn update_encryption_key(
         &mut self,

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -1080,10 +1080,7 @@ impl Vmgs {
     /// Decrypts the extended file table by the encryption_key and
     /// updates the related metadata in memory.
     #[cfg(with_encryption)]
-    pub async fn unlock_with_encryption_key(
-        &mut self,
-        encryption_key: &[u8],
-    ) -> Result<usize, Error> {
+    pub async fn unlock_with_encryption_key(&mut self, encryption_key: &[u8]) -> Result<(), Error> {
         if self.version < VMGS_VERSION_3_0 {
             return Err(Error::Other(anyhow!(
                 "unlock_with_encryption_key() not supported with VMGS version"
@@ -1168,7 +1165,7 @@ impl Vmgs {
         self.datastore_keys[valid_index].copy_from_slice(encryption_key);
         self.active_datastore_key_index = Some(valid_index);
 
-        Ok(valid_index)
+        Ok(())
     }
 
     /// Encrypts the plaintext data and writes the encrypted data to the storage.
@@ -1282,14 +1279,13 @@ impl Vmgs {
         Ok(())
     }
 
-    /// Associates a new root key with the data store. Returns the index of the newly associated key.
-    // TODO: make this function private
+    /// Associates a new root key with the data store.
     #[cfg(with_encryption)]
-    pub async fn add_new_encryption_key(
+    async fn add_new_encryption_key(
         &mut self,
         encryption_key: &[u8],
         encryption_algorithm: EncryptionAlgorithm,
-    ) -> Result<usize, Error> {
+    ) -> Result<(), Error> {
         if self.version < VMGS_VERSION_3_0 {
             return Err(Error::Other(anyhow!(
                 "add_new_encryption_key() not supported with VMGS version"
@@ -1405,7 +1401,7 @@ impl Vmgs {
         self.encryption_algorithm = encryption_algorithm;
         self.active_datastore_key_index = Some(new_key_index);
 
-        Ok(new_key_index)
+        Ok(())
     }
 
     /// Disassociates the root key at the specified index from the data store.
@@ -1490,6 +1486,31 @@ impl Vmgs {
             file_table_offset: file_table_fcb.block_offset,
             file_table_size: file_table_fcb.allocated_blocks.get(),
             ..VmgsHeader::new_zeroed()
+        }
+    }
+}
+
+/// Additional test-only functions for use in other crates that reveal
+/// implmentation details of the vmgs datastore encryption keys.
+#[cfg(feature = "test_helpers")]
+mod test_helpers {
+    use super::*;
+
+    impl Vmgs {
+        /// Get the active datastore key index
+        pub fn test_get_active_datastore_key_index(&self) -> Option<usize> {
+            self.active_datastore_key_index
+        }
+
+        /// Associates a new root key with the data store.
+        #[cfg(with_encryption)]
+        pub async fn test_add_new_encryption_key(
+            &mut self,
+            encryption_key: &[u8],
+            encryption_algorithm: EncryptionAlgorithm,
+        ) -> Result<(), Error> {
+            self.add_new_encryption_key(encryption_key, encryption_algorithm)
+                .await
         }
     }
 }
@@ -2393,7 +2414,7 @@ mod tests {
         let buf = b"hello world";
         let buf_1 = b"hello universe";
         vmgs.write_file(FileId::BIOS_NVRAM, buf).await.unwrap();
-        vmgs.add_new_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.update_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
         vmgs.write_file_encrypted(FileId::TPM_PPI, buf_1)
@@ -2438,11 +2459,10 @@ mod tests {
         let buf_1 = vec![2; 8 * 1024];
 
         // Add root key.
-        let key_index = vmgs
-            .add_new_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.add_new_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
-        assert_eq!(key_index, 0);
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
 
         // Write a file to the store.
         vmgs.write_file_encrypted(FileId::BIOS_NVRAM, &buf)
@@ -2469,11 +2489,10 @@ mod tests {
         let mut vmgs = Vmgs::format_new(disk.clone(), None).await.unwrap();
 
         // Add datastore key.
-        let key_index = vmgs
-            .add_new_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.add_new_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
-        assert_eq!(key_index, 0);
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
 
         // Write a file to the store.
         vmgs.write_file_encrypted(FileId::BIOS_NVRAM, &buf)
@@ -2494,20 +2513,18 @@ mod tests {
 
         // Unlock the store.
 
-        let key_index = vmgs
-            .unlock_with_encryption_key(&encryption_key)
+        vmgs.unlock_with_encryption_key(&encryption_key)
             .await
             .unwrap();
 
-        assert_eq!(key_index, 0);
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
 
         // Change to a new datastore key.
         let new_encryption_key = [2; VMGS_ENCRYPTION_KEY_SIZE];
-        let key_index = vmgs
-            .add_new_encryption_key(&new_encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.add_new_encryption_key(&new_encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
-        assert_eq!(key_index, 1);
+        assert_eq!(vmgs.active_datastore_key_index, Some(1));
         vmgs.remove_encryption_key(0).await.unwrap();
 
         let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
@@ -2526,11 +2543,10 @@ mod tests {
         let mut vmgs = Vmgs::format_new(disk.clone(), None).await.unwrap();
 
         // Add datastore key.
-        let key_index = vmgs
-            .add_new_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.add_new_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
-        assert_eq!(key_index, 0);
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
 
         // Write a file to the store.
         vmgs.write_file_encrypted(FileId::BIOS_NVRAM, &buf)
@@ -2540,44 +2556,39 @@ mod tests {
         // Read the file, after closing and reopening the data store.
         drop(vmgs);
         let mut vmgs = Vmgs::open(disk.clone(), None).await.unwrap();
-        let key_index = vmgs
-            .unlock_with_encryption_key(&encryption_key)
+        vmgs.unlock_with_encryption_key(&encryption_key)
             .await
             .unwrap();
-        assert_eq!(key_index, 0);
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
         let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
         assert_eq!(read_buf, buf);
 
         // Add new datastore key.
-        let key_index = vmgs
-            .add_new_encryption_key(&new_encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.add_new_encryption_key(&new_encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
-        assert_eq!(key_index, 1);
+        assert_eq!(vmgs.active_datastore_key_index, Some(1));
 
         // Read the file by using two different datastore keys, after closing and reopening the data store.
         drop(vmgs);
         let mut vmgs = Vmgs::open(disk, None).await.unwrap();
-        let key_index = vmgs
-            .unlock_with_encryption_key(&encryption_key)
+        vmgs.unlock_with_encryption_key(&encryption_key)
             .await
             .unwrap();
-        assert_eq!(key_index, 0);
-        let key_index = vmgs
-            .unlock_with_encryption_key(&new_encryption_key)
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
+        vmgs.unlock_with_encryption_key(&new_encryption_key)
             .await
             .unwrap();
-        assert_eq!(key_index, 1);
+        assert_eq!(vmgs.active_datastore_key_index, Some(1));
         let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
         assert_eq!(read_buf, buf);
 
         // Remove the newly added datastore key and add it again.
-        vmgs.remove_encryption_key(key_index).await.unwrap();
-        let key_index = vmgs
-            .add_new_encryption_key(&new_encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.remove_encryption_key(1).await.unwrap();
+        vmgs.add_new_encryption_key(&new_encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
-        assert_eq!(key_index, 1);
+        assert_eq!(vmgs.active_datastore_key_index, Some(1));
 
         // Remove the old datastore key
         vmgs.remove_encryption_key(0).await.unwrap();
@@ -2639,7 +2650,7 @@ mod tests {
 
         // write
         let buf = b"hello world";
-        vmgs.add_new_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.update_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .unwrap();
         vmgs.write_file_encrypted(FileId::BIOS_NVRAM, buf)
@@ -2658,5 +2669,137 @@ mod tests {
         // verify that the string is logged
         let result = data.lock();
         assert_eq!(*result, "test logger");
+    }
+
+    #[cfg(with_encryption)]
+    #[async_test]
+    async fn update_key() {
+        let buf: Vec<u8> = (0..255).collect();
+        let encryption_key = [1; VMGS_ENCRYPTION_KEY_SIZE];
+
+        let disk = new_test_file();
+        let mut vmgs = Vmgs::format_new(disk.clone(), None).await.unwrap();
+
+        // Add datastore key.
+        vmgs.update_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
+        assert_eq!(vmgs.datastore_key_count, 1);
+
+        // Write a file to the store.
+        vmgs.write_file_encrypted(FileId::BIOS_NVRAM, &buf)
+            .await
+            .unwrap();
+
+        // Read the file, without closing the datastore
+        let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
+        assert_eq!(buf, read_buf);
+
+        // Close and reopen the store
+        drop(vmgs);
+        let mut vmgs = Vmgs::open(disk.clone(), None).await.unwrap();
+
+        // Unlock the store.
+        vmgs.unlock_with_encryption_key(&encryption_key)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
+
+        // Read the file again
+        let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
+        assert_eq!(buf, read_buf);
+
+        // Change to a new datastore key.
+        let new_encryption_key = [2; VMGS_ENCRYPTION_KEY_SIZE];
+        vmgs.update_encryption_key(&new_encryption_key, EncryptionAlgorithm::AES_GCM)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(1));
+        assert_eq!(vmgs.datastore_key_count, 1);
+
+        // Read the file again
+        let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
+        assert_eq!(buf, read_buf);
+
+        // Close and reopen the store
+        drop(vmgs);
+        let mut vmgs = Vmgs::open(disk, None).await.unwrap();
+
+        // Unlock the store.
+        vmgs.unlock_with_encryption_key(&new_encryption_key)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(1));
+
+        // Read the file again
+        let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
+        assert_eq!(buf, read_buf);
+    }
+
+    #[cfg(with_encryption)]
+    #[async_test]
+    async fn update_key_no_space() {
+        let buf: Vec<u8> = (0..255).collect();
+        let encryption_key = [1; VMGS_ENCRYPTION_KEY_SIZE];
+
+        let disk = new_test_file();
+        let mut vmgs = Vmgs::format_new(disk.clone(), None).await.unwrap();
+
+        // Add datastore key.
+        vmgs.update_encryption_key(&encryption_key, EncryptionAlgorithm::AES_GCM)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
+        assert_eq!(vmgs.datastore_key_count, 1);
+
+        // Write a file to the store.
+        vmgs.write_file_encrypted(FileId::BIOS_NVRAM, &buf)
+            .await
+            .unwrap();
+
+        // Read the file, without closing the datastore
+        let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
+        assert_eq!(buf, read_buf);
+
+        // Add a new datastore key, but don't remove the old one.
+        let new_encryption_key = [2; VMGS_ENCRYPTION_KEY_SIZE];
+        vmgs.add_new_encryption_key(&new_encryption_key, EncryptionAlgorithm::AES_GCM)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(1));
+        assert_eq!(vmgs.datastore_key_count, 2);
+
+        // Close and reopen the store
+        drop(vmgs);
+        let mut vmgs = Vmgs::open(disk.clone(), None).await.unwrap();
+
+        // Unlock the store.
+        vmgs.unlock_with_encryption_key(&new_encryption_key)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(1));
+
+        // Add yet another new datastore key. This should remove both previous keys
+        let another_encryption_key = [2; VMGS_ENCRYPTION_KEY_SIZE];
+        vmgs.update_encryption_key(&another_encryption_key, EncryptionAlgorithm::AES_GCM)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
+        assert_eq!(vmgs.datastore_key_count, 1);
+
+        // Close and reopen the store
+        drop(vmgs);
+        let mut vmgs = Vmgs::open(disk, None).await.unwrap();
+
+        // Unlock the store.
+        vmgs.unlock_with_encryption_key(&another_encryption_key)
+            .await
+            .unwrap();
+        assert_eq!(vmgs.active_datastore_key_index, Some(0));
+
+        // Read the file again
+        let read_buf = vmgs.read_file(FileId::BIOS_NVRAM).await.unwrap();
+        assert_eq!(buf, read_buf);
     }
 }

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -326,7 +326,7 @@ async fn do_create(
         .map_err(|_| VmgsError::InvalidVmgs)?;
 
     if let Some(encryption_key) = key {
-        vmgs.add_new_encryption_key(encryption_key, EncryptionAlgorithm::AES_GCM)
+        vmgs.update_encryption_key(encryption_key, EncryptionAlgorithm::AES_GCM)
             .await
             .map_err(|_| VmgsError::EncryptionFailed)?;
     }

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -132,8 +132,7 @@ async fn do_read(
     let data_size = info.valid_bytes;
 
     if let Some(encryption_key) = key {
-        let _key_index = vmgs
-            .unlock_with_encryption_key(encryption_key)
+        vmgs.unlock_with_encryption_key(encryption_key)
             .await
             .map_err(|_| VmgsError::DecryptionFailed)?;
     }

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -472,13 +472,9 @@ async fn vmgs_update_key(
     #[cfg(with_encryption)]
     {
         eprintln!("Updating encryption key");
-        let old_key_index = vmgs.get_active_datastore_key_index();
-        vmgs.add_new_encryption_key(new_encryption_key, encryption_alg)
+        vmgs.update_encryption_key(new_encryption_key, encryption_alg)
             .await
             .map_err(Error::EncryptionKey)?;
-        if let Some(key_index) = old_key_index {
-            vmgs.remove_encryption_key(key_index).await?;
-        }
 
         Ok(())
     }
@@ -574,8 +570,7 @@ async fn vmgs_create(
     if let Some((algorithm, encryption_key)) = encryption_alg_key {
         eprintln!("Adding encryption key");
         #[cfg(with_encryption)]
-        let _key_index = vmgs
-            .add_new_encryption_key(encryption_key, algorithm)
+        vmgs.update_encryption_key(encryption_key, algorithm)
             .await
             .map_err(Error::EncryptionKey)?;
         #[cfg(not(with_encryption))]

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -934,7 +934,7 @@ async fn vmgs_open(disk: Disk, encryption_key: Option<&[u8]>) -> Result<Vmgs, Er
     if let Some(encryption_key) = encryption_key {
         #[cfg(with_encryption)]
         if vmgs.is_encrypted() {
-            let _key_index = vmgs.unlock_with_encryption_key(encryption_key).await?;
+            vmgs.unlock_with_encryption_key(encryption_key).await?;
         } else {
             return Err(Error::NotEncrypted);
         }


### PR DESCRIPTION
Unify the logic for updating the VMGS encryption key by moving the logic into a new function in `vmgs_impl`. OpenHCL already had the logic for recovering when adding a new key and there was already two datastore keys, but this error was encountered when using VmgsTool. This can occur if the previous add key operation failed mid-way through and we did not remove the old key.