### PR TITLE
vmm_tests: Disable flaky mnf vmm_test

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/vmbus_relay.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/vmbus_relay.rs
@@ -98,9 +98,10 @@ async fn vmbus_relay_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> any
 
 /// MNF guest support: capture and print recursive listing of vmbus drivers.
 /// TODO: add entries for CVM guests once MNF support in CVMs is added. Tracked by  #1940
+/// TODO: investigate flakiness for openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 #[openvmm_test(
     openvmm_openhcl_linux_direct_x64,
-    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
+    // openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
 async fn validate_mnf_usage_in_guest(
     config: PetriVmBuilder<OpenVmmPetriBackend>,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/vmbus_relay.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/vmbus_relay.rs
@@ -98,7 +98,7 @@ async fn vmbus_relay_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> any
 
 /// MNF guest support: capture and print recursive listing of vmbus drivers.
 /// TODO: add entries for CVM guests once MNF support in CVMs is added. Tracked by  #1940
-/// TODO: investigate flakiness for openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
+/// TODO: investigate flakiness for openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)). Tracked by: #2100
 #[openvmm_test(
     openvmm_openhcl_linux_direct_x64,
     // openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))


### PR DESCRIPTION
#2003 Introduced a change to potentially fix a flaky vmm_test related to validating mnf usage in guests. However, it looks like the test flakiness has not been resolved. I am disabling the test for now to unblock contributors while I have a proper chance to investigate the issue. 