### PR TITLE
Revert "vmgs: dont upgrade vmgs encryption on auto (#2280)"

### DIFF
--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -107,10 +107,9 @@ pub enum GuestStateLifetime {
 pub enum GuestStateEncryptionPolicy {
     /// Use the best encryption available, allowing fallback.
     ///
-    /// VMs will be created using the best encryption available,
+    /// VMs will be created as or migrated to the best encryption available,
     /// attempting GspKey, then GspById, and finally leaving the data
-    /// unencrypted if neither are available. VMs will not be migrated
-    /// to a different encryption method.
+    /// unencrypted if neither are available.
     #[default]
     Auto,
     /// Prefer (or require, if strict) no encryption.

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -220,5 +220,5 @@ open_enum! {
 pub struct VmgsMarkers {
     pub reprovisioned: bool,
     #[bits(15)]
-    _reserved: u16,
+    _reserved: u32,
 }

--- a/vm/vmgs/vmgs_resources/src/lib.rs
+++ b/vm/vmgs/vmgs_resources/src/lib.rs
@@ -72,17 +72,31 @@ pub struct VmgsDisk {
 }
 
 /// Guest state encryption policy
-///
-/// See detailed comments in `get_protocol`
 #[derive(MeshPayload, Debug, Clone, Copy)]
 pub enum GuestStateEncryptionPolicy {
     /// Use the best encryption available, allowing fallback.
+    ///
+    /// VMs will be created as or migrated to the best encryption available,
+    /// attempting GspKey, then GspById, and finally leaving the data
+    /// unencrypted if neither are available.
     Auto,
     /// Prefer (or require, if strict) no encryption.
+    ///
+    /// Do not encrypt the guest state unless it is already encrypted and
+    /// strict encryption policy is disabled.
     None(bool),
     /// Prefer (or require, if strict) GspById.
+    ///
+    /// This prevents a VM from being created as or migrated to GspKey even
+    /// if it is available. Exisiting GspKey encryption will be used unless
+    /// strict encryption policy is enabled. Fails if the data cannot be
+    /// encrypted.
     GspById(bool),
     /// Prefer (or require, if strict) GspKey.
+    ///
+    /// VMs will be created as or migrated to GspKey. GspById encryption will
+    /// be used if GspKey is unavailable unless strict encryption policy is
+    /// enabled. Fails if the data cannot be encrypted.
     GspKey(bool),
 }
 


### PR DESCRIPTION
This reverts commit 64c47a90f0a48ca153e3277e6a65eb145db40a44. Due to a performance issue that is not yet understood.