### PR TITLE
Update windows-* crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ dependencies = [
  "pal_async",
  "resolv-conf",
  "smoltcp",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "tracing",
  "windows-sys 0.61.0",
@@ -1008,7 +1008,7 @@ dependencies = [
  "mesh",
  "mesh_worker",
  "pal_async",
- "socket2 0.5.10",
+ "socket2",
  "tracelimit",
  "tracing",
  "vmm_core_defs",
@@ -1096,7 +1096,7 @@ dependencies = [
  "inspect_proto",
  "mesh_rpc",
  "pal_async",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "unix_socket",
  "vmsocket",
@@ -1139,7 +1139,7 @@ dependencies = [
  "parking_lot",
  "profiler_worker",
  "safe_intrinsics",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "underhill_confidentiality",
  "unix_socket",
@@ -3244,7 +3244,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4210,7 +4210,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "zerocopy 0.8.25",
 ]
@@ -4232,7 +4232,7 @@ dependencies = [
  "pal_async",
  "pal_event",
  "parking_lot",
- "socket2 0.5.10",
+ "socket2",
  "test_with_tracing",
  "thiserror 2.0.16",
  "tracing",
@@ -4925,7 +4925,7 @@ dependencies = [
  "mesh",
  "pal",
  "pal_async",
- "socket2 0.5.10",
+ "socket2",
  "term",
  "thiserror 2.0.16",
  "tracing-subscriber",
@@ -5341,7 +5341,7 @@ dependencies = [
  "ntapi",
  "pal_event",
  "seccompiler",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "tracing",
  "widestring",
@@ -5368,7 +5368,7 @@ dependencies = [
  "parking_lot",
  "slab",
  "smallbox",
- "socket2 0.5.10",
+ "socket2",
  "tempfile",
  "unicycle",
  "unix_socket",
@@ -5757,7 +5757,7 @@ dependencies = [
  "mesh_remote",
  "pal_async",
  "pipette_protocol",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "tracing-subscriber",
  "unicycle",
@@ -5927,7 +5927,7 @@ dependencies = [
  "mesh",
  "mesh_worker",
  "pal_async",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
 ]
 
@@ -6639,7 +6639,7 @@ dependencies = [
  "pal",
  "pal_async",
  "serial_core",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "unix_socket",
  "vm_resource",
@@ -6811,16 +6811,6 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "managed",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7355,7 +7345,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "windows-sys 0.59.0",
 ]
 
@@ -7692,7 +7682,7 @@ dependencies = [
  "libc",
  "mesh",
  "pal_async",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "tracing",
 ]
@@ -7880,7 +7870,7 @@ dependencies = [
  "serde_helpers",
  "serde_json",
  "serial_16550_resources",
- "socket2 0.5.10",
+ "socket2",
  "sparse_mmap",
  "state_unit",
  "storage_string",
@@ -8086,7 +8076,7 @@ version = "0.0.0"
 dependencies = [
  "getrandom 0.3.3",
  "mesh_protobuf",
- "socket2 0.5.10",
+ "socket2",
  "windows-sys 0.61.0",
 ]
 
@@ -9381,7 +9371,7 @@ dependencies = [
  "libc",
  "mesh",
  "pal_async",
- "socket2 0.5.10",
+ "socket2",
  "windows-sys 0.61.0",
 ]
 
@@ -9408,7 +9398,7 @@ version = "0.0.0"
 dependencies = [
  "futures",
  "pal_async",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "zerocopy 0.8.25",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,7 +515,7 @@ slab = "0.4"
 smallbox = "0.8"
 smallvec = "1.8"
 smoltcp = { version = "0.8", default-features = false }
-socket2 = "0.5"
+socket2 = "0.6"
 stackfuture = "0.3"
 static_assertions = "1.1"
 syn = "2"


### PR DESCRIPTION
For a closed-source change, we need the newest version of the windows crates, specifically https://github.com/microsoft/windows-rs/pull/3724 and https://github.com/microsoft/windows-rs/pull/3743.

We also needed to update `socket2`, which was using a very old `windows-sys` version and was causing some issues with the tests.