### PR TITLE
vmm_tests: disable openvmm_openhcl_uefi_x64_ubuntu_2504_server_x64_storvsp

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -200,7 +200,7 @@ async fn test_storage_linux(
 /// vmbus relay. This should expose two disks to VTL0 via vmbus.
 #[openvmm_test(
     openhcl_linux_direct_x64,
-    openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+    //openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)) TODO: re-enable once pipette issues in #2039 are resolved
 )]
 async fn storvsp(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     const NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");


### PR DESCRIPTION
Unfortunately, this test seems to be a big hitter of the pipette flakiness in #2039.
The test is relatively new, and the core storvsp functionality is well tested by
linux direct (the value in an Ubuntu variant is to ensure device enumeration plays
well).

Disable the test until we understand why pipette can't seem to connect from the VTL0 guest
to avoid manual re-runs from devs.
