### PR TITLE
Guide: Mention supporting KVM/aarch64

### DIFF
--- a/Guide/src/index.md
+++ b/Guide/src/index.md
@@ -18,7 +18,7 @@ virtualization backends:
 | ------------------- | ------------- | -------------------------------------- |
 | Linux ([paravisor]) | x64 / Aarch64 | MSHV (using [VSM] / [TDX] / [SEV-SNP]) |
 | Windows             | x64 / Aarch64 | WHP (Windows Hypervisor Platform)      |
-| Linux               | x64           | KVM                                    |
+| Linux               | x64 / Aarch64 | KVM                                    |
 |                     | x64           | MSHV (Microsoft Hypervisor)            |
 | macOS               | Aarch64       | Hypervisor.framework                   |
 


### PR DESCRIPTION
I did bring KVM/aarch64 up but missed somehow updating the Guide.

Update the Guide to provide correct information.

<img width="1054" height="561" alt="Captura de pantalla 2025-09-04 a la(s) 7 39 00 a m" src="https://github.com/user-attachments/assets/8d2436ea-d4bd-498d-bbbc-3a91fabeb938" />
