### PR TITLE
virt_mshv: init vm after creation

### DIFF
--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -138,6 +138,13 @@ impl virt::Hypervisor for LinuxMshv {
             break;
         }
 
+        match vmfd.initialize() {
+            Ok(()) => {}
+            Err(_) => {
+                return Err(Error::CreateVMFailed);
+            }
+        }
+
         // Create virtual CPUs.
         let mut vps: Vec<MshvVpInner> = Vec::new();
         for vp in config.processor_topology.vps_arch() {

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -138,12 +138,8 @@ impl virt::Hypervisor for LinuxMshv {
             break;
         }
 
-        match vmfd.initialize() {
-            Ok(()) => {}
-            Err(_) => {
-                return Err(Error::CreateVMFailed);
-            }
-        }
+        vmfd.initialize()
+            .map_err(|e| Error::CreateVMInitFailed(e.into()))?;
 
         // Create virtual CPUs.
         let mut vps: Vec<MshvVpInner> = Vec::new();
@@ -1083,6 +1079,8 @@ pub enum Error {
     NotSupported,
     #[error("create_vm failed")]
     CreateVMFailed,
+    #[error("failed to initialize VM")]
+    CreateVMInitFailed(#[source] anyhow::Error),
     #[error("failed to create VCPU")]
     CreateVcpu(#[source] MshvError),
     #[error("vtl2 not supported")]


### PR DESCRIPTION
To configure custom VM features during VM creation, the create and initialize steps have been broken up in mshv-ioctls, starting with:

1afa433 mshv-ioctls: Don't initialize partition after creation

So, any uses of v0.5.0 and newer versions of mshv-ioctls should explicitly initialize the vm after creation.