### PR TITLE
[DO NOT MERGE] Control Test for TDX Reset Vector

### DIFF
--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -631,6 +631,7 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     validate_vp_hw_ids(partition_info);
 
     setup_vtl2_memory(&p, partition_info);
+    //↑ ↑ ↓ ↓ ← → ← → B A
     setup_vtl2_vp(partition_info);
 
     verify_imported_regions_hash(&p);


### PR DESCRIPTION
Using this PR, paired with #2332, to investigate an intermittent failure.

This PR contains no real change, it is so we can see the current rate of failure of multi-vp TDs in petri.  