### PR TITLE
vmgstool: exit code for unknown GSP type

### DIFF
--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -122,6 +122,7 @@ enum ExitCode {
     ErrorNotFound = 4,
     ErrorV1 = 5,
     ErrorGspById = 6,
+    ErrorGspUnknown = 7,
 }
 
 #[derive(Args)]
@@ -359,6 +360,7 @@ fn main() {
                 Error::Vmgs(VmgsError::FileInfoNotAllocated) => ExitCode::ErrorNotFound,
                 Error::V1Format => ExitCode::ErrorV1,
                 Error::GspByIdEncryption => ExitCode::ErrorGspById,
+                Error::GspUnknown => ExitCode::ErrorGspUnknown,
                 _ => ExitCode::Error,
             };
 


### PR DESCRIPTION
Add a return code to VmgsTool that indicates that no guest state protector was found (for either GspById or GspKey). Should enable consumers to recover from certain classes of failures.