### PR TITLE
vmm_tests: removed keepalive test with uefi

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -95,27 +95,6 @@ async fn nvme_relay_private_pool(
     nvme_relay_test_core(config, "OPENHCL_ENABLE_VTL2_GPA_POOL=512").await
 }
 
-/// Servicing test of an OpenHCL uefi VM with a NVME disk assigned to VTL2 that boots
-/// linux, with vmbus relay. This should expose a disk to VTL0 via vmbus.
-/// Use the private pool override to test the private pool dma path.
-/// Pass 'keepalive' servicing flag which impacts NVMe save/restore.
-#[openvmm_test(openhcl_uefi_x64[nvme](vhd(ubuntu_2204_server_x64))[LATEST_STANDARD_X64])]
-async fn nvme_keepalive(
-    config: PetriVmBuilder<OpenVmmPetriBackend>,
-    (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
-) -> Result<(), anyhow::Error> {
-    nvme_relay_servicing_core(
-        config,
-        "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_SIDECAR=off", // disable sidecar until #1345 is fixed
-        igvm_file,
-        OpenHclServicingFlags {
-            enable_nvme_keepalive: true,
-            ..Default::default()
-        },
-    )
-    .await
-}
-
 /// Boot the UEFI firmware, with a VTL2 range automatically configured by
 /// hvlite.
 #[openvmm_test_no_agent(openhcl_uefi_x64(none))]


### PR DESCRIPTION
As discussed offline this test can be removed as a similar test that exercises the keepalive codebase already exists in the `openhcl_servicing.rs` file. This test is being flaky for no good reason so it should be ok to remove.