### PR TITLE
netvsp: write ring packets more efficiently

### DIFF
--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -806,6 +806,18 @@ impl TestNicSubchannel {
     }
 }
 
+struct NvspMessage<T> {
+    header: protocol::MessageHeader,
+    data: T,
+    padding: &'static [u8],
+}
+
+impl<T: IntoBytes + Immutable + KnownLayout> NvspMessage<T> {
+    fn payload(&self) -> [&[u8]; 3] {
+        [self.header.as_bytes(), self.data.as_bytes(), self.padding]
+    }
+}
+
 struct TestNicChannel<'a> {
     pub mtu: u32,
     nic: &'a mut TestNicDevice,

--- a/vm/devices/vmbus/vmbus_ring/benches/ring.rs
+++ b/vm/devices/vmbus/vmbus_ring/benches/ring.rs
@@ -120,7 +120,7 @@ fn paged_ring_mem(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("write");
-    for size in &[16usize, 256, 8192] {
+    for size in &[16usize, 40, 256, 8192] {
         group
             .throughput(Throughput::Bytes(*size as u64))
             .bench_with_input(

--- a/vm/devices/vmbus/vmbus_ring/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_ring/src/lib.rs
@@ -257,6 +257,15 @@ impl RingRange {
         }
     }
 
+    /// Writes the full range using aligned writes of `u64` values.
+    ///
+    /// # Panics
+    /// Panics if the ring range is not exactly the size of `data`.
+    pub fn write_aligned_full<T: Ring>(&self, ring: &T, data: &[u64]) {
+        assert_eq!(self.size as usize, data.len() * 8);
+        ring.mem().write_aligned(self.off as usize, data.as_bytes());
+    }
+
     /// Retrieves a `MemoryRead` that allows for writing to the range.
     pub fn reader<'a, T: Ring>(&self, ring: &'a T) -> RingRangeReader<'a, T::Memory> {
         RingRangeReader {


### PR DESCRIPTION
The netvsp ring buffer send path is inefficient, as it writes using the unaligned ring buffer path in three pieces. Change this to use a single aligned write.