### PR TITLE
disk_striped: Fix the divide-by-zero error when chunk_size_in_kb field is missing in VTL2 settings

### DIFF
--- a/vm/devices/storage/disk_striped/src/lib.rs
+++ b/vm/devices/storage/disk_striped/src/lib.rs
@@ -250,10 +250,8 @@ impl StripedDisk {
         let sector_size = devices[0].sector_size();
         let sector_count = devices[0].sector_count();
         let read_only = devices[0].is_read_only();
-        let chunk_size_in_bytes = chunk_size_in_bytes
-            .filter(|&chunk_size| chunk_size != 0)
-            .unwrap_or(CHUNK_SIZE_128K);
-        if !chunk_size_in_bytes.is_multiple_of(sector_size) {
+        let chunk_size_in_bytes = chunk_size_in_bytes.unwrap_or(CHUNK_SIZE_128K);
+        if chunk_size_in_bytes == 0 || !chunk_size_in_bytes.is_multiple_of(sector_size) {
             return Err(NewDeviceError::InvalidChunkSize(
                 chunk_size_in_bytes,
                 sector_size,


### PR DESCRIPTION
### **Issue:**
The VTL2 settings processing code crashes with a divide-by-zero panic when the chunk_size_in_kb field is missing from LUN configurations in the protobuf schema.

Closes: #1796

### **Fix:**
Fix the code wherein `chunk_size_in_bytes` takes the default value when the field is missing in the protobuf schema. 


From the striped code,

```
// If chunk_size_in_bytes is missing in protobuf, the below code will be Some(0).unwrap_or(..) which will result in zero.
let chunk_size_in_bytes = chunk_size_in_bytes.unwrap_or(CHUNK_SIZE_128K); 
....
let sector_count_per_chunk = (chunk_size_in_bytes / sector_size) as u64;  // Will result in divide-by-zero.
```

Include a conditional filter for setting the chunk_size to default(`CHUNK_SIZE_128K`) for such scenarios.

### **Validation:**
Locally ran vmm_tests(striped_disk related tests) successfully.

>  Nextest run ID eeab7f93-a5a0-45a0-9ebf-3fad41281477 with nextest profile: default
>     Starting 2 tests across 2 binaries (171 tests skipped)
>      Running [ 00:00:00] 0/2: 0 running, 0 passed, 0 skipped
>         SLOW [> 60.000s] vmm_tests::tests x86_64::storage::openvmm_openhcl_uefi_x64_ubuntu_2504_server_x64_openhcl_linux_stripe_storvsp
>         SLOW [> 60.000s] vmm_tests::tests x86_64::storage::openvmm_openhcl_linux_x64_openhcl_linux_stripe_storvsp
>         PASS [  97.852s] vmm_tests::tests x86_64::storage::openvmm_openhcl_linux_x64_openhcl_linux_stripe_storvsp
>         SLOW [>120.000s] vmm_tests::tests x86_64::storage::openvmm_openhcl_uefi_x64_ubuntu_2504_server_x64_openhcl_linux_stripe_storvsp
>         SLOW [>180.000s] vmm_tests::tests x86_64::storage::openvmm_openhcl_uefi_x64_ubuntu_2504_server_x64_openhcl_linux_stripe_storvsp
>         PASS [ 184.070s] vmm_tests::tests x86_64::storage::openvmm_openhcl_uefi_x64_ubuntu_2504_server_x64_openhcl_linux_stripe_storvsp
> ────────────
>      Summary [ 184.140s] 2 tests run: 2 passed (2 slow), 171 skipped