### PR TITLE
repo: Fix lints for Rust 1.90

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1299,7 +1299,7 @@ impl MshvHvcall {
             assert!(size_of::<O>() <= HV_PAGE_SIZE as usize);
         }
         assert_size::<I, O>();
-        assert!(variable_input.len() % 8 == 0);
+        assert!(variable_input.len().is_multiple_of(8));
 
         let input = [input.as_bytes(), variable_input].concat();
         if input.len() > HV_PAGE_SIZE as usize {

--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -33,7 +33,7 @@ impl<'a, T> VmsaWrapper<'a, T> {
 impl<T: Deref<Target = SevVmsa>> VmsaWrapper<'_, T> {
     /// 64 bit register read
     fn get_u64(&self, offset: usize) -> u64 {
-        assert!(offset % 8 == 0);
+        assert!(offset.is_multiple_of(8));
         let vmsa_raw = &self.vmsa;
         let v = u64::from_ne_bytes(vmsa_raw.as_bytes()[offset..offset + 8].try_into().unwrap());
         if is_protected(self.bitmap, offset) {
@@ -44,7 +44,7 @@ impl<T: Deref<Target = SevVmsa>> VmsaWrapper<'_, T> {
     }
     /// 32 bit register read
     fn get_u32(&self, offset: usize) -> u32 {
-        assert!(offset % 4 == 0);
+        assert!(offset.is_multiple_of(4));
         (self.get_u64(offset & !7) >> ((offset & 4) * 8)) as u32
     }
     /// 128 bit register read
@@ -77,7 +77,7 @@ impl<T: Deref<Target = SevVmsa>> VmsaWrapper<'_, T> {
 impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
     /// 64 bit value to set in register
     fn set_u64(&self, v: u64, offset: usize) -> u64 {
-        assert!(offset % 8 == 0);
+        assert!(offset.is_multiple_of(8));
         if is_protected(self.bitmap, offset) {
             v ^ self.vmsa.register_protection_nonce
         } else {
@@ -86,7 +86,7 @@ impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
     }
     /// 32 bit value to set in register
     fn set_u32(&self, v: u32, offset: usize) -> u32 {
-        assert!(offset % 4 == 0);
+        assert!(offset.is_multiple_of(4));
         let val = (v as u64) << ((offset & 4) * 8);
         (self.set_u64(val, offset & !7) >> ((offset & 4) * 8)) as u32
     }

--- a/openhcl/openhcl_boot/src/arch/x86_64/address_space.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/address_space.rs
@@ -254,7 +254,7 @@ static LOCAL_MAP_INITIALIZED: SingleThreaded<Cell<bool>> = SingleThreaded(Cell::
 /// It returns a LocalMap structure with a static lifetime.
 /// `va` is the virtual address of the local map region. It must be 2MB aligned.
 pub fn init_local_map(va: u64) -> LocalMap<'static> {
-    assert!(va % X64_LARGE_PAGE_SIZE == 0);
+    assert!(va.is_multiple_of(X64_LARGE_PAGE_SIZE));
 
     // SAFETY: The va for the local map is part of the measured build. This routine will only be
     // called once. The boot shim is a single threaded environment, the contained assertion is
@@ -292,7 +292,7 @@ impl TdxHypercallPage {
         unsafe {
             let entry = get_pde_for_va(va);
             assert!(entry.is_present() & entry.is_large_page());
-            assert!(va % X64_LARGE_PAGE_SIZE == 0);
+            assert!(va.is_multiple_of(X64_LARGE_PAGE_SIZE));
             assert!(entry.tdx_is_shared());
             TdxHypercallPage(va)
         }

--- a/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
@@ -126,7 +126,7 @@ pub fn setup_vtl2_memory(shim_params: &ShimParams, partition_info: &PartitionInf
     // TODO: find an approach that does not require re-using the ram_buffer
     if shim_params.isolation_type == IsolationType::Tdx {
         let free_buffer = ram_buffer.as_mut_ptr() as u64;
-        assert!(free_buffer % X64_LARGE_PAGE_SIZE == 0);
+        assert!(free_buffer.is_multiple_of(X64_LARGE_PAGE_SIZE));
         // SAFETY: The bottom 2MB region of the ram_buffer is unused by the shim
         // The region is aligned to 2MB, and mapped as a large page
         let tdx_io_page = unsafe {

--- a/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
@@ -89,9 +89,9 @@ fn pvalidate(
     validate: bool,
 ) -> Result<AcceptGpaStatus, AcceptGpaError> {
     if large_page {
-        assert!(va % x86defs::X64_LARGE_PAGE_SIZE == 0);
+        assert!(va.is_multiple_of(x86defs::X64_LARGE_PAGE_SIZE));
     } else {
-        assert!(va % hvdef::HV_PAGE_SIZE == 0)
+        assert!(va.is_multiple_of(hvdef::HV_PAGE_SIZE))
     }
 
     let validate_page = validate as u32;
@@ -149,7 +149,7 @@ pub fn set_page_acceptance(
             MemoryRange::from_4k_gpn_range(page_base..page_base + 1),
             true,
         );
-        if page_base % pages_per_large_page == 0 && page_count >= pages_per_large_page {
+        if page_base.is_multiple_of(pages_per_large_page) && page_count >= pages_per_large_page {
             let res = pvalidate(page_base, mapping.data.as_ptr() as u64, true, validate)?;
             match res {
                 AcceptGpaStatus::Success => {

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -41,7 +41,7 @@ impl HvcallPage {
         let addr = self.buffer.as_ptr() as u64;
 
         // These should be page-aligned
-        assert!(addr % HV_PAGE_SIZE == 0);
+        assert!(addr.is_multiple_of(HV_PAGE_SIZE));
 
         addr
     }

--- a/openhcl/sidecar_client/src/lib.rs
+++ b/openhcl/sidecar_client/src/lib.rs
@@ -350,7 +350,7 @@ struct VpSharedPages {
     register_page: hvdef::HvX64RegisterPage,
 }
 
-const _: () = assert!(size_of::<VpSharedPages>() % PAGE_SIZE == 0);
+const _: () = assert!(size_of::<VpSharedPages>().is_multiple_of(PAGE_SIZE));
 
 impl Drop for SidecarVp<'_> {
     fn drop(&mut self) {

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -404,7 +404,8 @@ impl GuestMemoryBitmap {
     }
 
     fn init(&mut self, range: MemoryRange, state: bool) -> Result<(), MappingError> {
-        if range.start() % (PAGE_SIZE as u64 * 8) != 0 || range.end() % (PAGE_SIZE as u64 * 8) != 0
+        if !range.start().is_multiple_of(PAGE_SIZE as u64 * 8)
+            || !range.end().is_multiple_of(PAGE_SIZE as u64 * 8)
         {
             return Err(MappingError::BadAlignment(range));
         }

--- a/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
@@ -99,7 +99,7 @@ pub enum Error {
 }
 
 fn from_memory_range(range: &MemoryRange) -> IGVM_VHS_MEMORY_RANGE {
-    assert!(range.len() % HV_PAGE_SIZE == 0);
+    assert!(range.len().is_multiple_of(HV_PAGE_SIZE));
     IGVM_VHS_MEMORY_RANGE {
         starting_gpa_page_number: range.start() / HV_PAGE_SIZE,
         number_of_pages: range.len() / HV_PAGE_SIZE,
@@ -107,7 +107,7 @@ fn from_memory_range(range: &MemoryRange) -> IGVM_VHS_MEMORY_RANGE {
 }
 
 fn memory_map_entry(range: &MemoryRange) -> IGVM_VHS_MEMORY_MAP_ENTRY {
-    assert!(range.len() % HV_PAGE_SIZE == 0);
+    assert!(range.len().is_multiple_of(HV_PAGE_SIZE));
     IGVM_VHS_MEMORY_MAP_ENTRY {
         starting_gpa_page_number: range.start() / HV_PAGE_SIZE,
         number_of_pages: range.len() / HV_PAGE_SIZE,
@@ -879,7 +879,7 @@ fn load_igvm_x86(
                 data_type,
                 ref data,
             } => {
-                debug_assert!(data.len() as u64 % HV_PAGE_SIZE == 0);
+                debug_assert!((data.len() as u64).is_multiple_of(HV_PAGE_SIZE));
 
                 // TODO: only 4k or empty page data supported right now
                 assert!(data.len() as u64 == HV_PAGE_SIZE || data.is_empty());

--- a/support/fdt/src/parser.rs
+++ b/support/fdt/src/parser.rs
@@ -185,7 +185,7 @@ impl<'a> Parser<'a> {
 
     /// Create a new instance of a FDT parser.
     pub fn new(buf: &'a [u8]) -> Result<Self, Error<'a>> {
-        if buf.as_ptr() as usize % size_of::<u32>() != 0 {
+        if !(buf.as_ptr() as usize).is_multiple_of(size_of::<u32>()) {
             return Err(Error(ErrorKind::BufferAlignment));
         }
 
@@ -235,7 +235,7 @@ impl<'a> Parser<'a> {
         let struct_offset = u32::from(header.off_dt_struct) as usize;
         let struct_len = u32::from(header.size_dt_struct) as usize;
 
-        if struct_offset % size_of::<u32>() != 0 {
+        if !struct_offset.is_multiple_of(size_of::<u32>()) {
             return Err(Error(ErrorKind::StructureBlockAlignment));
         }
 

--- a/support/pal/src/unix/affinity.rs
+++ b/support/pal/src/unix/affinity.rs
@@ -64,7 +64,7 @@ impl CpuSet {
     /// This is useful for parsing the output of `/sys/devices/system/cpu/topology`.
     pub fn set_mask_hex_string(&mut self, string_mask: &[u8]) -> Result<(), InvalidHexString> {
         let err = || InvalidHexString(String::from_utf8_lossy(string_mask).into_owned());
-        if string_mask.len() % 2 != 0 {
+        if !string_mask.len().is_multiple_of(2) {
             return Err(err());
         }
         let mask = string_mask

--- a/support/pal/src/unix/process/linux.rs
+++ b/support/pal/src/unix/process/linux.rs
@@ -90,7 +90,7 @@ impl Builder<'_> {
         // Common page sizes are 4KiB, 16KiB, and 64KiB. The stack size must be a multiple
         // of the page size.
         let stack_len: usize = std::cmp::max(16 * 1024, page_size);
-        assert!(stack_len % page_size == 0);
+        assert!(stack_len.is_multiple_of(page_size));
 
         // Create a stack with one guard page.
         let stack_len = stack_len + page_size;

--- a/support/sparse_mmap/fuzz/fuzz_sparse_mmap.rs
+++ b/support/sparse_mmap/fuzz/fuzz_sparse_mmap.rs
@@ -153,7 +153,7 @@ fn generate_blocks(
                 blocks.push(block);
             }
 
-            if max_pages % num_blocks != 0 {
+            if !max_pages.is_multiple_of(num_blocks) {
                 let offset = num_blocks * safe_mul!(pages_per_block, page_size);
                 let len = (max_pages % num_blocks) * page_size;
                 let block = Block::new(offset, len)?;

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -184,7 +184,7 @@ impl SparseMapping {
     fn validate_offset_len(&self, offset: usize, len: usize) -> io::Result<usize> {
         let end = offset.checked_add(len).ok_or(io::ErrorKind::InvalidInput)?;
         let page_size = page_size();
-        if offset % page_size != 0 || end % page_size != 0 || end > self.len {
+        if !offset.is_multiple_of(page_size) || !end.is_multiple_of(page_size) || end > self.len {
             return Err(io::ErrorKind::InvalidInput.into());
         }
         Ok(end)

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -379,7 +379,7 @@ impl SparseMapping {
 
     fn validate_offset_len(&self, offset: usize, len: usize) -> io::Result<usize> {
         let end = offset.checked_add(len).ok_or(io::ErrorKind::InvalidInput)?;
-        if offset % PAGE_SIZE != 0 || end % PAGE_SIZE != 0 || end > self.len {
+        if !offset.is_multiple_of(PAGE_SIZE) || !end.is_multiple_of(PAGE_SIZE) || end > self.len {
             return Err(io::ErrorKind::InvalidInput.into());
         }
         Ok(end)

--- a/support/ucs2/src/lib.rs
+++ b/support/ucs2/src/lib.rs
@@ -153,7 +153,7 @@ impl Ucs2LeSlice {
     /// Validate that the provided `&[u8]` is a valid null-terminated UCS-2 LE
     /// string, truncating the slice to the position of the first null u16.
     pub fn from_slice_with_nul(buf: &[u8]) -> Result<&Ucs2LeSlice, Ucs2ParseError> {
-        if buf.len() % 2 != 0 {
+        if !buf.len().is_multiple_of(2) {
             return Err(Ucs2ParseError::NotMultiple2);
         }
 

--- a/vm/acpi/src/builder.rs
+++ b/vm/acpi/src/builder.rs
@@ -111,7 +111,7 @@ impl Builder {
     pub fn append(&mut self, table: &Table<'_>) -> u64 {
         let addr = self.base_addr + self.v.len() as u64;
         let len = table.append_to_vec(&self.oem, &mut self.v);
-        if len % 8 != 0 {
+        if !len.is_multiple_of(8) {
             self.v.extend_from_slice(&[0; 8][..8 - len % 8]);
         }
         if table.signature != *b"XSDT" && table.signature != *b"DSDT" {
@@ -127,7 +127,7 @@ impl Builder {
             self.tables.push(self.base_addr + offset);
         }
         self.v.extend_from_slice(data);
-        if data.len() % 8 != 0 {
+        if !data.len().is_multiple_of(8) {
             self.v.extend_from_slice(&[0; 8][..8 - data.len() % 8]);
         }
         self.base_addr + offset

--- a/vm/devices/chipset/src/dma.rs
+++ b/vm/devices/chipset/src/dma.rs
@@ -283,7 +283,7 @@ impl Controller {
     fn read(&mut self, reg: u16) -> Result<u8, IoError> {
         let res = if reg < 8 {
             let channel = reg as usize / 2;
-            let data = if reg % 2 == 0 {
+            let data = if reg.is_multiple_of(2) {
                 // Address port.
                 if !self.flip_flop_high {
                     self.latched_address = self.channels[channel].address;
@@ -328,7 +328,7 @@ impl Controller {
     fn write(&mut self, reg: u16, data: u8) -> IoResult {
         if reg < 8 {
             let channel = reg as usize / 2;
-            let mem = if reg % 2 == 0 {
+            let mem = if reg.is_multiple_of(2) {
                 // Address port.
                 &mut self.channels[channel].address
             } else {

--- a/vm/devices/firmware/uefi_nvram_specvars/src/signature_list.rs
+++ b/vm/devices/firmware/uefi_nvram_specvars/src/signature_list.rs
@@ -347,7 +347,7 @@ impl<'a> ParseSignatureSha256<'a> {
 
         // sha256 has consistent signature sizes, so we can perform some early
         // validation as an optimization
-        if buf.len() % expected_signature_size != 0 {
+        if !buf.len().is_multiple_of(expected_signature_size) {
             return Err(ParseError::Sha256TruncatedData);
         }
 

--- a/vm/devices/hyperv_ic/src/kvp.rs
+++ b/vm/devices/hyperv_ic/src/kvp.rs
@@ -699,7 +699,7 @@ fn msg2<T: IntoBytes + Immutable>(
 }
 
 fn parse_str(v: &[u16], n: u32) -> anyhow::Result<String> {
-    if n % 2 != 0 {
+    if !n.is_multiple_of(2) {
         anyhow::bail!("invalid string length");
     }
     let v = v.get(..n as usize / 2).context("string length too large")?;

--- a/vm/devices/net/gdma/src/dma.rs
+++ b/vm/devices/net/gdma/src/dma.rs
@@ -52,7 +52,7 @@ impl DmaRegion {
 
     pub fn is_aligned_to(&self, align: usize) -> bool {
         assert!(align <= PAGE_SIZE64 as usize);
-        (self.start | self.len) % align == 0
+        (self.start | self.len).is_multiple_of(align)
     }
 
     pub fn range(&self) -> PagedRange<'_> {

--- a/vm/devices/net/gdma/src/queues.rs
+++ b/vm/devices/net/gdma/src/queues.rs
@@ -254,7 +254,10 @@ impl Wq {
         let old_len = self.available();
         assert!(old_len <= self.cap);
         let new_len = val.wrapping_sub(self.head);
-        if self.head % WQE_ALIGNMENT as u32 == 0 && new_len > old_len && new_len <= self.cap {
+        if self.head.is_multiple_of(WQE_ALIGNMENT as u32)
+            && new_len > old_len
+            && new_len <= self.cap
+        {
             self.tail = val;
             self.waker.take()
         } else {

--- a/vm/devices/net/mana_driver/src/queues.rs
+++ b/vm/devices/net/mana_driver/src/queues.rs
@@ -291,7 +291,7 @@ impl Wq {
 
     /// Advances the head, indicating that `n` more bytes are available in the ring.
     pub fn advance_head(&mut self, n: u32) {
-        assert!(n % WQE_ALIGNMENT as u32 == 0);
+        assert!(n.is_multiple_of(WQE_ALIGNMENT as u32));
         self.head = self.head.wrapping_add(n);
     }
 

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -1631,7 +1631,7 @@ mod tests {
 
             let mut segments = Vec::new();
             let segment_len = packet_len / num_segments;
-            assert!(packet_len % num_segments == 0);
+            assert!(packet_len.is_multiple_of(num_segments));
             assert!(sent_data.len() == packet_len);
             segments.push(TxSegment {
                 ty: net_backend::TxSegmentType::Head(net_backend::TxMetadata {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4344,12 +4344,7 @@ impl Coordinator {
                 );
 
                 initial_rx = (RX_RESERVED_CONTROL_BUFFERS..state.buffers.recv_buffer.count)
-                    .filter(|&n| {
-                        states
-                            .clone()
-                            .flatten()
-                            .all(|s| (s.state.rx_bufs.is_free(n)))
-                    })
+                    .filter(|&n| states.clone().flatten().all(|s| s.state.rx_bufs.is_free(n)))
                     .map(RxId)
                     .collect::<Vec<_>>();
 

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -531,7 +531,7 @@ impl ConfigSpaceType0Emulator {
                 self.state.interrupt_line = ((val & 0xff00) >> 8) as u8;
             }
             // all other base regs are noops
-            _ if offset < 0x40 && offset % 4 == 0 => (),
+            _ if offset < 0x40 && offset.is_multiple_of(4) => (),
             // rest of the range is reserved for extended device capabilities
             _ if (0x40..0x100).contains(&offset) => {
                 if let Some((cap_index, cap_offset)) =

--- a/vm/devices/storage/disk_backend/src/sync_wrapper.rs
+++ b/vm/devices/storage/disk_backend/src/sync_wrapper.rs
@@ -91,7 +91,7 @@ impl BlockingDisk {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // If the buffer size is a multiple of sector size and the buffer is not dirty
         // use the read_full_sector method
-        if buf.len() % self.inner.sector_size() as usize == 0 && !self.buffer_dirty {
+        if buf.len().is_multiple_of(self.inner.sector_size() as usize) && !self.buffer_dirty {
             return self.read_full_sector(buf);
         }
         // Buffer size is not multiple of sector size
@@ -122,7 +122,7 @@ impl BlockingDisk {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         // If the buffer size is a multiple of sector size and the buffer is not dirty
         // use the write_full_sector method
-        if buf.len() % self.inner.sector_size() as usize == 0 && !self.buffer_dirty {
+        if buf.len().is_multiple_of(self.inner.sector_size() as usize) && !self.buffer_dirty {
             return self.write_full_sector(buf);
         }
         // Buffer size is not multiple of sector size

--- a/vm/devices/storage/disk_get_vmgs/src/lib.rs
+++ b/vm/devices/storage/disk_get_vmgs/src/lib.rs
@@ -123,7 +123,7 @@ impl GetVmgsDisk {
             Err(NewGetVmgsDiskError::InvalidPhysicalSectorSize)
         } else if sector_count.checked_mul(sector_size as u64).is_none() {
             Err(NewGetVmgsDiskError::InvalidSectorCount)
-        } else if sector_count % (physical_sector_size / sector_size) as u64 != 0 {
+        } else if !sector_count.is_multiple_of((physical_sector_size / sector_size) as u64) {
             Err(NewGetVmgsDiskError::IncompletePhysicalSector)
         } else if max_transfer_size < physical_sector_size {
             Err(NewGetVmgsDiskError::InvalidMaxTransferSize)

--- a/vm/devices/storage/disk_striped/src/lib.rs
+++ b/vm/devices/storage/disk_striped/src/lib.rs
@@ -251,7 +251,7 @@ impl StripedDisk {
         let sector_count = devices[0].sector_count();
         let read_only = devices[0].is_read_only();
         let chunk_size_in_bytes = chunk_size_in_bytes.unwrap_or(CHUNK_SIZE_128K);
-        if chunk_size_in_bytes % sector_size != 0 {
+        if !chunk_size_in_bytes.is_multiple_of(sector_size) {
             return Err(NewDeviceError::InvalidChunkSize(
                 chunk_size_in_bytes,
                 sector_size,
@@ -296,7 +296,7 @@ impl StripedDisk {
             ));
         }
 
-        if logic_sector_count % (devices.len() as u64 * sector_count_per_chunk) != 0 {
+        if !logic_sector_count.is_multiple_of(devices.len() as u64 * sector_count_per_chunk) {
             return Err(NewDeviceError::InvalidStripingDiskSize(
                 logic_sector_count,
                 devices.len() as u64 * sector_count_per_chunk,

--- a/vm/devices/storage/disklayer_ram/src/lib.rs
+++ b/vm/devices/storage/disklayer_ram/src/lib.rs
@@ -113,7 +113,7 @@ impl RamDiskLayer {
             if size == 0 {
                 return Err(Error::EmptyDisk);
             }
-            if size % SECTOR_SIZE as u64 != 0 {
+            if !size.is_multiple_of(SECTOR_SIZE as u64) {
                 return Err(Error::NotSectorMultiple {
                     disk_size: size,
                     sector_size: SECTOR_SIZE,

--- a/vm/devices/storage/nvme/src/workers.rs
+++ b/vm/devices/storage/nvme/src/workers.rs
@@ -24,6 +24,6 @@ const MAX_DATA_TRANSFER_SIZE: usize = 256 * 1024;
 
 const _: () = assert!(
     MAX_DATA_TRANSFER_SIZE.is_power_of_two()
-        && MAX_DATA_TRANSFER_SIZE % PAGE_SIZE == 0
+        && MAX_DATA_TRANSFER_SIZE.is_multiple_of(PAGE_SIZE)
         && MAX_DATA_TRANSFER_SIZE / PAGE_SIZE > 1
 );

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -128,7 +128,7 @@ impl AdminQueueFaultConfig {
         if self
             .admin_submission_queue_faults
             .iter()
-            .any(|(c, _)| (pattern == *c))
+            .any(|(c, _)| pattern == *c)
         {
             panic!(
                 "Duplicate submission queue fault for Compare {:?} and Mask {:?}",
@@ -153,7 +153,7 @@ impl AdminQueueFaultConfig {
         if self
             .admin_completion_queue_faults
             .iter()
-            .any(|(c, _)| (pattern == *c))
+            .any(|(c, _)| pattern == *c)
         {
             panic!(
                 "Duplicate completion queue fault for Compare {:?} and Mask {:?}",

--- a/vm/devices/storage/nvme_test/src/workers.rs
+++ b/vm/devices/storage/nvme_test/src/workers.rs
@@ -25,6 +25,6 @@ const MAX_DATA_TRANSFER_SIZE: usize = 256 * 1024;
 
 const _: () = assert!(
     MAX_DATA_TRANSFER_SIZE.is_power_of_two()
-        && MAX_DATA_TRANSFER_SIZE % PAGE_SIZE == 0
+        && MAX_DATA_TRANSFER_SIZE.is_multiple_of(PAGE_SIZE)
         && MAX_DATA_TRANSFER_SIZE / PAGE_SIZE > 1
 );

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -90,7 +90,7 @@ impl Drop for Mapping {
 
 impl LockedMemory {
     pub fn new(len: usize) -> anyhow::Result<Self> {
-        if len % PAGE_SIZE != 0 {
+        if !len.is_multiple_of(PAGE_SIZE) {
             anyhow::bail!("not a page-size multiple");
         }
         let mapping = Mapping::new(len).context("failed to create mapping")?;

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -402,7 +402,9 @@ impl DeviceRegisterIo for vfio_sys::MappedRegion {
 
 impl MappedRegionWithFallback {
     fn mapping<T>(&self, offset: usize) -> *mut T {
-        assert!(offset <= self.mapping.len() - size_of::<T>() && offset % align_of::<T>() == 0);
+        assert!(
+            offset <= self.mapping.len() - size_of::<T>() && offset.is_multiple_of(align_of::<T>())
+        );
         if cfg!(feature = "mmio_simulate_fallback") {
             return std::ptr::NonNull::dangling().as_ptr();
         }

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -64,8 +64,8 @@ impl LegacyVirtioDevice for VirtioPlan9Device {
     }
 
     fn read_registers_u32(&self, offset: u16) -> u32 {
-        assert!(self.tag.len() % 4 == 0);
-        assert!(offset % 4 == 0);
+        assert!(self.tag.len().is_multiple_of(4));
+        assert!(offset.is_multiple_of(4));
 
         let offset = offset as usize;
         if offset < self.tag.len() {

--- a/vm/devices/virtio/virtiofs/src/section.rs
+++ b/vm/devices/virtio/virtiofs/src/section.rs
@@ -384,7 +384,7 @@ impl fuse::Fuse for SectionFs {
 
         let mut inodes = self.inodes.lock();
         let inode = inodes.get_mut(request.node_id()).ok_or(lx::Error::EINVAL)?;
-        if arg.offset != 0 || arg.length % PAGE_SIZE != 0 {
+        if arg.offset != 0 || !arg.length.is_multiple_of(PAGE_SIZE) {
             return Err(lx::Error::EINVAL);
         }
         let size = arg.length;

--- a/vm/devices/vmbus/vmbfs/src/protocol.rs
+++ b/vm/devices/vmbus/vmbfs/src/protocol.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(dead_code)]
+
 use bitfield_struct::bitfield;
 use guid::Guid;
 use open_enum::open_enum;

--- a/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
@@ -40,7 +40,7 @@ impl AlignedGpadlView {
             return Err(gpadl);
         }
         let range = gpadl.first().unwrap();
-        if range.len() % ring::PAGE_SIZE != 0 || range.offset() != 0 {
+        if !range.len().is_multiple_of(ring::PAGE_SIZE) || range.offset() != 0 {
             return Err(gpadl);
         }
         let count = range.gpns().len() as u32;

--- a/vm/devices/vmbus/vmbus_ring/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_ring/src/lib.rs
@@ -443,8 +443,8 @@ pub trait RingMem: Send {
     ///
     /// `read_at` may be faster for large or variable-sized reads.
     fn read_aligned(&self, addr: usize, data: &mut [u8]) {
-        debug_assert!(addr % 8 == 0);
-        debug_assert!(data.len() % 8 == 0);
+        debug_assert!(addr.is_multiple_of(8));
+        debug_assert!(data.len().is_multiple_of(8));
         self.read_at(addr, data)
     }
 
@@ -457,8 +457,8 @@ pub trait RingMem: Send {
     ///
     /// `write_at` may be faster for large or variable-sized writes.
     fn write_aligned(&self, addr: usize, data: &[u8]) {
-        debug_assert!(addr % 8 == 0);
-        debug_assert!(data.len() % 8 == 0);
+        debug_assert!(addr.is_multiple_of(8));
+        debug_assert!(data.len().is_multiple_of(8));
         self.write_at(addr, data)
     }
 
@@ -671,8 +671,8 @@ impl<T: PagedMemory> RingMem for PagedRingMem<T> {
 
     #[inline]
     fn read_aligned(&self, addr: usize, data: &mut [u8]) {
-        debug_assert!(addr % 8 == 0);
-        debug_assert!(data.len() % 8 == 0);
+        debug_assert!(addr.is_multiple_of(8));
+        debug_assert!(data.len().is_multiple_of(8));
         for (i, b) in data.chunks_exact_mut(8).enumerate() {
             let addr = (addr & !7) + i * 8;
             let page = addr / PAGE_SIZE;
@@ -689,8 +689,8 @@ impl<T: PagedMemory> RingMem for PagedRingMem<T> {
 
     #[inline]
     fn write_aligned(&self, addr: usize, data: &[u8]) {
-        debug_assert!(addr % 8 == 0);
-        debug_assert!(data.len() % 8 == 0);
+        debug_assert!(addr.is_multiple_of(8));
+        debug_assert!(data.len().is_multiple_of(8));
         for (i, b) in data.chunks_exact(8).enumerate() {
             let addr = (addr & !7) + i * 8;
             let page = addr / PAGE_SIZE;
@@ -1274,7 +1274,7 @@ impl<M: RingMem> InnerRing<M> {
     }
 
     fn validate(&self, p: u32) -> Result<u32, Error> {
-        if p >= self.size || p % 8 != 0 {
+        if p >= self.size || !p.is_multiple_of(8) {
             Err(Error::InvalidRingPointer)
         } else {
             Ok(p)

--- a/vm/devices/vmbus/vmbus_server/src/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/tests.rs
@@ -167,7 +167,7 @@ impl SynicPortAccess for MockSynic {
         _vtl: Vtl,
         _vp: u32,
         _sint: u8,
-    ) -> Result<Box<(dyn GuestMessagePort)>, vmcore::synic::HypervisorError> {
+    ) -> Result<Box<dyn GuestMessagePort>, vmcore::synic::HypervisorError> {
         Ok(Box::new(MockGuestMessagePort {
             send: self.message_send.clone(),
             spawner: self.spawner.clone(),
@@ -183,7 +183,7 @@ impl SynicPortAccess for MockSynic {
         _sint: u8,
         _flag: u16,
         _monitor_info: Option<MonitorInfo>,
-    ) -> Result<Box<(dyn GuestEventPort)>, vmcore::synic::HypervisorError> {
+    ) -> Result<Box<dyn GuestEventPort>, vmcore::synic::HypervisorError> {
         Ok(Box::new(MockGuestPort {}))
     }
 

--- a/vm/hv1/hv1_hypercall/src/support.rs
+++ b/vm/hv1/hv1_hypercall/src/support.rs
@@ -293,7 +293,7 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
                 }
 
                 // The buffer must be 8 byte aligned.
-                if len != 0 && gpa % 8 != 0 {
+                if len != 0 && !gpa.is_multiple_of(8) {
                     return Err(HvError::from(HypercallParseError::Unaligned));
                 }
 

--- a/vm/hv1/hv1_hypercall/src/tests.rs
+++ b/vm/hv1/hv1_hypercall/src/tests.rs
@@ -916,7 +916,7 @@ impl TestController {
     where
         InputHeaderT: IntoBytes + FromBytes + Sized + Copy + Immutable + KnownLayout,
     {
-        assert!(size_of::<InputHeaderT>() % 8 == 0);
+        assert!(size_of::<InputHeaderT>().is_multiple_of(8));
         *InputHeaderT::ref_from_bytes(vec![FILL_PATTERN; size_of::<TestInput>() / 8].as_bytes())
             .unwrap()
     }
@@ -946,7 +946,7 @@ impl TestController {
     where
         OutputT: IntoBytes + FromBytes + FromZeros + Sized + Copy + Immutable + KnownLayout,
     {
-        assert!(size_of::<TestOutput>() % 16 == 0);
+        assert!(size_of::<TestOutput>().is_multiple_of(16));
         *OutputT::ref_from_bytes(vec![!FILL_PATTERN; size_of::<TestOutput>() / 8].as_bytes())
             .unwrap()
     }
@@ -1223,9 +1223,9 @@ where
     OutputT: IntoBytes + FromBytes + Sized + Immutable + KnownLayout,
     OutRepT: IntoBytes + FromBytes + Sized + Immutable + KnownLayout,
 {
-    assert!(size_of::<InputT>() % 8 == 0);
-    assert!(size_of::<OutputT>() % 8 == 0);
-    assert!(var_header.len() % 8 == 0);
+    assert!(size_of::<InputT>().is_multiple_of(8));
+    assert!(size_of::<OutputT>().is_multiple_of(8));
+    assert!(var_header.len().is_multiple_of(8));
     assert!(params.in_offset < PAGE_SIZE);
     assert!(params.out_offset < PAGE_SIZE);
     assert!(size_of::<OutputT>() == 0 || output_reps.is_empty());
@@ -1672,14 +1672,16 @@ fn hypercall_rep(test_params: TestParams) {
     );
 
     let elements_processed = test_params.test_result.expected_elements_processed();
-    let elements_processed =
-        if test_params.fast && elements_processed % 2 != 0 && elements_processed < rep_count {
-            // Since only 16 byte writes are supported, the top 8 bytes are 0s.
-            assert_eq!(output_reps[elements_processed], 0);
-            elements_processed + 1
-        } else {
-            elements_processed
-        };
+    let elements_processed = if test_params.fast
+        && !elements_processed.is_multiple_of(2)
+        && elements_processed < rep_count
+    {
+        // Since only 16 byte writes are supported, the top 8 bytes are 0s.
+        assert_eq!(output_reps[elements_processed], 0);
+        elements_processed + 1
+    } else {
+        elements_processed
+    };
 
     assert_eq!(
         output_reps[elements_processed..].as_bytes(),
@@ -1692,11 +1694,13 @@ fn hypercall_rep(test_params: TestParams) {
             .as_bytes()
             .len();
 
-        if (rep_start * size_of::<u64>()) % 16 != 0 {
+        if !(rep_start * size_of::<u64>()).is_multiple_of(16) {
             expected_output_size += (rep_start * size_of::<u64>()) % 16;
         }
 
-        if (test_params.test_result.expected_elements_processed() * size_of::<u64>()) % 16 != 0 {
+        if !(test_params.test_result.expected_elements_processed() * size_of::<u64>())
+            .is_multiple_of(16)
+        {
             expected_output_size += 16
                 - ((test_params.test_result.expected_elements_processed() * size_of::<u64>()) % 16);
         }
@@ -1862,14 +1866,16 @@ fn hypercall_variable_rep(test_params: TestParams) {
     );
 
     let elements_processed = test_params.test_result.expected_elements_processed();
-    let elements_processed =
-        if test_params.fast && elements_processed % 2 != 0 && elements_processed < rep_count {
-            // Since only 16 byte writes are supported, the top 8 bytes are 0s.
-            assert_eq!(output_reps[elements_processed], 0);
-            elements_processed + 1
-        } else {
-            elements_processed
-        };
+    let elements_processed = if test_params.fast
+        && !elements_processed.is_multiple_of(2)
+        && elements_processed < rep_count
+    {
+        // Since only 16 byte writes are supported, the top 8 bytes are 0s.
+        assert_eq!(output_reps[elements_processed], 0);
+        elements_processed + 1
+    } else {
+        elements_processed
+    };
 
     assert_eq!(
         output_reps[elements_processed..].as_bytes(),
@@ -1881,11 +1887,13 @@ fn hypercall_variable_rep(test_params: TestParams) {
         .as_bytes()
         .len();
 
-    if (rep_start * size_of::<u64>()) % 16 != 0 {
+    if !(rep_start * size_of::<u64>()).is_multiple_of(16) {
         expected_output_size += (rep_start * size_of::<u64>()) % 16;
     }
 
-    if (test_params.test_result.expected_elements_processed() * size_of::<u64>()) % 16 != 0 {
+    if !(test_params.test_result.expected_elements_processed() * size_of::<u64>())
+        .is_multiple_of(16)
+    {
         expected_output_size +=
             16 - ((test_params.test_result.expected_elements_processed() * size_of::<u64>()) % 16);
     }
@@ -2264,7 +2272,7 @@ fn max_test_fast_rep_count(abi: &TestHypercallAbi) -> usize {
     // of that is for the input reps (8 bytes each in our tests) and half is for the output
     // reps. However output must be on a 16 byte alignment.
     let mut max_rep_count = (abi.max_fast_output_size() - size_of::<TestInput>()) / (8 + 8);
-    if max_rep_count % 2 != 0 {
+    if !max_rep_count.is_multiple_of(2) {
         max_rep_count -= 1;
     }
 

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -1109,29 +1109,29 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
             );
         }
 
-        if size_bytes % PAGE_SIZE_4K != 0 {
+        if !size_bytes.is_multiple_of(PAGE_SIZE_4K) {
             anyhow::bail!("relocation size {size_bytes:#x} must be a multiple of 4K");
         }
 
-        if relocation_alignment % PAGE_SIZE_4K != 0 {
+        if !relocation_alignment.is_multiple_of(PAGE_SIZE_4K) {
             anyhow::bail!(
                 "relocation alignment {relocation_alignment:#x} must be a multiple of 4K"
             );
         }
 
-        if gpa % relocation_alignment != 0 {
+        if !gpa.is_multiple_of(relocation_alignment) {
             anyhow::bail!(
                 "relocation base {gpa:#x} must be aligned to relocation alignment {relocation_alignment:#x}"
             );
         }
 
-        if minimum_relocation_gpa % relocation_alignment != 0 {
+        if !minimum_relocation_gpa.is_multiple_of(relocation_alignment) {
             anyhow::bail!(
                 "relocation minimum GPA {minimum_relocation_gpa:#x} must be aligned to relocation alignment {relocation_alignment:#x}"
             );
         }
 
-        if maximum_relocation_gpa % relocation_alignment != 0 {
+        if !maximum_relocation_gpa.is_multiple_of(relocation_alignment) {
             anyhow::bail!(
                 "relocation maximum GPA {maximum_relocation_gpa:#x} must be aligned to relocation alignment {relocation_alignment:#x}"
             );

--- a/vm/loader/page_table/src/x64.rs
+++ b/vm/loader/page_table/src/x64.rs
@@ -347,12 +347,12 @@ impl PageTableBuilder {
             panic!("more than 512 gb size not supported");
         }
 
-        if self.size % X64_LARGE_PAGE_SIZE != 0 {
+        if !self.size.is_multiple_of(X64_LARGE_PAGE_SIZE) {
             panic!("size not 2mb aligned");
         }
 
         // start_gpa and size must be 2MB aligned.
-        if self.start_gpa % X64_LARGE_PAGE_SIZE != 0 {
+        if !self.start_gpa.is_multiple_of(X64_LARGE_PAGE_SIZE) {
             panic!("start_gpa not 2mb aligned");
         }
 

--- a/vm/loader/src/linux.rs
+++ b/vm/loader/src/linux.rs
@@ -202,7 +202,7 @@ pub struct LoadInfo {
 
 /// Check if an address is aligned to a page.
 fn check_address_alignment(address: u64) -> Result<(), Error> {
-    if address % HV_PAGE_SIZE != 0 {
+    if !address.is_multiple_of(HV_PAGE_SIZE) {
         Err(Error::UnalignedAddress(address))
     } else {
         Ok(())
@@ -337,7 +337,7 @@ pub fn load_config(
         IdentityMapSize::Size4Gb,
         None,
     );
-    assert!(page_table.len() as u64 % HV_PAGE_SIZE == 0);
+    assert!((page_table.len() as u64).is_multiple_of(HV_PAGE_SIZE));
     importer
         .import_pages(
             registers.page_table_address / HV_PAGE_SIZE,

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -147,11 +147,11 @@ where
     // --- Low memory, 2MB aligned ---
 
     // Paravisor memory ranges must be 2MB (large page) aligned.
-    if memory_start_address % X64_LARGE_PAGE_SIZE != 0 {
+    if !memory_start_address.is_multiple_of(X64_LARGE_PAGE_SIZE) {
         return Err(Error::MemoryUnaligned(memory_start_address));
     }
 
-    if memory_size % X64_LARGE_PAGE_SIZE != 0 {
+    if !memory_size.is_multiple_of(X64_LARGE_PAGE_SIZE) {
         return Err(Error::MemoryUnaligned(memory_size));
     }
 
@@ -423,7 +423,7 @@ where
 
     let page_table = page_table_builder.build();
 
-    assert!(page_table.len() as u64 % HV_PAGE_SIZE == 0);
+    assert!((page_table.len() as u64).is_multiple_of(HV_PAGE_SIZE));
     let page_table_page_base = page_table_region_start / HV_PAGE_SIZE;
     assert!(page_table.len() as u64 <= page_table_region_size);
 
@@ -898,11 +898,11 @@ where
     let memory_size = memory_page_count * HV_PAGE_SIZE;
 
     // Paravisor memory ranges must be 2MB (large page) aligned.
-    if memory_start_address % u64::from(Arm64PageSize::Large) != 0 {
+    if !memory_start_address.is_multiple_of(u64::from(Arm64PageSize::Large)) {
         return Err(Error::MemoryUnaligned(memory_start_address));
     }
 
-    if memory_size % u64::from(Arm64PageSize::Large) != 0 {
+    if !memory_size.is_multiple_of(u64::from(Arm64PageSize::Large)) {
         return Err(Error::MemoryUnaligned(memory_size));
     }
 
@@ -1153,7 +1153,7 @@ where
         memory_attribute_indirection,
         page_table_region_size as usize,
     );
-    assert!(page_tables.len() as u64 % HV_PAGE_SIZE == 0);
+    assert!((page_tables.len() as u64).is_multiple_of(HV_PAGE_SIZE));
     let page_table_page_base = page_table_region_start / HV_PAGE_SIZE;
     assert!(page_tables.len() as u64 <= page_table_region_size);
     assert!(page_table_region_size as usize > page_tables.len());

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -858,7 +858,7 @@ impl Drop for PagePoolAllocator {
 
 impl user_driver::DmaClient for PagePoolAllocator {
     fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<user_driver::memory::MemoryBlock> {
-        if len as u64 % PAGE_SIZE != 0 {
+        if !(len as u64).is_multiple_of(PAGE_SIZE) {
             anyhow::bail!("not a page-size multiple");
         }
 

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1406,7 +1406,7 @@ impl GuestMemory {
         op: GuestMemoryOperation,
         err: GuestMemoryBackingError,
     ) -> GuestMemoryError {
-        let range = gpa_len.map(|(gpa, len)| (gpa..gpa.wrapping_add(len)));
+        let range = gpa_len.map(|(gpa, len)| gpa..gpa.wrapping_add(len));
         GuestMemoryError::new(&self.inner.debug_name, range, op, err)
     }
 
@@ -1948,7 +1948,7 @@ impl GuestMemory {
             let mut byte_index = 0;
             let mut len = range.len();
             let mut page = 0;
-            if offset % PAGE_SIZE != 0 {
+            if !offset.is_multiple_of(PAGE_SIZE) {
                 let head_len = std::cmp::min(len, PAGE_SIZE - (offset % PAGE_SIZE));
                 let addr = gpn_to_gpa(gpns[page]).map_err(GuestMemoryBackingError::gpn)?
                     + offset as u64 % PAGE_SIZE64;

--- a/vm/vmcore/memory_range/src/lib.rs
+++ b/vm/vmcore/memory_range/src/lib.rs
@@ -232,7 +232,7 @@ impl MemoryRange {
     #[track_caller]
     pub fn split_at_offset(&self, offset: u64) -> (Self, Self) {
         assert!(offset <= self.len());
-        assert!(offset % PAGE_SIZE == 0);
+        assert!(offset.is_multiple_of(PAGE_SIZE));
         (
             Self {
                 start: self.start,

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -173,7 +173,7 @@ pub struct VmgsFileTable {
 }
 
 const_assert!(size_of::<VmgsFileTable>() == 4096);
-const_assert!(size_of::<VmgsFileTable>() as u32 % VMGS_BYTES_PER_BLOCK == 0);
+const_assert!((size_of::<VmgsFileTable>() as u32).is_multiple_of(VMGS_BYTES_PER_BLOCK));
 pub const VMGS_FILE_TABLE_BLOCK_SIZE: u32 =
     size_of::<VmgsFileTable>() as u32 / VMGS_BYTES_PER_BLOCK;
 
@@ -184,7 +184,7 @@ pub struct VmgsExtendedFileTable {
 }
 
 const_assert!(size_of::<VmgsExtendedFileTable>() == 4096);
-const_assert!(size_of::<VmgsExtendedFileTable>() as u32 % VMGS_BYTES_PER_BLOCK == 0);
+const_assert!((size_of::<VmgsExtendedFileTable>() as u32).is_multiple_of(VMGS_BYTES_PER_BLOCK));
 pub const VMGS_EXTENDED_FILE_TABLE_BLOCK_SIZE: u32 =
     size_of::<VmgsExtendedFileTable>() as u32 / VMGS_BYTES_PER_BLOCK;
 

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -297,7 +297,9 @@ async fn do_create(
         }
     }
 
-    if file_size != 0 && file_size < (VMGS_BYTES_PER_BLOCK * 4) as u64 || file_size % 512 != 0 {
+    if file_size != 0 && file_size < (VMGS_BYTES_PER_BLOCK * 4) as u64
+        || !file_size.is_multiple_of(512)
+    {
         return Err(VmgsError::InvalidFileSize);
     }
     let file_size = if file_size == 0 {

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -509,7 +509,7 @@ fn vhdfiledisk_create(
     const SECTOR_SIZE: u64 = 512;
 
     let file_size = req_file_size.unwrap_or(VMGS_DEFAULT_CAPACITY);
-    if file_size < MIN_VMGS_FILE_SIZE || file_size % SECTOR_SIZE != 0 {
+    if file_size < MIN_VMGS_FILE_SIZE || !file_size.is_multiple_of(SECTOR_SIZE) {
         return Err(Error::InvalidVmgsFileSize(
             file_size,
             format!(

--- a/vm/x86/tdcall/src/lib.rs
+++ b/vm/x86/tdcall/src/lib.rs
@@ -488,7 +488,7 @@ pub fn accept_pages<T: Tdcall>(
     let mut range = range;
     while !range.is_empty() {
         // Attempt to accept in large page chunks if possible.
-        if range.start() % x86defs::X64_LARGE_PAGE_SIZE == 0
+        if range.start().is_multiple_of(x86defs::X64_LARGE_PAGE_SIZE)
             && range.len() >= x86defs::X64_LARGE_PAGE_SIZE
         {
             match tdcall_accept_pages(call, range.start_4k_gpn(), true) {
@@ -566,7 +566,7 @@ pub fn set_page_attributes(
     let mut range = range;
     while !range.is_empty() {
         // Attempt to set in large page chunks if possible.
-        if range.start() % x86defs::X64_LARGE_PAGE_SIZE == 0
+        if range.start().is_multiple_of(x86defs::X64_LARGE_PAGE_SIZE)
             && range.len() >= x86defs::X64_LARGE_PAGE_SIZE
         {
             let mapping = TdgMemPageAttrWriteRcx::new()

--- a/vm/x86/x86emu/src/emulator.rs
+++ b/vm/x86/x86emu/src/emulator.rs
@@ -405,7 +405,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
     ) -> Result<(), Error<T::Error>> {
         match alignment {
             AlignmentMode::Aligned(a) => {
-                if gva % a != 0 {
+                if !gva.is_multiple_of(a) {
                     Err(Error::InstructionException(
                         Exception::GENERAL_PROTECTION_FAULT,
                         Some(0),
@@ -419,7 +419,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
                     && self.cpu.rflags().alignment_check()
                     && self.cpu.cr0() & x86defs::X64_CR0_AM != 0
                 {
-                    if gva % len as u64 != 0 {
+                    if !gva.is_multiple_of(len as u64) {
                         Err(Error::InstructionException(
                             Exception::ALIGNMENT_CHECK,
                             None,

--- a/vmm_core/src/synic.rs
+++ b/vmm_core/src/synic.rs
@@ -163,7 +163,7 @@ impl SynicPortAccess for SynicPorts {
         vtl: Vtl,
         vp: u32,
         sint: u8,
-    ) -> Result<Box<(dyn GuestMessagePort)>, vmcore::synic::HypervisorError> {
+    ) -> Result<Box<dyn GuestMessagePort>, vmcore::synic::HypervisorError> {
         Ok(Box::new(DirectGuestMessagePort {
             partition: Arc::clone(&self.partition),
             vtl,
@@ -180,7 +180,7 @@ impl SynicPortAccess for SynicPorts {
         sint: u8,
         flag: u16,
         _monitor_info: Option<MonitorInfo>,
-    ) -> Result<Box<(dyn GuestEventPort)>, vmcore::synic::HypervisorError> {
+    ) -> Result<Box<dyn GuestEventPort>, vmcore::synic::HypervisorError> {
         Ok(self.partition.new_guest_event_port(vtl, vp, sint, flag))
     }
 

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -506,7 +506,9 @@ impl KvmProtoPartition<'_> {
         const GIC_ALIGNMENT: u64 = 0x10000;
         let gic_dist_base: u64 = self.config.processor_topology.gic_distributor_base();
         let gic_redist_base: u64 = self.config.processor_topology.gic_redistributors_base();
-        if gic_dist_base % GIC_ALIGNMENT != 0 || gic_redist_base % GIC_ALIGNMENT != 0 {
+        if !gic_dist_base.is_multiple_of(GIC_ALIGNMENT)
+            || !gic_redist_base.is_multiple_of(GIC_ALIGNMENT)
+        {
             return Err(KvmError::Misaligned);
         }
 


### PR DESCRIPTION
The vast majority of these are a new lint that replaces manual modular arithmetic with the is_multiple_of helper, which were all just applied automatically. There were also a few cases of extra unneeded parentheses, and one new allow(dead_code) in a protocol definitions file since not all of it is used today.