### PR TITLE
openhcl_boot: provide flag to disable nvme keepalive

### DIFF
--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -26,12 +26,16 @@ const ENABLE_VTL2_GPA_POOL: &str = "OPENHCL_ENABLE_VTL2_GPA_POOL=";
 /// * `log`: Enable sidecar logging.
 const SIDECAR: &str = "OPENHCL_SIDECAR=";
 
+/// Disable NVME keep alive regardless if the host supports it.
+const DISABLE_NVME_KEEP_ALIVE: &str = "OPENHCL_DISABLE_NVME_KEEP_ALIVE=";
+
 #[derive(Debug, PartialEq)]
 pub struct BootCommandLineOptions {
     pub confidential_debug: bool,
     pub enable_vtl2_gpa_pool: Option<u64>,
     pub sidecar: bool,
     pub sidecar_logging: bool,
+    pub disable_nvme_keep_alive: bool,
 }
 
 impl BootCommandLineOptions {
@@ -41,6 +45,7 @@ impl BootCommandLineOptions {
             enable_vtl2_gpa_pool: None,
             sidecar: true, // sidecar is enabled by default
             sidecar_logging: false,
+            disable_nvme_keep_alive: false,
         }
     }
 }
@@ -71,6 +76,11 @@ impl BootCommandLineOptions {
                             _ => {}
                         }
                     }
+                }
+            } else if arg.starts_with(DISABLE_NVME_KEEP_ALIVE) {
+                let arg = arg.split_once('=').map(|(_, arg)| arg);
+                if arg.is_some_and(|a| a != "0") {
+                    self.disable_nvme_keep_alive = true;
                 }
             }
         }

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -76,16 +76,32 @@ impl From<core::fmt::Error> for CommandLineTooLong {
     }
 }
 
-/// Read and setup the underhill kernel command line into the specified buffer.
-fn build_kernel_command_line(
-    params: &ShimParams,
-    cmdline: &mut ArrayString<COMMAND_LINE_SIZE>,
-    partition_info: &PartitionInfo,
+struct BuildKernelCommandLineParams<'a> {
+    params: &'a ShimParams,
+    cmdline: &'a mut ArrayString<COMMAND_LINE_SIZE>,
+    partition_info: &'a PartitionInfo,
     can_trust_host: bool,
     is_confidential_debug: bool,
-    sidecar: Option<&SidecarConfig<'_>>,
+    sidecar: Option<&'a SidecarConfig<'a>>,
     vtl2_pool_supported: bool,
+    disable_keep_alive: bool,
+}
+
+/// Read and setup the underhill kernel command line into the specified buffer.
+fn build_kernel_command_line(
+    fn_params: BuildKernelCommandLineParams<'_>,
 ) -> Result<(), CommandLineTooLong> {
+    let BuildKernelCommandLineParams {
+        params,
+        cmdline,
+        partition_info,
+        can_trust_host,
+        is_confidential_debug,
+        sidecar,
+        vtl2_pool_supported,
+        disable_keep_alive,
+    } = fn_params;
+
     // For reference:
     // https://www.kernel.org/doc/html/v5.15/admin-guide/kernel-parameters.html
     const KERNEL_PARAMETERS: &[&str] = &[
@@ -275,7 +291,7 @@ fn build_kernel_command_line(
 
     // Only when explicitly supported by Host.
     // TODO: Move from command line to device tree when stabilized.
-    if partition_info.nvme_keepalive && vtl2_pool_supported {
+    if partition_info.nvme_keepalive && vtl2_pool_supported && !disable_keep_alive {
         write!(cmdline, "OPENHCL_NVME_KEEP_ALIVE=1 ")?;
     }
 
@@ -633,15 +649,16 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     let address_space: &AddressSpaceManager = address_space;
 
     let mut cmdline = off_stack!(ArrayString<COMMAND_LINE_SIZE>, ArrayString::new_const());
-    build_kernel_command_line(
-        &p,
-        &mut cmdline,
+    build_kernel_command_line(BuildKernelCommandLineParams {
+        params: &p,
+        cmdline: &mut cmdline,
         partition_info,
         can_trust_host,
         is_confidential_debug,
-        sidecar.as_ref(),
-        address_space.has_vtl2_pool(),
-    )
+        sidecar: sidecar.as_ref(),
+        vtl2_pool_supported: address_space.has_vtl2_pool(),
+        disable_keep_alive: partition_info.boot_options.disable_nvme_keep_alive,
+    })
     .unwrap();
 
     let mut fdt = off_stack!(Fdt, zeroed());


### PR DESCRIPTION
This came from @chris-oo. This is belt-and-suspenders, to allow the host explicit fine grained control. We expect this to be used for dev/test scenarios only (or an escape valve in some future production).