### PR TITLE
repo: upload petri results for new pipeline names

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -5,8 +5,9 @@ on:
     types:
       - completed
     workflows:
-      - '\[flowey\] OpenVMM CI'
-      - '\[flowey\] OpenVMM PR'
+      - 'OpenVMM CI'
+      - 'OpenVMM PR'
+      - '\[Optional\] OpenVMM Release PR'
 
 permissions:
   id-token: write


### PR DESCRIPTION
Looks like we aren't getting logs in our test results repo. The pipeline that uploads the logs matches on workflow name, which has changed.
