### PR TITLE
Promote a few logs to info level (#2046)

### DIFF
--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -462,7 +462,7 @@ async fn unlock_vmgs_data_store(
                 if let Some(key) = old_egress_key {
                     // Key rolling did not complete successfully last time and there's an old
                     // egress key in the VMGS. It may be needed for decryption.
-                    tracing::trace!(CVM_ALLOWED, "Old EgressKey found");
+                    tracing::info!(CVM_ALLOWED, "Old EgressKey found");
                     old_index = vmgs
                         .unlock_with_encryption_key(&key)
                         .await
@@ -959,7 +959,7 @@ async fn get_derived_keys(
         if gsp_response.decrypted_gsp[ingress_idx].length == 0
             && gsp_response.decrypted_gsp[egress_idx].length == 0
         {
-            tracing::trace!(CVM_ALLOWED, "Applying GSP.");
+            tracing::info!(CVM_ALLOWED, "Applying GSP.");
 
             // VMGS has never had any GSP applied.
             // Leave ingress key untouched, derive egress key with new seed.
@@ -972,7 +972,7 @@ async fn get_derived_keys(
                 derived_keys.ingress = ingress_key;
             }
         } else {
-            tracing::trace!(CVM_ALLOWED, "Using GSP.");
+            tracing::info!(CVM_ALLOWED, "Using GSP.");
 
             ingress_seed = Some(
                 gsp_response.decrypted_gsp[ingress_idx].buffer


### PR DESCRIPTION
This change brings a few more GSP-related logs to info level. This might have made the diagnosis for a recent outage a little easier.