### PR TITLE
vm/devices/vpci: track vtom and register for mmio with vtom (#2306)

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2861,6 +2861,7 @@ async fn new_underhill_vm(
                                 .context("failed to create direct mmio accessor")?,
                         )
                     },
+                    vtom,
                 );
 
                 // Allow NVMe devices.
@@ -2990,6 +2991,7 @@ async fn new_underhill_vm(
                     let device = Arc::new(device);
                     Ok((device.clone(), VpciInterruptMapper::new(device)))
                 },
+                vtom,
             )
             .await?;
         }

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1833,6 +1833,7 @@ impl InitializedVm {
                         &mut mmio,
                         vmbus.control().as_ref(),
                         interrupt_mapper,
+                        None,
                     )
                     .await?;
 
@@ -1947,6 +1948,7 @@ impl InitializedVm {
                                 hv_device.clone().interrupt_mapper(),
                             ))
                         },
+                        None,
                     )
                     .await?;
                 }
@@ -1988,6 +1990,7 @@ impl InitializedVm {
                                 &mut services.register_mmio(),
                                 vmbus,
                                 crate::partition::VpciDevice::interrupt_mapper(hv_device),
+                                None,
                             )
                             .await
                         })

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -1048,14 +1048,27 @@ pub struct VpciChannel {
 pub struct VpciConfigSpace {
     offset: VpciConfigSpaceOffset,
     control_mmio: Box<dyn ControlMmioIntercept>,
+    vtom: Option<VpciConfigSpaceVtom>,
+}
+
+/// The vtom info used by config space.
+pub struct VpciConfigSpaceVtom {
+    /// The vtom bit.
+    pub vtom: u64,
+    /// The mmio control region to be registered with vtom.
+    pub control_mmio: Box<dyn ControlMmioIntercept>,
 }
 
 impl VpciConfigSpace {
-    /// Create New PCI Config space
-    pub fn new(control_mmio: Box<dyn ControlMmioIntercept>) -> Self {
+    /// Create New PCI Config space.
+    pub fn new(
+        control_mmio: Box<dyn ControlMmioIntercept>,
+        vtom: Option<VpciConfigSpaceVtom>,
+    ) -> Self {
         Self {
             offset: VpciConfigSpaceOffset::new(),
             control_mmio,
+            vtom,
         }
     }
 
@@ -1065,13 +1078,22 @@ impl VpciConfigSpace {
     }
 
     fn map(&mut self, addr: u64) {
-        tracing::debug!(addr, "mapping config space");
+        tracing::trace!(addr, "mapping config space");
+
+        // Remove the vtom bit if set
+        let vtom_bit = self.vtom.as_ref().map(|v| v.vtom).unwrap_or(0);
+        let addr = addr & !vtom_bit;
+
         self.offset.0.store(addr, Ordering::Relaxed);
         self.control_mmio.map(addr);
+
+        if let Some(vtom) = self.vtom.as_mut() {
+            vtom.control_mmio.map(addr | vtom_bit);
+        }
     }
 
     fn unmap(&mut self) {
-        tracing::debug!(
+        tracing::trace!(
             addr = self.offset.0.load(Ordering::Relaxed),
             "unmapping config space"
         );
@@ -1081,6 +1103,9 @@ impl VpciConfigSpace {
         //
         // This is idempotent. See [`impl_device_range!`].
         self.control_mmio.unmap();
+        if let Some(vtom) = self.vtom.as_mut() {
+            vtom.control_mmio.unmap();
+        }
         self.offset
             .0
             .store(VpciConfigSpaceOffset::INVALID, Ordering::Relaxed);
@@ -1287,6 +1312,7 @@ mod tests {
         }
         let config_space = VpciConfigSpace::new(
             ExternallyManagedMmioIntercepts.new_io_region("test", 2 * HV_PAGE_SIZE),
+            None,
         );
         let mut state = VpciChannel {
             msi_mapper: VpciInterruptMapper::new(msi_mapper),

--- a/vm/devices/pci/vpci_client/src/tests.rs
+++ b/vm/devices/pci/vpci_client/src/tests.rs
@@ -80,6 +80,7 @@ async fn test_negotiate_version(driver: DefaultDriver) {
         device,
         &mut ExternallyManagedMmioIntercepts,
         VpciInterruptMapper::new(msi_controller),
+        None,
     )
     .unwrap();
 

--- a/vm/devices/pci/vpci_relay/src/lib.rs
+++ b/vm/devices/pci/vpci_relay/src/lib.rs
@@ -74,6 +74,8 @@ pub struct VpciRelay {
     mmio_access: Box<dyn CreateMemoryAccess>,
     #[inspect(iter_by_index)]
     allowed_devices: Vec<AllowedDevice>,
+    #[inspect(hex)]
+    vtom: Option<u64>,
 }
 
 #[derive(Inspect)]
@@ -157,6 +159,7 @@ impl VpciRelay {
         dma_client: Arc<dyn DmaClient>,
         mmio_range: MemoryRange,
         mmio_access: Box<dyn CreateMemoryAccess>,
+        vtom: Option<u64>,
     ) -> Self {
         Self {
             driver_source,
@@ -168,6 +171,7 @@ impl VpciRelay {
             mmio_range,
             mmio_access,
             allowed_devices: Vec::new(),
+            vtom,
         }
     }
 
@@ -304,6 +308,7 @@ impl VpciRelay {
                             mmio,
                             self.vmbus.as_ref(),
                             interrupt_mapper,
+                            self.vtom,
                         )
                         .await?;
 

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -36,6 +36,7 @@ pub async fn build_vpci_device(
         Arc<dyn MsiInterruptTarget>,
         VpciInterruptMapper,
     )>,
+    vtom: Option<u64>,
 ) -> anyhow::Result<()> {
     let device_name = format!("{}:vpci-{instance_id}", resource.id());
 
@@ -82,6 +83,7 @@ pub async fn build_vpci_device(
                     &mut services.register_mmio(),
                     vmbus,
                     interrupt_mapper,
+                    vtom,
                 )
                 .await?;
 


### PR DESCRIPTION
On hardware isolated guests with vtom, the guest may access vpci config space with vtom set. Add this tracking in vpci and register for mmio with vtom, so we can correctly handle guest accesses on SNP & TDX.

This fixes vpci relay on TDX, as both Linux and Windows will access config space with vtom set.

Fixup of a cherry pick from #2306 (required changes in device_builder.rs)