### PR TITLE
deps: Remove tracing version restriction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -536,7 +536,6 @@ thiserror = { version = "2", default-features = false }
 time = "0.3"
 toml_edit = "0.23"
 tracing = "0.1"
-tracing-core = "=0.1.30" # Pin to avoid binary size increase https://github.com/tokio-rs/tracing/issues/3182
 tracing-subscriber = "0.3.20"
 typed-path = "0.11"
 uefi = "0.35.0"
@@ -560,10 +559,6 @@ xshell = "=0.2.2" # pin to 0.2.2 to work around https://github.com/matklad/xshel
 xshell-macros = "0.2"
 # We add the derive feature here since the vast majority of our crates use it.
 zerocopy = { version = "0.8.25", features = ["derive"]}
-
-[workspace.metadata.xtask.unused-deps]
-# Pulled in through "tracing", but we need to pin the version
-ignored = ["tracing-core"]
 
 [profile.release]
 panic = 'abort'


### PR DESCRIPTION
At some point we somehow managed to update to this new version, despite the restriction, and without a binary size increase. Presumably a compiler update improved the binary size situation, unknown. Remove the restriction since it apparently isn't working and is no longer needed.