### PR TITLE
vmgstool: skip vhd format and resize if not required

### DIFF
--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -556,14 +556,16 @@ fn vhdfiledisk_create(
         !exists || existing_size.is_some_and(|existing_size| file_size != existing_size);
 
     // resize the file if necessary
+    let default_label = if file_size == VMGS_DEFAULT_CAPACITY {
+        " (default)"
+    } else {
+        ""
+    };
     if needs_resize {
         eprintln!(
             "Setting file size to {}{}{}",
             file_size,
-            req_file_size
-                .is_some()
-                .then_some(" (default)")
-                .unwrap_or_default(),
+            default_label,
             existing_size
                 .map(|s| format!(" (previous size: {s})"))
                 .unwrap_or_default(),
@@ -572,12 +574,7 @@ fn vhdfiledisk_create(
     } else {
         eprintln!(
             "File size is already {}{}, skipping resize",
-            file_size,
-            if req_file_size.is_some() {
-                ""
-            } else {
-                " (default)"
-            }
+            file_size, default_label
         );
     }
 


### PR DESCRIPTION
Avoids truncating the VMGS file, resizing it, and re-adding the VHD footer if the file is already the right size and has a valid VHD footer.