### PR TITLE
tracelimit: mark rate-limited traces as cold

### DIFF
--- a/support/tracelimit/src/lib.rs
+++ b/support/tracelimit/src/lib.rs
@@ -82,6 +82,7 @@ impl RateLimiter {
     ///
     /// `missed_events` is `Some(n)` if there were any missed events or if this
     /// event is the last one before rate limiting kicks in.
+    #[cold]
     pub fn event_with_config(
         &self,
         period_ms: Option<u32>,


### PR DESCRIPTION
Any code path with a rate-limited trace is very unlikely to be in a hot path. Mark such traces as cold to get better codegen.