### PR TITLE
CI: Fix internal CI by tweaking nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,8 +24,8 @@ threads-required = 24
 
 # Profile for CI runs.
 [profile.ci]
-# Set the default timeout to 1 second, with tests terminated after 5 seconds
-slow-timeout = { period = "1s", terminate-after = 5 }
+# Set the default timeout to 1 second, with tests terminated after 10 seconds
+slow-timeout = { period = "1s", terminate-after = 10 }
 # Print out output for failing tests at the end of the run.
 failure-output = "final"
 # Do not cancel the test run on the first failure.
@@ -39,11 +39,6 @@ store-success-output = "true"
 # allow loom based tests more time, as they take a while
 filter = 'test(loom)'
 slow-timeout = { period = "30s", terminate-after = 2 }
-
-[[profile.ci.overrides]]
-# allow attestation tests more time, as they take a while
-filter = 'package(underhill_attestation)'
-slow-timeout = { period = "10s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
 # use fuzzy-matching for the package() to allow out-of-tree tests to use the


### PR DESCRIPTION
Adding an override for underhill_attestation broke part of the internal CI process, as internally we run tests on a workspace that does not contain a package named 'underhill_attestation' and nextest complains. Fixing this requires a broader rework & rethinking of how we share the nextest.toml with internal CI. For now just remove the breaking override and give all unit tests more time to hopefully make everything happy.