### PR TITLE
nvme_test: add completion queue fault infrastructure

### DIFF
--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -115,7 +115,10 @@ impl AdminQueueFaultConfig {
         self
     }
 
-    /// Add a CommandMatch -> FaultBehavior mapping for the completion queue. Cannot configure a CommandMatch more than once
+    /// Add a [`CommandMatch`] -> [`QueueFaultBehavior`] mapping for the completion queue.
+    ///
+    /// # Panics
+    /// Panics if an identical [`CommandMatch`] has already been configured.
     pub fn with_completion_queue_fault(
         mut self,
         pattern: CommandMatch,

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -93,7 +93,10 @@ impl AdminQueueFaultConfig {
         }
     }
 
-    /// Add a CommandMatch -> FaultBehavior mapping for the submission queue. Cannot configure a CommandMatch more than once
+    /// Add a [`CommandMatch`] -> [`QueueFaultBehavior`] mapping for the submission queue.
+    ///
+    /// # Panics
+    /// Panics if an identical [`CommandMatch`] has already been configured.
     pub fn with_submission_queue_fault(
         mut self,
         pattern: CommandMatch,

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -6,6 +6,7 @@
 use mesh::Cell;
 use mesh::MeshPayload;
 use nvme_spec::Command;
+use nvme_spec::Completion;
 use std::time::Duration;
 
 /// Supported fault behaviour for NVMe queues
@@ -42,8 +43,10 @@ pub struct PciFaultConfig {
 #[derive(MeshPayload, Clone)]
 /// A buildable fault configuration
 pub struct AdminQueueFaultConfig {
-    /// A map of NVME opcodes to the fault behavior for each. (This would ideally be a `HashMap`, but `mesh` doesn't support that type. Given that this is not performance sensitive, the lookup is okay)
+    /// A map of NVME opcodes to the submission fault behavior for each. (This would ideally be a `HashMap`, but `mesh` doesn't support that type. Given that this is not performance sensitive, the lookup is okay)
     pub admin_submission_queue_faults: Vec<(CommandMatch, QueueFaultBehavior<Command>)>,
+    /// A map of NVME opcodes to the completion fault behavior for each.
+    pub admin_completion_queue_faults: Vec<(CommandMatch, QueueFaultBehavior<Completion>)>,
 }
 
 #[derive(Clone, MeshPayload, PartialEq)]
@@ -86,10 +89,11 @@ impl AdminQueueFaultConfig {
     pub fn new() -> Self {
         Self {
             admin_submission_queue_faults: vec![],
+            admin_completion_queue_faults: vec![],
         }
     }
 
-    /// Add a CommandMatch -> FaultBehavior mapping. Cannot configure a CommandMatch more than once
+    /// Add a CommandMatch -> FaultBehavior mapping for the submission queue. Cannot configure a CommandMatch more than once
     pub fn with_submission_queue_fault(
         mut self,
         pattern: CommandMatch,
@@ -107,6 +111,28 @@ impl AdminQueueFaultConfig {
         }
 
         self.admin_submission_queue_faults
+            .push((pattern, behaviour));
+        self
+    }
+
+    /// Add a CommandMatch -> FaultBehavior mapping for the completion queue. Cannot configure a CommandMatch more than once
+    pub fn with_completion_queue_fault(
+        mut self,
+        pattern: CommandMatch,
+        behaviour: QueueFaultBehavior<Completion>,
+    ) -> Self {
+        if self
+            .admin_completion_queue_faults
+            .iter()
+            .any(|(c, _)| (pattern == *c))
+        {
+            panic!(
+                "Duplicate completion queue fault for Compare {:?} and Mask {:?}",
+                pattern.command, pattern.mask
+            );
+        }
+
+        self.admin_completion_queue_faults
             .push((pattern, behaviour));
         self
     }

--- a/vm/devices/storage/nvme_spec/src/lib.rs
+++ b/vm/devices/storage/nvme_spec/src/lib.rs
@@ -221,7 +221,7 @@ open_enum! {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, MeshPayload)]
 pub struct Completion {
     pub dw0: u32,
     pub dw1: u32,
@@ -232,7 +232,7 @@ pub struct Completion {
 }
 
 #[bitfield(u16)]
-#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, MeshPayload)]
 pub struct CompletionStatus {
     pub phase: bool,
     /// 8 bits of status code followed by 3 bits of the status code type.


### PR DESCRIPTION
This change adds infra for CompletionQueue faults. This will help enable payload based faults for the nvme_test crate where the dptr value can be changed before sending a completion.
Completion faults will still rely on command matching because `Completion` does not contain any command level information.