### PR TITLE
virt_*: Unify handling of guest_arch in virt backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8290,6 +8290,7 @@ version = "0.0.0"
 dependencies = [
  "aarch64defs",
  "anyhow",
+ "build_rs_guest_arch",
  "guestmem",
  "hv1_emulator",
  "hv1_hypercall",

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -5,12 +5,12 @@
 //! `/dev/mshv_vtl` to interact with the Microsoft hypervisor while running in
 //! VTL2.
 
-#![cfg(target_os = "linux")]
+#![cfg(all(guest_is_native, target_os = "linux"))]
 
 mod devmsr;
 
 cfg_if::cfg_if!(
-    if #[cfg(target_arch = "x86_64")] { // xtask-fmt allow-target-arch sys-crate
+    if #[cfg(guest_arch = "x86_64")] {
         mod cvm_cpuid;
         pub use processor::snp::SnpBacked;
         pub use processor::tdx::TdxBacked;
@@ -31,7 +31,7 @@ cfg_if::cfg_if!(
         /// Bitarray type for representing IRR bits in a x86-64 APIC
         /// Each bit represent the 256 possible vectors.
         type IrrBitmap = BitArray<[u32; 8], Lsb0>;
-    } else if #[cfg(target_arch = "aarch64")] { // xtask-fmt allow-target-arch sys-crate
+    } else if #[cfg(guest_arch = "aarch64")] {
         pub use crate::processor::mshv::arm64::HypervisorBackedArm64 as HypervisorBacked;
         use crate::processor::mshv::arm64::HypervisorBackedArm64Shared as HypervisorBackedShared;
     }

--- a/vmm_core/virt_hvf/Cargo.toml
+++ b/vmm_core/virt_hvf/Cargo.toml
@@ -27,5 +27,8 @@ parking_lot.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+[build-dependencies]
+build_rs_guest_arch.workspace = true
+
 [lints]
 workspace = true

--- a/vmm_core/virt_hvf/build.rs
+++ b/vmm_core/virt_hvf/build.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![expect(missing_docs)]
+
+fn main() {
+    build_rs_guest_arch::emit_guest_arch()
+}

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
-#![cfg(all(target_os = "macos", target_arch = "aarch64"))] // xtask-fmt allow-target-arch sys-crate
+#![cfg(all(target_os = "macos", guest_is_native, guest_arch = "aarch64"))]
 
 //! A hypervisor backend using macos's Hypervisor framework.
 

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -8,7 +8,7 @@
 //! KVM/aarch64.
 
 #![expect(dead_code)]
-#![cfg(all(target_os = "linux", guest_is_native, guest_arch = "aarch64"))]
+#![cfg(all(target_os = "linux", guest_arch = "aarch64"))]
 
 use crate::KvmError;
 use crate::KvmPartition;

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -3,7 +3,7 @@
 
 //! This module implements support for KVM on x86_64.
 
-#![cfg(all(target_os = "linux", guest_is_native, guest_arch = "x86_64"))]
+#![cfg(all(target_os = "linux", guest_arch = "x86_64"))]
 
 mod regs;
 mod vm_state;

--- a/vmm_core/virt_kvm/src/gsi.rs
+++ b/vmm_core/virt_kvm/src/gsi.rs
@@ -189,8 +189,7 @@ impl GsiRoute {
                 // the type of the interrupt: SPI or PPI handled by the in-kernel vGIC,
                 // or the user mode GIC emulator (where have to specify the target VP, too).
 
-                // xtask-fmt allow-target-arch sys-crate
-                assert!(cfg!(target_arch = "x86_64"));
+                assert!(cfg!(guest_arch = "x86_64"));
                 partition
                     .kvm
                     .irq_line(self.gsi, true)


### PR DESCRIPTION
This PR sets all of our current virt backends to require `guest_is_native` (since they're all native backends), which then allows us to change a few `target_arch`s to `guest_arch`s and avoid the xtask comment requirement.