### PR TITLE
guide: release: fixup 2505 + other minor updates

### DIFF
--- a/Guide/src/dev_guide/contrib/release.md
+++ b/Guide/src/dev_guide/contrib/release.md
@@ -40,9 +40,6 @@ We track the state of candidates for a given release by tagging the PRs with the
     the release.
 * `backported_YYMM`: This PR (to `main`) has been cherry-picked to the `YYMM`
   release.
-* `backport_YYMM_approved`: This PR (to `main`) has been reviewed by the OpenVMM
-  maintainers, who believe this meets the bar. This is a temporary tag until the
-  PR is cherry-picked (e.g. a TODO).
 
 #### Seeking Approval for Backport
 


### PR DESCRIPTION
Change the release stage of 2505 to Servicing and make minor updates and lint improvements to the release documentation.