### PR TITLE
openhcl: misc guest_arch cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "azure_profiler_proto",
- "build_rs_guest_arch",
  "cvm_tracing",
  "diag_proto",
  "fs-err",

--- a/openhcl/diag_server/Cargo.toml
+++ b/openhcl/diag_server/Cargo.toml
@@ -38,8 +38,5 @@ hvdef.workspace = true
 [features]
 profiler = ["dep:profiler_worker"]
 
-[build-dependencies]
-build_rs_guest_arch.workspace = true
-
 [lints]
 workspace = true

--- a/openhcl/diag_server/build.rs
+++ b/openhcl/diag_server/build.rs
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-#![expect(missing_docs)]
-
-fn main() {
-    build_rs_guest_arch::emit_guest_arch()
-}

--- a/openhcl/underhill_core/src/emuplat/firmware.rs
+++ b/openhcl/underhill_core/src/emuplat/firmware.rs
@@ -2,10 +2,6 @@
 // Licensed under the MIT License.
 
 use cvm_tracing::CVM_ALLOWED;
-#[cfg(guest_arch = "x86_64")]
-use firmware_pcat::PcatEvent;
-#[cfg(guest_arch = "x86_64")]
-use firmware_pcat::PcatLogger;
 use firmware_uefi::platform::logger::UefiEvent;
 use firmware_uefi::platform::logger::UefiLogger;
 use guest_emulation_transport::GuestEmulationTransportClient;
@@ -43,11 +39,11 @@ impl UefiLogger for UnderhillLogger {
 }
 
 #[cfg(guest_arch = "x86_64")]
-impl PcatLogger for UnderhillLogger {
-    fn log_event(&self, event: PcatEvent) {
+impl firmware_pcat::PcatLogger for UnderhillLogger {
+    fn log_event(&self, event: firmware_pcat::PcatEvent) {
         let log_event_id = match event {
-            PcatEvent::BootFailure => EventLogId::BOOT_FAILURE,
-            PcatEvent::BootAttempt => EventLogId::BOOT_ATTEMPT,
+            firmware_pcat::PcatEvent::BootFailure => EventLogId::BOOT_FAILURE,
+            firmware_pcat::PcatEvent::BootAttempt => EventLogId::BOOT_ATTEMPT,
         };
         self.get.event_log(log_event_id);
     }

--- a/openhcl/underhill_core/src/vp.rs
+++ b/openhcl/underhill_core/src/vp.rs
@@ -126,6 +126,7 @@ impl VpSpawner {
         saved_state: Option<vmcore::save_restore::SavedStateBlob>,
         control: Option<&mut IdleControl>,
     ) -> Option<vmcore::save_restore::SavedStateBlob> {
+        #[allow(unreachable_patterns)]
         let r = match self.isolation {
             virt::IsolationType::None | virt::IsolationType::Vbs => {
                 self.run_backed_vp::<virt_mshv_vtl::HypervisorBacked>(saved_state, control)
@@ -141,7 +142,6 @@ impl VpSpawner {
                 self.run_backed_vp::<virt_mshv_vtl::TdxBacked>(saved_state, control)
                     .await
             }
-            #[cfg(guest_arch = "aarch64")]
             _ => unimplemented!(),
         };
         match r {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2792,7 +2792,7 @@ async fn new_underhill_vm(
         0..=1,
         0,
         "bsp",
-        Arc::new(virt::irqcon::ApicLintLineTarget::new(
+        Arc::new(vmm_core::emuplat::apic::ApicLintLineTarget::new(
             partition.clone(),
             Vtl::Vtl0,
         )),

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -585,7 +585,6 @@ impl GetReferenceTime for TscReferenceTimeSource {
     }
 }
 
-#[cfg(guest_arch = "aarch64")]
 impl virt::irqcon::ControlGic for UhPartitionInner {
     fn set_spi_irq(&self, irq_id: u32, high: bool) {
         if let Err(err) = self.hcl.request_interrupt(
@@ -606,7 +605,6 @@ impl virt::irqcon::ControlGic for UhPartitionInner {
     }
 }
 
-#[cfg(guest_arch = "aarch64")]
 impl virt::Aarch64Partition for UhPartition {
     fn control_gic(&self, vtl: Vtl) -> Arc<dyn virt::irqcon::ControlGic> {
         debug_assert!(vtl == Vtl::Vtl0);

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![cfg(guest_arch = "x86_64")]
-
 use crate::UhProcessor;
 use crate::processor::HardwareIsolatedBacking;
 use cvm_tracing::CVM_ALLOWED;

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -22,7 +22,6 @@ use zerocopy::IntoBytes;
 
 pub(super) const FLUSH_GVA_LIST_SIZE: usize = 32;
 
-#[cfg(guest_arch = "x86_64")]
 #[derive(Debug, Inspect)]
 pub(super) struct TdxPartitionFlushState {
     /// A fixed-size ring buffer of GVAs that need to be flushed.
@@ -33,7 +32,6 @@ pub(super) struct TdxPartitionFlushState {
     pub(super) flush_entire_non_global_counter: AtomicU32,
 }
 
-#[cfg(guest_arch = "x86_64")]
 impl TdxPartitionFlushState {
     pub(super) fn new() -> Self {
         Self {
@@ -44,7 +42,6 @@ impl TdxPartitionFlushState {
     }
 }
 
-#[cfg(guest_arch = "x86_64")]
 #[derive(Debug, Inspect)]
 pub(super) struct TdxFlushState {
     /// The last observed value of the partition's counter.
@@ -60,7 +57,6 @@ pub(super) struct TdxFlushState {
     flush_entire_non_global_counter: Wrapping<u32>,
 }
 
-#[cfg(guest_arch = "x86_64")]
 impl TdxFlushState {
     pub(super) fn new() -> Self {
         Self {

--- a/openvmm/hvlite_core/src/partition.rs
+++ b/openvmm/hvlite_core/src/partition.rs
@@ -170,7 +170,7 @@ where
 {
     #[cfg(guest_arch = "x86_64")]
     fn into_lint_target(self: Arc<Self>, vtl: Vtl) -> Arc<dyn LineSetTarget> {
-        Arc::new(virt::irqcon::ApicLintLineTarget::new(self, vtl))
+        Arc::new(vmm_core::emuplat::apic::ApicLintLineTarget::new(self, vtl))
     }
 
     fn caps(&self) -> &PartitionCapabilities {

--- a/openvmm/hvlite_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/uefi.rs
@@ -152,12 +152,10 @@ pub fn load_uefi(
     .add(&flags);
 
     #[cfg(guest_arch = "aarch64")]
-    {
-        cfg.add(&config::Gic {
-            gic_distributor_base: processor_topology.gic_distributor_base(),
-            gic_redistributors_base: processor_topology.gic_redistributors_base(),
-        });
-    }
+    cfg.add(&config::Gic {
+        gic_distributor_base: processor_topology.gic_distributor_base(),
+        gic_redistributors_base: processor_topology.gic_redistributors_base(),
+    });
 
     if let Some(mcfg) = mcfg {
         cfg.add_raw(config::BlobStructureType::Mcfg, mcfg);

--- a/vmm_core/src/emuplat/apic.rs
+++ b/vmm_core/src/emuplat/apic.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Code to bridge between the `vmotherboard` interrupt controller and a `virt`
+//! partition APIC.
+
+use hvdef::Vtl;
+use std::sync::Arc;
+use virt::X86Partition;
+use vm_topology::processor::VpIndex;
+use vmcore::line_interrupt::LineSetTarget;
+
+/// A [`LineSetTarget`] implementation that raises APIC local interrupt lines.
+pub struct ApicLintLineTarget<T: X86Partition> {
+    partition: Arc<T>,
+    vtl: Vtl,
+}
+
+impl<T: X86Partition> ApicLintLineTarget<T> {
+    /// Creates a new APIC LINT line set target.
+    pub fn new(partition: Arc<T>, vtl: Vtl) -> Self {
+        Self { partition, vtl }
+    }
+}
+
+impl<T: X86Partition> LineSetTarget for ApicLintLineTarget<T> {
+    fn set_irq(&self, vector: u32, high: bool) {
+        if !high {
+            return;
+        }
+        let vp_index = VpIndex::new(vector / 2);
+        let lint = vector % 2;
+        self.partition.pulse_lint(vp_index, self.vtl, lint as u8);
+    }
+}

--- a/vmm_core/src/emuplat/mod.rs
+++ b/vmm_core/src/emuplat/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+pub mod apic;
 pub mod gic;
 pub mod hcl_compat_uefi_nvram_storage;
 pub mod ioapic;


### PR DESCRIPTION
Our position is generally that we should keep code building on all architectures where possible, to facilitate ease of development. Remove some guest_arch cfgs that aren't needed and tweak some things. Move ApicLintLineTarget to vmm_core/emuplat to match GicLineTarget.