### PR TITLE
virt: Return an error if host capabilities are insufficient instead of asserting

### DIFF
--- a/vmm_core/virt/src/aarch64/mod.rs
+++ b/vmm_core/virt/src/aarch64/mod.rs
@@ -8,6 +8,7 @@ pub mod vp;
 use crate::state::StateElement;
 use inspect::Inspect;
 use mesh_protobuf::Protobuf;
+use thiserror::Error;
 use vm_topology::processor::aarch64::Aarch64VpInfo;
 
 /// VP state that can be set for initial boot.
@@ -30,3 +31,6 @@ impl Aarch64InitialRegs {
 
 #[derive(Debug, Inspect)]
 pub struct Aarch64PartitionCapabilities {}
+
+#[derive(Error, Debug)]
+pub enum Aarch64PartitionCapabilitiesError {}

--- a/vmm_core/virt/src/lib.rs
+++ b/vmm_core/virt/src/lib.rs
@@ -21,6 +21,7 @@ mod arch {
     mod x86 {
         pub use crate::x86::X86InitialRegs as InitialRegs;
         pub use crate::x86::X86PartitionCapabilities as PartitionCapabilities;
+        pub use crate::x86::X86PartitionCapabilitiesError as PartitionCapabilitiesError;
         pub use crate::x86::vm;
         pub use crate::x86::vp;
     }
@@ -28,6 +29,7 @@ mod arch {
     mod aarch64 {
         pub use crate::aarch64::Aarch64InitialRegs as InitialRegs;
         pub use crate::aarch64::Aarch64PartitionCapabilities as PartitionCapabilities;
+        pub use crate::aarch64::Aarch64PartitionCapabilitiesError as PartitionCapabilitiesError;
         pub use crate::aarch64::vm;
         pub use crate::aarch64::vp;
     }

--- a/vmm_core/virt/src/x86/mod.rs
+++ b/vmm_core/virt/src/x86/mod.rs
@@ -11,6 +11,7 @@ use crate::state::StateElement;
 use inspect::Inspect;
 use mesh_protobuf::Protobuf;
 use std::fmt::Debug;
+use thiserror::Error;
 use vm_topology::processor::ProcessorTopology;
 use vm_topology::processor::x86::ApicMode;
 use vm_topology::processor::x86::X86Topology;
@@ -91,11 +92,21 @@ pub struct X86PartitionCapabilities {
     pub nxe_forced_on: bool,
 }
 
+#[derive(Error, Debug)]
+pub enum X86PartitionCapabilitiesError {
+    #[error(
+        "advertised xsave length ({advertised}) too small for features, requires ({required}) bytes"
+    )]
+    XSaveLengthTooSmall { advertised: u32, required: u32 },
+    #[error("x2apic topology and cpuid mismatch, expected x2apic={expected}, found {found}")]
+    X2ApicMismatch { expected: bool, found: bool },
+}
+
 impl X86PartitionCapabilities {
     pub fn from_cpuid(
         processor_topology: &ProcessorTopology<X86Topology>,
         f: &mut dyn FnMut(u32, u32) -> [u32; 4],
-    ) -> Self {
+    ) -> Result<Self, X86PartitionCapabilitiesError> {
         let mut this = Self {
             vendor: Vendor([0; 12]),
             hv1: false,
@@ -185,12 +196,13 @@ impl X86PartitionCapabilities {
             }
             this.xsave.compact_len = this.xsave.compact_len_for(!0);
             this.xsave.standard_len = this.xsave.standard_len_for(!0);
-            assert!(
-                this.xsave.standard_len <= standard_len,
-                "advertised xsave length ({}) too small for features, requires ({}) bytes",
-                standard_len,
-                this.xsave.standard_len
-            );
+
+            if this.xsave.standard_len <= standard_len {
+                return Err(X86PartitionCapabilitiesError::XSaveLengthTooSmall {
+                    advertised: standard_len,
+                    required: this.xsave.standard_len,
+                });
+            }
         }
 
         // Hypervisor info.
@@ -223,16 +235,21 @@ impl X86PartitionCapabilities {
             }
         }
 
-        match processor_topology.apic_mode() {
-            ApicMode::XApic => assert!(
-                !this.x2apic,
-                "x2apic disabled in topology, enabled in cpuid"
-            ),
-            ApicMode::X2ApicSupported => {
-                assert!(this.x2apic, "x2apic enabled in topology, disabled in cpuid")
+        match (processor_topology.apic_mode(), this.x2apic) {
+            (ApicMode::XApic, true) => {
+                return Err(X86PartitionCapabilitiesError::X2ApicMismatch {
+                    expected: false,
+                    found: true,
+                });
             }
-            ApicMode::X2ApicEnabled => {
-                assert!(this.x2apic, "x2apic enabled in topology, disabled in cpuid");
+            (ApicMode::X2ApicSupported | ApicMode::X2ApicEnabled, false) => {
+                return Err(X86PartitionCapabilitiesError::X2ApicMismatch {
+                    expected: true,
+                    found: false,
+                });
+            }
+            (ApicMode::XApic, false) | (ApicMode::X2ApicSupported, true) => {}
+            (ApicMode::X2ApicEnabled, true) => {
                 this.x2apic_enabled = true;
             }
         }
@@ -256,7 +273,7 @@ impl X86PartitionCapabilities {
             rdtscp || rdpid
         };
 
-        this
+        Ok(this)
     }
 }
 

--- a/vmm_core/virt/src/x86/mod.rs
+++ b/vmm_core/virt/src/x86/mod.rs
@@ -197,7 +197,7 @@ impl X86PartitionCapabilities {
             this.xsave.compact_len = this.xsave.compact_len_for(!0);
             this.xsave.standard_len = this.xsave.standard_len_for(!0);
 
-            if this.xsave.standard_len <= standard_len {
+            if this.xsave.standard_len > standard_len {
                 return Err(X86PartitionCapabilitiesError::XSaveLengthTooSmall {
                     advertised: standard_len,
                     required: this.xsave.standard_len,

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -297,7 +297,8 @@ impl ProtoPartition for KvmProtoPartition<'_> {
         let mut caps = virt::PartitionCapabilities::from_cpuid(
             self.config.processor_topology,
             &mut |function, index| cpuid.result(function, index, &[0; 4]),
-        );
+        )
+        .map_err(KvmError::Capabilities)?;
 
         caps.can_freeze_time = false;
 

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -47,6 +47,8 @@ pub enum KvmError {
     InvalidState(&'static str),
     #[error("misaligned gic base address")]
     Misaligned,
+    #[error("host does not support required cpu capabilities")]
+    Capabilities(virt::PartitionCapabilitiesError),
 }
 
 #[derive(Debug, Inspect)]

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -210,7 +210,7 @@ pub struct MshvProtoPartition<'a> {
 impl ProtoPartition for MshvProtoPartition<'_> {
     type Partition = MshvPartition;
     type ProcessorBinder = MshvProcessorBinder;
-    type Error = Infallible;
+    type Error = Error;
 
     fn cpuid(&self, eax: u32, ecx: u32) -> [u32; 4] {
         // This call should never fail unless there is a kernel or hypervisor
@@ -240,7 +240,8 @@ impl ProtoPartition for MshvProtoPartition<'_> {
                     .get_cpuid_values(function, index, 0, 0)
                     .expect("cpuid should not fail")
             },
-        );
+        )
+        .map_err(Error::Capabilities)?;
 
         // Attach all the resources created above to a Partition object.
         let partition = MshvPartition {
@@ -1089,6 +1090,8 @@ pub enum Error {
     Register(#[source] MshvError),
     #[error("install instercept failed")]
     InstallIntercept(#[source] MshvError),
+    #[error("host does not support required cpu capabilities")]
+    Capabilities(virt::PartitionCapabilitiesError),
 }
 
 impl MshvPartitionInner {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -707,6 +707,8 @@ pub enum Error {
     AcceptPages(#[source] anyhow::Error),
     #[error("invalid apic base")]
     InvalidApicBase(#[source] virt_support_apic::InvalidApicBase),
+    #[error("host does not support required cpu capabilities")]
+    Capabilities(virt::PartitionCapabilitiesError),
 }
 
 trait WhpResultExt<T> {
@@ -1004,7 +1006,8 @@ impl WhpPartitionInner {
                         &[output.Eax, output.Ebx, output.Ecx, output.Edx],
                     )
                 },
-            );
+            )
+            .map_err(Error::Capabilities)?;
             caps.can_freeze_time = true;
             caps.xsaves_state_bv_broken = true;
             caps.dr6_tsx_broken = true;


### PR DESCRIPTION
It is currently possible to easily hit these asserts through the openvmm command line, but we also had an openhcl ICM come in that hit one of these. Return a proper error instead of panicking to present the failure in a nicer manner.