### PR TITLE
vmm_tests: add behavioral checks for shared vis pool

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -165,7 +165,7 @@ async fn nvme_relay_shared_pool(
         "OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1",
         Some(ExpectedNvmeDeviceProperties {
             save_restore_supported: false, // No private pool, so no save/restore of memory.
-            qsize: 64,                     // No private pool, so we can only get 1 page for the SQ.
+            qsize: 64,                     // After #2061 goes in, this should be 256.
             nvme_keepalive: false,
         }),
     )


### PR DESCRIPTION
Assert that save/restore is false for shared vis pool.
