### PR TITLE
clippy: add build-essential to check_clippy pre build deps

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -95,7 +95,7 @@ impl SimpleFlowNode for Node {
 
         pre_build_deps.push(
             ctx.reqv(|v| flowey_lib_common::install_dist_pkg::Request::Install {
-                package_names: vec!["libssl-dev".into()],
+                package_names: vec!["libssl-dev".into(), "build-essential".into()],
                 done: v,
             }),
         );


### PR DESCRIPTION
Build essential is required for these clippy checks to pass, add it as a dependency.