### PR TITLE
wip: move logic for aer processing to the queue handler instead of the driver

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1024,6 +1024,8 @@ impl<T: DeviceBacking> InspectTask<WorkerState> for DriverWorkerTask<T> {
 }
 
 pub mod save_restore {
+    use crate::queue_pair::AerState;
+
     use super::*;
 
     /// Save and Restore errors for this module.
@@ -1120,6 +1122,10 @@ pub mod save_restore {
         pub cq_state: CompletionQueueSavedState,
         #[mesh(3)]
         pub pending_cmds: PendingCommandsSavedState,
+        #[mesh(4)]
+        pub aer_processing_state: AerState,
+        #[mesh(5)]
+        pub last_aen_seen: Option<nvme_spec::Completion>,
     }
 
     #[derive(Protobuf, Clone, Debug)]


### PR DESCRIPTION
This PR will move the AER implementation over to the queue handler. The driver now triggers the aer handling using the issue_async function. AERs are always modelled as "detached" rpc's because that way we never have to reconstruct the RPC channel after restore. 