### PR TITLE
petri: lower severity of com3 emitted logs for all vmm_tests

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -278,7 +278,10 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         };
 
         if with_agent {
-            vm.set_console_loglevel(3).await?;
+            let result = vm.set_console_loglevel(3).await;
+            if result.is_err() {
+                tracing::warn!("failed to set console loglevel: {}", result.unwrap_err());
+            }
         }
 
         vm.wait_for_expected_boot_event().await?;
@@ -689,7 +692,10 @@ impl<T: PetriVmmBackend> PetriVm<T> {
     pub async fn wait_for_reset(&mut self) -> anyhow::Result<PipetteClient> {
         self.wait_for_reset_no_agent().await?;
         let client = self.wait_for_agent().await?;
-        self.set_console_loglevel(3).await?;
+        let result = self.set_console_loglevel(3).await;
+        if result.is_err() {
+            tracing::warn!("failed to set console loglevel: {}", result.unwrap_err());
+        }
         Ok(client)
     }
 


### PR DESCRIPTION
#1937 introduced new vmm_tests which seem to be flaky as they will occasionally timeout. Upon further investigation, the following message can be observed in the petri logs: `hv_vmbus: probe failed for device 766e96f8-2ceb-437e-afe3-a93169e48a7b`. It's likely that openhcl is busy with other tasks (such as writing to com3) so it is unable to handle the vmbus probe request from vtl0. This PR attempts to fix that by only emitting high severity logs once kmsg is available. 