### PR TITLE
openvmm: ide disk is only supported on pcat

### DIFF
--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -487,7 +487,7 @@ flags:
     `s`                            attach drive to secondary ide channel
     `dvd`                          specifies that device is cd/dvd and it is read_only
 "#)]
-    #[clap(long, value_name = "FILE")]
+    #[clap(long, value_name = "FILE", requires("pcat"))]
     pub ide: Vec<IdeDiskCli>,
 
     /// attach a floppy drive (should be able to be passed multiple times). VM must be generation 1 (no UEFI)
@@ -508,7 +508,7 @@ valid disk kinds:
 flags:
     `ro`                           open disk as read-only
 "#)]
-    #[clap(long, value_name = "FILE", requires("pcat"), conflicts_with("uefi"))]
+    #[clap(long, value_name = "FILE", requires("pcat"))]
     pub floppy: Vec<FloppyDiskCli>,
 
     /// enable guest watchdog device


### PR DESCRIPTION
Don't allow it to be specified on non-pcat guest types, because it won't actually work and users are confused otherwise since most likely `--disk` is what they want. 

Also fix a small extra `conflicts_with` as the top level `pcat` option already has it. 