### PR TITLE
ci: let very_heavy tests run on their own

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,7 +29,7 @@
 filter = 'package(~vmm_tests) and test(very_heavy)'
 # Mark very heavy tests as extra very heavy, as they include up to 32 vps.
 # However most of these vps should spend most of their time idle.
-threads-required = 16
+threads-required = 32
 
 [[profile.default.overrides]]
 # use fuzzy-matching for the package() to allow out-of-tree tests to use the


### PR DESCRIPTION
Recent PRs lowered the thread requirement of very_heavy tests to 16 to gain additional concurrency.
We're seeing these tests run very slowly and then fail. Promote them back to 1 required nextest thread
per VP.
