### PR TITLE
nvme_driver: add logging to the nvme_driver for keepalive

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager/device.rs
+++ b/openhcl/underhill_core/src/nvme_manager/device.rs
@@ -463,7 +463,7 @@ impl NvmeDriverManagerWorker {
                     .await
                 }
                 NvmeDriverRequest::Save(rpc) => {
-                    rpc.handle(async |span| self.driver.as_mut().unwrap().save().await)
+                    rpc.handle(async |_span| self.driver.as_mut().unwrap().save().await)
                         .await
                 }
                 NvmeDriverRequest::Shutdown(rpc) => {


### PR DESCRIPTION
A first pass to add more visibility in to the nvme keepalive feature by adding more logging for the save/restore states. Still a work in progress.