### PR TITLE
support: Remove target-arch justification comments

### DIFF
--- a/support/atomic_ringbuf/src/lib.rs
+++ b/support/atomic_ringbuf/src/lib.rs
@@ -12,7 +12,7 @@
 #![forbid(unsafe_code)]
 
 cfg_if::cfg_if! {
-    if #[cfg(all(target_arch = "x86_64", test))] { // xtask-fmt allow-target-arch dependency
+    if #[cfg(all(target_arch = "x86_64", test))] {
         use loom::sync::Mutex;
         use loom::sync::MutexGuard;
         use loom::sync::atomic::AtomicU64;
@@ -80,7 +80,7 @@ impl<const N: usize, T: Copy + From<u64> + Into<u64>> AtomicRingBuffer<N, T> {
     /// Obtain a write lock for the buffer.
     pub fn write(&self) -> AtomicRingBufferWriteGuard<'_, N, T> {
         let write_lock = self.write_lock.lock();
-        #[cfg(all(target_arch = "x86_64", test))] // xtask-fmt allow-target-arch dependency
+        #[cfg(all(target_arch = "x86_64", test))]
         let write_lock = write_lock.unwrap();
         AtomicRingBufferWriteGuard {
             buf: self,
@@ -156,7 +156,7 @@ impl<const N: usize, T: Copy + From<u64> + Into<u64>> AtomicRingBufferWriteGuard
     }
 }
 
-#[cfg(all(target_arch = "x86_64", test))] // xtask-fmt allow-target-arch dependency
+#[cfg(all(target_arch = "x86_64", test))]
 mod loom_tests {
     use super::*;
     use loom::sync::Arc;

--- a/support/pal/src/unix/process.rs
+++ b/support/pal/src/unix/process.rs
@@ -564,7 +564,7 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
-    #[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch sys-crate
+    #[cfg(target_arch = "x86_64")]
     fn test_seccomp_sandbox() {
         use crate::sys::SyscallResult;
         use crate::sys::while_eintr;

--- a/support/trycopy/src/aarch64.rs
+++ b/support/trycopy/src/aarch64.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// xtask-fmt allow-target-arch sys-crate
 #![cfg(target_arch = "aarch64")]
 
 use super::Context;

--- a/support/trycopy/src/lib.rs
+++ b/support/trycopy/src/lib.rs
@@ -84,10 +84,8 @@ mod aarch64;
 mod memcpy;
 mod x86_64;
 
-// xtask-fmt allow-target-arch sys-crate
 #[cfg(target_arch = "aarch64")]
 use aarch64::*;
-// xtask-fmt allow-target-arch sys-crate
 #[cfg(target_arch = "x86_64")]
 use x86_64::*;
 

--- a/support/trycopy/src/x86_64.rs
+++ b/support/trycopy/src/x86_64.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// xtask-fmt allow-target-arch sys-crate
 #![cfg(target_arch = "x86_64")]
 
 use super::Context;


### PR DESCRIPTION
Now that we exclude all support/ crates from needing this xtask check, we can remove the previous comments to remove some noise.