### PR TITLE
vmbus_server: move SINT constant to vmbus_core

### DIFF
--- a/vm/devices/vmbus/vmbus_core/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_core/src/lib.rs
@@ -22,6 +22,9 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
+/// The standard, non-redirected synthetic interrupt used by VMBus.
+pub const VMBUS_SINT: u8 = 2;
+
 #[derive(Debug)]
 pub struct TaggedStream<T, S>(Option<T>, S);
 

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -6,7 +6,6 @@ pub mod saved_state;
 mod tests;
 
 use crate::Guid;
-use crate::SINT;
 use crate::SynicMessage;
 use crate::monitor::AssignedMonitors;
 use crate::protocol::Version;
@@ -37,6 +36,7 @@ use vmbus_core::HvsockConnectRequest;
 use vmbus_core::HvsockConnectResult;
 use vmbus_core::MaxVersionInfo;
 use vmbus_core::OutgoingMessage;
+use vmbus_core::VMBUS_SINT;
 use vmbus_core::VersionInfo;
 use vmbus_core::protocol;
 use vmbus_core::protocol::ChannelId;
@@ -867,7 +867,7 @@ impl Channel {
 
         let channel_id = entry.id();
         entry.insert(offer_id);
-        let connection_id = ConnectionId::new(channel_id.0, assigned_channels.vtl, SINT);
+        let connection_id = ConnectionId::new(channel_id.0, assigned_channels.vtl, VMBUS_SINT);
 
         // Allocate a monitor ID if the channel uses MNF.
         // N.B. If the synic doesn't support MNF or MNF is disabled by the server, use_mnf should
@@ -2111,7 +2111,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         {
             target_info.sint()
         } else {
-            SINT
+            VMBUS_SINT
         };
 
         let target_vtl = if message.multiclient
@@ -2205,7 +2205,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             return;
         }
 
-        if request.target_sint != SINT {
+        if request.target_sint != VMBUS_SINT {
             tracelimit::warn_ratelimited!(
                 target_vtl = request.target_vtl,
                 target_sint = request.target_sint,

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -83,6 +83,7 @@ use vmbus_core::HvsockConnectResult;
 use vmbus_core::MaxVersionInfo;
 use vmbus_core::OutgoingMessage;
 use vmbus_core::TaggedStream;
+use vmbus_core::VMBUS_SINT;
 use vmbus_core::VersionInfo;
 use vmbus_core::protocol;
 pub use vmbus_core::protocol::GpadlId;
@@ -99,7 +100,6 @@ use vmcore::synic::MessagePort;
 use vmcore::synic::MonitorPageGpas;
 use vmcore::synic::SynicPortAccess;
 
-const SINT: u8 = 2;
 pub const REDIRECT_SINT: u8 = 7;
 pub const REDIRECT_VTL: Vtl = Vtl::Vtl2;
 const SHARED_EVENT_CONNECTION_ID: u32 = 2;
@@ -463,7 +463,7 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
         let (redirect_vtl, redirect_sint) = if self.use_message_redirect {
             (REDIRECT_VTL, REDIRECT_SINT)
         } else {
-            (self.vtl, SINT)
+            (self.vtl, VMBUS_SINT)
         };
 
         // If this server is not for VTL2, use a server-specific connection ID rather than the
@@ -1792,11 +1792,11 @@ impl ServerTaskInner {
         let (target_vtl, target_sint) = if open_params.flags.redirect_interrupt() {
             (self.redirect_vtl, self.redirect_sint)
         } else {
-            (self.vtl, SINT)
+            (self.vtl, VMBUS_SINT)
         };
 
         let guest_event_port = self.synic.new_guest_event_port(
-            VmbusServer::get_child_event_port_id(open_params.channel_id, SINT, self.vtl),
+            VmbusServer::get_child_event_port_id(open_params.channel_id, VMBUS_SINT, self.vtl),
             target_vtl,
             target_vp,
             target_sint,


### PR DESCRIPTION
This change moves the `SINT` constant to the `vmbus_core` crate, so it can be used in other places. It also renames it to `VMBUS_SINT` for clarity.