### PR TITLE
Support for firmware managed devices

### DIFF
--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -582,7 +582,13 @@ fn vm_config_from_command_line(
                     subordinate_instance_id: None,
                     max_sub_channels: None,
                 });
-                (vpci_instance_id, GdmaDeviceHandle { vports: Vec::new() })
+                (
+                    vpci_instance_id,
+                    GdmaDeviceHandle {
+                        vports: Vec::new(),
+                        is_firmware_managed: false,
+                    },
+                )
             });
             mana.1.vports.push(VportDefinition {
                 mac_address: vport.mac_address,
@@ -656,7 +662,15 @@ fn vm_config_from_command_line(
     for vport in &opt.mana {
         let vport = parse_endpoint(vport, &mut nic_index, &mut resources)?;
         mana_nics[vport.vtl as usize]
-            .get_or_insert_with(|| (Guid::new_random(), GdmaDeviceHandle { vports: Vec::new() }))
+            .get_or_insert_with(|| {
+                (
+                    Guid::new_random(),
+                    GdmaDeviceHandle {
+                        vports: Vec::new(),
+                        is_firmware_managed: false,
+                    },
+                )
+            })
             .1
             .vports
             .push(VportDefinition {

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -133,6 +133,7 @@ impl PetriVmConfigOpenVmm {
                         mac_address: NIC_MAC_ADDRESS,
                         endpoint,
                     }],
+                    is_firmware_managed: false,
                 }
                 .into_resource(),
             });

--- a/vm/chipset_device/src/lib.rs
+++ b/vm/chipset_device/src/lib.rs
@@ -61,6 +61,12 @@ pub trait ChipsetDevice: 'static + Send /* see DEVNOTE before adding bounds */ {
     ) -> Option<&mut dyn interrupt::AcknowledgePicInterrupt> {
         None
     }
+
+    /// Indicates whether the device is managed by firmware.
+    #[inline(always)]
+    fn is_firmware_managed(&mut self) -> bool {
+        false
+    }
 }
 
 /// Shared by `mmio` and `pio`

--- a/vm/chipset_device_resources/src/lib.rs
+++ b/vm/chipset_device_resources/src/lib.rs
@@ -173,6 +173,10 @@ impl ChipsetDevice for ErasedChipsetDevice {
     ) -> Option<&mut dyn chipset_device::interrupt::AcknowledgePicInterrupt> {
         self.0.supports_acknowledge_pic_interrupt()
     }
+
+    fn is_firmware_managed(&mut self) -> bool {
+        self.0.is_firmware_managed()
+    }
 }
 
 impl ProtobufSaveRestore for ErasedChipsetDevice {

--- a/vm/devices/net/gdma/src/lib.rs
+++ b/vm/devices/net/gdma/src/lib.rs
@@ -75,6 +75,7 @@ pub struct GdmaDevice {
     destroying_hwc: bool,
     queues: Arc<Queues>,
     hwc: TaskControl<Devices, HwControl>,
+    is_firmware_managed: bool,
 }
 
 impl InspectMut for GdmaDevice {
@@ -129,6 +130,7 @@ impl GdmaDevice {
         register_msi: &mut dyn RegisterMsi,
         vports: Vec<VportConfig>,
         mmio_registration: &mut dyn RegisterMmioIntercept,
+        is_firmware_managed: bool,
     ) -> Self {
         let (msix, msix_capability) = MsixEmulator::new(4, 64, register_msi);
 
@@ -183,6 +185,7 @@ impl GdmaDevice {
             hwc: TaskControl::new(Devices {
                 bnic: bnic::BasicNic::new(vports),
             }),
+            is_firmware_managed,
         }
     }
 
@@ -371,6 +374,10 @@ impl ChipsetDevice for GdmaDevice {
 
     fn supports_pci(&mut self) -> Option<&mut dyn PciConfigSpace> {
         Some(self)
+    }
+
+    fn is_firmware_managed(&mut self) -> bool {
+        self.is_firmware_managed
     }
 }
 

--- a/vm/devices/net/gdma/src/resolver.rs
+++ b/vm/devices/net/gdma/src/resolver.rs
@@ -69,6 +69,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, GdmaDeviceHandle> for GdmaDeviceR
             input.register_msi,
             vports,
             input.register_mmio,
+            resource.is_firmware_managed,
         );
         Ok(device.into())
     }

--- a/vm/devices/net/gdma_resources/src/lib.rs
+++ b/vm/devices/net/gdma_resources/src/lib.rs
@@ -17,6 +17,9 @@ use vm_resource::kind::PciDeviceHandleKind;
 pub struct GdmaDeviceHandle {
     /// The vports to instantiate on the NIC.
     pub vports: Vec<VportDefinition>,
+
+    /// Whether the device is managed by firmware.
+    pub is_firmware_managed: bool,
 }
 
 impl ResourceId<PciDeviceHandleKind> for GdmaDeviceHandle {


### PR DESCRIPTION
This change adds a flag to the device structure such that the devices can present themselves as firmware managed devices. Firmware managed devices are conceptually guest visible devices that require some coordination with the OpenHCL firmware to be usable. For example, MANA devices that require netvsp to be operational are considered firmware managed devices.