### PR TITLE
Implement update target vp call for packet capture

### DIFF
--- a/vm/devices/net/net_packet_capture/src/lib.rs
+++ b/vm/devices/net/net_packet_capture/src/lib.rs
@@ -456,6 +456,10 @@ impl PacketCaptureQueue {
 
 #[async_trait]
 impl Queue for PacketCaptureQueue {
+    async fn update_target_vp(&mut self, target_vp: u32) {
+        self.current_mut().update_target_vp(target_vp).await
+    }
+
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         self.current_mut().poll_ready(cx)
     }


### PR DESCRIPTION
Currently, the packet capture queue implementation is not plumbing the `update_target_vp` call and thereby queues don't get retargeted while capturing packets. As soon as the packet capture is done and detaches, the queues were getting retargeted, so this is an issue only while the packet capture is attached.