### PR TITLE
openhcl_dma_manager: build fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5045,6 +5045,7 @@ dependencies = [
  "memory_range",
  "mesh",
  "page_pool_alloc",
+ "tracing",
  "user_driver",
  "virt",
  "vmcore",

--- a/openhcl/openhcl_dma_manager/Cargo.toml
+++ b/openhcl/openhcl_dma_manager/Cargo.toml
@@ -16,6 +16,7 @@ inspect.workspace = true
 memory_range.workspace = true
 mesh.workspace = true
 page_pool_alloc.workspace = true
+tracing.workspace = true
 user_driver.workspace = true
 virt.workspace = true
 vmcore.workspace = true


### PR DESCRIPTION
Post-CI semantic conflict between two PRs today. Add the tracing dependency back.
