### PR TITLE
xflowey: Fix local vmm test command for build-only mode

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -866,6 +866,9 @@ impl SimpleFlowNode for Node {
 
         if build_only {
             ctx.emit_side_effect_step(side_effects, [done]);
+            if let Some(prep_steps) = register_prep_steps {
+                prep_steps.claim_unused(ctx);
+            }
         } else {
             side_effects.push(ctx.reqv(crate::install_vmm_tests_deps::Request::Install));
             if let Some(prep_steps) = register_prep_steps {


### PR DESCRIPTION
Flowey insists that everything be used, and this variable isn't in build-only mode.