### PR TITLE
Add OpenHCL telemetry for VMGS provisioning (#2024)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,6 +2630,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chipset_resources",
+ "cvm_tracing",
  "futures",
  "futures-concurrency",
  "get_protocol",
@@ -7051,18 +7052,21 @@ name = "tpm"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bitfield-struct 0.10.1",
  "chipset_device",
  "chipset_device_resources",
  "cvm_tracing",
  "getrandom 0.3.2",
  "guestmem",
+ "guid",
  "inspect",
  "mesh",
  "ms-tpm-20-ref",
  "open_enum",
  "pal_async",
  "parking_lot",
+ "sha2",
  "thiserror 2.0.12",
  "tpm_resources",
  "tracelimit",
@@ -7077,6 +7081,7 @@ dependencies = [
 name = "tpm_resources"
 version = "0.0.0"
 dependencies = [
+ "guid",
  "inspect",
  "mesh",
  "vm_resource",

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -21,6 +21,7 @@ pub use igvm_attest::IgvmAttestRequestHelper;
 pub use igvm_attest::ak_cert::parse_response as parse_ak_cert_response;
 
 use ::vmgs::EncryptionAlgorithm;
+use ::vmgs::GspType;
 use ::vmgs::Vmgs;
 use cvm_tracing::CVM_ALLOWED;
 use get_protocol::dps_json::GuestStateEncryptionPolicy;
@@ -161,6 +162,14 @@ enum PersistAllKeyProtectorsError {
     WriteKeyProtectorById(#[source] vmgs::WriteToVmgsError),
 }
 
+// Operation types for provisioning telemetry.
+#[derive(Debug)]
+enum LogOpType {
+    BeginDecryptVmgs,
+    DecryptVmgs,
+    ConvertEncryptionType,
+}
+
 /// Label used by `derive_key`
 const VMGS_KEY_DERIVE_LABEL: &[u8; 7] = b"VMGSKEY";
 
@@ -172,6 +181,7 @@ struct Keys {
 }
 
 /// Key protector settings
+#[derive(Clone, Copy)]
 struct KeyProtectorSettings {
     /// Whether to update key protector
     should_write_kp: bool,
@@ -179,6 +189,10 @@ struct KeyProtectorSettings {
     use_gsp_by_id: bool,
     /// Whether hardware key sealing is used
     use_hardware_unlock: bool,
+    /// GSP type used for decryption (for logging)
+    decrypt_gsp_type: GspType,
+    /// GSP type used for encryption (for logging)
+    encrypt_gsp_type: GspType,
 }
 
 /// Helper struct for [`protocol::vmgs::KeyProtectorById`]
@@ -349,7 +363,14 @@ pub async fn initialize_platform_security(
 
     let vmgs_encrypted: bool = vmgs.is_encrypted();
 
-    tracing::info!(tcb_version=?tcb_version, vmgs_encrypted = vmgs_encrypted, "Deriving keys");
+    let start_time = std::time::SystemTime::now();
+    tracing::info!(
+        ?tcb_version,
+        vmgs_encrypted,
+        op_type = ?LogOpType::BeginDecryptVmgs,
+        "Deriving keys"
+    );
+
     let derived_keys_result = get_derived_keys(
         get,
         tee_call.as_deref(),
@@ -366,7 +387,19 @@ pub async fn initialize_platform_security(
         strict_encryption_policy,
     )
     .await
-    .map_err(AttestationErrorInner::GetDerivedKeys)?;
+    .map_err(|e| {
+        tracing::error!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::DecryptVmgs,
+            success = false,
+            err = &e as &dyn std::error::Error,
+            latency = std::time::SystemTime::now()
+                .duration_since(start_time)
+                .map_or(0, |d| d.as_millis()),
+            "Failed to derive keys"
+        );
+        AttestationErrorInner::GetDerivedKeys(e)
+    })?;
 
     // All Underhill VMs use VMGS encryption
     tracing::info!("Unlocking VMGS");
@@ -381,11 +414,35 @@ pub async fn initialize_platform_security(
     )
     .await
     {
+        tracing::error!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::DecryptVmgs,
+            success = false,
+            err = &e as &dyn std::error::Error,
+            latency = std::time::SystemTime::now()
+                .duration_since(start_time)
+                .map_or(0, |d| d.as_millis()),
+            "Failed to unlock datastore"
+        );
         get.event_log_fatal(guest_emulation_transport::api::EventLogId::ATTESTATION_FAILED)
             .await;
 
         Err(AttestationErrorInner::UnlockVmgsDataStore(e))?
     }
+
+    tracing::info!(
+        CVM_ALLOWED,
+        op_type = ?LogOpType::DecryptVmgs,
+        success = true,
+        decrypt_gsp_type = ?derived_keys_result
+            .key_protector_settings
+            .decrypt_gsp_type,
+        encrypt_gsp_type = ?derived_keys_result
+            .key_protector_settings
+            .encrypt_gsp_type,
+        latency = std::time::SystemTime::now().duration_since(start_time).map_or(0, |d| d.as_millis()),
+        "Unlocked datastore"
+    );
 
     let state_refresh_request_from_gsp = derived_keys_result
         .gsp_extended_status_flags
@@ -591,6 +648,8 @@ async fn get_derived_keys(
         should_write_kp: true,
         use_gsp_by_id: false,
         use_hardware_unlock: false,
+        decrypt_gsp_type: GspType::None,
+        encrypt_gsp_type: GspType::None,
     };
 
     let mut derived_keys = Keys {
@@ -909,6 +968,8 @@ async fn get_derived_keys(
             // Not required for Id protection
             key_protector_settings.should_write_kp = false;
             key_protector_settings.use_gsp_by_id = true;
+            key_protector_settings.decrypt_gsp_type = GspType::GspById;
+            key_protector_settings.encrypt_gsp_type = GspType::GspById;
 
             return Ok(DerivedKeyResult {
                 derived_keys: Some(derived_keys_by_id),
@@ -919,7 +980,11 @@ async fn get_derived_keys(
 
         derived_keys.ingress = derived_keys_by_id.ingress;
 
-        tracing::info!(CVM_ALLOWED, "Converting GSP method.");
+        tracing::info!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::ConvertEncryptionType,
+            "Converting GSP method."
+        );
     }
 
     let egress_seed;
@@ -939,9 +1004,12 @@ async fn get_derived_keys(
                     gsp_response_by_id.seed.buffer[..gsp_response_by_id.seed.length as usize]
                         .to_vec(),
                 );
+                key_protector_settings.decrypt_gsp_type = GspType::GspById;
             } else {
                 derived_keys.ingress = ingress_key;
             }
+        } else {
+            key_protector_settings.decrypt_gsp_type = GspType::GspById;
         }
 
         // Choose best available egress seed
@@ -949,9 +1017,11 @@ async fn get_derived_keys(
             egress_seed =
                 gsp_response_by_id.seed.buffer[..gsp_response_by_id.seed.length as usize].to_vec();
             key_protector_settings.use_gsp_by_id = true;
+            key_protector_settings.encrypt_gsp_type = GspType::GspById;
         } else {
             egress_seed =
                 gsp_response.new_gsp.buffer[..gsp_response.new_gsp.length as usize].to_vec();
+            key_protector_settings.encrypt_gsp_type = GspType::GspKey;
         }
     } else {
         // `no_gsp` is false, using `gsp_response`
@@ -971,6 +1041,8 @@ async fn get_derived_keys(
             if !no_kek {
                 derived_keys.ingress = ingress_key;
             }
+
+            key_protector_settings.encrypt_gsp_type = GspType::GspKey;
         } else {
             tracing::info!(CVM_ALLOWED, "Using GSP.");
 
@@ -995,6 +1067,9 @@ async fn get_derived_keys(
                 key_protector_settings.should_write_kp = false;
                 decrypt_egress_key = Some(encrypt_egress_key);
             }
+
+            key_protector_settings.decrypt_gsp_type = GspType::GspKey;
+            key_protector_settings.encrypt_gsp_type = GspType::GspKey;
         }
     }
 
@@ -1302,6 +1377,8 @@ mod tests {
             should_write_kp: false,
             use_gsp_by_id: false,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::None,
+            encrypt_gsp_type: GspType::None,
         };
 
         let bios_guid = Guid::new_random();
@@ -1326,6 +1403,8 @@ mod tests {
             should_write_kp: false,
             use_gsp_by_id: false,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::None,
+            encrypt_gsp_type: GspType::None,
         };
 
         // Even if the VMGS is encrypted, if no derived keys are provided, nothing should happen
@@ -1364,6 +1443,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: true,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::GspById,
+            encrypt_gsp_type: GspType::GspById,
         };
 
         let bios_guid = Guid::new_random();
@@ -1415,6 +1496,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: true,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::GspById,
+            encrypt_gsp_type: GspType::GspById,
         };
 
         // Ingress is now the old egress, and we provide a new new egress key
@@ -1486,6 +1569,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: true,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::GspById,
+            encrypt_gsp_type: GspType::GspById,
         };
 
         let bios_guid = Guid::new_random();
@@ -1558,6 +1643,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: true,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::GspById,
+            encrypt_gsp_type: GspType::GspById,
         };
 
         let bios_guid = Guid::new_random();
@@ -1638,6 +1725,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: true,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::GspById,
+            encrypt_gsp_type: GspType::GspById,
         };
 
         let bios_guid = Guid::new_random();
@@ -1692,6 +1781,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: true,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::GspById,
+            encrypt_gsp_type: GspType::GspById,
         };
 
         let bios_guid = Guid::new_random();
@@ -1781,6 +1872,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: true,
             use_hardware_unlock: true,
+            decrypt_gsp_type: GspType::GspById,
+            encrypt_gsp_type: GspType::GspById,
         };
         persist_all_key_protectors(
             &mut vmgs,
@@ -1816,6 +1909,8 @@ mod tests {
             should_write_kp: false,
             use_gsp_by_id: true,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::GspById,
+            encrypt_gsp_type: GspType::GspById,
         };
         persist_all_key_protectors(
             &mut vmgs,
@@ -1858,6 +1953,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: false,
             use_hardware_unlock: false,
+            decrypt_gsp_type: GspType::None,
+            encrypt_gsp_type: GspType::None,
         };
         persist_all_key_protectors(
             &mut vmgs,
@@ -1903,6 +2000,8 @@ mod tests {
             should_write_kp: true,
             use_gsp_by_id: false,
             use_hardware_unlock: true,
+            decrypt_gsp_type: GspType::None,
+            encrypt_gsp_type: GspType::None,
         };
 
         persist_all_key_protectors(

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2585,6 +2585,7 @@ async fn new_underhill_vm(
                 register_layout,
                 guest_secret_key: platform_attestation_data.guest_secret_key,
                 logger: Some(GetTpmLoggerHandle.into_resource()),
+                bios_guid: dps.general.bios_guid,
             }
             .into_resource(),
         });

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -2416,6 +2416,7 @@ impl LoadedVmInner {
                 enable_vpci_boot,
                 uefi_console_mode,
                 default_boot_always_attempt,
+                bios_guid,
             } => {
                 let madt = acpi_builder.build_madt();
                 let srat = acpi_builder.build_srat();
@@ -2431,6 +2432,7 @@ impl LoadedVmInner {
                     serial: enable_serial,
                     uefi_console_mode,
                     default_boot_always_attempt,
+                    bios_guid,
                 };
                 let regs = super::vm_loaders::uefi::load_uefi(
                     firmware,

--- a/openvmm/hvlite_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/uefi.rs
@@ -37,6 +37,7 @@ pub struct UefiLoadSettings {
     pub serial: bool,
     pub uefi_console_mode: Option<UefiConsoleMode>,
     pub default_boot_always_attempt: bool,
+    pub bios_guid: Guid,
 }
 
 /// Loads the UEFI firmware.
@@ -123,7 +124,7 @@ pub fn load_uefi(
     .add_raw(config::BlobStructureType::Madt, madt)
     .add_raw(config::BlobStructureType::Srat, srat)
     .add_raw(config::BlobStructureType::MemoryMap, memory_map.as_bytes())
-    .add(&config::BiosGuid(Guid::new_random()))
+    .add(&config::BiosGuid(load_settings.bios_guid))
     .add(&config::Entropy(entropy))
     .add(&config::MmioRanges([
         config::Mmio {

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -114,6 +114,7 @@ pub enum LoadMode {
         enable_vpci_boot: bool,
         uefi_console_mode: Option<UefiConsoleMode>,
         default_boot_always_attempt: bool,
+        bios_guid: Guid,
     },
     Pcat {
         firmware: RomFileLocation,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -742,6 +742,9 @@ fn vm_config_from_command_line(
         );
     }
 
+    // TODO: load from VMGS file if it exists
+    let bios_guid = Guid::new_random();
+
     let VmChipsetResult {
         chipset,
         mut chipset_devices,
@@ -810,6 +813,7 @@ fn vm_config_from_command_line(
                 UefiConsoleModeCli::None => UefiConsoleMode::None,
             }),
             default_boot_always_attempt: opt.default_boot_always_attempt,
+            bios_guid,
         };
     } else {
         // Linux Direct
@@ -1007,6 +1011,7 @@ fn vm_config_from_command_line(
                 register_layout,
                 guest_secret_key: None,
                 logger: None,
+                bios_guid,
             }
             .into_resource(),
         });

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -671,6 +671,7 @@ impl PetriVmConfigSetupCore<'_> {
                     enable_serial: true,
                     enable_vpci_boot: false,
                     uefi_console_mode: Some(hvlite_defs::config::UefiConsoleMode::Com1),
+                    bios_guid: Guid::new_random(),
                     default_boot_always_attempt: false,
                 }
             }

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -55,6 +55,8 @@ impl PetriVmConfigOpenVmm {
                     register_layout: TpmRegisterLayout::IoPort,
                     guest_secret_key: None,
                     logger: None,
+                    // TODO: generate an actual BIOS GUID and put it here
+                    bios_guid: guid::guid!("00000000-0000-0000-0000-000000000000"),
                 }
                 .into_resource(),
             });

--- a/vm/devices/get/guest_emulation_transport/Cargo.toml
+++ b/vm/devices/get/guest_emulation_transport/Cargo.toml
@@ -38,6 +38,7 @@ parking_lot.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+cvm_tracing.workspace = true
 unicycle.workspace = true
 zerocopy.workspace = true
 vmbus_user_channel.workspace = true

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -6,6 +6,7 @@ use super::process_loop::msg::IgvmAttestRequestData;
 use crate::api::GuestSaveRequest;
 use crate::api::platform_settings;
 use chipset_resources::battery::HostBatteryUpdate;
+use cvm_tracing::CVM_ALLOWED;
 use get_protocol::RegisterState;
 use get_protocol::TripleFaultType;
 use guid::Guid;
@@ -16,6 +17,13 @@ use std::sync::Arc;
 use user_driver::DmaClient;
 use vpci::bus_control::VpciBusEvent;
 use zerocopy::IntoBytes;
+
+/// Operation types for provisioning telemetry.
+#[derive(Debug)]
+enum LogOpType {
+    BeginGspCallback,
+    GspCallback,
+}
 
 /// Guest-side client for the GET.
 ///
@@ -351,7 +359,14 @@ impl GuestEmulationTransportClient {
         gsp_extended_status: crate::api::GspExtendedStatusFlags,
     ) -> crate::api::GuestStateProtection {
         let mut buffer = [0; get_protocol::GSP_CLEARTEXT_MAX as usize * 2];
+        let start_time = std::time::SystemTime::now();
         getrandom::fill(&mut buffer).expect("rng failure");
+
+        tracing::info!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::BeginGspCallback,
+            "Getting guest state protection data"
+        );
 
         let gsp_request = get_protocol::GuestStateProtectionRequest::new(
             buffer,
@@ -363,6 +378,15 @@ impl GuestEmulationTransportClient {
             .control
             .call(msg::Msg::GuestStateProtection, Box::new(gsp_request))
             .await;
+
+        tracing::info!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::GspCallback,
+            latency = std::time::SystemTime::now()
+                .duration_since(start_time)
+                .map_or(0, |d| d.as_millis()),
+            "Got guest state protection data"
+        );
 
         crate::api::GuestStateProtection {
             encrypted_gsp: response.encrypted_gsp,

--- a/vm/devices/tpm/Cargo.toml
+++ b/vm/devices/tpm/Cargo.toml
@@ -23,6 +23,7 @@ underhill_confidentiality = { workspace = true, features = ["std"] }
 vmcore.workspace = true
 vm_resource.workspace = true
 
+guid = { workspace = true, features = ["inspect"] }
 inspect.workspace = true
 mesh.workspace = true
 open_enum.workspace = true
@@ -36,5 +37,8 @@ thiserror.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
+
+sha2.workspace = true
+base64.workspace = true
 [lints]
 workspace = true

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -24,6 +24,7 @@ use self::io_port_interface::TpmIoCommand;
 use crate::ak_cert::TpmAkCertType;
 use crate::tpm20proto::TpmaObject;
 use crate::tpm20proto::TpmaObjectBits;
+use base64::Engine;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
@@ -33,12 +34,15 @@ use chipset_device::poll_device::PollDevice;
 use cvm_tracing::CVM_ALLOWED;
 use cvm_tracing::CVM_CONFIDENTIAL;
 use guestmem::GuestMemory;
+use guid::Guid;
 use inspect::Inspect;
 use inspect::InspectMut;
 use logger::TpmLogEvent;
 use logger::TpmLogger;
 use ms_tpm_20_ref::MsTpm20RefPlatform;
 use parking_lot::Mutex;
+use sha2::Digest;
+use sha2::Sha256;
 use std::future::Future;
 use std::ops::RangeInclusive;
 use std::pin::Pin;
@@ -87,6 +91,8 @@ const RSA_2K_MODULUS_BITS: u16 = 2048;
 const RSA_2K_MODULUS_SIZE: usize = (RSA_2K_MODULUS_BITS / 8) as usize;
 const RSA_2K_EXPONENT_SIZE: usize = 3;
 
+const SHA_256_OUTPUT_SIZE_BYTES: usize = 32;
+
 const TPM_RSA_SRK_HANDLE: ReservedHandle = ReservedHandle::new(TPM20_HT_PERSISTENT, 0x01);
 const TPM_AZURE_AIK_HANDLE: ReservedHandle = ReservedHandle::new(TPM20_HT_PERSISTENT, 0x03);
 const TPM_GUEST_SECRET_HANDLE: ReservedHandle = ReservedHandle::new(TPM20_HT_PERSISTENT, 0x04);
@@ -108,6 +114,26 @@ const REPORT_TIMER_PERIOD: std::time::Duration = std::time::Duration::new(2, 0);
 
 // 16kB: vtpmservice provisions a 16kB blob for the vTPM; HCL/OpenHCL provisions a 32k blob
 const LEGACY_VTPM_SIZE: usize = 16384;
+
+/// Operation types for provisioning telemetry.
+#[derive(Debug)]
+enum LogOpType {
+    BeginVtpmKeysProvision,
+    VtpmKeysProvision,
+    BeginAkCertProvision,
+    AkCertProvision,
+    BeginNvWrite,
+    NvWrite,
+    BeginNvRead,
+    NvRead,
+}
+
+/// Key types for provisioning telemetry.
+#[derive(Debug)]
+enum KeyType {
+    AkPub,
+    EkPub,
+}
 
 #[derive(Debug, Copy, Clone, Inspect)]
 #[repr(C)]
@@ -215,6 +241,12 @@ type AkCertRequestFuture = Box<
     dyn Send + Future<Output = Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>>>,
 >;
 
+struct AkCertRequest {
+    is_renew: bool,
+    start_time: std::time::SystemTime,
+    fut: Pin<AkCertRequestFuture>,
+}
+
 /// Implementation of [`ms_tpm_20_ref::PlatformCallbacks::monotonic_timer`]
 pub type MonotonicTimer = Box<dyn Send + FnMut() -> std::time::Duration>;
 
@@ -228,6 +260,10 @@ pub struct Tpm {
     #[inspect(skip)]
     mmio_region: Vec<(&'static str, RangeInclusive<u64>)>,
     allow_ak_cert_renewal: bool,
+
+    // For logging
+    bios_guid: Guid,
+    ak_pub_hash: [u8; SHA_256_OUTPUT_SIZE_BYTES],
 
     // Runtime glue
     rt: TpmRuntime,
@@ -245,7 +281,7 @@ pub struct Tpm {
     #[inspect(rename = "has_pending_nvram", with = "|x| !x.lock().is_empty()")]
     pending_nvram: Arc<Mutex<Vec<u8>>>,
     #[inspect(skip)]
-    async_ak_cert_request: Option<Pin<AkCertRequestFuture>>,
+    async_ak_cert_request: Option<Pin<Box<AkCertRequest>>>,
     #[inspect(skip)]
     waker: Option<Waker>,
     #[inspect(debug)]
@@ -347,6 +383,7 @@ impl Tpm {
         ak_cert_type: TpmAkCertType,
         guest_secret_key: Option<Vec<u8>>,
         logger: Option<Arc<dyn TpmLogger>>,
+        bios_guid: Guid,
     ) -> Result<Self, TpmError> {
         tracing::info!("initializing TPM");
 
@@ -401,6 +438,8 @@ impl Tpm {
             io_region,
             mmio_region,
             allow_ak_cert_renewal: false,
+            bios_guid,
+            ak_pub_hash: [0; SHA_256_OUTPUT_SIZE_BYTES],
 
             rt: TpmRuntime {
                 mem,
@@ -556,14 +595,85 @@ impl Tpm {
             // Initialize `TpmKeys`.
             // The procedure also generates randomized AK based on the TPM seed
             // and writes the AK into `TPM_AZURE_AIK_HANDLE` NV store.
+            let start_time = std::time::SystemTime::now();
+            tracing::info!(
+                CVM_ALLOWED,
+                op_type = ?LogOpType::BeginVtpmKeysProvision,
+                key_type = ?KeyType::AkPub,
+                bios_guid = %self.bios_guid,
+                force_ak_regen,
+                "Creating AKPub key"
+            );
             let (ak_pub, can_renew_ak) = self
                 .tpm_engine_helper
                 .create_ak_pub(force_ak_regen)
-                .map_err(TpmErrorKind::CreateAkPublic)?;
-            let ek_pub = self
-                .tpm_engine_helper
-                .create_ek_pub()
-                .map_err(TpmErrorKind::CreateEkPublic)?;
+                .map_err(|e| {
+                    tracing::error!(
+                        CVM_ALLOWED,
+                        op_type = ?LogOpType::VtpmKeysProvision,
+                        key_type = ?KeyType::AkPub,
+                        bios_guid = %self.bios_guid,
+                        success = false,
+                        err = &e as &dyn std::error::Error,
+                        latency = std::time::SystemTime::now()
+                            .duration_since(start_time)
+                            .map_or(0, |d| d.as_millis()),
+                        "Error creating AKPub key"
+                    );
+                    TpmErrorKind::CreateAkPublic(e)
+                })?;
+
+            // Log a hash of the AKPub for auditing purposes.
+            let mut ak_pub_hasher = Sha256::new();
+            ak_pub_hasher.update(ak_pub.exponent);
+            ak_pub_hasher.update(ak_pub.modulus);
+            self.ak_pub_hash = ak_pub_hasher.finalize().into();
+
+            tracing::info!(
+                CVM_ALLOWED,
+                op_type = ?LogOpType::VtpmKeysProvision,
+                key_type = ?KeyType::AkPub,
+                bios_guid = %self.bios_guid,
+                pub_key = self.ak_pub_str(),
+                success = true,
+                latency = std::time::SystemTime::now()
+                    .duration_since(start_time)
+                    .map_or(0, |d| d.as_millis()),
+                "Created AKPub key"
+            );
+
+            let start_time = std::time::SystemTime::now();
+            tracing::info!(
+                CVM_ALLOWED,
+                op_type = ?LogOpType::BeginVtpmKeysProvision,
+                key_type = ?KeyType::EkPub,
+                "Creating EKPub key"
+            );
+            let ek_pub = self.tpm_engine_helper.create_ek_pub().map_err(|e| {
+                tracing::error!(
+                    CVM_ALLOWED,
+                    op_type = ?LogOpType::VtpmKeysProvision,
+                    key_type = ?KeyType::EkPub,
+                    success = false,
+                    err = &e as &dyn std::error::Error,
+                    latency = std::time::SystemTime::now()
+                        .duration_since(start_time)
+                        .map_or(0, |d| d.as_millis()),
+                    "Error creating EKPub key"
+                );
+                TpmErrorKind::CreateEkPublic(e)
+            })?;
+            tracing::info!(
+                CVM_ALLOWED,
+                op_type = ?LogOpType::VtpmKeysProvision,
+                key_type = ?KeyType::EkPub,
+                success = true,
+                latency = std::time::SystemTime::now()
+                    .duration_since(start_time)
+                    .map_or(0, |d| d.as_millis()),
+                "Created EKPub key"
+            );
+
             self.keys = Some(TpmKeys { ak_pub, ek_pub });
             tracing::info!(
                 CVM_ALLOWED,
@@ -590,7 +700,7 @@ impl Tpm {
             //
             // Only renew AK cert if hardware isolated.
             if matches!(self.ak_cert_type, TpmAkCertType::HwAttested(_)) {
-                self.renew_ak_cert()?;
+                self.get_ak_cert(false)?;
             }
         }
 
@@ -887,7 +997,10 @@ impl Tpm {
 
     /// This routine calls (via GET) external server to issue AK cert.
     /// This function can only be called when `ak_cert_type` is `Trusted` or `HwAttested`.
-    fn renew_ak_cert(&mut self) -> Result<(), TpmError> {
+    /// This function is used both to issue the initial AKCert and renew it
+    /// later. is_renew indicates whether this is a subsequent renewal, for
+    /// logging purposes.
+    fn get_ak_cert(&mut self, is_renew: bool) -> Result<(), TpmError> {
         // Silently do nothing if renewal is not allowed.
         if !self.allow_ak_cert_renewal {
             tracing::info!(CVM_ALLOWED, "AK cert renewal is not allowed");
@@ -899,7 +1012,14 @@ impl Tpm {
             return Ok(());
         }
 
-        tracing::trace!("Request AK cert renewal");
+        tracing::info!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::BeginAkCertProvision,
+            is_renew,
+            pub_key = self.ak_pub_str(),
+            bios_guid = %self.bios_guid,
+            "Request AK cert renewal"
+        );
 
         let ak_cert_request = self.create_ak_cert_request()?;
         // Store the ak cert request that includes the attestation report if `ak_cert_type` is `HwAttested`.
@@ -920,7 +1040,11 @@ impl Tpm {
             }
         };
 
-        self.async_ak_cert_request = Some(Box::pin(fut));
+        self.async_ak_cert_request = Some(Box::pin(AkCertRequest {
+            is_renew,
+            start_time: std::time::SystemTime::now(),
+            fut: Box::pin(fut),
+        }));
 
         // Ensure poll gets called again.
         if let Some(waker) = self.waker.take() {
@@ -930,14 +1054,17 @@ impl Tpm {
         Ok(())
     }
 
-    /// Poll the AK cert request made by `renew_ak_cert`. This function is called by [`PollDevice::poll_device`].
+    /// Poll the AK cert request made by `get_ak_cert`. This function is called by [`PollDevice::poll_device`].
     fn poll_ak_cert_request(&mut self, cx: &mut std::task::Context<'_>) {
         if let Some(async_ak_cert_request) = self.async_ak_cert_request.as_mut() {
-            if let Poll::Ready(result) = async_ak_cert_request.as_mut().poll(cx) {
+            let is_renew = async_ak_cert_request.is_renew;
+
+            if let Poll::Ready(result) = async_ak_cert_request.fut.as_mut().poll(cx) {
                 // Once the received the response, update the renew time using `SystemTime::now`.
                 // DEVNOTE: The system time may not reflect the real time when suspension and resumption occur.
                 // See more details in `refresh_device_attestation_data_on_nv_read`.
                 let now = std::time::SystemTime::now();
+                let latency = now.duration_since(async_ak_cert_request.start_time);
 
                 // Clear `async_ak_cert_request` to allow the next renewal request.
                 self.async_ak_cert_request = None;
@@ -955,8 +1082,14 @@ impl Tpm {
                     Ok(_data) => {
                         tracelimit::warn_ratelimited!(
                             CVM_ALLOWED,
-                            "The requested TPM AK cert is empty - now: {:?}",
-                            now.duration_since(std::time::UNIX_EPOCH),
+                            op_type = ?LogOpType::AkCertProvision,
+                            bios_guid = %self.bios_guid,
+                            pub_key = self.ak_pub_str(),
+                            is_renew,
+                            got_cert = 0,
+                            latency = latency.map_or(0, |d| d.as_millis()),
+                            now = ?now.duration_since(std::time::UNIX_EPOCH),
+                            "The requested TPM AK cert is empty"
                         );
 
                         // Set the renew time if the ak cert is empty, avoiding retrying on each nv read
@@ -970,9 +1103,15 @@ impl Tpm {
                     Err(error) => {
                         tracelimit::warn_ratelimited!(
                             CVM_ALLOWED,
+                            op_type = ?LogOpType::AkCertProvision,
+                            bios_guid = %self.bios_guid,
+                            pub_key = self.ak_pub_str(),
+                            is_renew,
+                            got_cert = 0,
+                            latency = latency.map_or(0, |d| d.as_millis()),
+                            now = ?now.duration_since(std::time::UNIX_EPOCH),
                             error,
-                            "Failed to request new TPM AK cert - now: {:?}",
-                            now.duration_since(std::time::UNIX_EPOCH),
+                            "Failed to request new TPM AK cert",
                         );
 
                         // Use the non-async version of function to log the event (without flushing).
@@ -996,10 +1135,19 @@ impl Tpm {
                     return;
                 }
 
+                let duration = now.duration_since(std::time::UNIX_EPOCH);
+
                 tracing::info!(
-                    "ak cert renewal is complete - now: {:?}, size: {}",
-                    now.duration_since(std::time::UNIX_EPOCH),
-                    response.len()
+                    CVM_ALLOWED,
+                    op_type = ?LogOpType::AkCertProvision,
+                    bios_guid = %self.bios_guid,
+                    pub_key = self.ak_pub_str(),
+                    is_renew,
+                    got_cert = 1,
+                    size = response.len(),
+                    latency = latency.map_or(0, |d| d.as_millis()),
+                    cert_renew_time = ?duration,
+                    "ak cert renewal is complete",
                 );
             }
         }
@@ -1087,7 +1235,7 @@ impl Tpm {
             tracing::debug!(renew_cert_needed, ak_cert_renew_time =? self.ak_cert_renew_time, "tpm: cert renew check");
 
             if renew_cert_needed {
-                if let Err(e) = self.renew_ak_cert() {
+                if let Err(e) = self.get_ak_cert(true) {
                     tracelimit::error_ratelimited!(
                         CVM_ALLOWED,
                         error = &e as &dyn std::error::Error,
@@ -1096,6 +1244,10 @@ impl Tpm {
                 }
             }
         }
+    }
+
+    fn ak_pub_str(&self) -> String {
+        base64::engine::general_purpose::STANDARD.encode(self.ak_pub_hash)
     }
 }
 

--- a/vm/devices/tpm/src/resolver.rs
+++ b/vm/devices/tpm/src/resolver.rs
@@ -117,6 +117,7 @@ impl AsyncResolveResource<ChipsetDeviceHandleKind, TpmDeviceHandle> for TpmDevic
             ak_cert_type,
             resource.guest_secret_key,
             logger,
+            resource.bios_guid,
         )
         .await
         .map_err(ResolveTpmError::Tpm)?;

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -3,6 +3,7 @@
 
 //! The module includes the helper functions for sending TPM commands.
 
+use crate::LogOpType;
 use crate::TPM_AZURE_AIK_HANDLE;
 use crate::TPM_GUEST_SECRET_HANDLE;
 use crate::TPM_NV_INDEX_AIK_CERT;
@@ -606,15 +607,44 @@ impl TpmEngineHelper {
                                 }
                             })?;
 
-                            self.nv_write(TPM20_RH_OWNER, None, TPM_NV_INDEX_AIK_CERT, &cert)
-                                .map_err(|error| TpmHelperError::TpmCommandError {
+                            let start_time = std::time::SystemTime::now();
+                            if let Err(error) =
+                                self.nv_write(TPM20_RH_OWNER, None, TPM_NV_INDEX_AIK_CERT, &cert)
+                            {
+                                tracing::error!(
+                                    CVM_ALLOWED,
+                                    op_type = ?LogOpType::NvWrite,
+                                    nv_index = TPM_NV_INDEX_AIK_CERT,
+                                    data_size = cert.len(),
+                                    success = false,
+                                    err = &error as &dyn std::error::Error,
+                                    latency = std::time::SystemTime::now()
+                                        .duration_since(start_time)
+                                        .map_or(0, |d| d.as_millis()),
+                                    "Error writing AKCert TPM NVRAM index"
+                                );
+
+                                return Err(TpmHelperError::TpmCommandError {
                                     command_debug_info: CommandDebugInfo {
                                         command_code: CommandCodeEnum::NV_Write,
                                         auth_handle: Some(TPM20_RH_OWNER),
                                         nv_index: Some(TPM_NV_INDEX_AIK_CERT),
                                     },
                                     error,
-                                })?;
+                                });
+                            } else {
+                                tracing::info!(
+                                    CVM_ALLOWED,
+                                    op_type = ?LogOpType::NvWrite,
+                                    nv_index = TPM_NV_INDEX_AIK_CERT,
+                                    data_size = cert.len(),
+                                    success = true,
+                                    latency = std::time::SystemTime::now()
+                                        .duration_since(start_time)
+                                        .map_or(0, |d| d.as_millis()),
+                                    "Wrote AKCert TPM NVRAM index"
+                                );
+                            }
                         }
                     }
                 }
@@ -730,8 +760,23 @@ impl TpmEngineHelper {
                             // boot-time AK cert request fails.
                             tracing::info!("Preserve previous AK cert across boot");
 
-                            self.nv_write(write_auth_handle, auth, TPM_NV_INDEX_AIK_CERT, &cert)
-                                .map_err(|error| TpmHelperError::TpmCommandError {
+                            let start_time = std::time::SystemTime::now();
+                            if let Err(error) =
+                                self.nv_write(write_auth_handle, auth, TPM_NV_INDEX_AIK_CERT, &cert)
+                            {
+                                tracing::error!(
+                                    CVM_ALLOWED,
+                                    op_type = ?LogOpType::NvWrite,
+                                    nv_index = TPM_NV_INDEX_AIK_CERT,
+                                    data_size = cert.len(),
+                                    success = false,
+                                    err = &error as &dyn std::error::Error,
+                                    latency = std::time::SystemTime::now()
+                                        .duration_since(start_time)
+                                        .map_or(0, |d| d.as_millis()),
+                                    "Error rewriting existing AKCert TPM NVRAM index"
+                                );
+                                return Err(TpmHelperError::TpmCommandError {
                                     command_debug_info: CommandDebugInfo {
                                         command_code: CommandCodeEnum::NV_Write,
                                         auth_handle: Some(ReservedHandle(
@@ -740,7 +785,20 @@ impl TpmEngineHelper {
                                         nv_index: Some(TPM_NV_INDEX_AIK_CERT),
                                     },
                                     error,
-                                })?;
+                                });
+                            } else {
+                                tracing::info!(
+                                    CVM_ALLOWED,
+                                    op_type = ?LogOpType::NvWrite,
+                                    nv_index = TPM_NV_INDEX_AIK_CERT,
+                                    data_size = cert.len(),
+                                    success = true,
+                                    latency = std::time::SystemTime::now()
+                                        .duration_since(start_time)
+                                        .map_or(0, |d| d.as_millis()),
+                                    "Rewrote existing AKCert TPM NVRAM index"
+                                );
+                            }
                         }
                     }
                 }
@@ -908,20 +966,46 @@ impl TpmEngineHelper {
             });
         }
 
-        self.nv_write(
+        let start_time = std::time::SystemTime::now();
+        if let Err(error) = self.nv_write(
             ReservedHandle(nv_index.into()),
             Some(auth_value),
             nv_index,
             &data,
-        )
-        .map_err(|error| TpmHelperError::TpmCommandError {
-            command_debug_info: CommandDebugInfo {
-                command_code: CommandCodeEnum::NV_Write,
-                auth_handle: Some(ReservedHandle(nv_index.into())),
-                nv_index: Some(nv_index),
-            },
-            error,
-        })?;
+        ) {
+            tracing::error!(
+                CVM_ALLOWED,
+                op_type = ?LogOpType::NvWrite,
+                nv_index,
+                data_size = data.len(),
+                success = false,
+                err = &error as &dyn std::error::Error,
+                latency = std::time::SystemTime::now()
+                    .duration_since(start_time)
+                    .map_or(0, |d| d.as_millis()),
+                "Error writing TPM NVRAM index"
+            );
+            return Err(TpmHelperError::TpmCommandError {
+                command_debug_info: CommandDebugInfo {
+                    command_code: CommandCodeEnum::NV_Write,
+                    auth_handle: Some(ReservedHandle(nv_index.into())),
+                    nv_index: Some(nv_index),
+                },
+                error,
+            });
+        } else {
+            tracing::info!(
+                CVM_ALLOWED,
+                op_type = ?LogOpType::NvWrite,
+                nv_index,
+                data_size = data.len(),
+                success = true,
+                latency = std::time::SystemTime::now()
+                    .duration_since(start_time)
+                    .map_or(0, |d| d.as_millis()),
+                "Wrote TPM NVRAM index"
+            );
+        }
 
         Ok(())
     }
@@ -951,24 +1035,34 @@ impl TpmEngineHelper {
         }
 
         let nv_index_size = res.nv_public.nv_public.data_size.get();
-        match self.nv_read(TPM20_RH_OWNER, nv_index, nv_index_size, data) {
-            Err(error) => {
-                if let TpmCommandError::TpmCommandFailed { response_code } = error {
-                    if response_code == ResponseCode::NvUninitialized as u32 {
-                        Ok(NvIndexState::Uninitialized)
-                    } else {
-                        // Unexpected response code
-                        Err(TpmHelperError::TpmCommandError {
-                            command_debug_info: CommandDebugInfo {
-                                command_code: CommandCodeEnum::NV_Read,
-                                auth_handle: Some(TPM20_RH_OWNER),
-                                nv_index: Some(nv_index),
-                            },
-                            error,
-                        })?
-                    }
+        let start_time = std::time::SystemTime::now();
+        tracing::info!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::BeginNvRead,
+            nv_index,
+            data_size = nv_index_size,
+            "Reading TPM NVRAM index"
+        );
+
+        if let Err(error) = self.nv_read(TPM20_RH_OWNER, nv_index, nv_index_size, data) {
+            tracing::error!(
+                CVM_ALLOWED,
+                op_type = ?LogOpType::NvRead,
+                nv_index,
+                data_size = nv_index_size,
+                success = false,
+                err = &error as &dyn std::error::Error,
+                latency = std::time::SystemTime::now()
+                    .duration_since(start_time)
+                    .map_or(0, |d| d.as_millis()),
+                "Error reading TPM NVRAM index"
+            );
+
+            if let TpmCommandError::TpmCommandFailed { response_code } = error {
+                if response_code == ResponseCode::NvUninitialized as u32 {
+                    Ok(NvIndexState::Uninitialized)
                 } else {
-                    // Unexpected failure
+                    // Unexpected response code
                     Err(TpmHelperError::TpmCommandError {
                         command_debug_info: CommandDebugInfo {
                             command_code: CommandCodeEnum::NV_Read,
@@ -978,8 +1072,30 @@ impl TpmEngineHelper {
                         error,
                     })?
                 }
+            } else {
+                // Unexpected failure
+                Err(TpmHelperError::TpmCommandError {
+                    command_debug_info: CommandDebugInfo {
+                        command_code: CommandCodeEnum::NV_Read,
+                        auth_handle: Some(TPM20_RH_OWNER),
+                        nv_index: Some(nv_index),
+                    },
+                    error,
+                })?
             }
-            Ok(_) => Ok(NvIndexState::Available),
+        } else {
+            tracing::info!(
+                CVM_ALLOWED,
+                op_type = ?LogOpType::NvRead,
+                nv_index,
+                data_size = nv_index_size,
+                success = true,
+                latency = std::time::SystemTime::now()
+                    .duration_since(start_time)
+                    .map_or(0, |d| d.as_millis()),
+                "Read TPM NVRAM index"
+            );
+            Ok(NvIndexState::Available)
         }
     }
 
@@ -1609,6 +1725,14 @@ impl TpmEngineHelper {
         data: &[u8],
     ) -> Result<(), TpmCommandError> {
         use tpm20proto::protocol::NvWriteCmd;
+
+        tracing::info!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::BeginNvWrite,
+            nv_index,
+            data_size = data.len(),
+            "Writing TPM NVRAM index"
+        );
 
         let session_tag = SessionTagEnum::Sessions;
 
@@ -3754,6 +3878,7 @@ mod tests {
             TpmAkCertType::Trusted(Arc::new(TestRequestAkCertHelper {})),
             None,
             None,
+            guid::guid!("00000000-0000-0000-0000-000000000000"),
         )
         .await
         .unwrap();

--- a/vm/devices/tpm_resources/Cargo.toml
+++ b/vm/devices/tpm_resources/Cargo.toml
@@ -8,9 +8,9 @@ rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true
-
 inspect.workspace = true
 mesh.workspace = true
+guid = { workspace = true, features = ["mesh"] }
 
 [lints]
 workspace = true

--- a/vm/devices/tpm_resources/src/lib.rs
+++ b/vm/devices/tpm_resources/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![forbid(unsafe_code)]
 
+use guid::Guid;
 use inspect::Inspect;
 use mesh::MeshPayload;
 use vm_resource::Resource;
@@ -30,6 +31,8 @@ pub struct TpmDeviceHandle {
     pub guest_secret_key: Option<Vec<u8>>,
     /// Optional logger to send event to the host
     pub logger: Option<Resource<TpmLoggerKind>>,
+    /// BIOS GUID (for logging purposes)
+    pub bios_guid: Guid,
 }
 
 impl ResourceId<ChipsetDeviceHandleKind> for TpmDeviceHandle {

--- a/vm/vmgs/vmgs/src/lib.rs
+++ b/vm/vmgs/vmgs/src/lib.rs
@@ -29,6 +29,7 @@ mod vmgs_impl;
 pub use error::Error;
 pub use vmgs_format::EncryptionAlgorithm;
 pub use vmgs_format::FileId;
+pub use vmgs_impl::GspType;
 pub use vmgs_impl::Vmgs;
 pub use vmgs_impl::VmgsFileInfo;
 #[cfg(feature = "save_restore")]

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -38,6 +38,12 @@ use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
 
+/// Operation types for provisioning telemetry.
+#[derive(Debug)]
+enum LogOpType {
+    VmgsProvision,
+}
+
 /// Info about a specific VMGS file.
 #[derive(Debug)]
 pub struct VmgsFileInfo {
@@ -45,6 +51,17 @@ pub struct VmgsFileInfo {
     pub allocated_bytes: u64,
     /// Number of valid bytes in the file.
     pub valid_bytes: u64,
+}
+
+/// GSP types that can be used to encrypt a VMGS file.
+#[derive(Debug, Clone, Copy)]
+pub enum GspType {
+    /// No GSP
+    None,
+    /// GSP by ID
+    GspById,
+    /// GSP key
+    GspKey,
 }
 
 // Aggregates fully validated data from the FILE_TABLE and EXTENDED_FILE_TABLE
@@ -179,7 +196,11 @@ impl Vmgs {
         logger: Option<Arc<dyn VmgsLogger>>,
     ) -> Result<Self, Error> {
         let mut storage = VmgsStorage::new(disk);
-        tracing::debug!(CVM_ALLOWED, "formatting and initializing VMGS datastore");
+        tracing::info!(
+            CVM_ALLOWED,
+            op_type = ?LogOpType::VmgsProvision,
+            "formatting and initializing VMGS datastore"
+        );
         // Errors from validate_file are fatal, as they involve invalid device metadata
         Vmgs::validate_file(&storage)?;
 

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 use uefi_nvram::UefiNvramOperation;
 use vmgs::Error as VmgsError;
+use vmgs::GspType;
 use vmgs::Vmgs;
 use vmgs::vmgs_helpers::get_active_header;
 use vmgs::vmgs_helpers::read_headers;
@@ -103,13 +104,6 @@ enum ExitCode {
     ErrorNotFound = 4,
     ErrorV1 = 5,
     ErrorGspById = 6,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum VmgsEncryptionScheme {
-    GspKey,
-    GspById,
-    None,
 }
 
 #[derive(Args)]
@@ -998,20 +992,17 @@ async fn vmgs_file_query_encryption(file_path: impl AsRef<Path>) -> Result<(), E
 
     let vmgs = vmgs_file_open(file_path, None as Option<PathBuf>, OpenMode::ReadOnly, true).await?;
 
-    match (
-        vmgs.get_encryption_algorithm(),
-        vmgs_get_encryption_scheme(&vmgs),
-    ) {
-        (EncryptionAlgorithm::NONE, VmgsEncryptionScheme::None) => {
+    match (vmgs.get_encryption_algorithm(), vmgs_get_gsp_type(&vmgs)) {
+        (EncryptionAlgorithm::NONE, GspType::None) => {
             println!("not encrypted");
             // Returning an error for HA to easily parse
             Err(Error::NotEncrypted)
         }
-        (EncryptionAlgorithm::AES_GCM, VmgsEncryptionScheme::GspKey) => {
+        (EncryptionAlgorithm::AES_GCM, GspType::GspKey) => {
             println!("encrypted with AES GCM encryption algorithm using GspKey");
             Ok(())
         }
-        (EncryptionAlgorithm::AES_GCM, VmgsEncryptionScheme::GspById) => {
+        (EncryptionAlgorithm::AES_GCM, GspType::GspById) => {
             println!("encrypted with AES GCM encryption algorithm using GspById");
             Err(Error::GspByIdEncryption)
         }
@@ -1021,13 +1012,13 @@ async fn vmgs_file_query_encryption(file_path: impl AsRef<Path>) -> Result<(), E
     }
 }
 
-fn vmgs_get_encryption_scheme(vmgs: &Vmgs) -> VmgsEncryptionScheme {
+fn vmgs_get_gsp_type(vmgs: &Vmgs) -> GspType {
     if vmgs_query_file_size(vmgs, FileId::KEY_PROTECTOR).is_ok() {
-        VmgsEncryptionScheme::GspKey
+        GspType::GspKey
     } else if vmgs_query_file_size(vmgs, FileId::VM_UNIQUE_ID).is_ok() {
-        VmgsEncryptionScheme::GspById
+        GspType::GspById
     } else {
-        VmgsEncryptionScheme::None
+        GspType::None
     }
 }
 


### PR DESCRIPTION
This change adds telemetry (in the form of event markers in our logs) around operations of interest for VMGS provisioning and certain vTPM features (AKPub, AKCert, etc.). The goal of this approach is to have structured, easily queryable data that can show that provisioning is successful and indicate whether Trusted Launch features (OpenHCL-provisioned VMGS, GSP key) are being enabled.

This PR is intended to match a corresponding legacy HCL change as closely as possible, given the differences in their logging implementations. In particular, the operation names (here, added as an `op_type` property on traces) and other metadata properties should match.