### PR TITLE
storvsp: make poll-mode queue depth tunable via inspect

### DIFF
--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -145,9 +145,9 @@ impl InspectMut for StorageDevice {
                 .filter(|task| task.worker.has_state())
                 .enumerate(),
         )
-        .field_mut(
+        .field(
             "poll_mode_queue_depth",
-            &mut &self.controller.poll_mode_queue_depth,
+            inspect::AtomicMut(&self.controller.poll_mode_queue_depth),
         );
     }
 }


### PR DESCRIPTION
Storvsp enters a kind of poll mode when at least one IO is outstanding. Make this threshold configurable via inspect for experimentation.