### PR TITLE
petri: pipette: log before sending shutdown request to the guest

### DIFF
--- a/petri/pipette_client/src/lib.rs
+++ b/petri/pipette_client/src/lib.rs
@@ -117,6 +117,7 @@ impl PipetteClient {
     }
 
     async fn shutdown(&self, shutdown_type: pipette_protocol::ShutdownType) -> anyhow::Result<()> {
+        tracing::debug!(?shutdown_type, "sending shutdown request to guest");
         let r = self.send.call(
             PipetteRequest::Shutdown,
             pipette_protocol::ShutdownRequest { shutdown_type },

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -601,6 +601,8 @@ async fn openhcl_linux_storvsp_dvd_nvme(
         .run()
         .await?;
 
+    tracing::info!("VM is running, issuing read to dvd drive");
+
     let b = agent
         .read_file("/dev/sr0")
         .await
@@ -613,6 +615,8 @@ async fn openhcl_linux_storvsp_dvd_nvme(
         b.len()
     );
     assert_eq!(b[..], bytes[..], "content mismatch");
+
+    tracing::info!("read complete and verified, powering off VM");
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;


### PR DESCRIPTION
Anecdotally, I noticed that `openvmm_openhcl_uefi_x64_ubuntu_2504_server_x64_openhcl_linux_storvsp_dvd_nvme`
times out from time to time (e.g. [here](https://openvmm.dev/test-results/test.html?run=18479962055&job=x64-windows-amd-vmm-tests-logs&test=x86_64__storage__openvmm_openhcl_uefi_x64_ubuntu_2504_server_x64_openhcl_linux_storvsp_dvd_nvme#log-4488)).

Add some additional logging in the test to narrow down where the test hangs.
Also, I noticed that pipette does not log before it sends the shutdown request to
the guest. Add that so that we can discern if pipette sent a request the guest
across all tests.

In this case, though, I anticipate that the failure is somewhere before the `read` call,
since `read` logs when complete (and I don't see that entry in the log I linked
above).
