### PR TITLE
EXPERIMENT: Mark derived inspect impls as 'cold'

### DIFF
--- a/support/inspect_derive/src/lib.rs
+++ b/support/inspect_derive/src/lib.rs
@@ -386,8 +386,8 @@ fn impl_defs(
     let type_name = &input.ident;
     let tokens = if mutable {
         quote! {
-            #[cold]
             impl #impl_generics ::inspect::InspectMut for #type_name #type_generics #where_clause {
+                #[cold]
                 fn inspect_mut(&mut self, #req: ::inspect::Request<'_>) {
                     #fmt
                     #respond
@@ -396,8 +396,8 @@ fn impl_defs(
         }
     } else {
         quote! {
-            #[cold]
             impl #impl_generics ::inspect::Inspect for #type_name #type_generics #where_clause {
+                #[cold]
                 fn inspect(&self, #req: ::inspect::Request<'_>) {
                     #fmt
                     #respond

--- a/support/inspect_derive/src/lib.rs
+++ b/support/inspect_derive/src/lib.rs
@@ -386,6 +386,7 @@ fn impl_defs(
     let type_name = &input.ident;
     let tokens = if mutable {
         quote! {
+            #[cold]
             impl #impl_generics ::inspect::InspectMut for #type_name #type_generics #where_clause {
                 fn inspect_mut(&mut self, #req: ::inspect::Request<'_>) {
                     #fmt
@@ -395,6 +396,7 @@ fn impl_defs(
         }
     } else {
         quote! {
+            #[cold]
             impl #impl_generics ::inspect::Inspect for #type_name #type_generics #where_clause {
                 fn inspect(&self, #req: ::inspect::Request<'_>) {
                     #fmt


### PR DESCRIPTION
We know that inspect impls are very rarely called in production, if at all, and are never a hot path. Try marking them as 'cold' to see what the optimizer does. Maybe we get some binary size out of it?