### PR TITLE
CI: Don't require ARM VMM tests to pass right now

### DIFF
--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3735,7 +3735,6 @@ jobs:
     - job18
     - job19
     - job2
-    - job20
     - job21
     - job3
     - job4

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1048,7 +1048,12 @@ impl IntoPipeline for CheckinGatesCli {
                 })
             }
 
-            all_jobs.push(vmm_tests_run_job.finish());
+            // ARM VMM tests currently are hitting a UEFI bug that causes them to randomly fail.
+            // For now to unblock other devs don't require them to pass in PRs.
+            // TODO: Remove this if
+            if arch != FlowArch::Aarch64 {
+                all_jobs.push(vmm_tests_run_job.finish());
+            }
         }
 
         // test the flowey local backend by running cargo xflowey build-igvm on x64


### PR DESCRIPTION
There is a bug somewhere in ARM's UEFI that is causing VMM tests to randomly fail with spurious VMBus errors. The investigation of this bug is ongoing. However, until we have a fix, we should unblock CI for others. Don't require these tests to pass for the moment to allow merges, but still run them.