### PR TITLE
vmm_tests: fix release build by remove expect(dead_code) for memory validation tests

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -3,8 +3,6 @@
 
 //! Memory Validation for VMM Tests
 
-#![cfg_attr(not(debug_assertions), expect(dead_code))]
-
 use pal_async::DefaultDriver;
 use pal_async::timer::PolledTimer;
 use petri::IsolationType;


### PR DESCRIPTION
https://github.com/microsoft/openvmm/commit/5441d0af80f994d814b68b4513d985b4ac1c2133 broke release CI.