### PR TITLE
vmbus_server: allow proxy driver to specify a device order

### DIFF
--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -277,7 +277,7 @@ pub struct OfferParams {
     pub mnf_interrupt_latency: Option<Duration>,
     /// The order in which channels with the same interface will be offered to
     /// the guest (optional).
-    pub offer_order: Option<u32>,
+    pub offer_order: Option<u64>,
     /// Indicates whether the channel supports using encrypted memory for any
     /// external GPADLs and GPA direct ranges. This is only used when hardware
     /// isolation is in use.

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -20,6 +20,7 @@ use pal_async::windows::overlapped::IoBufMut;
 use pal_async::windows::overlapped::OverlappedFile;
 use pal_event::Event;
 use std::mem::zeroed;
+use std::num::NonZeroU32;
 use std::os::windows::prelude::*;
 use vmbus_core::HvsockConnectRequest;
 use vmbus_core::HvsockConnectResult;
@@ -93,7 +94,7 @@ pub enum ProxyAction {
         offer: VMBUS_CHANNEL_OFFER,
         incoming_event: Event,
         outgoing_event: Option<Event>,
-        device_order: Option<u32>,
+        device_order: Option<NonZeroU32>,
     },
     Revoke {
         id: u64,
@@ -238,8 +239,7 @@ impl VmbusProxy {
                     } else {
                         None
                     },
-                    device_order: (output.u.Offer.DeviceOrder != 0)
-                        .then_some(output.u.Offer.DeviceOrder),
+                    device_order: NonZeroU32::new(output.u.Offer.DeviceOrder),
                 })
             },
             proxyioctl::VmbusProxyActionTypeRevoke => {

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -93,6 +93,7 @@ pub enum ProxyAction {
         offer: VMBUS_CHANNEL_OFFER,
         incoming_event: Event,
         outgoing_event: Option<Event>,
+        device_order: Option<u32>,
     },
     Revoke {
         id: u64,
@@ -237,6 +238,8 @@ impl VmbusProxy {
                     } else {
                         None
                     },
+                    device_order: (output.u.Offer.DeviceOrder != 0)
+                        .then_some(output.u.Offer.DeviceOrder),
                 })
             },
             proxyioctl::VmbusProxyActionTypeRevoke => {

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -100,6 +100,7 @@ pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT_union_Offer {
     pub Offer: VMBUS_CHANNEL_OFFER,
     pub DeviceIncomingRingEvent: u64, // BUGBUG: HANDLE
     pub DeviceOutgoingRingEvent: u64, // BUGBUG: HANDLE
+    pub DeviceOrder: u32,
 }
 
 #[repr(C)]

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -686,7 +686,7 @@ impl RelayTask {
             use_mnf,
             // Preserve channel enumeration order from the host within the same
             // interface type.
-            offer_order: Some(channel_id as u64),
+            offer_order: Some(channel_id.into()),
             // Strip the confidential flags for relay channels if the host set them.
             flags: offer
                 .offer

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -686,7 +686,7 @@ impl RelayTask {
             use_mnf,
             // Preserve channel enumeration order from the host within the same
             // interface type.
-            offer_order: Some(channel_id),
+            offer_order: Some(channel_id as u64),
             // Strip the confidential flags for relay channels if the host set them.
             flags: offer
                 .offer

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -642,7 +642,7 @@ pub struct OfferParamsInternal {
     pub mmio_megabytes_optional: u16,
     pub subchannel_index: u16,
     pub use_mnf: MnfUsage,
-    pub offer_order: Option<u32>,
+    pub offer_order: Option<u64>,
     pub flags: OfferFlags,
     pub user_defined: UserDefinedData,
 }
@@ -2664,7 +2664,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         if self.inner.use_absolute_channel_order {
             sorted_channels.sort_unstable_by_key(|(_, channel)| {
                 (
-                    channel.offer.offer_order.unwrap_or(u32::MAX),
+                    channel.offer.offer_order.unwrap_or(u64::MAX),
                     channel.offer.interface_id,
                     channel.offer.instance_id,
                 )
@@ -2673,7 +2673,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             sorted_channels.sort_unstable_by_key(|(_, channel)| {
                 (
                     channel.offer.interface_id,
-                    channel.offer.offer_order.unwrap_or(u32::MAX),
+                    channel.offer.offer_order.unwrap_or(u64::MAX),
                     channel.offer.instance_id,
                 )
             });

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -2358,7 +2358,7 @@ impl TestEnv {
         &mut self,
         interface_id: u32,
         instance_id: u32,
-        order: Option<u32>,
+        order: Option<u64>,
     ) -> OfferId {
         self.offer_inner(
             interface_id,
@@ -2378,7 +2378,7 @@ impl TestEnv {
         interface_id: u32,
         instance_id: u32,
         use_mnf: MnfUsage,
-        offer_order: Option<u32>,
+        offer_order: Option<u64>,
         flags: OfferFlags,
     ) -> OfferId {
         self.c()


### PR DESCRIPTION
This change allows vmbusproxy to specify a device order that will be used to determine the offer order for offers provided by `proxyintegration`. This means that in combination with the `use_absolute_channel_order` option, vmbusproxy can control the order in which devices get assigned channel IDs.

This is not a breaking change; although the `VMBUS_PROXY_NEXT_ACTION_OUTPUT` structure has increased in size, older versions of vmbusproxy.sys which don't support device order will simply not write to the new field, which is therefore left at zero.