### PR TITLE
vmm_tests: Only run memory usage validation tests in debug builds for now

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -475,6 +475,9 @@ async fn guest_test_uefi<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
     Ok(())
 }
 
+// We can't get a VTL 2 pipette with release build CVM debugging restrictions,
+// so only run these tests in debug builds.
+#[cfg(debug_assertions)]
 #[vmm_test_no_agent(
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64)),
@@ -496,6 +499,9 @@ async fn memory_validation_small<T: PetriVmmBackend>(
     .await
 }
 
+// We can't get a VTL 2 pipette with release build CVM debugging restrictions,
+// so only run these tests in debug builds.
+#[cfg(debug_assertions)]
 #[vmm_test_no_agent(
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64)),


### PR DESCRIPTION
These tests rely on getting a VTL 2 pipette to gather their data, and that currently is not possible on release build CVMs due to our debugging restrictions. We have work planned to allow for the host to re-enable debugging on these builds, but that work isn't done yet. Restrict these tests to debug builds only for now.