### PR TITLE
cross_tool.py: remove unrelated folder from SDK search paths

### DIFF
--- a/build_support/windows_cross/cross_tool.py
+++ b/build_support/windows_cross/cross_tool.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import glob
 import argparse
+import re
 
 tools = ['clang-cl', 'lld-link', 'llvm-lib', 'llvm-dlltool', 'llvm-rc', 'midlrt.exe']
 
@@ -68,6 +69,8 @@ def sdk_paths(arch):
     roots = wslpath(
         reg('HKLM\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots'))
     versions = os.listdir(f'{roots}/Lib')
+    pattern = re.compile(r'^[\d.]+$')
+    versions = [v for v in versions if pattern.fullmatch(v)]
     versions.sort()
     version = versions[-1]
     lib = [f'{roots}/Lib/{version}/{dir}/{arch}' for dir in ['ucrt', 'um']]


### PR DESCRIPTION
cross_tool attempts to use the latest available SDK and assumes all SDK
versions are installed in the same directory, with folder names consisting
only of digits and dots (e.g., 10.0.26100.0).

However, there is a potential issue: the Windows Driver Kit (WDK) may also
be installed in the same location as the SDKs, leading to additional
directories like the following:

  .
  ├── 10.0.22621.0
  ├── 10.0.26100.0
  └── wdf

In such cases, the sorting logic may incorrectly select wdf instead of the
latest SDK version (10.0.26100.0).

This PR updates cross_tool to ignore any directories that do not follow the
expected version pattern (i.e., names containing only digits and dots),
ensuring only valid SDK version folders are considered.