### PR TITLE
ci: Fix gh workflow id fetching steps to use successful workflow runs

### DIFF
--- a/flowey/flowey_lib_common/src/gh_latest_completed_workflow_id.rs
+++ b/flowey/flowey_lib_common/src/gh_latest_completed_workflow_id.rs
@@ -46,7 +46,7 @@ impl SimpleFlowNode for Node {
 
                 let id = xshell::cmd!(
                     sh,
-                    "{gh_cli} run list -R {repo} -b {branch} -w {pipeline_name} -s completed --limit 1 --json databaseId -q .[0].databaseId"
+                    "{gh_cli} run list -R {repo} -b {branch} -w {pipeline_name} -s success --limit 1 --json databaseId -q .[0].databaseId"
                 )
                 .read()?;
 

--- a/flowey/flowey_lib_common/src/gh_workflow_id.rs
+++ b/flowey/flowey_lib_common/src/gh_workflow_id.rs
@@ -63,7 +63,7 @@ impl SimpleFlowNode for Node {
                         "{gh_cli} run list
                         --commit {commit}
                         -w {pipeline_name}
-                        -s completed
+                        -s success
                         -L 1
                         --json databaseId
                         --jq .[].databaseId"


### PR DESCRIPTION
This PR addresses #2048. In CI, when fetching github workflow ids, we specify the condition that the workflow run must be completed, which returns workflow ids in which the run has failed. Thus, when we go to use the workflow id to download artifacts produced from that run the step fails. This PR changes that filter to use successful workflow runs instead. 