### PR TITLE
mana_driver: add builder pattern for WQEs

### DIFF
--- a/vm/devices/net/gdma/src/queues.rs
+++ b/vm/devices/net/gdma/src/queues.rs
@@ -228,7 +228,7 @@ impl Wq {
 
         let total_len = header.total_len();
         if total_len > size_of::<Wqe>() || total_len > self.available() as usize {
-            tracing::warn!("invalid wqe");
+            tracing::warn!(total_len, available = self.available(), "invalid wqe");
             return Poll::Pending;
         }
 

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -802,14 +802,12 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         let n = self
             .rq
             .push(
-                &(),
+                (),
                 [Sge {
                     address: self.dma_buffer.pfns()[RESPONSE_PAGE] * PAGE_SIZE64,
                     mem_key: self.gpa_mkey,
                     size: PAGE_SIZE as u32,
                 }],
-                None,
-                0,
             )
             .expect("rq is not full");
         assert_eq!(n, RWQE_SIZE);
@@ -871,14 +869,12 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             let sqe_len = self
                 .sq
                 .push(
-                    &oob,
+                    oob,
                     [Sge {
                         address: self.dma_buffer.pfns()[REQUEST_PAGE] * PAGE_SIZE64,
                         mem_key: self.gpa_mkey,
                         size: (size_of_val(&hdr) + size_of_val(&req)) as u32,
                     }],
-                    None,
-                    0,
                 )
                 .expect("send queue should not be full");
 


### PR DESCRIPTION
When writing tx work queue entries, `net_mana` creates an array of scatter gather elements on the stack and then writes them into the work queue in a loop. This creates a large array (496 bytes) on the stack, which is zero initialized for each packet, creating expensive calls to `memset` in the hot path.

Introduce a builder pattern that allows `net_mana` to build the scatter gather elements directly into the work queue memory, and use this pattern in the tx path.