### PR TITLE
inspect: improve json output format

### DIFF
--- a/support/inspect/src/initiate.rs
+++ b/support/inspect/src/initiate.rs
@@ -295,14 +295,35 @@ struct JsonDisplay<'a>(&'a Node);
 impl fmt::Display for JsonDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            Node::Unevaluated | Node::Failed(_) => f.write_str("null"),
+            Node::Unevaluated => f.write_str("null"),
+            // Errors are serialized using a key that should not occur in valid output, since those
+            // are normally valid Rust identifiers.
+            Node::Failed(error) => write!(f, "{{\"$error\":{:?}}}", error.to_string()),
             Node::Value(value) => match &value.kind {
-                ValueKind::Signed(v) => write!(f, "{}", v),
-                ValueKind::Unsigned(v) => write!(f, "{}", v),
-                ValueKind::Float(v) => write!(f, "{}", v),
-                ValueKind::Double(v) => write!(f, "{}", v),
-                ValueKind::Bool(v) => write!(f, "{}", v),
-                ValueKind::String(v) => write!(f, "{:?}", v),
+                ValueKind::Signed(v) => {
+                    // For human readability, values that should be hex or binary are serialized as
+                    // strings.
+                    if value.flags.hex() {
+                        write!(f, "\"{v:#x}\"")
+                    } else if value.flags.binary() {
+                        write!(f, "\"{v:#b}\"")
+                    } else {
+                        write!(f, "{v}")
+                    }
+                }
+                ValueKind::Unsigned(v) => {
+                    if value.flags.hex() {
+                        write!(f, "\"{v:#x}\"")
+                    } else if value.flags.binary() {
+                        write!(f, "\"{v:#b}\"")
+                    } else {
+                        write!(f, "{v}")
+                    }
+                }
+                ValueKind::Float(v) => write!(f, "{v}"),
+                ValueKind::Double(v) => write!(f, "{v}"),
+                ValueKind::Bool(v) => write!(f, "{v}"),
+                ValueKind::String(v) => write!(f, "{v:?}"),
                 ValueKind::Bytes(b) => {
                     // Use base64 encoding to match typical JSON conventions.
                     write!(

--- a/support/inspect/src/initiate.rs
+++ b/support/inspect/src/initiate.rs
@@ -298,24 +298,24 @@ impl fmt::Display for JsonDisplay<'_> {
             Node::Unevaluated => f.write_str("null"),
             // Errors are serialized using a key that should not occur in valid output, since those
             // are normally valid Rust identifiers.
-            Node::Failed(error) => write!(f, "{{\"$error\":{:?}}}", error.to_string()),
+            Node::Failed(error) => write!(f, r#"{{"$error":{:?}}}"#, error.to_string()),
             Node::Value(value) => match &value.kind {
                 ValueKind::Signed(v) => {
                     // For human readability, values that should be hex or binary are serialized as
                     // strings.
                     if value.flags.hex() {
-                        write!(f, "\"{v:#x}\"")
+                        write!(f, r#""{v:#x}""#)
                     } else if value.flags.binary() {
-                        write!(f, "\"{v:#b}\"")
+                        write!(f, r#""{v:#b}""#)
                     } else {
                         write!(f, "{v}")
                     }
                 }
                 ValueKind::Unsigned(v) => {
                     if value.flags.hex() {
-                        write!(f, "\"{v:#x}\"")
+                        write!(f, r#""{v:#x}""#)
                     } else if value.flags.binary() {
-                        write!(f, "\"{v:#b}\"")
+                        write!(f, r#""{v:#b}""#)
                     } else {
                         write!(f, "{v}")
                     }

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -2364,7 +2364,7 @@ mod tests {
 
     #[async_test]
     async fn test_timeout(driver: DefaultDriver) {
-        inspect_async_expect(
+        let node = inspect_async_expect(
             &driver,
             "",
             None,
@@ -2379,6 +2379,8 @@ mod tests {
             expect!("error (unresolved)"),
         )
         .await;
+        let expected_json = expect!([r#"{"$error":"unresolved"}"#]);
+        expected_json.assert_eq(&node.json().to_string());
     }
 
     #[test]
@@ -2587,7 +2589,7 @@ mod tests {
                 .field("1d/2b/3b", 0);
         });
 
-        inspect_sync_expect(
+        let node = inspect_sync_expect(
             "1d",
             Some(0),
             &mut obj,
@@ -2597,7 +2599,9 @@ mod tests {
                 2b: _,
             }"#]),
         );
-        inspect_sync_expect(
+        let expected_json = expect!([r#"{"2a":0,"2b":null}"#]);
+        expected_json.assert_eq(&node.json().to_string());
+        let node = inspect_sync_expect(
             "",
             Some(0),
             &mut obj,
@@ -2609,7 +2613,9 @@ mod tests {
                     1d: _,
                 }"#]),
         );
-        inspect_sync_expect(
+        let expected_json = expect!([r#"{"1a":0,"1b":0,"1c":0,"1d":null}"#]);
+        expected_json.assert_eq(&node.json().to_string());
+        let node = inspect_sync_expect(
             "",
             Some(1),
             &mut obj,
@@ -2624,38 +2630,49 @@ mod tests {
                     },
                 }"#]),
         );
+        let expected_json = expect!([r#"{"1a":0,"1b":0,"1c":0,"1d":{"2a":0,"2b":null}}"#]);
+        expected_json.assert_eq(&node.json().to_string());
     }
 
     #[test]
     fn test_hex() {
         let mut obj = adhoc(|req| {
-            req.respond().hex("a", 0x1234);
+            req.respond().hex("a", 0x1234i32).hex("b", 0x5678u32);
         });
-        inspect_sync_expect(
+        let node = inspect_sync_expect(
             "",
             Some(0),
             &mut obj,
             expect!([r#"
             {
                 a: 0x1234,
+                b: 0x5678,
             }"#]),
         );
+
+        let expected_json = expect!([r#"{"a":"0x1234","b":"0x5678"}"#]);
+        expected_json.assert_eq(&node.json().to_string());
     }
 
     #[test]
     fn test_binary() {
         let mut obj = adhoc(|req| {
-            req.respond().binary("a", 0b1001000110100);
+            req.respond()
+                .binary("a", 0b1001000110100i32)
+                .binary("b", 0b1101010101111000u32);
         });
-        inspect_sync_expect(
+        let node = inspect_sync_expect(
             "",
             Some(0),
             &mut obj,
             expect!([r#"
             {
                 a: 0b1001000110100,
+                b: 0b1101010101111000,
             }"#]),
         );
+        let expected_json = expect!([r#"{"a":"0b1001000110100","b":"0b1101010101111000"}"#]);
+        expected_json.assert_eq(&node.json().to_string());
     }
 
     #[test]


### PR DESCRIPTION
This change makes the following improvements to the JSON output produced by inspect nodes:

- Hex and binary values are formatted as strings, for readability.
- Errors are output as a special `{"$error":"message"}` object rather than as `null`.
- Some additional tests of the JSON output format were added.

Note: this affects the JSON output, which is not the output shown by the "inspect" command in OpenVMM or ohcldiag.