### PR TITLE
petri: Bump timeout again

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -322,7 +322,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         let mut tasks = Vec::new();
 
         {
-            const TIMEOUT_DURATION_MINUTES: u64 = 6;
+            const TIMEOUT_DURATION_MINUTES: u64 = 7;
             const TIMER_DURATION: Duration = Duration::from_secs(TIMEOUT_DURATION_MINUTES * 60);
             let log_source = resources.log_source.clone();
             let inspect_task =


### PR DESCRIPTION
Ubuntu reboot tests are still bumping up against the 6 minute timer. Make it 7.