### PR TITLE
dma_client: remove fallback allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,7 +5040,6 @@ dependencies = [
  "memory_range",
  "mesh",
  "page_pool_alloc",
- "tracing",
  "user_driver",
  "virt",
  "vmcore",

--- a/openhcl/openhcl_dma_manager/Cargo.toml
+++ b/openhcl/openhcl_dma_manager/Cargo.toml
@@ -21,7 +21,6 @@ virt.workspace = true
 vmcore.workspace = true
 
 anyhow.workspace = true
-tracing.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
#2061 added a fallback allocator for situations where the private pool is available but persistence isn't needed. This had the unintended effect of MANA devices using the private pool when available even though its memory won't be persisted or restored. This leads to restoration failures on servicing because not all memory from the private pool is restored, and could also lead to scenarios where MANA could exhaust the private pool even though it doesn't need to use it.

This change removes the fallback allocator so this scenario isn't possible.