### PR TITLE
ci: disable hyperv arm tests

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -974,7 +974,8 @@ impl IntoPipeline for CheckinGatesCli {
                 label: "aarch64-windows",
                 target: CommonTriple::AARCH64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_aarch64,
-                nextest_filter_expr: "all()".to_string(),
+                // disable hyper-v tests for now until runners are updated
+                nextest_filter_expr: "all() & !test(hyperv)".to_string(),
                 test_artifacts: vec![
                     KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
                     KnownTestArtifacts::Windows11EnterpriseAarch64Vhdx,


### PR DESCRIPTION
Disable Hyper-V ARM VMM tests until the runners are updated. The certs expired on the pre-release builds currently being used.