### PR TITLE
petri: use Trace-CimMethodExecution in powershell commands

### DIFF
--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -13,7 +13,7 @@ function Get-MsvmComputerSystem
     )
 
     $vmid = $Vm.Id
-    $msvmComputerSystem = Get-CimInstance -namespace $ROOT_HYPER_V_NAMESPACE -query "select * from msvm_ComputerSystem where Name = '$vmid'"
+    $msvmComputerSystem = Get-CimInstance -namespace $ROOT_HYPER_V_NAMESPACE -query "select * from Msvm_ComputerSystem where Name = '$vmid'"
 
     if (-not $msvmComputerSystem)
     {

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -368,8 +368,12 @@ impl HyperVVM {
         // guest unexpectedly restarts. This command may fail if the VM is
         // transitioning between states. In that case, the VM will be shut off
         // and destroyed later if necessary.
-        _ = powershell::run_set_turn_off_on_guest_restart(&self.vmid, &self.ps_mod, !allow_reset)
-            .await;
+        if let Err(e) =
+            powershell::run_set_turn_off_on_guest_restart(&self.vmid, &self.ps_mod, !allow_reset)
+                .await
+        {
+            tracing::warn!("failed to set turn off on guest restart: {e:#}");
+        }
 
         let (halt_reason, timestamp) = self.wait_for_some(Self::halt_event).await?;
         if halt_reason == PetriHaltReason::Reset {


### PR DESCRIPTION
This should help catch any wmi errors that would have otherwise been silent. Unfortunately, I had to ignore the output of one of the commands since it fails intermittently. However, it is ok since run_set_turn_off_on_guest_restart just helps kill rouge VMs faster, they should still get cleaned up eventually.