### PR TITLE
underhill_attestation: ci: give attestation tests more time

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -36,6 +36,11 @@ path = "junit.xml"
 store-success-output = "true"
 
 [[profile.ci.overrides]]
+# allow attestation end to end tests more time, as they take a while
+filter = 'package(underhill_attestation) and test(init_sec_secure_key_release)'
+slow-timeout = { period = "5s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
 # allow loom based tests more time, as they take a while
 filter = 'test(loom)'
 slow-timeout = { period = "30s", terminate-after = 2 }


### PR DESCRIPTION
These relatively new attestation tests take multiple seconds in CI. On my
local, beefy, machine these take more than 3 seconds. Give them some
more time to avoid unreliable CI results.

From [this test run](https://github.com/microsoft/openvmm/actions/runs/18616876280/job/53082607183) (that doesn't change anything remotely related ...):

```
        SLOW [>  2.000s] underhill_attestation tests::init_sec_secure_key_release_without_wrapped_key_request
        PASS [   2.679s] netvsp test::send_rndis_set_packet_filter
        SLOW [>  3.000s] underhill_attestation tests::init_sec_secure_key_release_no_hw_sealing_backup
        SLOW [>  3.000s] underhill_attestation tests::init_sec_secure_key_release_hw_sealing_backup
        SLOW [>  3.000s] underhill_attestation tests::init_sec_secure_key_release_with_wrapped_key_request
        SLOW [>  3.000s] underhill_attestation tests::init_sec_secure_key_release_without_wrapped_key_request
        SLOW [>  4.000s] underhill_attestation tests::init_sec_secure_key_release_no_hw_sealing_backup
        PASS [   4.005s] underhill_attestation tests::init_sec_secure_key_release_hw_sealing_backup
        SLOW [>  4.000s] underhill_attestation tests::init_sec_secure_key_release_with_wrapped_key_request
        SLOW [>  4.000s] underhill_attestation tests::init_sec_secure_key_release_without_wrapped_key_request
        PASS [   4.058s] underhill_attestation tests::init_sec_secure_key_release_no_hw_sealing_backup
        PASS [   4.174s] underhill_attestation tests::init_sec_secure_key_release_with_wrapped_key_request
 TERMINATING [>  5.000s] underhill_attestation tests::init_sec_secure_key_release_without_wrapped_key_request
     TIMEOUT [   5.008s] underhill_attestation tests::init_sec_secure_key_release_without_wrapped_key_request
        SLOW [> 30.000s] atomic_ringbuf loom_tests::loom_multi_writer_wraparound
        PASS [  30.733s] atomic_ringbuf loom_tests::loom_multi_writer_wraparound
```
