### PR TITLE
netvsp: adding LSO validation logic to handle_rndis_packet_message

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -761,12 +761,12 @@ impl OffloadConfig {
             if self.lso4 {
                 lso.ipv4_encapsulation = rndisprot::NDIS_ENCAPSULATION_IEEE_802_3;
                 lso.ipv4_max_offload_size = MAX_OFFLOAD_SIZE;
-                lso.ipv4_min_segment_count = rndisprot::MIN_SEGMENT_COUNT;
+                lso.ipv4_min_segment_count = rndisprot::LSO_MIN_SEGMENT_COUNT;
             }
             if self.lso6 {
                 lso.ipv6_encapsulation = rndisprot::NDIS_ENCAPSULATION_IEEE_802_3;
                 lso.ipv6_max_offload_size = MAX_OFFLOAD_SIZE;
-                lso.ipv6_min_segment_count = rndisprot::MIN_SEGMENT_COUNT;
+                lso.ipv6_min_segment_count = rndisprot::LSO_MIN_SEGMENT_COUNT;
                 lso.ipv6_flags = rndisprot::Ipv6LsoFlags::new()
                     .with_ip_extension_headers_supported(rndisprot::NDIS_OFFLOAD_SUPPORTED)
                     .with_tcp_options_supported(rndisprot::NDIS_OFFLOAD_SUPPORTED);
@@ -2480,7 +2480,7 @@ impl<T: RingMem> NetChannel<T> {
         }
 
         if metadata.offload_tcp_segmentation {
-            if segments.len() < rndisprot::MIN_SEGMENT_COUNT as usize {
+            if segments.len() < rndisprot::LSO_MIN_SEGMENT_COUNT as usize {
                 return Err(WorkerError::InvalidLsoPacketInsufficientSegments(
                     segments.len() as u32,
                 ));

--- a/vm/devices/net/netvsp/src/rndisprot.rs
+++ b/vm/devices/net/netvsp/src/rndisprot.rs
@@ -955,7 +955,7 @@ pub struct Ipv6ChecksumOffload {
 
 pub const NDIS_ENCAPSULATION_IEEE_802_3: u32 = 2;
 // Use the same minimum as vswitch.
-pub const MIN_SEGMENT_COUNT: u32 = 2;
+pub const LSO_MIN_SEGMENT_COUNT: u32 = 2;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]


### PR DESCRIPTION
netvsp should be validating the LSO packets coming from the guest
* There should be at least two SGEs.
* The first SGE should only be the header, and therefore less than 256 bytes.