### PR TITLE
minimal_rt: fix intrinsics to correctly return original pointer

### DIFF
--- a/openhcl/minimal_rt/src/arch/aarch64/intrinsics.rs
+++ b/openhcl/minimal_rt/src/arch/aarch64/intrinsics.rs
@@ -10,7 +10,7 @@
 // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
 // there is no libc for this to conflict with.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *mut u8 {
+unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, len: usize) -> *mut u8 {
     // SAFETY: the caller guarantees the pointers and length are correct.
     unsafe {
         core::arch::asm!(r#"
@@ -25,7 +25,7 @@ unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *m
 2:
         add     x0, x0, x2
     "#,
-        inout("x0") dest,
+        inout("x0") dest => _,
         in("x1") src,
         in("x2") len,
         );
@@ -38,7 +38,7 @@ unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *m
 // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
 // there is no libc for this to conflict with.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
+unsafe extern "C" fn memset(ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
     // SAFETY: the caller guarantees the pointer and length are correct.
     unsafe {
         core::arch::asm!(r#"
@@ -52,7 +52,7 @@ unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
         add     x0, x0, x2
 2:
         "#,
-        inout("x0") ptr,
+        inout("x0") ptr => _,
         in("x1") val,
         in("x2") len);
     }

--- a/openhcl/minimal_rt/src/arch/x86_64/intrinsics.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/intrinsics.rs
@@ -10,7 +10,7 @@
 // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
 // there is no libc for this to conflict with.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
+unsafe extern "C" fn memset(ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
     // SAFETY: The caller guarantees that the pointer and length are correct.
     unsafe {
         core::arch::asm!(r#"
@@ -19,7 +19,7 @@ unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
             "#,
             in("rax") val,
             in("rcx") len,
-            inout("rdi") ptr);
+            inout("rdi") ptr => _);
     }
     ptr
 }

--- a/openhcl/minimal_rt/src/arch/x86_64/intrinsics.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/intrinsics.rs
@@ -29,7 +29,7 @@ unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
 // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
 // there is no libc for this to conflict with.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *mut u8 {
+unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, len: usize) -> *mut u8 {
     // SAFETY: The caller guarantees that the pointers and length are correct.
     unsafe {
         core::arch::asm!(r#"
@@ -38,7 +38,7 @@ unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *m
             "#,
             in("rsi") src,
             in("rcx") len,
-            inout("rdi") dest);
+            inout("rdi") dest => _);
     }
     dest
 }


### PR DESCRIPTION
The implementation for intrinsics in minimal_rt was incorrect. For example, the inline asm block for `memcpy` correctly describes that `rdi` will be clobbered by `rep movsb`, but `memcpy`'s API requires that the return value is the _original_ destination pointer, not the incremented pointer. Fix this by removing the mut on `dest` and indicating to the compiler to discard the clobbered value. 

It seems that in most cases, the compiler ignored the return value of memcpy, except when #2031 was being added. Certain compilation options or function implementations would cause the compiler to use the inlined returned value of `memcpy` directly from the call to realloc, which would then cause a later an assertion failure due to the pointer not being what was expected and overlapping with the new destination. 

Fix all the intrinsics in `minimal_rt` to correctly return the unmodified `dest` or `ptr` as they should. 