### PR TITLE
HCL: Allow ourselves access to VTL 1 private registers

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1448,10 +1448,7 @@ impl MshvHvcall {
                         | HvX64RegisterName::VsmVpSecureConfigVtl1
                 ));
             }
-            Some(Vtl::Vtl1) => {
-                todo!("TODO: allowed registers for VTL1");
-            }
-            Some(Vtl::Vtl0) => {
+            Some(Vtl::Vtl1) | Some(Vtl::Vtl0) => {
                 // Only VTL-private registers can go through this path.
                 // VTL-shared registers have to go through the kernel (either
                 // via the CPU context page or via the dedicated ioctl), as
@@ -1491,11 +1488,7 @@ impl MshvHvcall {
                         | HvArm64RegisterName::PrivilegesAndFeaturesInfo
                 ));
             }
-            Some(Vtl::Vtl1) => {
-                // TODO: allowed registers for VTL1
-                todo!();
-            }
-            Some(Vtl::Vtl0) => {
+            Some(Vtl::Vtl1) | Some(Vtl::Vtl0) => {
                 // Only VTL-private registers can go through this path.
                 // VTL-shared registers have to go through the kernel (either
                 // via the CPU context page or via the dedicated ioctl), as


### PR DESCRIPTION
This fixes the ability to get VTL 1 context when VTL 1 crashes, for better diagnostics.