### PR TITLE
vmm_tests: skip servicing shutdown_ic test on unsupported hosts

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -204,6 +204,10 @@ async fn shutdown_ic(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> anyhow::Result<()> {
+    if !host_supports_servicing() {
+        tracing::info!("skipping OpenHCL servicing test on unsupported host");
+        return Ok(());
+    }
     let (mut vm, agent) = config
         .with_vmbus_redirect(true)
         .modify_backend(move |b| {


### PR DESCRIPTION
#1918 Accidentally removed a check in the shutdown_ic servicing test checking if servicing is supported on the host. This PR re-adds the check. 