### PR TITLE
vmgstool: add test helper for creating a vmgs file with two keys

### DIFF
--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -14,6 +14,8 @@ encryption_win = ["vmgs/encryption_win"]
 # Use OpenSSL crypto APIs
 encryption_ossl = ["vmgs/encryption_ossl"]
 
+test_helpers = ["vmgs/test_helpers"]
+
 [dependencies]
 disk_backend.workspace = true
 disk_vhd1.workspace = true

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -4,9 +4,13 @@
 #![expect(missing_docs)]
 
 mod storage_backend;
+#[cfg(feature = "test_helpers")]
+mod test;
 mod uefi_nvram;
 mod vmgs_json;
 
+#[cfg(feature = "test_helpers")]
+use crate::test::TestOperation;
 use anyhow::Result;
 use clap::Args;
 use clap::Parser;
@@ -253,6 +257,12 @@ enum Options {
         #[clap(subcommand)]
         operation: UefiNvramOperation,
     },
+    #[cfg(feature = "test_helpers")]
+    /// Create a test VMGS file
+    Test {
+        #[clap(subcommand)]
+        operation: TestOperation,
+    },
 }
 
 fn parse_file_id(file_id: &str) -> Result<FileId, std::num::ParseIntError> {
@@ -378,6 +388,7 @@ async fn do_main() -> Result<(), Error> {
                 encryption_alg_key,
             )
             .await
+            .map(|_| ())
         }
         Options::Dump {
             file_path,
@@ -446,6 +457,8 @@ async fn do_main() -> Result<(), Error> {
             vmgs_file_query_encryption(file_path.file_path).await
         }
         Options::UefiNvram { operation } => uefi_nvram::do_command(operation).await,
+        #[cfg(feature = "test_helpers")]
+        Options::Test { operation } => test::do_command(operation).await,
     }
 }
 
@@ -485,7 +498,7 @@ async fn vmgs_file_create(
     file_size: Option<u64>,
     force_create: bool,
     encryption_alg_key: Option<(EncryptionAlgorithm, impl AsRef<Path>)>,
-) -> Result<(), Error> {
+) -> Result<Vmgs, Error> {
     let disk = vhdfiledisk_create(path, file_size, force_create)?;
 
     let encryption_key = encryption_alg_key
@@ -495,9 +508,9 @@ async fn vmgs_file_create(
     let encryption_alg_key =
         encryption_alg_key.map(|(alg, _)| (alg, encryption_key.as_deref().unwrap()));
 
-    let _ = vmgs_create(disk, encryption_alg_key).await?;
+    let vmgs = vmgs_create(disk, encryption_alg_key).await?;
 
-    Ok(())
+    Ok(vmgs)
 }
 
 fn vhdfiledisk_create(

--- a/vm/vmgs/vmgstool/src/test.rs
+++ b/vm/vmgs/vmgstool/src/test.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Functions for generating test VMGS files
+
+use crate::Error;
+use crate::FilePathArg;
+use crate::read_key_path;
+use crate::vmgs_file_create;
+use clap::Subcommand;
+use std::path::Path;
+use std::path::PathBuf;
+use vmgs::EncryptionAlgorithm;
+use vmgs_format::VMGS_ENCRYPTION_KEY_SIZE;
+
+#[derive(Subcommand)]
+pub(crate) enum TestOperation {
+    /// Create a VMGS file that has two encryption keys
+    ///
+    /// This is useful for testing recovery the recovery path in the
+    /// `update-key` command in this scenario. Also writes an extra key for
+    /// convenience when testing that command (extrakey.bin).
+    TwoKeys {
+        #[command(flatten)]
+        file_path: FilePathArg,
+        /// First encryption key file path.
+        ///
+        /// If not specified, use 0x01 repeated and write to firstkey.bin
+        /// If specified, but does not exist, write above key to path.
+        #[clap(long)]
+        first_key_path: Option<PathBuf>,
+        /// Second encryption key file path.
+        ///
+        /// If not specified, use 0x02 repeated and write to secondkey.bin
+        /// If specified, but does not exist, write above key to path.
+        #[clap(long)]
+        second_key_path: Option<PathBuf>,
+    },
+}
+
+pub(crate) async fn do_command(operation: TestOperation) -> Result<(), Error> {
+    match operation {
+        TestOperation::TwoKeys {
+            file_path,
+            first_key_path,
+            second_key_path,
+        } => vmgs_file_two_keys(file_path.file_path, first_key_path, second_key_path).await,
+    }
+}
+
+async fn vmgs_file_two_keys(
+    file_path: impl AsRef<Path>,
+    first_key_path_opt: Option<impl AsRef<Path>>,
+    second_key_path_opt: Option<impl AsRef<Path>>,
+) -> Result<(), Error> {
+    const DEFAULT_FIRST_KEY_PATH: &str = "firstkey.bin";
+    const DEFAULT_SECOND_KEY_PATH: &str = "secondkey.bin";
+    const EXTRA_KEY_PATH: &str = "extrakey.bin";
+
+    let first_key_path = first_key_path_opt
+        .as_ref()
+        .map_or_else(|| Path::new(DEFAULT_FIRST_KEY_PATH), |p| p.as_ref());
+    if !first_key_path.exists() {
+        fs_err::write(first_key_path, [1; VMGS_ENCRYPTION_KEY_SIZE]).map_err(Error::KeyFile)?;
+    }
+    let second_key_path = second_key_path_opt
+        .as_ref()
+        .map_or_else(|| Path::new(DEFAULT_SECOND_KEY_PATH), |p| p.as_ref());
+    if !second_key_path.exists() {
+        fs_err::write(second_key_path, [2; VMGS_ENCRYPTION_KEY_SIZE]).map_err(Error::KeyFile)?;
+    }
+    // write a third key for convenience
+    fs_err::write(EXTRA_KEY_PATH, [3; VMGS_ENCRYPTION_KEY_SIZE]).map_err(Error::KeyFile)?;
+
+    let mut vmgs = vmgs_file_create(
+        file_path,
+        None,
+        false,
+        Some((EncryptionAlgorithm::AES_GCM, first_key_path)),
+    )
+    .await?;
+
+    let second_key = read_key_path(second_key_path)?;
+    eprintln!("Adding encryption key without removing old key");
+    vmgs.test_add_new_encryption_key(&second_key, EncryptionAlgorithm::AES_GCM)
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Add test helper to VmgsTool that creates a VMGS file with two keys. This can happen if update-key successfully writes a new key but is interrupted before removing the old one. This allows for the recovery path in update-key (added in https://github.com/microsoft/openvmm/commit/1fd1b42ae46c61761bb543aab7f861ab92416a6d) to be tested synthetically.