### PR TITLE
vmbus_server: correctly handle enumerate_device_interface for proxy offers

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -533,15 +533,21 @@ impl ProxyTask {
                 },
             }
         } else if offer.ChannelFlags.enumerate_device_interface() {
-            let params = offer.UserDefined.as_pipe_params();
-            let message_mode = match params.pipe_type {
-                protocol::PipeType::BYTE => false,
-                protocol::PipeType::MESSAGE => true,
-                _ => {
-                    anyhow::bail!("unsupported offer pipe mode");
+            if offer.ChannelFlags.named_pipe_mode() {
+                let params = offer.UserDefined.as_pipe_params();
+                let message_mode = match params.pipe_type {
+                    protocol::PipeType::BYTE => false,
+                    protocol::PipeType::MESSAGE => true,
+                    _ => {
+                        anyhow::bail!("unsupported offer pipe mode");
+                    }
+                };
+                ChannelType::Pipe { message_mode }
+            } else {
+                ChannelType::Interface {
+                    user_defined: offer.UserDefined,
                 }
-            };
-            ChannelType::Pipe { message_mode }
+            }
         } else {
             ChannelType::Device {
                 pipe_packets: offer.ChannelFlags.named_pipe_mode(),


### PR DESCRIPTION
When offering channels from vmbusproxy, we were always handling offers with the `enumerate_device_interface` flag set as named pipes, even when they didn't have the `named_pipe_mode` flag set.

This changes makes sure that channels with `enumerate_device_interface` set but without `named_pipe_mode` are offered correctly.