### PR TITLE
Adding Test to verify VF_Association packet logic

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -5189,6 +5189,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
                     );
                     return Err(WorkerError::BufferRevoked);
                 }
+                // No operation for VF association completion packets as not all clients send them
                 PacketData::SendVfAssociationCompletion if state.primary.is_some() => (),
                 PacketData::SwitchDataPath(switch_data_path) if state.primary.is_some() => {
                     self.switch_data_path(

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -1782,6 +1782,15 @@ async fn initialize_rndis_no_sendbuffer_no_recvbuffer(driver: DefaultDriver) {
 
 #[async_test]
 async fn initialize_rndis_with_vf(driver: DefaultDriver) {
+    test_initialize_rndis_with_vf_common(driver, true).await;
+}
+
+#[async_test]
+async fn initialize_rndis_with_vf_without_completion(driver: DefaultDriver) {
+    test_initialize_rndis_with_vf_common(driver, false).await;
+}
+
+async fn test_initialize_rndis_with_vf_common(driver: DefaultDriver, with_vf_completion: bool) {
     let endpoint_state = TestNicEndpointState::new();
     let endpoint = TestNicEndpoint::new(Some(endpoint_state.clone()));
     let test_vf = Box::new(TestVirtualFunction::new(123));
@@ -1851,13 +1860,15 @@ async fn initialize_rndis_with_vf(driver: DefaultDriver) {
             .is_ok()
     );
 
-    channel
-        .write(OutgoingPacket {
-            transaction_id,
-            packet_type: OutgoingPacketType::Completion,
-            payload: &[],
-        })
-        .await;
+    if with_vf_completion {
+        channel
+            .write(OutgoingPacket {
+                transaction_id,
+                packet_type: OutgoingPacketType::Completion,
+                payload: &[],
+            })
+            .await;
+    }
 
     assert!(test_vf_state.is_ready_unchanged());
 


### PR DESCRIPTION
Currently we have a no-op for VF_ASSOCIATION completion packets. This is because not all clients send this packet back to us.

I made a comment in the code to point out this logic and added a test based on test_initialize_rndis_with_vf to verify that regardless of whether we receive a VF_ASSOCIATION completion packet we have the same functionality.

Let me know if I should refactor the new tests in a different way. I put most of the test functionality in a seperate function (test_initialize_rndis_with_vf_common) and call it with a boolean flag to indicate whether a VF_ASSOCIATION completion packet should be returned.