### PR TITLE
storvsp: choose the different poll_mode_queue_depth based on instance id of SCSI controllers

### DIFF
--- a/vm/devices/storage/storvsp/fuzz/fuzz_storvsp.rs
+++ b/vm/devices/storage/storvsp/fuzz/fuzz_storvsp.rs
@@ -206,7 +206,7 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> Result<(), anyhow::Error> {
         let guest_queue = Queue::new(guest_channel).unwrap();
 
         let test_guest_mem = GuestMemory::allocate(u.int_in_range(1..=256)? * PAGE_SIZE);
-        let controller = ScsiController::new();
+        let controller = ScsiController::new(None);
         let disk_len_sectors = u.int_in_range(1..=1048576)?; // up to 512mb in 512 byte sectors
         let disk = scsidisk::SimpleScsiDisk::new(
             disklayer_ram::ram_disk(disk_len_sectors * 512, false).unwrap(),

--- a/vm/devices/storage/storvsp/src/resolver.rs
+++ b/vm/devices/storage/storvsp/src/resolver.rs
@@ -61,7 +61,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, ScsiControllerHandle> for Storv
         resource: ScsiControllerHandle,
         input: ResolveVmbusDeviceHandleParams<'_>,
     ) -> Result<Self::Output, Self::Error> {
-        let controller = ScsiController::new();
+        let controller = ScsiController::new(Some(resource.instance_id));
         let device = StorageDevice::build_scsi(
             input.driver_source,
             &controller,


### PR DESCRIPTION
poll_mode_queue_depth impacts storage performance. the default value 1 works well for local disk with good latency. But it causes worse IOPS in single thread low QD benchmark (QD2-QD8) for remote disks with worse IO latency. To resolve this perf issue, we did experiments with different poll_mode_queue_depth values for both local and remote disks. poll_mode_queue_depth=4 improves IOPS for remote disk in single thread and low QD benchmark, but it causes regression for local disk. So, we decided to only set poll_mode_queue_depth=4 for SCSI controller with only remote disks. Azure VMs have the fixed SCSI controller. The one with f8b3781b-1e82-4818-a1c3-63d806ec15bb has data(remote) disks attached.