### PR TITLE
flowey: Mark condition parameters as used by their job

### DIFF
--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -1207,6 +1207,9 @@ impl PipelineJob<'_> {
     /// Only run the job if the specified condition is true.
     pub fn with_condition(self, cond: UseParameter<bool>) -> Self {
         self.pipeline.jobs[self.job_idx].cond_param_idx = Some(cond.idx);
+        self.pipeline.parameters[cond.idx]
+            .used_by_jobs
+            .insert(self.job_idx);
         self
     }
 


### PR DESCRIPTION
This should cause the parameters to get correctly initialized to their default values, which should allow local runs to work properly.