### PR TITLE
Enable IBPB on entry

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -679,6 +679,8 @@ fn init_vmsa(
     vmsa.sev_features_mut()
         .set_snp_btb_isolation(sev_status.snp_btb_isolation());
     vmsa.sev_features_mut()
+        .set_ibpb_on_entry(sev_status.ibpb_on_entry());
+    vmsa.sev_features_mut()
         .set_prevent_host_ibs(sev_status.prevent_host_ibs());
     vmsa.sev_features_mut()
         .set_vmsa_reg_prot(sev_status.vmsa_reg_prot());

--- a/vm/loader/igvmfilegen/src/vp_context_builder/snp.rs
+++ b/vm/loader/igvmfilegen/src/vp_context_builder/snp.rs
@@ -89,6 +89,7 @@ impl SnpHardwareContext {
                 vmsa.sev_features
                     .set_restrict_injection(injection_type == InjectionType::Restricted);
                 vmsa.sev_features.set_snp_btb_isolation(true);
+                vmsa.sev_features.set_ibpb_on_entry(true);
                 vmsa.sev_features.set_prevent_host_ibs(true);
                 vmsa.sev_features.set_vmsa_reg_prot(true);
                 vmsa.sev_features.set_vtom(false);

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -124,7 +124,10 @@ pub struct SevFeatures {
     pub vmsa_reg_prot: bool,
     pub smt_prot: bool,
     pub secure_avic: bool,
-    #[bits(47)]
+    #[bits(4)]
+    _reserved: u64,
+    pub ibpb_on_entry: bool,
+    #[bits(42)]
     _unused: u64,
 }
 
@@ -779,7 +782,10 @@ pub struct SevStatusMsr {
     pub _rsvd4: bool,
     pub _rsvd5: bool,
     pub vmsa_reg_prot: bool,
-    #[bits(47)]
+    #[bits(6)]
+    _reserved: u64,
+    pub ibpb_on_entry: bool,
+    #[bits(40)]
     _unused: u64,
 }
 


### PR DESCRIPTION
Enable branch prediction barrier on entry for VTL 2 in the IGVM file gen tool and VMSA.