### PR TITLE
vmgstool: encryption tests

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -2880,7 +2880,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmm-tests-archive}'
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -2916,6 +2916,7 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 19 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
@@ -2927,6 +2928,7 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
@@ -3083,7 +3085,7 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -2882,7 +2882,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmm-tests-archive}'
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -2918,6 +2918,7 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 19 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
@@ -2929,6 +2930,7 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
@@ -3085,7 +3087,7 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3342,7 +3342,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmm-tests-archive}'
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -3378,6 +3378,7 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 20 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 20 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 20 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
@@ -3389,6 +3390,7 @@ jobs:
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
@@ -3545,7 +3547,7 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
 name = "get_resources"
 version = "0.0.0"
 dependencies = [
+ "guid",
  "inspect",
  "mesh",
  "thiserror 2.0.16",
@@ -9299,6 +9300,7 @@ dependencies = [
  "unix_socket",
  "virtio_resources",
  "vm_resource",
+ "vmgs_resources",
  "vmm_test_macros",
  "zerocopy 0.8.25",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,7 +2486,6 @@ dependencies = [
 name = "get_resources"
 version = "0.0.0"
 dependencies = [
- "guid",
  "inspect",
  "mesh",
  "thiserror 2.0.16",

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -397,6 +397,7 @@ impl IntoPipeline for CheckinGatesCli {
                     },
                     profile: CommonProfile::from_release(release),
                     with_crypto: true,
+                    with_test_helpers: true,
                     vmgstool: ctx.publish_typed_artifact(pub_vmgstool),
                 });
 
@@ -507,6 +508,7 @@ impl IntoPipeline for CheckinGatesCli {
                     },
                     profile: CommonProfile::from_release(release),
                     with_crypto: true,
+                    with_test_helpers: true,
                     vmgstool: ctx.publish_typed_artifact(pub_vmgstool),
                 })
                 .dep_on(|ctx| flowey_lib_hvlite::build_and_test_vmgs_lib::Request {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -275,6 +275,7 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_windows_aarch64.use_pipette_windows =
                         Some(use_pipette_windows.clone());
                     vmm_tests_artifacts_windows_aarch64.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_vmgstool = Some(use_vmgstool.clone());
                 }
             }
             // emit a job for artifacts which _are not_ in the VMM tests "hot
@@ -1241,6 +1242,7 @@ mod vmm_tests_artifact_builders {
         pub use_openvmm: Option<UseTypedArtifact<OpenvmmOutput>>,
         pub use_pipette_windows: Option<UseTypedArtifact<PipetteOutput>>,
         pub use_tmk_vmm: Option<UseTypedArtifact<TmkVmmOutput>>,
+        pub use_vmgstool: Option<UseTypedArtifact<VmgstoolOutput>>,
         // linux build machine
         pub use_openhcl_igvm_files: Option<UseArtifact>,
         pub use_pipette_linux_musl: Option<UseTypedArtifact<PipetteOutput>>,
@@ -1261,6 +1263,7 @@ mod vmm_tests_artifact_builders {
                 use_tmk_vmm,
                 use_tmk_vmm_linux_musl,
                 use_tmks,
+                use_vmgstool,
             } = self;
 
             let use_openvmm = use_openvmm.ok_or("openvmm")?;
@@ -1271,6 +1274,7 @@ mod vmm_tests_artifact_builders {
             let use_tmk_vmm = use_tmk_vmm.ok_or("tmk_vmm")?;
             let use_tmk_vmm_linux_musl = use_tmk_vmm_linux_musl.ok_or("tmk_vmm_linux_musl")?;
             let use_tmks = use_tmks.ok_or("tmks")?;
+            let use_vmgstool = use_vmgstool.ok_or("vmgstool")?;
 
             Ok(Box::new(move |ctx| VmmTestsDepArtifacts {
                 openvmm: Some(ctx.use_typed_artifact(&use_openvmm)),
@@ -1282,7 +1286,7 @@ mod vmm_tests_artifact_builders {
                 tmk_vmm_linux_musl: Some(ctx.use_typed_artifact(&use_tmk_vmm_linux_musl)),
                 tmks: Some(ctx.use_typed_artifact(&use_tmks)),
                 prep_steps: None,
-                vmgstool: None,
+                vmgstool: Some(ctx.use_typed_artifact(&use_vmgstool)),
             }))
         }
     }

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -689,6 +689,7 @@ impl SimpleFlowNode for Node {
                 target: target.clone(),
                 profile: CommonProfile::from_release(release),
                 with_crypto: true,
+                with_test_helpers: true,
                 vmgstool: v,
             });
             if copy_extras {

--- a/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
@@ -8,7 +8,6 @@ use crate::run_cargo_build::common::CommonTriple;
 use flowey::node::prelude::*;
 use flowey_lib_common::run_cargo_build::CargoCrateType;
 use flowey_lib_common::run_cargo_build::CargoFeatureSet;
-use std::collections::BTreeSet;
 
 #[derive(Serialize, Deserialize)]
 #[serde(untagged)]
@@ -69,18 +68,16 @@ impl SimpleFlowNode for Node {
             }));
         }
 
-        let mut features: BTreeSet<String> = BTreeSet::new();
+        let mut features = Vec::new();
         if with_crypto {
             match target.as_triple().operating_system {
-                target_lexicon::OperatingSystem::Windows => {
-                    features.insert("encryption_win".into())
-                }
-                target_lexicon::OperatingSystem::Linux => features.insert("encryption_ossl".into()),
+                target_lexicon::OperatingSystem::Windows => features.push("encryption_win".into()),
+                target_lexicon::OperatingSystem::Linux => features.push("encryption_ossl".into()),
                 _ => unreachable!(),
             };
         }
         if with_test_helpers {
-            features.insert("test_helpers".into());
+            features.push("test_helpers".into());
         }
 
         let output = ctx.reqv(|v| crate::run_cargo_build::Request {
@@ -88,7 +85,7 @@ impl SimpleFlowNode for Node {
             out_name: "vmgstool".into(),
             crate_type: CargoCrateType::Bin,
             profile: profile.into(),
-            features: CargoFeatureSet::Specific(features.into_iter().collect()),
+            features: CargoFeatureSet::Specific(features),
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,

--- a/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
@@ -7,6 +7,7 @@ use crate::run_cargo_build::common::CommonProfile;
 use crate::run_cargo_build::common::CommonTriple;
 use flowey::node::prelude::*;
 use flowey_lib_common::run_cargo_build::CargoCrateType;
+use flowey_lib_common::run_cargo_build::CargoFeatureSet;
 use std::collections::BTreeSet;
 
 #[derive(Serialize, Deserialize)]
@@ -68,7 +69,7 @@ impl SimpleFlowNode for Node {
             }));
         }
 
-        let mut features = BTreeSet::new();
+        let mut features: BTreeSet<String> = BTreeSet::new();
         if with_crypto {
             match target.as_triple().operating_system {
                 target_lexicon::OperatingSystem::Windows => {
@@ -87,7 +88,7 @@ impl SimpleFlowNode for Node {
             out_name: "vmgstool".into(),
             crate_type: CargoCrateType::Bin,
             profile: profile.into(),
-            features,
+            features: CargoFeatureSet::Specific(features.into_iter().collect()),
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,

--- a/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
@@ -7,6 +7,7 @@ use crate::run_cargo_build::common::CommonProfile;
 use crate::run_cargo_build::common::CommonTriple;
 use flowey::node::prelude::*;
 use flowey_lib_common::run_cargo_build::CargoCrateType;
+use std::collections::BTreeSet;
 
 #[derive(Serialize, Deserialize)]
 #[serde(untagged)]
@@ -32,6 +33,7 @@ flowey_request! {
         pub target: CommonTriple,
         pub profile: CommonProfile,
         pub with_crypto: bool,
+        pub with_test_helpers: bool,
         pub vmgstool: WriteVar<VmgstoolOutput>,
     }
 }
@@ -51,6 +53,7 @@ impl SimpleFlowNode for Node {
             target,
             profile,
             with_crypto,
+            with_test_helpers,
             vmgstool,
         } = request;
 
@@ -65,20 +68,26 @@ impl SimpleFlowNode for Node {
             }));
         }
 
+        let mut features = BTreeSet::new();
+        if with_crypto {
+            match target.as_triple().operating_system {
+                target_lexicon::OperatingSystem::Windows => {
+                    features.insert("encryption_win".into())
+                }
+                target_lexicon::OperatingSystem::Linux => features.insert("encryption_ossl".into()),
+                _ => unreachable!(),
+            };
+        }
+        if with_test_helpers {
+            features.insert("test_helpers".into());
+        }
+
         let output = ctx.reqv(|v| crate::run_cargo_build::Request {
             crate_name: "vmgstool".into(),
             out_name: "vmgstool".into(),
             crate_type: CargoCrateType::Bin,
             profile: profile.into(),
-            features: if with_crypto {
-                match target.as_triple().operating_system {
-                    target_lexicon::OperatingSystem::Windows => ["encryption_win"].into(),
-                    target_lexicon::OperatingSystem::Linux => ["encryption_ossl"].into(),
-                    _ => unreachable!(),
-                }
-            } else {
-                Default::default()
-            },
+            features,
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -125,6 +125,7 @@ use vmcore::vmtime::VmTime;
 use vmcore::vmtime::VmTimeKeeper;
 use vmcore::vmtime::VmTimeSource;
 use vmgs_broker::resolver::VmgsFileResolver;
+use vmgs_resources::GuestStateEncryptionPolicy;
 use vmgs_resources::VmgsResource;
 use vmm_core::acpi_builder::AcpiTablesBuilder;
 use vmm_core::input_distributor::InputDistributor;
@@ -1030,10 +1031,18 @@ impl InitializedVm {
             }
         }
 
+        if cfg
+            .vmgs
+            .as_ref()
+            .is_some_and(|x| !matches!(x.encryption_policy(), GuestStateEncryptionPolicy::None(_)))
+        {
+            unimplemented!("guest state encryption not supported on openvmm");
+        }
+
         let vmgs = match cfg.vmgs {
             Some(VmgsResource::Disk(disk)) => Some(
                 vmgs::Vmgs::try_open(
-                    open_simple_disk(&resolver, disk, false, &driver_source).await?,
+                    open_simple_disk(&resolver, disk.disk, false, &driver_source).await?,
                     None,
                     true,
                     false,
@@ -1043,7 +1052,7 @@ impl InitializedVm {
             ),
             Some(VmgsResource::ReprovisionOnFailure(disk)) => Some(
                 vmgs::Vmgs::try_open(
-                    open_simple_disk(&resolver, disk, false, &driver_source).await?,
+                    open_simple_disk(&resolver, disk.disk, false, &driver_source).await?,
                     None,
                     true,
                     true,
@@ -1053,7 +1062,7 @@ impl InitializedVm {
             ),
             Some(VmgsResource::Reprovision(disk)) => Some(
                 vmgs::Vmgs::format_new(
-                    open_simple_disk(&resolver, disk, false, &driver_source).await?,
+                    open_simple_disk(&resolver, disk.disk, false, &driver_source).await?,
                     None,
                 )
                 .await

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -412,6 +412,10 @@ flags:
     #[clap(long)]
     pub vmgs: Option<VmgsCli>,
 
+    /// Use GspById guest state encryption policy with a test seed
+    #[clap(long, requires("vmgs"))]
+    pub test_gsp_by_id: bool,
+
     /// VGA firmware file
     #[clap(long, requires("pcat"), value_name = "FILE")]
     pub vga_firmware: Option<PathBuf>,

--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -450,19 +450,18 @@ function Set-TurnOffOnGuestRestart
     Set-VmSystemSettings $vssd
 }
 
-function Set-GuestStateFile
+function Get-GuestStateFile
 {
     [CmdletBinding()]
     Param (
         [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
         [System.Object]
-        $Vm,
-
-        [Parameter(Mandatory = $true)]
-        [string] $VmgsFile
+        $Vm
     )
 
     $vssd = Get-Vssd $Vm
-    $vssd.GuestStateFile = $VmgsFile
-    Set-VmSystemSettings $vssd
+    $guestStateDataRoot = $vssd.GuestStateDataRoot
+    $guestStateFile = $vssd.GuestStateFile
+    
+    return "$guestStateDataRoot\$guestStateFile"
 }

--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -449,3 +449,20 @@ function Set-TurnOffOnGuestRestart
     $vssd.TurnOffOnGuestRestart = $Enable
     Set-VmSystemSettings $vssd
 }
+
+function Set-GuestStateFile
+{
+    [CmdletBinding()]
+    Param (
+        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [System.Object]
+        $Vm,
+
+        [Parameter(Mandatory = $true)]
+        [string] $VmgsFile
+    )
+
+    $vssd = Get-Vssd $Vm
+    $vssd.GuestStateFile = $VmgsFile
+    Set-VmSystemSettings $vssd
+}

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -244,7 +244,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
             generation,
             guest_state_isolation_type,
             memory.startup_bytes,
-            vmgs_path.as_ref().map(|x| x.as_path()),
+            vmgs_path.as_deref(),
             log_source.log_file("hyperv")?,
             driver.clone(),
         )

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1067,3 +1067,27 @@ pub async fn run_get_vm_host() -> anyhow::Result<HyperVGetVmHost> {
     serde_json::from_str::<HyperVGetVmHost>(&output)
         .map_err(|e| anyhow::anyhow!("failed to parse HyperVGetVmHost: {}", e))
 }
+
+/// Runs Set-GuestStateFile with the given arguments.
+pub async fn run_set_guest_state_file(
+    vmid: &Guid,
+    ps_mod: &Path,
+    vmgs_file: &Path,
+) -> anyhow::Result<()> {
+    run_host_cmd(
+        PowerShellBuilder::new()
+            .cmdlet("Import-Module")
+            .positional(ps_mod)
+            .next()
+            .cmdlet("Get-VM")
+            .arg("Id", vmid)
+            .pipeline()
+            .cmdlet("Set-GuestStateFile")
+            .arg("VmgsFile", vmgs_file)
+            .finish()
+            .build(),
+    )
+    .await
+    .map(|_| ())
+    .context("set_guest_state_file")
+}

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -55,6 +55,7 @@ impl HyperVVM {
         generation: powershell::HyperVGeneration,
         guest_state_isolation_type: powershell::HyperVGuestStateIsolationType,
         memory: u64,
+        vmgs_path: Option<&Path>,
         log_file: PetriLogFile,
         driver: DefaultDriver,
     ) -> anyhow::Result<Self> {
@@ -106,6 +107,7 @@ impl HyperVVM {
             memory_startup_bytes: Some(memory),
             path: None,
             vhd_path: None,
+            source_guest_state_path: vmgs_path,
         })
         .await?;
 
@@ -509,9 +511,9 @@ impl HyperVVM {
         }
     }
 
-    /// Set the VM's guest state file
-    pub async fn set_guest_state_file(&self, vmgs_file: &Path) -> anyhow::Result<()> {
-        powershell::run_set_guest_state_file(&self.vmid, &self.ps_mod, vmgs_file).await
+    /// Get the VM's guest state file
+    pub async fn get_guest_state_file(&self) -> anyhow::Result<PathBuf> {
+        powershell::run_get_guest_state_file(&self.vmid, &self.ps_mod).await
     }
 }
 

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -481,7 +481,7 @@ impl HyperVVM {
         Ok(())
     }
 
-    /// Sets the VM firmware  command line.
+    /// Sets the VM firmware command line.
     pub async fn set_vm_firmware_command_line(
         &self,
         openhcl_command_line: &str,
@@ -507,6 +507,11 @@ impl HyperVVM {
             temp_bin_path: self.temp_dir.path().join("screenshot.bin"),
             ps_mod: self.ps_mod.clone(),
         }
+    }
+
+    /// Set the VM's guest state file
+    pub async fn set_guest_state_file(&self, vmgs_file: &Path) -> anyhow::Result<()> {
+        powershell::run_set_guest_state_file(&self.vmid, &self.ps_mod, vmgs_file).await
     }
 }
 

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1658,7 +1658,7 @@ impl Default for PetriVmgsDisk {
     fn default() -> Self {
         PetriVmgsDisk {
             disk: PetriDiskType::Memory,
-            // TODO: make this strict once we can set it in OpenHCL
+            // TODO: make this strict once we can set it in OpenHCL on Hyper-V
             encryption_policy: GuestStateEncryptionPolicy::None(false),
         }
     }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -699,7 +699,7 @@ impl PetriVmConfigSetupCore<'_> {
 
                 append_cmdline(
                     &mut cmdline,
-                    &format!("panic=-1 reboot=triple {openhcl_tracing} {openhcl_show_spans}"),
+                    format!("panic=-1 reboot=triple {openhcl_tracing} {openhcl_show_spans}"),
                 );
 
                 let isolated = match self.firmware {

--- a/vm/devices/get/get_resources/Cargo.toml
+++ b/vm/devices/get/get_resources/Cargo.toml
@@ -9,8 +9,6 @@ rust-version.workspace = true
 [dependencies]
 vm_resource.workspace = true
 vmgs_resources.workspace = true
-
-guid.workspace = true
 mesh.workspace = true
 inspect.workspace = true
 

--- a/vm/devices/get/get_resources/Cargo.toml
+++ b/vm/devices/get/get_resources/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 vm_resource.workspace = true
 vmgs_resources.workspace = true
 
+guid.workspace = true
 mesh.workspace = true
 inspect.workspace = true
 

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -89,6 +89,8 @@ pub mod ged {
         pub no_persistent_secrets: bool,
         /// Test configuration for IGVM Attest message.
         pub igvm_attest_test_config: Option<IgvmAttestTestConfig>,
+        /// Send the test seed for GspById requests
+        pub test_gsp_by_id: bool,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -283,6 +283,7 @@ pub fn create_host_channel(
         None,
         Some(disklayer_ram::ram_disk(TEST_VMGS_CAPACITY as u64, false).unwrap()),
         igvm_agent_plan.map(IgvmAgentTestSetting::TestPlan),
+        false,
     );
 
     if let Some(ged_responses) = ged_responses {

--- a/vm/vmgs/vmgs_resources/src/lib.rs
+++ b/vm/vmgs/vmgs_resources/src/lib.rs
@@ -41,11 +41,73 @@ impl ResourceId<NonVolatileStoreKind> for VmgsFileHandle {
 #[derive(MeshPayload, Debug)]
 pub enum VmgsResource {
     /// Use disk to store guest state
-    Disk(Resource<DiskHandleKind>),
+    Disk(VmgsDisk),
     /// Use disk to store guest state, reformatting if corrupted.
-    ReprovisionOnFailure(Resource<DiskHandleKind>),
+    ReprovisionOnFailure(VmgsDisk),
     /// Format and use disk to store guest state
-    Reprovision(Resource<DiskHandleKind>),
+    Reprovision(VmgsDisk),
     /// Store guest state in memory
     Ephemeral,
+}
+
+impl VmgsResource {
+    /// get the encryption policy (returns None for ephemeral guest state)
+    pub fn encryption_policy(&self) -> GuestStateEncryptionPolicy {
+        match self {
+            VmgsResource::Disk(vmgs)
+            | VmgsResource::ReprovisionOnFailure(vmgs)
+            | VmgsResource::Reprovision(vmgs) => vmgs.encryption_policy,
+            VmgsResource::Ephemeral => GuestStateEncryptionPolicy::None(true),
+        }
+    }
+}
+
+/// VMGS disk resource
+#[derive(MeshPayload, Debug)]
+pub struct VmgsDisk {
+    /// Backing disk
+    pub disk: Resource<DiskHandleKind>,
+    /// Guest state encryption policy
+    pub encryption_policy: GuestStateEncryptionPolicy,
+}
+
+/// Guest state encryption policy
+#[derive(MeshPayload, Debug, Clone, Copy)]
+pub enum GuestStateEncryptionPolicy {
+    /// Use the best encryption available, allowing fallback.
+    ///
+    /// VMs will be created as or migrated to the best encryption available,
+    /// attempting GspKey, then GspById, and finally leaving the data
+    /// unencrypted if neither are available.
+    Auto,
+    /// Prefer (or require, if strict) no encryption.
+    ///
+    /// Do not encrypt the guest state unless it is already encrypted and
+    /// strict encryption policy is disabled.
+    None(bool),
+    /// Prefer (or require, if strict) GspById.
+    ///
+    /// This prevents a VM from being created as or migrated to GspKey even
+    /// if it is available. Exisiting GspKey encryption will be used unless
+    /// strict encryption policy is enabled. Fails if the data cannot be
+    /// encrypted.
+    GspById(bool),
+    /// Require GspKey.
+    ///
+    /// VMs will be created as or migrated to GspKey. Fails if GspKey is
+    /// not available. Strict encryption policy has no effect here since
+    /// GspKey is currently the most secure policy.
+    GspKey(bool),
+}
+
+impl GuestStateEncryptionPolicy {
+    /// whether to use strict encryption policy
+    pub fn is_strict(&self) -> bool {
+        match self {
+            GuestStateEncryptionPolicy::Auto => false,
+            GuestStateEncryptionPolicy::None(strict)
+            | GuestStateEncryptionPolicy::GspById(strict)
+            | GuestStateEncryptionPolicy::GspKey(strict) => *strict,
+        }
+    }
 }

--- a/vmm_tests/vmm_tests/Cargo.toml
+++ b/vmm_tests/vmm_tests/Cargo.toml
@@ -42,6 +42,7 @@ mesh.workspace = true
 pal.workspace = true
 pal_async.workspace = true
 unix_socket.workspace = true
+vmgs_resources.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
@@ -131,7 +131,7 @@ async fn vmgstool_create<T: PetriVmmBackend>(
     // path here.
     let vmgs_path = vm.get_guest_state_file().await?.unwrap_or(vmgs_path);
 
-    run_vmgstool_verification(&vmgstool_path, &vmgs_path, None, &temp_dir).await?;
+    run_vmgstool_verification(vmgstool_path, &vmgs_path, None, &temp_dir).await?;
 
     vm.teardown().await?;
 
@@ -198,7 +198,7 @@ async fn vmgstool_encryption<T: PetriVmmBackend>(
     let key_path = temp_dir.path().join("key.bin");
     let vmgstool_path = vmgstool.get();
 
-    std::fs::write(&key_path, &TEST_GSP_BY_ID)?;
+    std::fs::write(&key_path, TEST_GSP_BY_ID)?;
 
     let mut cmd = Command::new(vmgstool_path);
     cmd.arg("create")
@@ -220,7 +220,7 @@ async fn vmgstool_encryption<T: PetriVmmBackend>(
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;
 
-    run_vmgstool_verification(&vmgstool_path, &vmgs_path, Some(&key_path), &temp_dir).await?;
+    run_vmgstool_verification(vmgstool_path, &vmgs_path, Some(&key_path), &temp_dir).await?;
 
     Ok(())
 }
@@ -329,7 +329,7 @@ async fn vmgstool_update_key<T: PetriVmmBackend>(
     let key3_path = temp_dir.path().join("key3.bin");
     let vmgstool_path = vmgstool.get();
 
-    std::fs::write(&key3_path, &TEST_GSP_BY_ID)?;
+    std::fs::write(&key3_path, TEST_GSP_BY_ID)?;
 
     let mut cmd = Command::new(vmgstool_path);
     cmd.arg("test")

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use petri::CommandError;
 use petri::PetriGuestStateLifetime;
 use petri::PetriVmBuilder;
 use petri::PetriVmmBackend;
@@ -10,7 +11,10 @@ use petri::run_host_cmd;
 use petri_artifacts_common::tags::IsVmgsTool;
 use petri_artifacts_vmm_test::artifacts::VMGSTOOL_NATIVE;
 use petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY;
+use std::path::Path;
 use std::process::Command;
+use tempfile::TempDir;
+use vmgs_resources::GuestStateEncryptionPolicy;
 use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
 use vmm_test_macros::vmm_test_no_agent;
@@ -114,24 +118,22 @@ async fn vmgstool_create<T: PetriVmmBackend>(
     cmd.arg("create").arg("--filepath").arg(&vmgs_path);
     run_host_cmd(cmd).await?;
 
-    let (vm, agent) = config
+    let (mut vm, agent) = config
         .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
         .with_persistent_vmgs(&vmgs_path)
         .run()
         .await?;
 
     agent.power_off().await?;
-    vm.wait_for_clean_teardown().await?;
+    vm.wait_for_clean_shutdown().await?;
 
-    // make sure the vmgs was actually used and that there are some boot
-    // entries now. (command will fail if the fileid is not allocated)
-    let mut cmd = Command::new(vmgstool_path);
-    cmd.arg("uefi-nvram")
-        .arg("remove-boot-entries")
-        .arg("--filepath")
-        .arg(&vmgs_path)
-        .arg("--dry-run");
-    run_host_cmd(cmd).await?;
+    // Hyper-V VMs copy the VMGS rather than use it in-place, so update the
+    // path here.
+    let vmgs_path = vm.get_guest_state_file().await?.unwrap_or(vmgs_path);
+
+    run_vmgstool_verification(&vmgstool_path, &vmgs_path, None, &temp_dir).await?;
+
+    vm.teardown().await?;
 
     Ok(())
 }
@@ -167,6 +169,195 @@ async fn vmgstool_remove_boot_entries<T: PetriVmmBackend>(
     let (vm, agent) = config
         .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
         .with_persistent_vmgs(&vmgs_path)
+        .run()
+        .await?;
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+
+    Ok(())
+}
+
+/// Test key for encrypting VMGS that matches test seed and bios guid in the
+/// openvmm guest emulation device.
+const TEST_GSP_BY_ID: [u8; 32] = [
+    0x30, 0x4, 0xE2, 0x1E, 0x2E, 0x5E, 0x26, 0xDA, 0x18, 0xFA, 0x7F, 0x3, 0x8, 0x29, 0xB8, 0x91,
+    0x61, 0xAD, 0x54, 0xB4, 0xAC, 0x4D, 0x9A, 0xEF, 0x72, 0xB3, 0x28, 0x41, 0xF2, 0xB7, 0x5, 0x1A,
+];
+
+/// Test vmgstool encryption
+#[openvmm_test(
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGSTOOL_NATIVE],
+)]
+async fn vmgstool_encryption<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+    (vmgstool,): (ResolvedArtifact<impl IsVmgsTool>,),
+) -> Result<(), anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    let vmgs_path = temp_dir.path().join("test.vmgs");
+    let key_path = temp_dir.path().join("key.bin");
+    let vmgstool_path = vmgstool.get();
+
+    std::fs::write(&key_path, &TEST_GSP_BY_ID)?;
+
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("create")
+        .arg("--filepath")
+        .arg(&vmgs_path)
+        .arg("--keypath")
+        .arg(&key_path)
+        .arg("--encryptionalgorithm")
+        .arg("AES_GCM");
+    run_host_cmd(cmd).await?;
+
+    let (vm, agent) = config
+        .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
+        .with_persistent_vmgs(&vmgs_path)
+        .with_guest_state_encryption(GuestStateEncryptionPolicy::GspById(true))
+        .run()
+        .await?;
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+
+    run_vmgstool_verification(&vmgstool_path, &vmgs_path, Some(&key_path), &temp_dir).await?;
+
+    Ok(())
+}
+
+/// test some vmgstool commands by verifying that the vmgs file is in a good state
+async fn run_vmgstool_verification(
+    vmgstool_path: &Path,
+    vmgs_path: &Path,
+    key_path: Option<&Path>,
+    temp_dir: &TempDir,
+) -> anyhow::Result<()> {
+    // check that the headers are valid
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("dump-headers").arg("--filepath").arg(vmgs_path);
+    run_host_cmd(cmd).await?;
+
+    // make sure the vmgs was actually used and that there are some boot
+    // entries now.
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("query-size")
+        .arg("--filepath")
+        .arg(vmgs_path)
+        .arg("--file-id")
+        .arg("1");
+    run_host_cmd(cmd).await?;
+
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("uefi-nvram")
+        .arg("remove-boot-entries")
+        .arg("--filepath")
+        .arg(vmgs_path)
+        .arg("--dry-run");
+    if let Some(key_path) = key_path {
+        cmd.arg("--keypath").arg(key_path);
+    }
+    run_host_cmd(cmd).await?;
+
+    // check encryption
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("query-encryption").arg("--filepath").arg(vmgs_path);
+    let res = run_host_cmd(cmd).await;
+    let code = match res {
+        Ok(_) => Some(0),
+        Err(CommandError::Command(status, _)) => status.code(),
+        _ => None,
+    };
+    if key_path.is_none() {
+        // No encryption
+        assert_eq!(code, Some(2));
+    } else {
+        // GspById
+        assert_eq!(code, Some(6));
+    }
+
+    // write and read
+    let data_path = temp_dir.path().join("test.bin");
+    let contents = b"hello world";
+    std::fs::write(&data_path, contents)?;
+
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("write")
+        .arg("--filepath")
+        .arg(vmgs_path)
+        .arg("--data-path")
+        .arg(&data_path)
+        .arg("--fileid")
+        .arg("3")
+        .arg("--allow-overwrite");
+    if let Some(key_path) = key_path {
+        cmd.arg("--keypath").arg(key_path);
+    }
+    run_host_cmd(cmd).await?;
+
+    let out_data_path = temp_dir.path().join("out.bin");
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("dump")
+        .arg("--filepath")
+        .arg(vmgs_path)
+        .arg("--data-path")
+        .arg(&out_data_path)
+        .arg("--fileid")
+        .arg("3");
+    if let Some(key_path) = key_path {
+        cmd.arg("--keypath").arg(key_path);
+    }
+    run_host_cmd(cmd).await?;
+
+    let output = std::fs::read(&out_data_path)?;
+    assert_eq!(&contents[..], &output[..]);
+
+    Ok(())
+}
+
+/// Test vmgstool encryption
+#[openvmm_test(
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGSTOOL_NATIVE],
+)]
+async fn vmgstool_update_key<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+    (vmgstool,): (ResolvedArtifact<impl IsVmgsTool>,),
+) -> Result<(), anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    let vmgs_path = temp_dir.path().join("test.vmgs");
+    let key1_path = temp_dir.path().join("key1.bin");
+    let key2_path = temp_dir.path().join("key2.bin");
+    let key3_path = temp_dir.path().join("key3.bin");
+    let vmgstool_path = vmgstool.get();
+
+    std::fs::write(&key3_path, &TEST_GSP_BY_ID)?;
+
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("test")
+        .arg("two-keys")
+        .arg("--filepath")
+        .arg(&vmgs_path)
+        .arg("--first-key-path")
+        .arg(&key1_path)
+        .arg("--first-key-path")
+        .arg(&key2_path);
+    run_host_cmd(cmd).await?;
+
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("update-key")
+        .arg("--filepath")
+        .arg(&vmgs_path)
+        .arg("--keypath")
+        .arg(&key2_path)
+        .arg("--newkeypath")
+        .arg(&key3_path)
+        .arg("--encryptionalgorithm")
+        .arg("AES_GCM");
+    run_host_cmd(cmd).await?;
+
+    let (vm, agent) = config
+        .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
+        .with_persistent_vmgs(&vmgs_path)
+        .with_guest_state_encryption(GuestStateEncryptionPolicy::GspById(true))
         .run()
         .await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
@@ -338,7 +338,7 @@ async fn vmgstool_update_key<T: PetriVmmBackend>(
         .arg(&vmgs_path)
         .arg("--first-key-path")
         .arg(&key1_path)
-        .arg("--first-key-path")
+        .arg("--second-key-path")
         .arg(&key2_path);
     run_host_cmd(cmd).await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
@@ -3,6 +3,7 @@
 
 use petri::PetriGuestStateLifetime;
 use petri::PetriVmBuilder;
+use petri::PetriVmmBackend;
 use petri::ResolvedArtifact;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::run_host_cmd;
@@ -11,7 +12,8 @@ use petri_artifacts_vmm_test::artifacts::VMGSTOOL_NATIVE;
 use petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY;
 use std::process::Command;
 use vmm_test_macros::openvmm_test;
-use vmm_test_macros::openvmm_test_no_agent;
+use vmm_test_macros::vmm_test;
+use vmm_test_macros::vmm_test_no_agent;
 
 /// Verify that UEFI default boots even if invalid boot entries exist
 /// when `default_boot_always_attempt` is enabled.
@@ -42,7 +44,7 @@ async fn default_boot(
 
 /// Verify that UEFI successfully boots an operating system after reprovisioning
 /// the VMGS when invalid boot entries existed initially.
-#[openvmm_test(
+#[vmm_test(
     openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
@@ -50,8 +52,8 @@ async fn default_boot(
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY]
 )]
-async fn clear_vmgs(
-    config: PetriVmBuilder<OpenVmmPetriBackend>,
+async fn clear_vmgs<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
@@ -70,7 +72,7 @@ async fn clear_vmgs(
 ///
 /// This test exists to ensure we are not getting a false positive for
 /// the `default_boot` and `clear_vmgs` test above.
-#[openvmm_test_no_agent(
+#[vmm_test_no_agent(
     openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
@@ -78,8 +80,8 @@ async fn clear_vmgs(
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY]
 )]
-async fn boot_expect_fail(
-    config: PetriVmBuilder<OpenVmmPetriBackend>,
+async fn invalid_boot_entries<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let vm = config
@@ -95,11 +97,13 @@ async fn boot_expect_fail(
 }
 
 /// Test vmgstool create command
-#[openvmm_test(
-    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGSTOOL_NATIVE]
+#[vmm_test(
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGSTOOL_NATIVE],
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGSTOOL_NATIVE],
+    hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGSTOOL_NATIVE]
 )]
-async fn vmgstool_create(
-    config: PetriVmBuilder<OpenVmmPetriBackend>,
+async fn vmgstool_create<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
     (vmgstool,): (ResolvedArtifact<impl IsVmgsTool>,),
 ) -> Result<(), anyhow::Error> {
     let temp_dir = tempfile::tempdir()?;
@@ -120,12 +124,13 @@ async fn vmgstool_create(
     vm.wait_for_clean_teardown().await?;
 
     // make sure the vmgs was actually used and that there are some boot
-    // entries now
+    // entries now. (command will fail if the fileid is not allocated)
     let mut cmd = Command::new(vmgstool_path);
     cmd.arg("uefi-nvram")
         .arg("remove-boot-entries")
         .arg("--filepath")
-        .arg(&vmgs_path);
+        .arg(&vmgs_path)
+        .arg("--dry-run");
     run_host_cmd(cmd).await?;
 
     Ok(())
@@ -133,11 +138,13 @@ async fn vmgstool_create(
 
 /// Test vmgstool remove-boot-entries command to make sure it removes the
 /// invalid boot entries and the vm boots.
-#[openvmm_test(
-    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGSTOOL_NATIVE, VMGS_WITH_BOOT_ENTRY]
+#[vmm_test(
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGSTOOL_NATIVE, VMGS_WITH_BOOT_ENTRY],
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGSTOOL_NATIVE, VMGS_WITH_BOOT_ENTRY],
+    hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGSTOOL_NATIVE, VMGS_WITH_BOOT_ENTRY],
 )]
-async fn vmgstool_remove_boot_entries(
-    config: PetriVmBuilder<OpenVmmPetriBackend>,
+async fn vmgstool_remove_boot_entries<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
     (vmgstool, initial_vmgs): (
         ResolvedArtifact<impl IsVmgsTool>,
         ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,


### PR DESCRIPTION
Adds the necessary infrastructure and plumbing to support testing VmgsTool and OpenHCL in petri with GspById VMGS encryption. Tests all VmgsTool commands used in production.