### PR TITLE
virt_whp/vtl2: fix eoi intercept remove

### DIFF
--- a/vmm_core/virt_whp/src/vtl2.rs
+++ b/vmm_core/virt_whp/src/vtl2.rs
@@ -114,7 +114,7 @@ impl Vtl2InterceptState {
             InterceptType::RetargetUnknownDeviceId => self
                 .retarget_unknown_device_id
                 .swap(false, Ordering::SeqCst),
-            InterceptType::Eoi => self.eoi.swap(true, Ordering::SeqCst),
+            InterceptType::Eoi => self.eoi.swap(false, Ordering::SeqCst),
         }
     }
 


### PR DESCRIPTION
We incorrectly stored true instead of false when removing the intercept. Found via code inspection. 