### PR TITLE
openhcl/virt_mshv_vtl: On TDX, always report that MCE,MCA,MTRR CPUID bits are set regardless of what the hardware says

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -163,6 +163,7 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
                 let mut result = Self::cpuid(leaf.0, subleaf);
 
                 // Apply TDX specific fixups.
+                #[expect(clippy::single_match)] // More may come later
                 match leaf {
                     // Always tell the guest that MCE, MCA, and MTRR are supported.
                     CpuidFunction::VersionAndFeatures => {


### PR DESCRIPTION
This fixes a regression with newer TDX firmware modules.

Closes #2131