### PR TITLE
rustfmt.toml: Fix casing error

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-newline_style="unix"
+newline_style="Unix"
 use_field_init_shorthand=true
 style_edition="2024"


### PR DESCRIPTION
Apparently rustfmt.toml settings are case sensitive, this was generating an error in rust-analyzer. Running a `cargo fmt` didn't show any changes however.