### PR TITLE
virt_mshv_vtl/mshv: Limit crash message size (#1953)

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1072,7 +1072,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 
                 if crash.control.crash_message() {
                     let message_gpa = crash.parameters[3];
-                    let message_size = crash.parameters[4];
+                    let message_size = std::cmp::min(crash.parameters[4], hvdef::HV_PAGE_SIZE);
                     let mut message = vec![0; message_size as usize];
                     match self.partition.gm[vtl].read_at(message_gpa, &mut message) {
                         Ok(()) => {


### PR DESCRIPTION
When guests are in the middle of crashing they can be in broken states and do weird things. We've seen cases where they pass some outrageously large number to this (or possibly a negative number?), which results in us attempting to alloc a giant Vec, which results in us OOMing. Limit this to a single page to match the spec, and the hypervisor.

Clean cherry-pick