### PR TITLE
nvme: todo comment cleanup/new devnote

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -750,6 +750,9 @@ impl LoadedVm {
         // Only save NVMe state when there are NVMe controllers and keep alive
         // was enabled.
         let nvme_state = if let Some(n) = &self.nvme_manager {
+            // DEVNOTE: A subtlety here is that the act of saving the NVMe state also causes the driver
+            // to enter a state where subsequent teardown operations will noop. There is a STRONG
+            // correlation between save/restore and keepalive.
             n.save(vf_keepalive_flag)
                 .instrument(tracing::info_span!("nvme_manager_save", CVM_ALLOWED))
                 .await

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -218,9 +218,6 @@ impl<T: AerHandler> QueuePair<T> {
             };
         let dma_client = device.dma_client();
 
-        // TODO: Keepalive: Detect when the allocation came from outside
-        // the private pool and put the device in a degraded state, so it
-        // is possible to inspect that a servicing with keepalive will fail.
         let mem = dma_client
             .allocate_dma_buffer(total_size)
             .context("failed to allocate memory for queues")?;


### PR DESCRIPTION
I explored the problem space for dealing with allocation characteristics in #2087. I've split
out a few PRs from this, and added tests to verify that the driver behaves as expected (see #2206).

All that's left is a couple behavioral comment updates. Those are included here.
