### PR TITLE
firmware_uefi: EfiDiagnostics adjust trace channel handling

### DIFF
--- a/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
@@ -51,10 +51,12 @@ pub const MAX_MESSAGE_LENGTH: u16 = 0x1000; // 4KB
 // These messages are the result of known issues with our UEFI firmware that do
 // not seem to affect the guest.
 // TODO: Fix UEFI to resolve this errors/warnings
-const SUPPRESS_LOGS: [&str; 3] = [
+const SUPPRESS_LOGS: [&str; 5] = [
     "WARNING: There is mismatch of supported HashMask (0x2 - 0x7) between modules",
     "that are linking different HashInstanceLib instances!",
     "ConvertPages: failed to find range",
+    "ConvertPages: Incompatible memory types",
+    "ConvertPages: range",
 ];
 
 /// Represents a processed log entry from the EFI diagnostics buffer


### PR DESCRIPTION
This change simply adjusts it so that UEFI logs that _contain_ ERROR or WARNING get sent to the tracing::error!() or tracing::warn!() channels respectively. This is different from the current behavior, where logs that are EXACTLY ERROR or WARNING would only get sent to the respective trace macros.

It also moves the string conversion logic to the processing function.