### PR TITLE
CI: A better fix than #2216

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,8 +41,10 @@ filter = 'test(loom)'
 slow-timeout = { period = "30s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
-# allow attestation tests more time, as they take a while
-filter = 'package(underhill_attestation)'
+# allow attestation tests more time, as they take a while.
+# this really should be a package-based filter, but that breaks the internal
+# repo due to this package not existing in that workspace.
+filter = 'test(underhill_attestation)'
 slow-timeout = { period = "10s", terminate-after = 2 }
 
 [[profile.ci.overrides]]


### PR DESCRIPTION
This reverts the change made by #2216 and replaces it with a more scoped fix. This allows us to keep the shorter timeout on non-attestation unit tests while also not breaking internal CI. The reason this works is that nextest allows a 'test()' filter to have 0 matches without error, but not a 'package()' filter, and all tests have their package's name in them. This isn't perfect, as technically this extended timeout would apply to any test that has "underhill_attestation" in its name regardless of package, but that feels unlikely to matter. Regardless, I've made a post on nextest's discussion forum to ask if there's a better way to handle this.

I tested this on my local clone of the internal repo and can confirm this doesn't error out, while the previous situation does.