### PR TITLE
nvme_resources: remove clone requirement from fault config

### DIFF
--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -58,7 +58,7 @@ pub struct CommandMatch {
     pub mask: [u8; 64],
 }
 
-#[derive(MeshPayload, Clone)]
+#[derive(MeshPayload)]
 /// A simple fault configuration with admin submission queue support
 pub struct FaultConfiguration {
     /// Fault active state

--- a/vm/devices/storage/nvme_test/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme_test/src/workers/coordinator.rs
@@ -32,18 +32,6 @@ use vmcore::interrupt::Interrupt;
 use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
 
-/// An input context for the NvmeWorkers
-pub struct NvmeWorkersContext<'a> {
-    pub driver_source: &'a VmTaskDriverSource,
-    pub mem: GuestMemory,
-    pub interrupts: Vec<Interrupt>,
-    pub max_sqs: u16,
-    pub max_cqs: u16,
-    pub qe_sizes: Arc<parking_lot::Mutex<IoQueueEntrySizes>>,
-    pub subsystem_id: Guid,
-    pub fault_configuration: FaultConfiguration,
-}
-
 pub struct NvmeWorkers {
     _task: Task<()>,
     send: mesh::Sender<CoordinatorRequest>,
@@ -66,18 +54,16 @@ impl InspectMut for NvmeWorkers {
 }
 
 impl NvmeWorkers {
-    pub fn new(context: NvmeWorkersContext<'_>) -> Self {
-        let NvmeWorkersContext {
-            driver_source,
-            mem,
-            interrupts,
-            subsystem_id,
-            max_sqs,
-            max_cqs,
-            qe_sizes,
-            fault_configuration,
-        } = context;
-
+    pub fn new(
+        driver_source: &VmTaskDriverSource,
+        mem: GuestMemory,
+        interrupts: Vec<Interrupt>,
+        max_sqs: u16,
+        max_cqs: u16,
+        qe_sizes: Arc<parking_lot::Mutex<IoQueueEntrySizes>>,
+        subsystem_id: Guid,
+        fault_configuration: FaultConfiguration,
+    ) -> Self {
         let num_qids = 2 + max_sqs.max(max_cqs) * 2;
         let doorbells = Arc::new(RwLock::new(DoorbellMemory::new(num_qids)));
 


### PR DESCRIPTION
This change had previously been added as a partial change to support the FLR implementation. However, since we chose to remove the FLR implementation, clone is no longer needed on FaultConfig. With that gone we also shouldn't need the NvmeWorkerContext struct either. Essentially a revert for #1913 but just reverting caused some conflicts. 
This is a 3 part change in order to add the namespace change fault to the controller.