### PR TITLE
petri: Derive Eq for OsFlavor

### DIFF
--- a/petri/petri_artifacts_common/src/lib.rs
+++ b/petri/petri_artifacts_common/src/lib.rs
@@ -30,7 +30,7 @@ pub mod tags {
 
     /// A coarse-grained label used to differentiate between different OS
     /// environments.
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[expect(missing_docs)] // Self-describing names.
     pub enum OsFlavor {
         Windows,


### PR DESCRIPTION
Just like MachineArch below it. This makes it a little more useful for test authors.