### PR TITLE
uh_mem: Fix a few oversights and edge cases

### DIFF
--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -122,10 +122,6 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
             // the future, the boot shim should be made aware of when it's booting
             // during a servicing operation and unify the application of vtl2
             // protections.
-
-            // Temporarily move HCL into an Arc so that it can be used across
-            // multiple processors.
-
             tracing::debug!("Applying VTL2 protections");
             apply_vtl2_protections(boot_init.tp, boot_init.vtl2_memory)
                 .instrument(tracing::info_span!("apply_vtl2_protections", CVM_ALLOWED))

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -818,17 +818,16 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
                 // this should track all pages that have been accepted and
                 // should be used instead.
                 // Also don't attempt to change the permissions of locked pages.
-                if !inner.valid_encrypted.check_valid(gpn)
-                    || self.check_gpn_not_locked(&inner, target_vtl, gpn).is_err()
-                {
+                if inner.valid_encrypted.check_valid(gpn) {
+                    self.check_gpn_not_locked(&inner, target_vtl, gpn)?;
+                    page_count += 1;
+                } else {
                     if page_count > 0 {
                         let end_address = protect_start + (page_count * PAGE_SIZE as u64);
                         ranges.push(MemoryRange::new(protect_start..end_address));
                     }
                     protect_start = (gpn + 1) * PAGE_SIZE as u64;
                     page_count = 0;
-                } else {
-                    page_count += 1;
                 }
             }
 

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -258,10 +258,20 @@ impl MemoryAcceptor {
             IsolationType::Vbs => {
                 // TODO VBS: is there something to do here?
             }
-            IsolationType::Snp => self
-                .mshv_vtl
-                .pvalidate_pages(range, false, false)
-                .expect("pvalidate should not fail"),
+            IsolationType::Snp => {
+                // Revoke permissions before unaccepting pages. This is required
+                // because a subsequent page acceptance is not guaranteed to
+                // reset permissions unless the hypervisor executed RMPUPDATE,
+                // which it cannot be trusted to do. We set new permissions
+                // ourselves, but that still leaves open a tiny window where the
+                // guest could access the pages with the old permissions.
+                for lower_vtl in [GuestVtl::Vtl0, GuestVtl::Vtl1] {
+                    self.apply_protections(range, lower_vtl, HV_MAP_GPA_PERMISSIONS_NONE)
+                        .unwrap();
+                }
+                self.mshv_vtl.pvalidate_pages(range, false, false).unwrap()
+            }
+
             IsolationType::Tdx => {
                 // Nothing to do for TDX.
             }
@@ -845,6 +855,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         // Invalidate the entire VTL 0 TLB to ensure that the new permissions
         // are observed.
         tlb_access.flush(GuestVtl::Vtl0);
+        tlb_access.set_wait_for_tlb_locks(target_vtl);
 
         Ok(())
     }
@@ -860,7 +871,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         // applied. This does not need to be synchronized against other
         // threads performing VTL protection changes; whichever thread
         // finishes last will control the outcome.
-        let mut inner = self.inner.lock();
+        let inner = self.inner.lock();
 
         // Validate the ranges are RAM.
         for &gpn in gpns {
@@ -871,6 +882,11 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             // Validate they're not locked.
             self.check_gpn_not_locked(&inner, target_vtl, gpn)
                 .map_err(|x| (x, 0))?;
+
+            // Validate they're not overlay pages.
+            if inner.overlay_pages[target_vtl].iter().any(|p| p.gpn == gpn) {
+                return Err((HvError::OperationDenied, 0));
+            }
         }
 
         // Protections cannot be applied to a host-visible page
@@ -886,13 +902,8 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             .unwrap(); // Ok to unwrap, we've validated the gpns above.
 
         for range in ranges {
-            self.apply_protections_with_overlay_handling(
-                range,
-                target_vtl,
-                protections,
-                &mut inner,
-            )
-            .unwrap();
+            self.apply_protections(range, target_vtl, protections, GpnSource::GuestMemory)
+                .unwrap();
         }
 
         // Flush any threads accessing pages that had their VTL protections


### PR DESCRIPTION
This fixes some oversights and edge cases in underhill_mem that were pointed out during an audit of our memory protections code.

1. We need to remove permissions when unaccepting pages on SNP
2. We need to completely forbid changing permissions on individual overlay pages to avoid a potential race condition (does not apply to the default permissions case)
3. We need to be careful around changing the default permissions when pages are locked, since we don't restore default permissions when they're unlocked
4. Remove a stale comment

Fixes #1021