### PR TITLE
petri: Fix expected event ordering

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -275,6 +275,8 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             vm.wait_for_reset_core().await?;
         }
 
+        vm.wait_for_expected_boot_event().await?;
+
         let client = if with_agent {
             Some(vm.wait_for_agent().await?)
         } else {
@@ -287,8 +289,6 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 tracing::warn!("failed to set console loglevel: {}", result.unwrap_err());
             }
         }
-
-        vm.wait_for_expected_boot_event().await?;
 
         Ok((vm, client))
     }


### PR DESCRIPTION
Boot events happen before pipette will be active and connected, so we need to wait for them in the right order. Should hopefully fix a source of test flakiness.