### PR TITLE
Revert "petri: lower severity of com3 emitted logs for all vmm_tests …

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -13,7 +13,6 @@ use crate::PetriTestParams;
 use crate::ShutdownKind;
 use crate::disk_image::AgentImage;
 use crate::openhcl_diag::OpenHclDiagHandler;
-use anyhow::Context;
 use async_trait::async_trait;
 use get_resources::ged::FirmwareEvent;
 use mesh::CancelContext;


### PR DESCRIPTION
…(#2003)"

This reverts commit a1ac1814fb93227709f128faafb7a75262f1a2ed.

This change restores COM3 logs until we can figure out a way to switch over to diag client once it is available.