### PR TITLE
openhcl: remove cmdline to configure shared vis pool + tests

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -319,7 +319,6 @@ async fn launch_workers(
         force_load_vtl0_image: opt.force_load_vtl0_image,
         nvme_vfio: opt.nvme_vfio,
         mcr: opt.mcr,
-        enable_shared_visibility_pool: opt.enable_shared_visibility_pool,
         halt_on_guest_halt: opt.halt_on_guest_halt,
         no_sidecar_hotplug: opt.no_sidecar_hotplug,
         gdbstub: opt.gdbstub,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -166,11 +166,6 @@ pub struct Options {
     /// MCR Device Enable
     pub mcr: bool, // TODO MCR: support closed-source ENV vars
 
-    /// (OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1)
-    /// Enable the shared visibility pool. This is enabled by default on
-    /// hardware isolated platforms, but can be enabled for testing.
-    pub enable_shared_visibility_pool: bool,
-
     /// (OPENHCL_HIDE_ISOLATION=1)
     /// Hide the isolation mode from the guest.
     pub hide_isolation: bool,
@@ -328,8 +323,6 @@ impl Options {
         let serial_wait_for_rts = parse_legacy_env_bool("OPENHCL_SERIAL_WAIT_FOR_RTS");
         let nvme_vfio = parse_legacy_env_bool("OPENHCL_NVME_VFIO");
         let mcr = parse_legacy_env_bool("OPENHCL_MCR_DEVICE");
-        let enable_shared_visibility_pool =
-            parse_legacy_env_bool("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL");
         let hide_isolation = parse_env_bool("OPENHCL_HIDE_ISOLATION");
         let halt_on_guest_halt = parse_legacy_env_bool("OPENHCL_HALT_ON_GUEST_HALT");
         let no_sidecar_hotplug = parse_legacy_env_bool("OPENHCL_NO_SIDECAR_HOTPLUG");
@@ -418,7 +411,6 @@ impl Options {
             force_load_vtl0_image,
             nvme_vfio,
             mcr,
-            enable_shared_visibility_pool,
             hide_isolation,
             halt_on_guest_halt,
             no_sidecar_hotplug,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -274,9 +274,6 @@ pub struct UnderhillEnvCfg {
     pub nvme_vfio: bool,
     // TODO MCR: support closed-source configuration logic for MCR device
     pub mcr: bool,
-    /// Enable the shared visibility pool. This is enabled by default on
-    /// hardware isolated platforms, but can be enabled for testing.
-    pub enable_shared_visibility_pool: bool,
     /// Halt on a guest halt request instead of forwarding to the host.
     pub halt_on_guest_halt: bool,
     /// Leave sidecar VPs remote even if they hit exits.
@@ -1381,7 +1378,6 @@ async fn new_underhill_vm(
             round_up_to_2mb(cpu_bytes + device_dma + attestation)
         }
         virt::IsolationType::Vbs => round_up_to_2mb(device_dma + attestation),
-        _ if env_cfg.enable_shared_visibility_pool => round_up_to_2mb(device_dma + attestation),
         _ => 0,
     };
 

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -64,7 +64,6 @@ async fn mana_nic_shared_pool(
     let (vm, agent) = config
         .with_vmbus_redirect(true)
         .modify_backend(|b| b.with_nic())
-        .with_openhcl_command_line("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1")
         .run()
         .await?;
 
@@ -87,7 +86,6 @@ async fn mana_nic_servicing(
     let (mut vm, agent) = config
         .with_vmbus_redirect(true)
         .modify_backend(|b| b.with_nic())
-        .with_openhcl_command_line("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1")
         .run()
         .await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -155,26 +155,6 @@ async fn nvme_relay(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), a
 /// Test an OpenHCL uefi VM with a NVME disk assigned to VTL2 that boots
 /// linux, with vmbus relay. This should expose a disk to VTL0 via vmbus.
 ///
-/// Use the shared pool override to test the shared pool dma path.
-#[openvmm_test(openhcl_uefi_x64[nvme](vhd(ubuntu_2504_server_x64)))]
-async fn nvme_relay_shared_pool(
-    config: PetriVmBuilder<OpenVmmPetriBackend>,
-) -> Result<(), anyhow::Error> {
-    nvme_relay_test_core(
-        config,
-        "OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1",
-        Some(ExpectedNvmeDeviceProperties {
-            save_restore_supported: false, // No private pool, so no save/restore of memory.
-            qsize: 64,                     // Should be 256, but #2185.
-            nvme_keepalive: false,
-        }),
-    )
-    .await
-}
-
-/// Test an OpenHCL uefi VM with a NVME disk assigned to VTL2 that boots
-/// linux, with vmbus relay. This should expose a disk to VTL0 via vmbus.
-///
 /// Use the private pool override to test the private pool dma path.
 #[openvmm_test(openhcl_uefi_x64[nvme](vhd(ubuntu_2504_server_x64)))]
 async fn nvme_relay_private_pool(


### PR DESCRIPTION
Tests were setting this flag, but weren't actually testing their device DMA
with shared visibility pool. The shared visibility pool is *only* used when
the VM is isolated.

Bring this back in one of two ways:
1. Add isolated tests (and get the right behavior), or
2. Change the devices to force into using the shared pool.

Sorta fixes #2185 (the real issue there is that we weren't testing what we thought we were ... :()
