### PR TITLE
RFC: memory/nvme: track if memory blocks are persistent, handle fallback in nvme keepalive save/restore

### DIFF
--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -99,10 +99,13 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
             PagesAccessibleToLowerVtl::new_from_pages(self.vtl_protect.clone(), mem.pfns())
                 .context("failed to lower VTL permissions on memory block")?;
 
-        Ok(MemoryBlock::new(LowerVtlDmaBuffer {
-            block: mem,
-            _vtl_guard: vtl_guard,
-        }))
+        Ok(MemoryBlock::new(
+            LowerVtlDmaBuffer {
+                block: mem,
+                _vtl_guard: vtl_guard,
+            },
+            mem.persistent(),
+        ))
     }
 
     fn attach_pending_buffers(&self) -> Result<Vec<MemoryBlock>> {

--- a/openhcl/openhcl_dma_manager/src/lib.rs
+++ b/openhcl/openhcl_dma_manager/src/lib.rs
@@ -133,9 +133,9 @@ pub enum LowerVtlPermissionPolicy {
 /// The CVM page visibility required for DMA allocations.
 #[derive(Copy, Clone, Inspect)]
 pub enum AllocationVisibility {
-    /// Allocations must be shared aka host visible.
+    /// Allocations must be shared with the host (aka host visible).
     Shared,
-    /// Allocations must be private.
+    /// Allocations must be private to the guest (but is allowed to be visible to the VTL0 guest).
     Private,
 }
 
@@ -148,7 +148,8 @@ pub struct DmaClientParameters {
     pub lower_vtl_policy: LowerVtlPermissionPolicy,
     /// The required CVM page visibility for allocations.
     pub allocation_visibility: AllocationVisibility,
-    /// Whether allocations must be persistent.
+    /// Whether allocations should be persistent. Persistent allocations can
+    /// survive save/restore.
     pub persistent_allocations: bool,
 }
 

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -751,6 +751,11 @@ impl LoadedVm {
         // Only save NVMe state when there are NVMe controllers and keep alive
         // was enabled.
         let nvme_state = if let Some(n) = &self.nvme_manager {
+            // DEVNOTE: A subtlety here is that the act of saving the NVMe state also causes the driver
+            // to enter a state where subsequent teardown operations will noop. There is a STRONG
+            // correlation between save/restore and keepalive. There are cases where the device
+            // may not be in a state where it can support keepalive. The particular device will handle that,
+            // logging appropriately and return `None`
             n.save(vf_keepalive_flag)
                 .instrument(tracing::info_span!("nvme_manager_save", CVM_ALLOWED))
                 .await

--- a/openhcl/underhill_core/src/nvme_manager/manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager/manager.rs
@@ -183,6 +183,7 @@ impl NvmeManagerClient {
     /// Send an RPC call to save NVMe worker data.
     pub async fn save(&self) -> Option<NvmeManagerSavedState> {
         match self.sender.call(Request::Save, ()).await {
+            // todo: check if we get save state here
             Ok(s) => s.ok(),
             Err(_) => None,
         }
@@ -437,6 +438,7 @@ impl NvmeManagerWorker {
             .map(|(pci_id, driver)| (pci_id.clone(), driver.client().clone()))
             .collect();
         for (pci_id, client) in devices_to_save.iter_mut() {
+            // todo: first call client.save() to see if we get a saved state
             nvme_disks.push(NvmeSavedDiskConfig {
                 pci_id: pci_id.clone(),
                 driver_state: client.save().await?,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1975,6 +1975,8 @@ async fn new_underhill_vm(
                 nvme_always_flr: env_cfg.nvme_always_flr,
                 is_isolated: isolation.is_isolated(),
                 dma_client_spawner: dma_manager.client_spawner(),
+                warn_no_private_pool: !private_pool_available,
+                warn_no_save_restore: !save_restore_supported,
             }),
         );
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -527,6 +527,11 @@ impl<T: DeviceBacking> NvmeDriver<T> {
 
     /// Saves the NVMe driver state during servicing.
     pub async fn save(&mut self) -> anyhow::Result<NvmeDriverSavedState> {
+        // todo: interrogate all queues to see if any are with non-persistent memory
+        // that's been allocated. If so, then fail the save (and make sure the stack above handles)
+        // that gracefully. By failing thye save, we should leave the driver
+        // in a state that is still running.
+        //
         // Nothing to save if Identify Controller was never queried.
         if self.identify.is_none() {
             return Err(save_restore::Error::InvalidState.into());

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -123,12 +123,18 @@ unsafe impl MappedDmaTarget for LockedMemory {
     }
 }
 
+/// A DMA client spawner that allocates memory at arbitrary locations in VTL2's
+/// address space. Use this spawner when you don't care about the PFNs being
+/// contiguous or able to survive an OpenHCL servicing event.
 #[derive(Clone, Inspect)]
 pub struct LockedMemorySpawner;
 
 impl crate::DmaClient for LockedMemorySpawner {
     fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<crate::memory::MemoryBlock> {
-        Ok(crate::memory::MemoryBlock::new(LockedMemory::new(len)?))
+        Ok(crate::memory::MemoryBlock::new(
+            LockedMemory::new(len)?,
+            false,
+        ))
     }
 
     fn attach_pending_buffers(&self) -> anyhow::Result<Vec<crate::memory::MemoryBlock>> {

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -400,10 +400,13 @@ impl PagePoolHandle {
     /// Create a memory block from this allocation.
     fn into_memory_block(self) -> anyhow::Result<user_driver::memory::MemoryBlock> {
         let pfns: Vec<_> = (self.base_pfn()..self.base_pfn() + self.size_pages).collect();
-        Ok(user_driver::memory::MemoryBlock::new(PagePoolDmaBuffer {
-            alloc: self,
-            pfns,
-        }))
+        Ok(user_driver::memory::MemoryBlock::new(
+            PagePoolDmaBuffer { alloc: self, pfns },
+            // While it is perhaps a bit simplistic to return `true` here, the `PagePool` is designed
+            // and used only for memory regions that are allocated externally to the VTL2 kernel
+            // control. Thus, the memory is persistent across OpenHCL servicing events.
+            true,
+        ))
     }
 }
 


### PR DESCRIPTION
    wip: memory/nvme: keep track of whether any given memory block is allocated from
    a memory store with persistent allocations or not. This is useful for the
    NVMe driver to know that it is safely in a state to be able to do keepalive.

    Sending out this change now to get some early feedback on if I'm on the right
    track. I also made some drive-by comments changes that helped me improve my
    understanding of the code. I can pull those out into a separate PR if once
    I get eyes on them.

    TODO:
    - [ ] Send out an initial RFC PR, especially on the per-memory-block persistence.
    - [ ] Fixup the handling in the nvme driver and nvme manager stacks (I left some todos there already)
    - [ ] Something smells wrong here; it's awfully complicated to handle save/restore, decide when it's enabled, etc. etc. There are lots of shared assumptions across the stack. I'd like to figure out a way to make this more elegant and easier to maintain.