### PR TITLE
dma_client: add force_locked parameter to DmaClientParams and use it for mana

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager/device.rs
+++ b/openhcl/underhill_core/src/nvme_manager/device.rs
@@ -92,6 +92,7 @@ impl CreateNvmeDriver for VfioNvmeDriverSpawner {
                     AllocationVisibility::Private
                 },
                 persistent_allocations: save_restore_supported,
+                force_locked: false,
             })
             .map_err(NvmeSpawnerError::DmaClient)?;
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -777,6 +777,7 @@ impl UhVmNetworkSettings {
                 AllocationVisibility::Private
             },
             persistent_allocations: false,
+            force_locked: true,
         })?;
 
         let (vf_manager, endpoints, save_state) = HclNetworkVFManager::new(
@@ -1706,6 +1707,7 @@ async fn new_underhill_vm(
                     AllocationVisibility::Private
                 },
                 persistent_allocations: false,
+                force_locked: false,
             })
             .context("get dma client")?,
     );
@@ -1883,12 +1885,14 @@ async fn new_underhill_vm(
                 lower_vtl_policy: LowerVtlPermissionPolicy::Any,
                 allocation_visibility: AllocationVisibility::Shared,
                 persistent_allocations: false,
+                force_locked: false,
             })?,
             private_dma_client: dma_manager.new_client(DmaClientParameters {
                 device_name: "partition-private".into(),
                 lower_vtl_policy: LowerVtlPermissionPolicy::Any,
                 allocation_visibility: AllocationVisibility::Private,
                 persistent_allocations: false,
+                force_locked: false,
             })?,
         })
     } else {
@@ -2951,6 +2955,7 @@ async fn new_underhill_vm(
                             AllocationVisibility::Private
                         },
                         persistent_allocations: false,
+                        force_locked: false,
                     })?,
                     vpci_relay_mmio,
                     if use_mmio_hypercalls {
@@ -3189,6 +3194,7 @@ async fn new_underhill_vm(
                     lower_vtl_policy: LowerVtlPermissionPolicy::Vtl0,
                     allocation_visibility: AllocationVisibility::Private,
                     persistent_allocations: false,
+                    force_locked: false,
                 })
                 .context("shutdown relay dma client")?,
             shutdown_guest,


### PR DESCRIPTION
There may be a cleaner way to do this, but putting it out for discussion. 

Right now in the scenario where AllocationVisibility::Private (is_isolated == false) and persistent_allocations == false, the DmaClientBacking::PrivatePoolWithFallback will be used for mana. This means that when the private pool is enabled for nvme keepalive, mana would also allocate its memory using the private pool and potentially exhausting the private pool This could potentially keep nvme keepalive from working depending on the order of allocation.