### PR TITLE
vmm_tests: fix path typo for release artifacts

### DIFF
--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -449,7 +449,7 @@ fn openhcl_bin_path(
             },
         ),
         (MachineArch::X86_64, OpenhclVersion::Release2505, OpenhclFlavor::LinuxDirect) => (
-            "flowey-out/artifacts/latest-release-igvm-files",
+            "flowey-out/artifacts/last-release-igvm-files",
             "release-2505-x64-direct-openhcl.bin",
             MissingCommand::XFlowey {
                 description: "Previous OpenHCL release IGVM file",
@@ -457,7 +457,7 @@ fn openhcl_bin_path(
             },
         ),
         (MachineArch::X86_64, OpenhclVersion::Release2505, OpenhclFlavor::Standard) => (
-            "flowey-out/artifacts/latest-release-igvm-files",
+            "flowey-out/artifacts/last-release-igvm-files",
             "release-2505-x64-openhcl.bin",
             MissingCommand::XFlowey {
                 description: "Previous OpenHCL release IGVM file",
@@ -465,7 +465,7 @@ fn openhcl_bin_path(
             },
         ),
         (MachineArch::Aarch64, OpenhclVersion::Release2505, OpenhclFlavor::Standard) => (
-            "flowey-out/artifacts/latest-release-igvm-files",
+            "flowey-out/artifacts/last-release-igvm-files",
             "release-2505-aarch64-openhcl.bin",
             MissingCommand::XFlowey {
                 description: "Previous OpenHCL release IGVM file",


### PR DESCRIPTION
Both CI and the vmm-tests command line rely on the `VMM_TESTS_CONTENT_DIR` environment to be set and that short-circuits path-checks in `get_path`. `cargo xflowey restore-packages` puts the latest release IGVM in a `last-release-igvm-files` folder but the path resolver looks for them in `latest-release-igvm-files`, which leads to the artifact not being found if you run a test outside of the `vmm-tests` command line (for example, `cargo nextest run -p vmm_tests --target x86_64-pc-windows-msvc servicing_upgrade` will fail even after a `cargo xflowey restore-packages` call. 

This change corrects the path to match where it'll be downloaded to. 