### PR TITLE
petri: Increase test timeout

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -320,7 +320,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         let mut tasks = Vec::new();
 
         {
-            const TIMEOUT_DURATION_MINUTES: u64 = 5;
+            const TIMEOUT_DURATION_MINUTES: u64 = 6;
             const TIMER_DURATION: Duration = Duration::from_secs(TIMEOUT_DURATION_MINUTES * 60);
             let log_source = resources.log_source.clone();
             let inspect_task =


### PR DESCRIPTION
We're seeing some tests that look like they're still active from the logs but are timing out. When I moved the vmm test timeout to be solely in petri's control instead of shared with nextest I lowered the timeout to 5 minutes from 6, hoping that that change would allows us to get a little time back. It seems I was overly optimistic. Raise the timeout back to 6 minutes.