### PR TITLE
nextest.toml: Try removing the windows unit test timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -47,14 +47,3 @@ filter = 'package(~vmm_tests)'
 # VMM tests contain their own watchdog timer, but keep an extra long timer
 # here as a backup.
 slow-timeout = { period = "10m", terminate-after = 1 }
-
-# TEMP (hopefully): For reasons that continue to befuddle, running Windows
-# release-mode unit tests in flowey CI is resulting in seemingly-random
-# tests occationally stalling by up to ~10 seconds.
-#
-# This did not occur in the "legacy" non-flowey CI, and so the question becomes:
-# what subtle different in execution environments between the new pipeline and
-# the old pipeline is causing this different behavior?
-[[profile.ci.overrides]]
-platform = 'cfg(windows)'
-slow-timeout = { period = "1s", terminate-after = 30 }


### PR DESCRIPTION
Let's see if this is still an issue.