### PR TITLE
nvme_test: Add builder notation for fault configuration struct to match the rest of the fault code

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -12,7 +12,6 @@ use mesh::CellUpdater;
 use nvme::NvmeControllerCaps;
 use nvme_resources::fault::AdminQueueFaultConfig;
 use nvme_resources::fault::FaultConfiguration;
-use nvme_resources::fault::PciFaultConfig;
 use nvme_resources::fault::QueueFaultBehavior;
 use nvme_spec::AdminOpcode;
 use nvme_spec::Cap;

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -46,16 +46,14 @@ async fn test_nvme_command_fault(driver: DefaultDriver) {
 
     test_nvme_fault_injection(
         driver,
-        FaultConfiguration {
-            fault_active: CellUpdater::new(true).cell(),
-            admin_fault: AdminQueueFaultConfig::new().with_submission_queue_fault(
+        FaultConfiguration::new(CellUpdater::new(true).cell()).with_admin_queue_fault(
+            AdminQueueFaultConfig::new().with_submission_queue_fault(
                 CommandMatchBuilder::new()
                     .match_cdw0_opcode(AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0)
                     .build(),
                 QueueFaultBehavior::Update(output_cmd),
             ),
-            pci_fault: PciFaultConfig::new(),
-        },
+        ),
     )
     .await;
 }

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -69,6 +69,29 @@ pub struct FaultConfiguration {
     pub pci_fault: PciFaultConfig,
 }
 
+impl FaultConfiguration {
+    /// Create a new empty fault configuration
+    pub fn new(fault_active: Cell<bool>) -> Self {
+        Self {
+            fault_active,
+            admin_fault: AdminQueueFaultConfig::new(),
+            pci_fault: PciFaultConfig::new(),
+        }
+    }
+
+    /// Add a PCI fault configuration to the fault configuration
+    pub fn with_pci_fault(mut self, pci_fault: PciFaultConfig) -> Self {
+        self.pci_fault = pci_fault;
+        self
+    }
+
+    /// Add an admin queue fault configuration to the fault configuration
+    pub fn with_admin_queue_fault(mut self, admin_fault: AdminQueueFaultConfig) -> Self {
+        self.admin_fault = admin_fault;
+        self
+    }
+}
+
 impl PciFaultConfig {
     /// Create a new no-op fault configuration
     pub fn new() -> Self {

--- a/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
@@ -19,7 +19,6 @@ use guid::Guid;
 use mesh::CellUpdater;
 use nvme_resources::fault::AdminQueueFaultConfig;
 use nvme_resources::fault::FaultConfiguration;
-use nvme_resources::fault::PciFaultConfig;
 use nvme_resources::fault::QueueFaultBehavior;
 use nvme_spec::Command;
 use nvme_spec::Completion;

--- a/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
@@ -358,7 +358,7 @@ async fn test_send_identify_with_sq_fault(driver: DefaultDriver) {
     let mut faulty_identify = Command::new_zeroed();
     faulty_identify.cdw0.set_cid(10);
 
-    let fault_configuration = FaultConfiguration::new(CellUpdater::new(false).cell())
+    let fault_configuration = FaultConfiguration::new(CellUpdater::new(true).cell())
         .with_admin_queue_fault(
             AdminQueueFaultConfig::new().with_submission_queue_fault(
                 CommandMatchBuilder::new()

--- a/vm/devices/storage/nvme_test/src/tests/shadow_doorbell_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/shadow_doorbell_tests.rs
@@ -13,9 +13,7 @@ use crate::tests::test_helpers::test_memory;
 use crate::tests::test_helpers::write_command_to_queue;
 use guestmem::GuestMemory;
 use mesh::CellUpdater;
-use nvme_resources::fault::AdminQueueFaultConfig;
 use nvme_resources::fault::FaultConfiguration;
-use nvme_resources::fault::PciFaultConfig;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
 use pci_core::test_helpers::TestPciInterruptController;
@@ -40,11 +38,9 @@ async fn setup_shadow_doorbells(
     int_controller: &TestPciInterruptController,
     dq_bases: Option<(u64, u64)>,
 ) -> crate::NvmeFaultController {
-    let fault_configuration = FaultConfiguration {
-        fault_active: CellUpdater::new(false).cell(),
-        admin_fault: AdminQueueFaultConfig::new(),
-        pci_fault: PciFaultConfig::new(),
-    }; // Build a controller with 64 entries in the admin queue (just so that the ASQ fits in one page).
+    let fault_configuration = FaultConfiguration::new(CellUpdater::new(false).cell());
+
+    // Build a controller with 64 entries in the admin queue (just so that the ASQ fits in one page).
     let mut nvmec = instantiate_and_build_admin_queue(
         cq_buf,
         64,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -16,7 +16,6 @@ use nvme_resources::NamespaceDefinition;
 use nvme_resources::NvmeFaultControllerHandle;
 use nvme_resources::fault::AdminQueueFaultConfig;
 use nvme_resources::fault::FaultConfiguration;
-use nvme_resources::fault::PciFaultConfig;
 use nvme_resources::fault::QueueFaultBehavior;
 use nvme_test::command_match::CommandMatchBuilder;
 use petri::OpenHclServicingFlags;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -295,14 +295,13 @@ async fn keepalive_with_nvme_fault(
 
     let mut fault_start_updater = CellUpdater::new(false);
 
-    let fault_configuration = FaultConfiguration {
-        fault_active: fault_start_updater.cell(),
-        admin_fault: AdminQueueFaultConfig::new().with_submission_queue_fault(
-            CommandMatchBuilder::new().match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0).build(),
-            QueueFaultBehavior::Panic("Received a CREATE_IO_COMPLETION_QUEUE command during servicing with keepalive enabled. THERE IS A BUG SOMEWHERE.".to_string()),
-        ),
-        pci_fault: PciFaultConfig::new(),
-    };
+    let fault_configuration = FaultConfiguration::new(fault_start_updater.cell())
+        .with_admin_queue_fault(
+            AdminQueueFaultConfig::new().with_submission_queue_fault(
+                CommandMatchBuilder::new().match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0).build(),
+                QueueFaultBehavior::Panic("Received a CREATE_IO_COMPLETION_QUEUE command during servicing with keepalive enabled. THERE IS A BUG SOMEWHERE.".to_string()),
+            ),
+        );
 
     let (mut vm, agent) = create_keepalive_test_config(config, fault_configuration).await?;
 
@@ -350,22 +349,21 @@ async fn keepalive_with_nvme_identify_namespace_fault(
     let mut buf: u64 = 256;
     let buf = buf.as_mut_bytes();
 
-    let fault_configuration = FaultConfiguration {
-        fault_active: fault_start_updater.cell(),
-        admin_fault: AdminQueueFaultConfig::new().with_completion_queue_fault(
-            CommandMatchBuilder::new()
-                .match_cdw0_opcode(nvme_spec::AdminOpcode::IDENTIFY.0)
-                .match_cdw10(
-                    nvme_spec::Cdw10Identify::new()
-                        .with_cns(nvme_spec::Cns::NAMESPACE.0)
-                        .into(),
-                    nvme_spec::Cdw10Identify::new().with_cns(u8::MAX).into(),
-                )
-                .build(),
-            QueueFaultBehavior::CustomPayload(buf.to_vec()),
-        ),
-        pci_fault: PciFaultConfig::new(),
-    };
+    let fault_configuration = FaultConfiguration::new(fault_start_updater.cell())
+        .with_admin_queue_fault(
+            AdminQueueFaultConfig::new().with_completion_queue_fault(
+                CommandMatchBuilder::new()
+                    .match_cdw0_opcode(nvme_spec::AdminOpcode::IDENTIFY.0)
+                    .match_cdw10(
+                        nvme_spec::Cdw10Identify::new()
+                            .with_cns(nvme_spec::Cns::NAMESPACE.0)
+                            .into(),
+                        nvme_spec::Cdw10Identify::new().with_cns(u8::MAX).into(),
+                    )
+                    .build(),
+                QueueFaultBehavior::CustomPayload(buf.to_vec()),
+            ),
+        );
 
     let (mut vm, agent) = create_keepalive_test_config(config, fault_configuration).await?;
 


### PR DESCRIPTION
FaultConfig now matches the rest of the code and has builder notation. Adding an empty fault config should be much cleaner now. 