### PR TITLE
Add Flowey support for Arch Linux

### DIFF
--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -908,6 +908,8 @@ pub enum FlowPlatformLinuxDistro {
     Fedora,
     /// Ubuntu (including WSL2)
     Ubuntu,
+    /// Arch Linux (including WSL2)
+    Arch,
     /// An unknown distribution
     Unknown,
 }

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -66,6 +66,8 @@ fn linux_distro() -> FlowPlatformLinuxDistro {
             FlowPlatformLinuxDistro::Ubuntu
         } else if etc_os_release.contains("ID=fedora") {
             FlowPlatformLinuxDistro::Fedora
+        } else if etc_os_release.contains("ID=arch") {
+            FlowPlatformLinuxDistro::Arch
         } else {
             FlowPlatformLinuxDistro::Unknown
         }

--- a/flowey/flowey_lib_common/src/_util/extract.rs
+++ b/flowey/flowey_lib_common/src/_util/extract.rs
@@ -38,6 +38,7 @@ pub fn extract_zip_if_new_deps(ctx: &mut NodeCtx<'_>) -> ExtractZipDeps {
                 FlowPlatform::Linux(linux_distribution) => match linux_distribution {
                     FlowPlatformLinuxDistro::Fedora => vec!["bsdtar".into()],
                     FlowPlatformLinuxDistro::Ubuntu => vec!["libarchive-tools".into()],
+                    FlowPlatformLinuxDistro::Arch => vec!["libarchive".into()],
                     FlowPlatformLinuxDistro::Unknown => vec![],
                 },
                 _ => {

--- a/flowey/flowey_lib_common/src/download_azcopy.rs
+++ b/flowey/flowey_lib_common/src/download_azcopy.rs
@@ -69,6 +69,7 @@ impl FlowNode for Node {
                 FlowPlatform::Linux(linux_distribution) => match linux_distribution {
                     FlowPlatformLinuxDistro::Fedora => vec!["bsdtar".into()],
                     FlowPlatformLinuxDistro::Ubuntu => vec!["libarchive-tools".into()],
+                    FlowPlatformLinuxDistro::Arch => vec!["libarchive".into()],
                     FlowPlatformLinuxDistro::Unknown => vec![],
                 },
                 _ => {

--- a/flowey/flowey_lib_hvlite/src/init_cross_build.rs
+++ b/flowey/flowey_lib_hvlite/src/init_cross_build.rs
@@ -54,32 +54,40 @@ impl FlowNode for Node {
 
             if !native(&target) {
                 let platform = ctx.platform();
-                let gcc_arch_str = match target.architecture {
-                    Architecture::X86_64 => match platform {
-                        FlowPlatform::Linux(linux_distribution) => match linux_distribution {
-                            FlowPlatformLinuxDistro::Fedora => "x86_64",
-                            FlowPlatformLinuxDistro::Ubuntu => "x86-64",
-                            FlowPlatformLinuxDistro::Unknown => {
-                                anyhow::bail!("Unknown Linux distribution")
-                            }
-                        },
-                        _ => anyhow::bail!("Unsupported platform"),
-                    },
-                    Architecture::Aarch64(_) => "aarch64",
-                    arch => anyhow::bail!("unsupported arch {arch}"),
-                };
 
                 match (platform, target.operating_system) {
                     (FlowPlatform::Linux(_), target_lexicon::OperatingSystem::Linux) => {
                         let (gcc_pkg, bin) = match target.architecture {
-                            Architecture::Aarch64(_) => (
-                                format!("gcc-{gcc_arch_str}-linux-gnu"),
-                                "aarch64-linux-gnu-gcc".to_string(),
-                            ),
-                            Architecture::X86_64 => (
-                                format!("gcc-{gcc_arch_str}-linux-gnu"),
-                                "x86_64-linux-gnu-gcc".to_string(),
-                            ),
+                            Architecture::X86_64 => match platform {
+                                FlowPlatform::Linux(linux_distribution) => {
+                                    let pkg = match linux_distribution {
+                                        FlowPlatformLinuxDistro::Fedora => "gcc-x86_64-linux-gnu",
+                                        FlowPlatformLinuxDistro::Ubuntu => "gcc-x86-64-linux-gnu",
+                                        FlowPlatformLinuxDistro::Arch => "gcc",
+                                        FlowPlatformLinuxDistro::Unknown => {
+                                            anyhow::bail!("Unknown Linux distribution")
+                                        }
+                                    };
+                                    (pkg.to_string(), "x86_64-linux-gnu-gcc".to_string())
+                                }
+                                _ => anyhow::bail!("Unsupported platform"),
+                            },
+                            Architecture::Aarch64(_) => match platform {
+                                FlowPlatform::Linux(linux_distribution) => {
+                                    let pkg = match linux_distribution {
+                                        FlowPlatformLinuxDistro::Fedora
+                                        | FlowPlatformLinuxDistro::Ubuntu => {
+                                            "gcc-aarch64-linux-gnu"
+                                        }
+                                        FlowPlatformLinuxDistro::Arch => "aarch64-linux-gnu-gcc",
+                                        FlowPlatformLinuxDistro::Unknown => {
+                                            anyhow::bail!("Unknown Linux distribution")
+                                        }
+                                    };
+                                    (pkg.to_string(), "aarch64-linux-gnu-gcc".to_string())
+                                }
+                                _ => anyhow::bail!("Unsupported platform"),
+                            },
                             arch => anyhow::bail!("unsupported arch {arch}"),
                         };
 

--- a/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
+++ b/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
@@ -33,22 +33,41 @@ impl SimpleFlowNode for Node {
         } = request;
 
         let platform = ctx.platform();
-        let arch_str = match arch {
+        let (objcopy_pkg, objcopy_bin) = match arch {
             CommonArch::X86_64 => match platform {
                 FlowPlatform::Linux(linux_distribution) => match linux_distribution {
-                    FlowPlatformLinuxDistro::Fedora => "x86_64",
-                    FlowPlatformLinuxDistro::Ubuntu => "x86-64",
+                    FlowPlatformLinuxDistro::Fedora => {
+                        ("binutils-x86_64-linux-gnu", "x86_64-linux-gnu-objcopy")
+                    }
+                    FlowPlatformLinuxDistro::Ubuntu => {
+                        ("binutils-x86-64-linux-gnu", "x86_64-linux-gnu-objcopy")
+                    }
+                    FlowPlatformLinuxDistro::Arch => ("binutils", "objcopy"),
                     FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
                 },
                 _ => anyhow::bail!("Unsupported platform"),
             },
-            CommonArch::Aarch64 => "aarch64",
+            CommonArch::Aarch64 => {
+                let pkg = match platform {
+                    FlowPlatform::Linux(linux_distribution) => match linux_distribution {
+                        FlowPlatformLinuxDistro::Fedora | FlowPlatformLinuxDistro::Ubuntu => {
+                            "binutils-aarch64-linux-gnu"
+                        }
+                        FlowPlatformLinuxDistro::Arch => "aarch64-linux-gnu-binutils",
+                        FlowPlatformLinuxDistro::Unknown => {
+                            anyhow::bail!("Unknown Linux distribution")
+                        }
+                    },
+                    _ => anyhow::bail!("Unsupported platform"),
+                };
+                (pkg, "aarch64-linux-gnu-objcopy")
+            }
         };
 
         let installed_objcopy =
             ctx.reqv(
                 |side_effect| flowey_lib_common::install_dist_pkg::Request::Install {
-                    package_names: vec![format!("binutils-{arch_str}-linux-gnu")],
+                    package_names: vec![objcopy_pkg.into()],
                     done: side_effect,
                 },
             );
@@ -63,11 +82,10 @@ impl SimpleFlowNode for Node {
 
                 let sh = xshell::Shell::new()?;
                 let output = sh.current_dir().join(in_bin.file_name().unwrap());
-                let objcopy = format!("{}-linux-gnu-objcopy", arch.as_arch());
-                xshell::cmd!(sh, "{objcopy} --only-keep-debug {in_bin} {output}.dbg").run()?;
+                xshell::cmd!(sh, "{objcopy_bin} --only-keep-debug {in_bin} {output}.dbg").run()?;
                 xshell::cmd!(
                     sh,
-                    "{objcopy} --strip-all --keep-section=.build_info --add-gnu-debuglink={output}.dbg {in_bin} {output}"
+                    "{objcopy_bin} --strip-all --keep-section=.build_info --add-gnu-debuglink={output}.dbg {in_bin} {output}"
                 )
                 .run()?;
 


### PR DESCRIPTION
I use Arch btw

This was mostly straightforward, thanks to previous work to add support for additional Linux distros. This change mostly changes a few places from building package/binary names from arch strings, to just giving the whole package/binary name explicitly.