### PR TITLE
vmbus_server: add an option to assign channel IDs on offer

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -15,25 +15,17 @@ use zerocopy::FromBytes;
 
 #[test]
 fn test_version_negotiation_not_supported() {
-    let (mut notifier, _recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
 
-    test_initiate_contact(
-        &mut server,
-        &mut notifier,
-        TestVersion::Unsupported(0xffffffff),
-        0,
-    );
+    test_initiate_contact(&mut env, TestVersion::Unsupported(0xffffffff), 0);
 }
 
 #[test]
 fn test_version_negotiation_success() {
-    let (mut notifier, _recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
 
     test_initiate_contact(
-        &mut server,
-        &mut notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Win10,
             expected_features: 0,
@@ -44,16 +36,14 @@ fn test_version_negotiation_success() {
 
 #[test]
 fn test_version_negotiation_multiclient_sint() {
-    let (mut notifier, _recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
 
     let target_info = TargetInfo::new()
         .with_sint(3)
         .with_vtl(0)
         .with_feature_flags(FeatureFlags::new().into());
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .handle_synic_message(in_msg_ex(
             protocol::MessageType::INITIATE_CONTACT,
             protocol::InitiateContact {
@@ -70,9 +60,9 @@ fn test_version_negotiation_multiclient_sint() {
 
     // No action is taken when a different SINT is requested, since it's not supported. An
     // unsupported message is sent to the requested SINT.
-    assert!(notifier.modify_requests.is_empty());
-    assert!(matches!(server.state, ConnectionState::Disconnected));
-    notifier.check_message_with_target(
+    assert!(env.notifier.modify_requests.is_empty());
+    assert!(matches!(env.server.state, ConnectionState::Disconnected));
+    env.notifier.check_message_with_target(
         OutgoingMessage::new(&protocol::VersionResponse {
             version_supported: 0,
             connection_state: protocol::ConnectionState::SUCCESSFUL,
@@ -84,8 +74,7 @@ fn test_version_negotiation_multiclient_sint() {
 
     // SINT is ignored if the multiclient port is not used.
     test_initiate_contact(
-        &mut server,
-        &mut notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Win10Rs3_1,
             expected_features: 0,
@@ -96,16 +85,14 @@ fn test_version_negotiation_multiclient_sint() {
 
 #[test]
 fn test_version_negotiation_multiclient_vtl() {
-    let (mut notifier, _recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
 
     let target_info = TargetInfo::new()
         .with_sint(SINT)
         .with_vtl(2)
         .with_feature_flags(FeatureFlags::new().into());
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .handle_synic_message(in_msg_ex(
             protocol::MessageType::INITIATE_CONTACT,
             protocol::InitiateContact {
@@ -120,17 +107,16 @@ fn test_version_negotiation_multiclient_vtl() {
         ))
         .unwrap();
 
-    let action = notifier.forward_request.take().unwrap();
+    let action = env.notifier.forward_request.take().unwrap();
     assert!(matches!(action, InitiateContactRequest { .. }));
 
     // The VTL contact message was forwarded but no action was taken by this server.
-    assert!(notifier.messages.is_empty());
-    assert!(matches!(server.state, ConnectionState::Disconnected));
+    assert!(env.notifier.messages.is_empty());
+    assert!(matches!(env.server.state, ConnectionState::Disconnected));
 
     // VTL is ignored if the multiclient port is not used.
     test_initiate_contact(
-        &mut server,
-        &mut notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Win10Rs4,
             expected_features: 0,
@@ -138,7 +124,7 @@ fn test_version_negotiation_multiclient_vtl() {
         target_info.into(),
     );
 
-    assert!(notifier.forward_request.is_none());
+    assert!(env.notifier.forward_request.is_none());
 }
 
 #[test]
@@ -151,8 +137,7 @@ fn test_version_negotiation_feature_flags() {
         .with_vtl(0)
         .with_feature_flags(FeatureFlags::new().into());
     test_initiate_contact(
-        &mut env.server,
-        &mut env.notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Copper,
             expected_features: 0,
@@ -170,8 +155,7 @@ fn test_version_negotiation_feature_flags() {
             .into(),
     );
     test_initiate_contact(
-        &mut env.server,
-        &mut env.notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Copper,
             expected_features: FeatureFlags::new()
@@ -189,8 +173,7 @@ fn test_version_negotiation_feature_flags() {
         u32::from(FeatureFlags::new().with_guest_specified_signal_parameters(true)) | 0xf0000000,
     );
     test_initiate_contact(
-        &mut env.server,
-        &mut env.notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Copper,
             expected_features: FeatureFlags::new()
@@ -206,8 +189,7 @@ fn test_version_negotiation_feature_flags() {
     // Verify client ID feature flag.
     target_info.set_feature_flags(FeatureFlags::new().with_client_id(true).into());
     test_initiate_contact(
-        &mut env.server,
-        &mut env.notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Copper,
             expected_features: FeatureFlags::new().with_client_id(true).into(),
@@ -218,11 +200,9 @@ fn test_version_negotiation_feature_flags() {
 
 #[test]
 fn test_version_negotiation_interrupt_page() {
-    let (mut notifier, _recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
     test_initiate_contact(
-        &mut server,
-        &mut notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::V1,
             expected_features: 0,
@@ -230,11 +210,9 @@ fn test_version_negotiation_interrupt_page() {
         1234,
     );
 
-    let (mut notifier, _recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
     test_initiate_contact(
-        &mut server,
-        &mut notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Win7,
             expected_features: 0,
@@ -242,11 +220,9 @@ fn test_version_negotiation_interrupt_page() {
         1234,
     );
 
-    let (mut notifier, _recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
     test_initiate_contact(
-        &mut server,
-        &mut notifier,
+        &mut env,
         TestVersion::Supported {
             version: Version::Win8,
             expected_features: 0,
@@ -263,18 +239,12 @@ enum TestVersion {
     },
 }
 
-fn test_initiate_contact(
-    server: &mut Server,
-    notifier: &mut TestNotifier,
-    version: TestVersion,
-    target_info: u64,
-) {
+fn test_initiate_contact(env: &mut TestEnv, version: TestVersion, target_info: u64) {
     let raw_version = match version {
         TestVersion::Unsupported(version) => version,
         TestVersion::Supported { version, .. } => version as u32,
     };
-    server
-        .with_notifier(notifier)
+    env.c()
         .handle_synic_message(in_msg(
             protocol::MessageType::INITIATE_CONTACT,
             protocol::InitiateContact2 {
@@ -296,7 +266,7 @@ fn test_initiate_contact(
             expected_features,
         } = version
         {
-            let request = notifier.next_action();
+            let request = env.notifier.next_action();
             let interrupt_page = if raw_version < Version::Win8 as u32 {
                 Update::Set(target_info)
             } else {
@@ -323,13 +293,12 @@ fn test_initiate_contact(
                 }
             );
 
-            server.with_notifier(notifier).complete_initiate_contact(
-                ModifyConnectionResponse::Supported(
+            env.c()
+                .complete_initiate_contact(ModifyConnectionResponse::Supported(
                     protocol::ConnectionState::SUCCESSFUL,
                     SUPPORTED_FEATURE_FLAGS,
                     None,
-                ),
-            );
+                ));
 
             let selected_version_or_connection_id = if raw_version >= Version::Win10Rs3_1 as u32 {
                 1
@@ -350,32 +319,37 @@ fn test_initiate_contact(
     };
 
     if raw_version >= Version::Copper as u32 && expect_supported {
-        notifier.check_message(OutgoingMessage::new(&protocol::VersionResponse2 {
-            version_response,
-            supported_features: expected_features,
-        }));
+        env.notifier
+            .check_message(OutgoingMessage::new(&protocol::VersionResponse2 {
+                version_response,
+                supported_features: expected_features,
+            }));
     } else {
-        notifier.check_message(OutgoingMessage::new(&version_response));
+        env.notifier
+            .check_message(OutgoingMessage::new(&version_response));
         assert_eq!(expected_features, 0);
     }
 
-    assert!(notifier.messages.is_empty());
+    assert!(env.notifier.messages.is_empty());
     if expect_supported {
-        assert!(matches!(server.state, ConnectionState::Connected { .. }));
+        assert!(matches!(
+            env.server.state,
+            ConnectionState::Connected { .. }
+        ));
         if raw_version < Version::Win8_1 as u32 {
-            assert_eq!(Some(0), notifier.target_message_vp);
+            assert_eq!(Some(0), env.notifier.target_message_vp);
         } else {
-            assert_eq!(Some(1), notifier.target_message_vp);
+            assert_eq!(Some(1), env.notifier.target_message_vp);
         }
     } else {
-        assert!(matches!(server.state, ConnectionState::Disconnected));
-        assert!(notifier.target_message_vp.is_none());
+        assert!(matches!(env.server.state, ConnectionState::Disconnected));
+        assert!(env.notifier.target_message_vp.is_none());
     }
 
     if raw_version < Version::Win8 as u32 {
-        assert_eq!(notifier.interrupt_page, Some(target_info));
+        assert_eq!(env.notifier.interrupt_page, Some(target_info));
     } else {
-        assert!(notifier.interrupt_page.is_none());
+        assert!(env.notifier.interrupt_page.is_none());
     }
 }
 
@@ -411,12 +385,11 @@ fn test_channel_lifetime_copper_open_flags() {
 }
 
 fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
-    let (mut notifier, recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
     let interface_id = Guid::new_random();
     let instance_id = Guid::new_random();
-    let offer_id = server
-        .with_notifier(&mut notifier)
+    let offer_id = env
+        .c()
         .offer_channel(OfferParamsInternal {
             interface_name: "test".to_owned(),
             instance_id,
@@ -433,8 +406,7 @@ fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
         target_info.set_feature_flags(feature_flags.into());
     }
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .handle_synic_message(in_msg(
             protocol::MessageType::INITIATE_CONTACT,
             protocol::InitiateContact {
@@ -447,7 +419,7 @@ fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
         ))
         .unwrap();
 
-    let request = notifier.next_action();
+    let request = env.notifier.next_action();
     assert_eq!(
         request,
         ModifyConnectionRequest {
@@ -462,8 +434,7 @@ fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
         }
     );
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .complete_initiate_contact(ModifyConnectionResponse::Supported(
             protocol::ConnectionState::SUCCESSFUL,
             SUPPORTED_FEATURE_FLAGS,
@@ -477,21 +448,22 @@ fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
     };
 
     if version >= Version::Copper {
-        notifier.check_message(OutgoingMessage::new(&protocol::VersionResponse2 {
-            version_response,
-            supported_features: feature_flags.into(),
-        }));
+        env.notifier
+            .check_message(OutgoingMessage::new(&protocol::VersionResponse2 {
+                version_response,
+                supported_features: feature_flags.into(),
+            }));
     } else {
-        notifier.check_message(OutgoingMessage::new(&version_response));
+        env.notifier
+            .check_message(OutgoingMessage::new(&version_response));
     }
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .handle_synic_message(in_msg(protocol::MessageType::REQUEST_OFFERS, ()))
         .unwrap();
 
     let channel_id = ChannelId(1);
-    notifier.check_messages([
+    env.notifier.check_messages([
         OutgoingMessage::new(&protocol::OfferChannel {
             interface_id,
             instance_id,
@@ -529,8 +501,7 @@ fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
             connection_id = 0x2002;
         }
 
-        server
-            .with_notifier(&mut notifier)
+        env.c()
             .handle_synic_message(in_msg(
                 protocol::MessageType::OPEN_CHANNEL,
                 protocol::OpenChannel2 {
@@ -545,13 +516,12 @@ fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
             ))
             .unwrap();
     } else {
-        server
-            .with_notifier(&mut notifier)
+        env.c()
             .handle_synic_message(in_msg(protocol::MessageType::OPEN_CHANNEL, open_channel))
             .unwrap();
     }
 
-    let (id, action) = recv.recv().unwrap();
+    let (id, action) = env.recv.recv().unwrap();
     assert_eq!(id, offer_id);
     let Action::Open(op, ..) = action else {
         panic!("unexpected action: {:?}", action);
@@ -566,18 +536,16 @@ fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
     assert_eq!(op.monitor_info, None);
     assert_eq!(op.flags, expected_flags);
 
-    server
-        .with_notifier(&mut notifier)
-        .open_complete(offer_id, 0);
+    env.c().open_complete(offer_id, 0);
 
-    notifier.check_message(OutgoingMessage::new(&protocol::OpenResult {
-        channel_id,
-        open_id: 1,
-        status: 0,
-    }));
+    env.notifier
+        .check_message(OutgoingMessage::new(&protocol::OpenResult {
+            channel_id,
+            open_id: 1,
+            status: 0,
+        }));
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .handle_synic_message(in_msg(
             protocol::MessageType::MODIFY_CHANNEL,
             protocol::ModifyChannel {
@@ -587,27 +555,25 @@ fn test_channel_lifetime_helper(version: Version, feature_flags: FeatureFlags) {
         ))
         .unwrap();
 
-    let (id, action) = recv.recv().unwrap();
+    let (id, action) = env.recv.recv().unwrap();
     assert_eq!(id, offer_id);
     assert!(matches!(action, Action::Modify { target_vp: 4 }));
 
-    server
-        .with_notifier(&mut notifier)
-        .modify_channel_complete(id, 0);
+    env.c().modify_channel_complete(id, 0);
 
     if version >= Version::Iron {
-        notifier.check_message(OutgoingMessage::new(&protocol::ModifyChannelResponse {
-            channel_id,
-            status: 0,
-        }));
+        env.notifier
+            .check_message(OutgoingMessage::new(&protocol::ModifyChannelResponse {
+                channel_id,
+                status: 0,
+            }));
     }
 
-    assert!(notifier.messages.is_empty());
+    assert!(env.notifier.messages.is_empty());
 
-    server.with_notifier(&mut notifier).revoke_channel(offer_id);
+    env.c().revoke_channel(offer_id);
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .handle_synic_message(in_msg(
             protocol::MessageType::REL_ID_RELEASED,
             protocol::RelIdReleased { channel_id },
@@ -632,11 +598,9 @@ fn test_hvsock_rs5() {
 }
 
 fn test_hvsock_helper(version: Version, force_small_message: bool) {
-    let (mut notifier, _recv) = TestNotifier::new();
-    let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+    let mut env = TestEnv::new();
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .handle_synic_message(in_msg(
             protocol::MessageType::INITIATE_CONTACT,
             protocol::InitiateContact {
@@ -649,7 +613,7 @@ fn test_hvsock_helper(version: Version, force_small_message: bool) {
         ))
         .unwrap();
 
-    let request = notifier.next_action();
+    let request = env.notifier.next_action();
     assert_eq!(
         request,
         ModifyConnectionRequest {
@@ -664,8 +628,7 @@ fn test_hvsock_helper(version: Version, force_small_message: bool) {
         }
     );
 
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .complete_initiate_contact(ModifyConnectionResponse::Supported(
             protocol::ConnectionState::SUCCESSFUL,
             SUPPORTED_FEATURE_FLAGS,
@@ -673,7 +636,7 @@ fn test_hvsock_helper(version: Version, force_small_message: bool) {
         ));
 
     // Discard the version response message.
-    notifier.messages.pop_front();
+    env.notifier.messages.pop_front();
 
     let service_id = Guid::new_random();
     let endpoint_id = Guid::new_random();
@@ -698,30 +661,27 @@ fn test_hvsock_helper(version: Version, force_small_message: bool) {
         )
     };
 
-    server
-        .with_notifier(&mut notifier)
-        .handle_synic_message(request_msg)
-        .unwrap();
+    env.c().handle_synic_message(request_msg).unwrap();
 
-    let request = notifier.hvsock_requests.pop().unwrap();
+    let request = env.notifier.hvsock_requests.pop().unwrap();
     assert_eq!(request.service_id, service_id);
     assert_eq!(request.endpoint_id, endpoint_id);
-    assert!(notifier.hvsock_requests.is_empty());
+    assert!(env.notifier.hvsock_requests.is_empty());
 
     // Notify the guest of connection failure.
-    server
-        .with_notifier(&mut notifier)
+    env.c()
         .send_tl_connect_result(HvsockConnectResult::from_request(&request, false));
 
     if version >= Version::Win10Rs3_0 {
-        notifier.check_message(OutgoingMessage::new(&protocol::TlConnectResult {
-            service_id: request.service_id,
-            endpoint_id: request.endpoint_id,
-            status: protocol::STATUS_CONNECTION_REFUSED,
-        }));
+        env.notifier
+            .check_message(OutgoingMessage::new(&protocol::TlConnectResult {
+                service_id: request.service_id,
+                endpoint_id: request.endpoint_id,
+                status: protocol::STATUS_CONNECTION_REFUSED,
+            }));
     }
 
-    assert!(notifier.messages.is_empty());
+    assert!(env.notifier.messages.is_empty());
 }
 
 /// Ensure that channels can be offered at each stage of connection.
@@ -1101,14 +1061,8 @@ fn test_save_restore_offers_not_sent() {
     env.c().handle_request_offers().unwrap();
     env.notifier.check_messages([
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 1,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 1,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(1),
+            instance_id: guid_from_id(1),
             channel_id: ChannelId(1),
             connection_id: 0x2001,
             is_dedicated: 1,
@@ -1116,14 +1070,8 @@ fn test_save_restore_offers_not_sent() {
             ..protocol::OfferChannel::new_zeroed()
         }),
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 2,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 2,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(2),
+            instance_id: guid_from_id(2),
             channel_id: ChannelId(2),
             connection_id: 0x2002,
             is_dedicated: 1,
@@ -1131,14 +1079,8 @@ fn test_save_restore_offers_not_sent() {
             ..protocol::OfferChannel::new_zeroed()
         }),
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 3,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 3,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(3),
+            instance_id: guid_from_id(3),
             channel_id: ChannelId(3),
             connection_id: 0x2003,
             is_dedicated: 1,
@@ -1179,14 +1121,8 @@ fn test_save_restore_hot_add_during_restore() {
     env.c().revoke_unclaimed_channels();
     env.notifier
         .check_message(OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 4,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 4,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(4),
+            instance_id: guid_from_id(4),
             channel_id: ChannelId(4),
             connection_id: 0x2004,
             is_dedicated: 1,
@@ -1484,14 +1420,8 @@ fn test_mnf_channel() {
 
     let mut expected_channels = [
         protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 1,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 1,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(1),
+            instance_id: guid_from_id(1),
             channel_id: ChannelId(1),
             connection_id: 0x2001,
             is_dedicated: 1,
@@ -1499,14 +1429,8 @@ fn test_mnf_channel() {
             ..protocol::OfferChannel::new_zeroed()
         },
         protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 2,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 2,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(2),
+            instance_id: guid_from_id(2),
             channel_id: ChannelId(2),
             connection_id: 0x2002,
             is_dedicated: 1,
@@ -1514,14 +1438,8 @@ fn test_mnf_channel() {
             ..protocol::OfferChannel::new_zeroed()
         },
         protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 3,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 3,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(3),
+            instance_id: guid_from_id(3),
             channel_id: ChannelId(3),
             connection_id: 0x2003,
             is_dedicated: 1,
@@ -1675,14 +1593,8 @@ fn test_server_monitor_page_helper(provide_guest_pages: bool) {
     env.c().handle_request_offers().unwrap();
     env.notifier.check_messages([
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 1,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 1,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(1),
+            instance_id: guid_from_id(1),
             channel_id: ChannelId(1),
             connection_id: 0x2001,
             is_dedicated: 1,
@@ -1711,14 +1623,8 @@ fn test_channel_id_order() {
 
     env.notifier.check_messages([
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 3,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 3,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(3),
+            instance_id: guid_from_id(3),
             channel_id: ChannelId(1),
             connection_id: 0x2001,
             is_dedicated: 1,
@@ -1726,14 +1632,8 @@ fn test_channel_id_order() {
             ..protocol::OfferChannel::new_zeroed()
         }),
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 5,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 8,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(5),
+            instance_id: guid_from_id(8),
             channel_id: ChannelId(2),
             connection_id: 0x2002,
             is_dedicated: 1,
@@ -1741,14 +1641,8 @@ fn test_channel_id_order() {
             ..protocol::OfferChannel::new_zeroed()
         }),
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 5,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 6,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(5),
+            instance_id: guid_from_id(6),
             channel_id: ChannelId(3),
             connection_id: 0x2003,
             is_dedicated: 1,
@@ -1756,14 +1650,8 @@ fn test_channel_id_order() {
             ..protocol::OfferChannel::new_zeroed()
         }),
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 5,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 1,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(5),
+            instance_id: guid_from_id(1),
             channel_id: ChannelId(4),
             connection_id: 0x2004,
             is_dedicated: 1,
@@ -1771,14 +1659,8 @@ fn test_channel_id_order() {
             ..protocol::OfferChannel::new_zeroed()
         }),
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 5,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 5,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(5),
+            instance_id: guid_from_id(5),
             channel_id: ChannelId(5),
             connection_id: 0x2005,
             is_dedicated: 1,
@@ -1786,14 +1668,8 @@ fn test_channel_id_order() {
             ..protocol::OfferChannel::new_zeroed()
         }),
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 10,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 10,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(10),
+            instance_id: guid_from_id(10),
             channel_id: ChannelId(6),
             connection_id: 0x2006,
             is_dedicated: 1,
@@ -1801,14 +1677,94 @@ fn test_channel_id_order() {
             ..protocol::OfferChannel::new_zeroed()
         }),
         OutgoingMessage::new(&protocol::OfferChannel {
-            interface_id: Guid {
-                data1: 17,
-                ..Guid::ZERO
-            },
-            instance_id: Guid {
-                data1: 17,
-                ..Guid::ZERO
-            },
+            interface_id: guid_from_id(17),
+            instance_id: guid_from_id(17),
+            channel_id: ChannelId(7),
+            connection_id: 0x2007,
+            is_dedicated: 1,
+            monitor_id: 0xff,
+            ..protocol::OfferChannel::new_zeroed()
+        }),
+        OutgoingMessage::new(&protocol::AllOffersDelivered {}),
+    ])
+}
+
+#[test]
+fn test_assign_channel_id_on_offer() {
+    let mut env = TestEnv::with_params(true);
+
+    let _offer_id1 = env.offer(3);
+    let _offer_id2 = env.offer(10);
+    let _offer_id3 = env.offer(5);
+    let _offer_id4 = env.offer(17);
+
+    // The "order" values are completely ignored in this mode.
+    let _offer_id5 = env.offer_with_order(5, 6, Some(2));
+    let _offer_id6 = env.offer_with_order(5, 8, Some(1));
+    let _offer_id7 = env.offer_with_order(5, 1, None);
+
+    env.connect(Version::Win10, FeatureFlags::new());
+    env.c().handle_request_offers().unwrap();
+
+    // Channel IDs are assigned in the order the offers were created.
+    env.notifier.check_messages([
+        OutgoingMessage::new(&protocol::OfferChannel {
+            interface_id: guid_from_id(3),
+            instance_id: guid_from_id(3),
+            channel_id: ChannelId(1),
+            connection_id: 0x2001,
+            is_dedicated: 1,
+            monitor_id: 0xff,
+            ..protocol::OfferChannel::new_zeroed()
+        }),
+        OutgoingMessage::new(&protocol::OfferChannel {
+            interface_id: guid_from_id(10),
+            instance_id: guid_from_id(10),
+            channel_id: ChannelId(2),
+            connection_id: 0x2002,
+            is_dedicated: 1,
+            monitor_id: 0xff,
+            ..protocol::OfferChannel::new_zeroed()
+        }),
+        OutgoingMessage::new(&protocol::OfferChannel {
+            interface_id: guid_from_id(5),
+            instance_id: guid_from_id(5),
+            channel_id: ChannelId(3),
+            connection_id: 0x2003,
+            is_dedicated: 1,
+            monitor_id: 0xff,
+            ..protocol::OfferChannel::new_zeroed()
+        }),
+        OutgoingMessage::new(&protocol::OfferChannel {
+            interface_id: guid_from_id(17),
+            instance_id: guid_from_id(17),
+            channel_id: ChannelId(4),
+            connection_id: 0x2004,
+            is_dedicated: 1,
+            monitor_id: 0xff,
+            ..protocol::OfferChannel::new_zeroed()
+        }),
+        OutgoingMessage::new(&protocol::OfferChannel {
+            interface_id: guid_from_id(5),
+            instance_id: guid_from_id(6),
+            channel_id: ChannelId(5),
+            connection_id: 0x2005,
+            is_dedicated: 1,
+            monitor_id: 0xff,
+            ..protocol::OfferChannel::new_zeroed()
+        }),
+        OutgoingMessage::new(&protocol::OfferChannel {
+            interface_id: guid_from_id(5),
+            instance_id: guid_from_id(8),
+            channel_id: ChannelId(6),
+            connection_id: 0x2006,
+            is_dedicated: 1,
+            monitor_id: 0xff,
+            ..protocol::OfferChannel::new_zeroed()
+        }),
+        OutgoingMessage::new(&protocol::OfferChannel {
+            interface_id: guid_from_id(5),
+            instance_id: guid_from_id(1),
             channel_id: ChannelId(7),
             connection_id: 0x2007,
             is_dedicated: 1,
@@ -2335,8 +2291,17 @@ struct TestEnv {
 
 impl TestEnv {
     fn new() -> Self {
+        Self::with_params(false)
+    }
+
+    fn with_params(assign_channel_id_on_offer: bool) -> Self {
         let (notifier, recv) = TestNotifier::new();
-        let server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
+        let server = Server::new(
+            Vtl::Vtl0,
+            MESSAGE_CONNECTION_ID,
+            0,
+            assign_channel_id_on_offer,
+        );
         Self {
             server,
             notifier,
@@ -2420,14 +2385,8 @@ impl TestEnv {
     ) -> OfferId {
         self.c()
             .offer_channel(OfferParamsInternal {
-                instance_id: Guid {
-                    data1: instance_id,
-                    ..Guid::ZERO
-                },
-                interface_id: Guid {
-                    data1: interface_id,
-                    ..Guid::ZERO
-                },
+                instance_id: guid_from_id(instance_id),
+                interface_id: guid_from_id(interface_id),
                 use_mnf,
                 offer_order,
                 flags,
@@ -2654,5 +2613,12 @@ fn in_msg_ex<T: IntoBytes + Immutable + KnownLayout>(
         data,
         multiclient,
         trusted,
+    }
+}
+
+fn guid_from_id(id: u32) -> Guid {
+    Guid {
+        data1: id,
+        ..Guid::ZERO
     }
 }

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -135,6 +135,7 @@ pub struct VmbusServerBuilder<T: SpawnDriver> {
     force_confidential_external_memory: bool,
     send_messages_while_stopped: bool,
     channel_unstick_delay: Option<Duration>,
+    assign_channel_id_on_offer: bool,
 }
 
 #[derive(mesh::MeshPayload)]
@@ -311,6 +312,7 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
             force_confidential_external_memory: false,
             send_messages_while_stopped: false,
             channel_unstick_delay: Some(Duration::from_millis(100)),
+            assign_channel_id_on_offer: false,
         }
     }
 
@@ -438,6 +440,18 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
         self
     }
 
+    /// Sets whether the server should assign channel IDs when a channel is offered, rather than
+    /// the default behavior of assigning them in a deterministic order when the offers are sent to
+    /// the guest.
+    ///
+    /// When this option is set to `true`, it's up to the source of the offers to ensure that they
+    /// are in a consistent order, as some guests may rely on stable channel IDs across hibernate
+    /// and resume.
+    pub fn assign_channel_id_on_offer(mut self, assign: bool) -> Self {
+        self.assign_channel_id_on_offer = assign;
+        self
+    }
+
     /// Creates a new instance of the server.
     ///
     /// When the object is dropped, all channels will be closed and revoked
@@ -502,7 +516,12 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
             force_confidential_external_memory: self.force_confidential_external_memory,
         });
 
-        let mut server = channels::Server::new(self.vtl, connection_id, self.channel_id_offset);
+        let mut server = channels::Server::new(
+            self.vtl,
+            connection_id,
+            self.channel_id_offset,
+            self.assign_channel_id_on_offer,
+        );
 
         // If MNF is handled by this server and this is a paravisor for an isolated VM, the monitor
         // pages must be allocated by the server, not the guest, since the guest will provide shared


### PR DESCRIPTION
Some guests have taken unfortunate dependencies on VMBus channel IDs; in particular older Windows guests require that the channel IDs do not change between hibernation and resume from hibernate. The VMBus server already supports that by ensuring channel IDs are assigned in a deterministic order, but in some cases we need to match the behavior used by Hyper-V, where channel IDs are assigned based on the order the channel offers were created.

This change adds an option to assign channel IDs at the time a channel is offered, rather than when they are sent to the guest (the default behavior), which mirrors Hyper-V behavior. This option should not be used by OpenVMM or OpenHCL, but is for other uses of the vmbus_server crate.