### PR TITLE
petri: check the vmms log for vmwp crash

### DIFF
--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -843,7 +843,7 @@ pub async fn hyperv_halt_events(
 ) -> anyhow::Result<Vec<WinEvent>> {
     let vmid = vmid.to_string();
     run_get_winevent(
-        &[HYPERV_WORKER_TABLE],
+        &[HYPERV_WORKER_TABLE, HYPERV_VMMS_TABLE],
         Some(start_time),
         Some(&vmid),
         &HALT_EVENT_IDS,


### PR DESCRIPTION
Fix for https://github.com/microsoft/openvmm/commit/99042b367a9fbc2c4f2f56863aa0a35ec779d81a, which failed to catch the failure since the event comes from the VMMS not the VMWP.