### PR TITLE
CI: Fix release-pr label flow not running after push

### DIFF
--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -16,7 +16,14 @@ on:
     - main
     - release/*
     types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
     - labeled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   job0:
     name: xtask fmt (windows)

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -85,14 +85,12 @@ impl IntoPipeline for CheckinGatesCli {
                         .gh_set_name("[flowey] OpenVMM PR");
                 }
                 PipelineConfig::PrRelease => {
-                    // This workflow is triggered when a specific label is added to a PR.
+                    // This workflow is triggered when a specific label is present on a PR.
+                    let mut triggers = GhPrTriggers::new_draftable();
+                    triggers.branches = branches;
+                    triggers.types.push("labeled".into());
                     pipeline
-                        .gh_set_pr_triggers(GhPrTriggers {
-                            branches,
-                            types: vec!["labeled".into()],
-                            auto_cancel: false,
-                            exclude_branches: vec![],
-                        })
+                        .gh_set_pr_triggers(triggers)
                         .gh_set_name("[flowey] OpenVMM Release PR");
                 }
             }


### PR DESCRIPTION
The PrRelease workflow only runs when a PR is labeled with the release-ci-required label, however it was only running at the moment that label was applied. After pushing a new commit it would disappear. This fixes that by making the flow check for all the same events as the normal PR flow.