### PR TITLE
misc: Clean up some uses of target_arch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6285,6 +6285,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "safe_intrinsics"
 version = "0.0.0"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "safeatomic"

--- a/openhcl/diag_server/src/diag_service.rs
+++ b/openhcl/diag_server/src/diag_service.rs
@@ -335,28 +335,17 @@ impl DiagServiceHandler {
         // HACK: A hack to fix segfault caused by glibc bug in L1 TDX VMM.
         // Should be removed after glibc update or a clean CPUID virtualization solution.
         // Please refer to https://github.com/microsoft/HvLite/issues/872 for more information.
-        let tdx_isolated = if cfg!(guest_arch = "x86_64") {
-            // xtask-fmt allow-target-arch cpu-intrinsic
-            #[cfg(target_arch = "x86_64")]
-            {
-                let result = safe_intrinsics::cpuid(
-                    hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION,
-                    0,
-                );
-                // Value 3 means TDX.
-                (result.ebx & 0xF) == 3
+        // xtask-fmt allow-target-arch cpu-intrinsic
+        #[cfg(target_arch = "x86_64")]
+        {
+            let result =
+                safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION, 0);
+            // Value 3 means TDX.
+            let tdx_isolated = (result.ebx & 0xF) == 3;
+            if tdx_isolated {
+                builder.env("GLIBC_TUNABLES", "glibc.cpu.x86_non_temporal_threshold=0x11a000:glibc.cpu.x86_rep_movsb_threshold=0x4000");
             }
-            // xtask-fmt allow-target-arch cpu-intrinsic
-            #[cfg(not(target_arch = "x86_64"))]
-            {
-                false
-            }
-        } else {
-            false
         };
-        if tdx_isolated {
-            builder.env("GLIBC_TUNABLES", "glibc.cpu.x86_non_temporal_threshold=0x11a000:glibc.cpu.x86_rep_movsb_threshold=0x4000");
-        }
 
         let mut stdin_relay = None;
         let mut stdout_relay = None;

--- a/openhcl/minimal_rt/src/reloc.rs
+++ b/openhcl/minimal_rt/src/reloc.rs
@@ -39,18 +39,9 @@ const R_ERROR_REL: u64 = 3;
 const R_ERROR_RELSZ: u64 = 4;
 
 #[cfg(target_arch = "x86_64")]
-const fn r_relative() -> u32 {
-    const R_X64_RELATIVE: u32 = 8;
-    R_X64_RELATIVE
-}
-
+const R_RELATIVE: u32 = 8;
 #[cfg(target_arch = "aarch64")]
-const fn r_relative() -> u32 {
-    const R_AARCH64_RELATIVE: u32 = 0x403;
-    R_AARCH64_RELATIVE
-}
-
-const R_RELATIVE: u32 = r_relative();
+const R_RELATIVE: u32 = 0x403;
 
 #[derive(Clone, Copy)]
 #[repr(C)]

--- a/openhcl/minimal_rt/src/reloc.rs
+++ b/openhcl/minimal_rt/src/reloc.rs
@@ -38,24 +38,16 @@ const R_ERROR_RELASZ: u64 = 2;
 const R_ERROR_REL: u64 = 3;
 const R_ERROR_RELSZ: u64 = 4;
 
+#[cfg(target_arch = "x86_64")]
 const fn r_relative() -> u32 {
-    // `cfg_if::cfg_if` and `cfg_if!` would not work in the const context.
-    #[cfg(target_arch = "x86_64")]
-    {
-        const R_X64_RELATIVE: u32 = 8;
-        R_X64_RELATIVE
-    }
+    const R_X64_RELATIVE: u32 = 8;
+    R_X64_RELATIVE
+}
 
-    #[cfg(target_arch = "aarch64")]
-    {
-        const R_AARCH64_RELATIVE: u32 = 0x403;
-        R_AARCH64_RELATIVE
-    }
-
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-    {
-        compile_error!("Unsupported architecture")
-    }
+#[cfg(target_arch = "aarch64")]
+const fn r_relative() -> u32 {
+    const R_AARCH64_RELATIVE: u32 = 0x403;
+    R_AARCH64_RELATIVE
 }
 
 const R_RELATIVE: u32 = r_relative();

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -10,7 +10,7 @@
 mod devmsr;
 
 cfg_if::cfg_if!(
-    if #[cfg(guest_arch = "x86_64")] {
+    if #[cfg(target_arch = "x86_64")] { // xtask-fmt allow-target-arch sys-crate
         mod cvm_cpuid;
         pub use processor::snp::SnpBacked;
         pub use processor::tdx::TdxBacked;
@@ -30,7 +30,7 @@ cfg_if::cfg_if!(
         /// Bitarray type for representing IRR bits in a x86-64 APIC
         /// Each bit represent the 256 possible vectors.
         type IrrBitmap = BitArray<[u32; 8], Lsb0>;
-    } else if #[cfg(guest_arch = "aarch64")] {
+    } else if #[cfg(target_arch = "aarch64")] { // xtask-fmt allow-target-arch sys-crate
         pub use crate::processor::mshv::arm64::HypervisorBackedArm64 as HypervisorBacked;
         use crate::processor::mshv::arm64::HypervisorBackedArm64Shared as HypervisorBackedShared;
     }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -10,7 +10,7 @@
 mod devmsr;
 
 cfg_if::cfg_if!(
-    if #[cfg(target_arch = "x86_64")] { // xtask-fmt allow-target-arch sys-crate
+    if #[cfg(guest_arch = "x86_64")] {
         mod cvm_cpuid;
         pub use processor::snp::SnpBacked;
         pub use processor::tdx::TdxBacked;
@@ -30,7 +30,7 @@ cfg_if::cfg_if!(
         /// Bitarray type for representing IRR bits in a x86-64 APIC
         /// Each bit represent the 256 possible vectors.
         type IrrBitmap = BitArray<[u32; 8], Lsb0>;
-    } else if #[cfg(target_arch = "aarch64")] { // xtask-fmt allow-target-arch sys-crate
+    } else if #[cfg(guest_arch = "aarch64")] {
         pub use crate::processor::mshv::arm64::HypervisorBackedArm64 as HypervisorBacked;
         use crate::processor::mshv::arm64::HypervisorBackedArm64Shared as HypervisorBackedShared;
     }

--- a/support/safe_intrinsics/Cargo.toml
+++ b/support/safe_intrinsics/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+cfg-if.workspace = true
 
 [lints]
 workspace = true

--- a/support/safe_intrinsics/src/lib.rs
+++ b/support/safe_intrinsics/src/lib.rs
@@ -28,19 +28,21 @@ pub fn rdtsc() -> u64 {
 
 /// Emit a store fence to flush the processor's store buffer
 pub fn store_fence() {
-    #[cfg(target_arch = "x86_64")]
-    {
-        // SAFETY: this instruction has no safety requirements.
-        unsafe { core::arch::x86_64::_mm_sfence() }
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        // SAFETY: this instruction has no safety requirements.
-        unsafe { core::arch::asm!("dsb st", options(nostack)) };
-    }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-    {
-        compile_error!("Unsupported architecture");
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "x86_64")]
+        {
+            // SAFETY: this instruction has no safety requirements.
+            unsafe { core::arch::x86_64::_mm_sfence() }
+        }
+        else if #[cfg(target_arch = "aarch64")]
+        {
+            // SAFETY: this instruction has no safety requirements.
+            unsafe { core::arch::asm!("dsb st", options(nostack)) };
+        }
+        else
+        {
+            compile_error!("Unsupported architecture");
+        }
     }
 
     // Make the compiler aware.

--- a/vm/loader/build.rs
+++ b/vm/loader/build.rs
@@ -7,7 +7,7 @@ fn main() {
     // TODO: loader shouldn't have any `cfg`s (or typedefs for that matter)!
     //
     // this is only here for expediency during the initial switch over to
-    // `target_arch`. A follow-up change should switch `loader` + the code it
+    // `guest_arch`. A follow-up change should switch `loader` + the code it
     // depends on to a more sustainable model...
     build_rs_guest_arch::emit_guest_arch()
 }

--- a/vm/loader/igvmfilegen/Cargo.toml
+++ b/vm/loader/igvmfilegen/Cargo.toml
@@ -31,8 +31,6 @@ thiserror.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing.workspace = true
 zerocopy.workspace = true
-[target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.build-dependencies]
-loader_defs.workspace = true
 
 [lints]
 workspace = true

--- a/vm/vmcore/vm_topology/src/processor/x86.rs
+++ b/vm/vmcore/vm_topology/src/processor/x86.rs
@@ -86,18 +86,11 @@ impl TopologyBuilder<X86Topology> {
     ///
     /// Note that this only queries SMT state and the socket size, it does not
     /// otherwise affect APIC configuration.
+    #[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch cpu-intrinsic
     pub fn from_host_topology() -> Result<Self, HostTopologyError> {
         fn cpuid(leaf: u32, sub_leaf: u32) -> [u32; 4] {
-            #[cfg(not(target_arch = "x86_64"))] // xtask-fmt allow-target-arch cpu-intrinsic
-            {
-                let (_, _) = (leaf, sub_leaf);
-                unimplemented!("cannot invoke from_host_topology: host arch is not x86_64");
-            }
-            #[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch cpu-intrinsic
-            {
-                let result = safe_intrinsics::cpuid(leaf, sub_leaf);
-                [result.eax, result.ebx, result.ecx, result.edx]
-            }
+            let result = safe_intrinsics::cpuid(leaf, sub_leaf);
+            [result.eax, result.ebx, result.ecx, result.edx]
         }
 
         Self::from_cpuid(&mut cpuid)
@@ -107,6 +100,7 @@ impl TopologyBuilder<X86Topology> {
     ///
     /// Note that this only queries SMT state and the socket size, it does not
     /// otherwise affect APIC configuration.
+    #[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch cpu-intrinsic
     pub fn from_cpuid(
         cpuid: &mut dyn FnMut(u32, u32) -> [u32; 4],
     ) -> Result<Self, HostTopologyError> {

--- a/vmm_core/virt_kvm/src/gsi.rs
+++ b/vmm_core/virt_kvm/src/gsi.rs
@@ -189,7 +189,7 @@ impl GsiRoute {
                 // the type of the interrupt: SPI or PPI handled by the in-kernel vGIC,
                 // or the user mode GIC emulator (where have to specify the target VP, too).
 
-                // xtask-fmt allow-target-arch oneoff-guest-arch-impl
+                // xtask-fmt allow-target-arch sys-crate
                 assert!(cfg!(target_arch = "x86_64"));
                 partition
                     .kvm

--- a/xtask/src/tasks/fmt/house_rules/cfg_target_arch.rs
+++ b/xtask/src/tasks/fmt/house_rules/cfg_target_arch.rs
@@ -19,9 +19,6 @@ const SUPPRESS_REASON_DEPENDENCY: &str = "dependency";
 /// One off - support for the auto-arch selection logic in
 /// `build_rs_guest_arch`.
 const SUPPRESS_REASON_ONEOFF_GUEST_ARCH_IMPL: &str = "oneoff-guest-arch-impl";
-/// One off - considiton to check that `virt_hvf` is being used when both guest
-/// and host arch to be the same.
-const SUPPRESS_REASON_ONEOFF_VIRT_HVF: &str = "oneoff-virt-hvf";
 /// One off - used as part of flowey CI infra
 const SUPPRESS_REASON_ONEOFF_FLOWEY: &str = "oneoff-flowey";
 /// One off - used by petri to select native test dependencies
@@ -43,7 +40,6 @@ fn has_suppress(s: &str) -> bool {
             | SUPPRESS_REASON_SYS_CRATE
             | SUPPRESS_REASON_DEPENDENCY
             | SUPPRESS_REASON_ONEOFF_GUEST_ARCH_IMPL
-            | SUPPRESS_REASON_ONEOFF_VIRT_HVF
             | SUPPRESS_REASON_ONEOFF_FLOWEY
             | SUPPRESS_REASON_ONEOFF_PETRI_NATIVE_TEST_DEPS
             | SUPPRESS_REASON_ONEOFF_PETRI_HOST_ARCH


### PR DESCRIPTION
Various small things, like cases that could go away entirely, cases that could just be cleaner, exemptions using the wrong reasons, etc.