### PR TITLE
vmm_tests: memstat: mark 32+vp tests as very_heavy

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -500,7 +500,7 @@ async fn memory_validation_debug_small<T: PetriVmmBackend>(
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
-async fn memory_validation_release_heavy<T: PetriVmmBackend>(
+async fn memory_validation_release_very_heavy<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
     _: (),
     driver: DefaultDriver,
@@ -527,7 +527,7 @@ async fn memory_validation_release_heavy<T: PetriVmmBackend>(
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
-async fn memory_validation_debug_heavy<T: PetriVmmBackend>(
+async fn memory_validation_debug_very_heavy<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
     _: (),
     driver: DefaultDriver,


### PR DESCRIPTION
As recommended in #2256, mark the memstat LargeVp tests as very_heavy (since they use
32 or 64 vps).
