### PR TITLE
CI: Give vmm tests more threads and more time

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,21 +6,21 @@ filter = 'package(~vmm_tests)'
 # Mark VMM tests as heavy and requiring more threads due to their memory and CPU
 # usage. For local dev runs, you may need to manually restrict the number of
 # threads running via the -j cli arg.
-threads-required = 2
+threads-required = 3
 
 [[profile.default.overrides]]
 # use fuzzy-matching for the package() to allow out-of-tree tests to use the
 # same profile
 filter = 'package(~vmm_tests) and test(openhcl)'
-# Mark OpenHCL VMM tests as extra heavy, as they have to also simulate VTL2.
-threads-required = 4
+# Mark OpenHCL VMM tests as extra heavy, as they have to also run VTL2.
+threads-required = 6
 
 [[profile.default.overrides]]
 # use fuzzy-matching for the package() to allow out-of-tree tests to use the
 # same profile
 filter = 'package(~vmm_tests) and test(heavy)'
 # Mark heavy tests as extra heavy, as they include up to 16 vps.
-threads-required = 16
+threads-required = 24
 
 # Profile for CI runs.
 [profile.ci]
@@ -46,4 +46,4 @@ slow-timeout = { period = "30s", terminate-after = 2 }
 filter = 'package(~vmm_tests)'
 # VMM tests contain their own watchdog timer, but keep an extra long timer
 # here as a backup.
-slow-timeout = { period = "10m", terminate-after = 1 }
+slow-timeout = { period = "15m", terminate-after = 1 }

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -323,7 +323,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         let mut tasks = Vec::new();
 
         {
-            const TIMEOUT_DURATION_MINUTES: u64 = 7;
+            const TIMEOUT_DURATION_MINUTES: u64 = 10;
             const TIMER_DURATION: Duration = Duration::from_secs(TIMEOUT_DURATION_MINUTES * 60);
             let log_source = resources.log_source.clone();
             let inspect_task =

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -521,7 +521,7 @@ async fn memory_validation_cvm_small<T: PetriVmmBackend>(
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
-async fn memory_validation_gp_large<T: PetriVmmBackend>(
+async fn memory_validation_gp_heavy<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
     _: (),
     driver: pal_async::DefaultDriver,
@@ -543,7 +543,7 @@ async fn memory_validation_gp_large<T: PetriVmmBackend>(
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
-async fn memory_validation_cvm_large<T: PetriVmmBackend>(
+async fn memory_validation_cvm_heavy<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
     _: (),
     driver: pal_async::DefaultDriver,


### PR DESCRIPTION
We're still seeing occasional PR failures due to timeouts where the test content is just running very slowly. Mark vmm tests as needing more threads in nextest to try to reduce any possible core contention, give these tests a bunch more time, and mark two new tests with the correct magic word to have nextest account for them.