### PR TITLE
netvsp: adding packet filter and pending rx packets to netvsp inspect

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -210,6 +210,7 @@ impl<T: RingMem + 'static + Sync> InspectTaskMut<Worker<T>> for NetQueue {
                     "outstanding_tx_packets",
                     state.state.pending_tx_packets.len() - state.state.free_tx_packets.len(),
                 )
+                .field("pending_rx_packets", state.state.pending_rx_packets.len())
                 .field(
                     "pending_tx_completions",
                     state.state.pending_tx_completions.len(),
@@ -217,6 +218,8 @@ impl<T: RingMem + 'static + Sync> InspectTaskMut<Worker<T>> for NetQueue {
                 .field("free_tx_packets", state.state.free_tx_packets.len())
                 .merge(&state.state.stats);
             }
+
+            resp.field("packet_filter", worker.channel.packet_filter);
         }
 
         if let Some(queue_state) = &mut self.queue_state {


### PR DESCRIPTION
Adding two new fields to inspect output:
* pending_rx_packets counter indicates the number of inbound packets await processing. Grows when packet_filter is blocking inbound packets.
* packet_filter indicates whether inbound traffic is being processed or filtered out.