### PR TITLE
petri: use vhdmp to create differencing disks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5586,6 +5586,7 @@ dependencies = [
  "diag_client",
  "disk_backend_resources",
  "disk_vhd1",
+ "disk_vhdmp",
  "fatfs",
  "framebuffer",
  "fs-err",

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -86,6 +86,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(windows)'.dependencies]
+disk_vhdmp.workspace = true
 windows-version.workspace = true
 
 [lints]

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -396,22 +396,6 @@ pub async fn run_set_vm_scsi_controller_target_vtl(
     .context("set_vm_scsi_controller_target_vtl")
 }
 
-/// Create a new differencing VHD with the provided parent.
-pub async fn create_child_vhd(path: &Path, parent_path: &Path) -> anyhow::Result<()> {
-    run_cmd(
-        PowerShellBuilder::new()
-            .cmdlet("New-VHD")
-            .arg("Path", path)
-            .arg("ParentPath", parent_path)
-            .flag("Differencing")
-            .finish()
-            .build(),
-    )
-    .await
-    .map(|_| ())
-    .context("create_child_vhd")
-}
-
 /// Runs Dismount-VHD with the given arguments.
 pub async fn run_dismount_vhd(path: &Path) -> anyhow::Result<()> {
     run_cmd(


### PR DESCRIPTION
Use the Win32 VirtualDisk APIs instead of powershell for creating differencing disks in Petri. Hopefully this will remove the need for a lock file. https://github.com/microsoft/openvmm/issues/1600