### PR TITLE
vmm_tests: fixed the function definition for the helper function for keep alive tests

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -281,13 +281,7 @@ async fn servicing_keepalive_with_nvme_fault(
             ),
         );
 
-    apply_fault_with_keepalive(
-        config,
-        fault_configuration,
-        fault_start_updater,
-        igvm_file,
-    )
-    .await
+    apply_fault_with_keepalive(config, fault_configuration, fault_start_updater, igvm_file).await
 }
 
 /// Verifies that the driver awaits an existing AER instead of issuing a new one after servicing.
@@ -306,13 +300,7 @@ async fn servicing_keepalive_verify_no_duplicate_aers(
             ),
         );
 
-    apply_fault_with_keepalive(
-        config,
-        fault_configuration,
-        fault_start_updater,
-        igvm_file,
-    )
-    .await
+    apply_fault_with_keepalive(config, fault_configuration, fault_start_updater, igvm_file).await
 }
 
 /// Test servicing an OpenHCL VM from the current version to itself with NVMe keepalive support
@@ -346,13 +334,7 @@ async fn servicing_keepalive_with_nvme_identify_fault(
             ),
         );
 
-    apply_fault_with_keepalive(
-        config,
-        fault_configuration,
-        fault_start_updater,
-        igvm_file,
-    )
-    .await
+    apply_fault_with_keepalive(config, fault_configuration, fault_start_updater, igvm_file).await
 }
 
 async fn apply_fault_with_keepalive(


### PR DESCRIPTION
Minor fix to the helper function definition in the vmm tests. This slipped through in the last PR. 