### PR TITLE
deps: update mu_msvm to v25.1.6 release

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -23,7 +23,7 @@ pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const RUSTUP_TOOLCHAIN: &str = "1.90.0";
-pub const MU_MSVM: &str = "25.1.5";
+pub const MU_MSVM: &str = "25.1.6";
 pub const NEXTEST: &str = "0.9.101";
 pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly


### PR DESCRIPTION
mu_msvm release here: https://github.com/microsoft/mu_msvm/releases/tag/v25.1.6

NOTE: This includes a UEFI submodule change that demotes UEFI driver load messages to INFO instead of ERROR. 

The default log level for UEFI diagnostics is ERROR and WARN.

So, you will not see those messages again unless you rebuild UEFI with INFO logging by default.

There will be a future change soon to allow log level toggling.