### PR TITLE
[WIP] vmm_tests: enabling GP x64 memory validation tests

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -472,7 +472,7 @@ async fn guest_test_uefi<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
 }
 
 #[vmm_test(
-    // hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
 )]
 #[cfg_attr(not(windows), expect(dead_code))]


### PR DESCRIPTION
Description:
Updating the GP x64 baseline numbers to account for internal repository overhead, and enabling these tests for the pipeline.

Changes:
- Modified baseline values for GP x64 memory validation from hvlite data collection
- Enabling GP x64 memory validation tests