### PR TITLE
vmm_tests: Enable TDX Guest VSM test

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -293,7 +293,7 @@ async fn reboot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
 #[vmm_test(
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
-    //hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64_prepped)),
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64_prepped)),
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
 async fn reboot_into_guest_vsm<T: PetriVmmBackend>(


### PR DESCRIPTION
We should now have an updated runner capable of version 12.2 VMs, which TDX + VSM needs.