### PR TITLE
local_clock: Allow rounding error to hopefully fix flaky unit test

### DIFF
--- a/support/local_clock/src/clock_impls.rs
+++ b/support/local_clock/src/clock_impls.rs
@@ -144,7 +144,7 @@ mod tests {
         // cannot use assert_eq, because there is a *bit* of extra time elapsed
         // aside from the thread sleep.
         eprintln!("delta: {delta:?}");
-        assert!(delta >= LocalClockDelta::from_millis(999)); // allow for rounding to lose a mili
+        assert!(delta >= LocalClockDelta::from_millis(999)); // allow for rounding to lose a milli
         assert!(delta < LocalClockDelta::from_millis(2000)); // sanity check
     }
 

--- a/support/local_clock/src/clock_impls.rs
+++ b/support/local_clock/src/clock_impls.rs
@@ -144,7 +144,7 @@ mod tests {
         // cannot use assert_eq, because there is a *bit* of extra time elapsed
         // aside from the thread sleep.
         eprintln!("delta: {delta:?}");
-        assert!(delta >= LocalClockDelta::from_millis(1000));
+        assert!(delta >= LocalClockDelta::from_millis(999)); // allow for rounding to lose a mili
         assert!(delta < LocalClockDelta::from_millis(2000)); // sanity check
     }
 


### PR DESCRIPTION
Finally caught a run of this unit test failing with the new debug output: `delta: 999ms`. Allow this case, to hopefully make this flakiness finally go away.