### PR TITLE
virt_mshv_vtl/arm: Add missing reset types

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -194,8 +194,14 @@ impl BackingPrivate for HypervisorBackedArm64 {
                         .exit_message()
                         .as_message::<hvdef::HvArm64ResetInterceptMessage>();
                     match message.reset_type {
-                        HvArm64ResetType::POWER_OFF => return Err(VpHaltReason::PowerOff),
-                        HvArm64ResetType::REBOOT => return Err(VpHaltReason::Reset),
+                        HvArm64ResetType::POWER_OFF | HvArm64ResetType::HIBERNATE => {
+                            return Err(VpHaltReason::PowerOff);
+                        }
+                        // TODO: Should we be checking reset code for SYSTEM_RESET?
+                        // What values can it have?
+                        HvArm64ResetType::REBOOT | HvArm64ResetType::SYSTEM_RESET => {
+                            return Err(VpHaltReason::Reset);
+                        }
                         ty => unreachable!("unknown reset type: {:#x?}", ty),
                     }
                 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -194,8 +194,11 @@ impl BackingPrivate for HypervisorBackedArm64 {
                         .exit_message()
                         .as_message::<hvdef::HvArm64ResetInterceptMessage>();
                     match message.reset_type {
-                        HvArm64ResetType::POWER_OFF | HvArm64ResetType::HIBERNATE => {
+                        HvArm64ResetType::POWER_OFF => {
                             return Err(VpHaltReason::PowerOff);
+                        }
+                        HvArm64ResetType::HIBERNATE => {
+                            return Err(VpHaltReason::Hibernate);
                         }
                         HvArm64ResetType::REBOOT => {
                             return Err(VpHaltReason::Reset);

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -197,9 +197,12 @@ impl BackingPrivate for HypervisorBackedArm64 {
                         HvArm64ResetType::POWER_OFF | HvArm64ResetType::HIBERNATE => {
                             return Err(VpHaltReason::PowerOff);
                         }
-                        // TODO: Should we be checking reset code for SYSTEM_RESET?
-                        // What values can it have?
-                        HvArm64ResetType::REBOOT | HvArm64ResetType::SYSTEM_RESET => {
+                        HvArm64ResetType::REBOOT => {
+                            return Err(VpHaltReason::Reset);
+                        }
+                        HvArm64ResetType::SYSTEM_RESET => {
+                            // TODO: What values can it have?
+                            tracing::debug!(reset_code = message.reset_code, "system reset");
                             return Err(VpHaltReason::Reset);
                         }
                         ty => unreachable!("unknown reset type: {:#x?}", ty),

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -205,7 +205,12 @@ impl BackingPrivate for HypervisorBackedArm64 {
                             tracing::debug!(reset_code = message.reset_code, "system reset");
                             return Err(VpHaltReason::Reset);
                         }
-                        ty => unreachable!("unknown reset type: {:#x?}", ty),
+                        ty => {
+                            unreachable!(
+                                "unknown reset type: {:#x?}, {:#x}",
+                                ty, message.reset_code
+                            )
+                        }
                     }
                 }
                 reason => unreachable!("unknown exit reason: {:#x?}", reason),

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -3022,7 +3022,7 @@ impl MessagePayload for HvX64HaltMessage {}
 pub struct HvArm64ResetInterceptMessage {
     pub header: HvArm64InterceptMessageHeader,
     pub reset_type: HvArm64ResetType,
-    pub padding: u32,
+    pub reset_code: u32,
 }
 
 impl MessagePayload for HvArm64ResetInterceptMessage {}
@@ -3032,6 +3032,8 @@ open_enum! {
     pub enum HvArm64ResetType: u32 {
         POWER_OFF = 0,
         REBOOT = 1,
+        SYSTEM_RESET = 2,
+        HIBERNATE = 3,
     }
 }
 

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -135,6 +135,7 @@ where
             VpHaltReason::Cancel => Ok(StopReason::Cancel),
             VpHaltReason::PowerOff => Err(HaltReason::PowerOff),
             VpHaltReason::Reset => Err(HaltReason::Reset),
+            VpHaltReason::Hibernate => Err(HaltReason::Hibernate),
             VpHaltReason::TripleFault { vtl } => {
                 let registers = self.vp.access_state(vtl).registers().ok().map(Arc::new);
 

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -557,6 +557,8 @@ pub enum VpHaltReason {
     PowerOff,
     /// The processor initiated a reboot.
     Reset,
+    /// The processor initiated a hibernation.
+    Hibernate,
     /// The processor triple faulted.
     TripleFault {
         /// The faulting VTL.

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1860,7 +1860,13 @@ mod aarch64 {
             match info.reset_type {
                 hvdef::HvArm64ResetType::POWER_OFF => VpHaltReason::PowerOff,
                 hvdef::HvArm64ResetType::REBOOT => VpHaltReason::Reset,
-                ty => unreachable!("unexpected reset type: {ty:?}",),
+                hvdef::HvArm64ResetType::HIBERNATE => VpHaltReason::Hibernate,
+                HvArm64ResetType::SYSTEM_RESET => {
+                    // TODO: What values can it have?
+                    tracing::debug!(reset_code = info.reset_code, "system reset");
+                    VpHaltReason::Reset
+                }
+                ty => unreachable!("unknown reset type: {:#x?}, {:#x}", ty, info.reset_code),
             }
         }
 

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1861,7 +1861,7 @@ mod aarch64 {
                 hvdef::HvArm64ResetType::POWER_OFF => VpHaltReason::PowerOff,
                 hvdef::HvArm64ResetType::REBOOT => VpHaltReason::Reset,
                 hvdef::HvArm64ResetType::HIBERNATE => VpHaltReason::Hibernate,
-                HvArm64ResetType::SYSTEM_RESET => {
+                hvdef::HvArm64ResetType::SYSTEM_RESET => {
                     // TODO: What values can it have?
                     tracing::debug!(reset_code = info.reset_code, "system reset");
                     VpHaltReason::Reset


### PR DESCRIPTION
We were hitting this unreachable occasionally in some tests, add the missing values to provide cleaner error messages.