### PR TITLE
remove or lower some logs to reduce noise

### DIFF
--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -953,11 +953,8 @@ impl PetriVmConfigSetupCore<'_> {
             .into_resource(),
         )]);
 
-        let gel = get_resources::gel::GuestEmulationLogHandle.into_resource();
-
         let crash = spawn_dump_handler(self.driver, self.logger).into_resource();
-
-        devices.extend([(DeviceVtl::Vtl2, crash), (DeviceVtl::Vtl2, gel)]);
+        devices.extend([(DeviceVtl::Vtl2, crash)]);
 
         let (guest_request_send, guest_request_recv) = mesh::channel();
 

--- a/vm/devices/chipset/src/ioapic.rs
+++ b/vm/devices/chipset/src/ioapic.rs
@@ -297,7 +297,7 @@ impl IoApicDevice {
             redirection |= val & REDIRECTION_WRITE_MASK;
             irq.redirection = redirection.into();
 
-            tracing::debug!(n, entry = ?irq.redirection, "new redirection entry");
+            tracing::trace!(n, entry = ?irq.redirection, "new redirection entry");
 
             let request = irq.redirection.as_msi();
             if request != irq.registered_request {

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
@@ -155,8 +155,6 @@ impl<S: StorageBackend> HclCompatNvram<S> {
             return Ok(());
         }
 
-        tracing::info!("loading uefi nvram from storage");
-
         let nvram_buf = self
             .storage
             .restore()
@@ -301,7 +299,6 @@ impl<S: StorageBackend> HclCompatNvram<S> {
 
     /// Dump in-memory nvram to the underlying storage device.
     async fn flush_storage(&mut self) -> Result<(), NvramStorageError> {
-        tracing::info!("flushing uefi nvram to storage");
         self.nvram_buf.clear();
 
         for in_memory::VariableEntry {

--- a/vm/devices/serial/serial_16550/src/lib.rs
+++ b/vm/devices/serial/serial_16550/src/lib.rs
@@ -653,7 +653,7 @@ impl State {
 
     fn write_mcr(&mut self, data: u8) {
         let mcr = ModemControlRegister::from(data).with_reserved(0);
-        tracing::debug!(?mcr, "mcr update");
+        tracing::trace!(?mcr, "mcr update");
         // mcr.loopback may have changed, which could cause an MSR update.
         self.update_msr(|this| this.mcr = mcr);
     }
@@ -667,12 +667,12 @@ impl State {
         let fcr = FifoControlRegister::from(data).with_reserved(0);
         if fcr.enable_fifos() {
             if fcr.clear_rx_fifo() {
-                tracing::debug!("clearing rx fifo");
+                tracing::trace!("clearing rx fifo");
                 stats.rx_dropped.add(self.rx_buffer.len() as u64);
                 self.rx_buffer.clear();
             }
             if fcr.clear_tx_fifo() {
-                tracing::debug!("clearing tx fifo");
+                tracing::trace!("clearing tx fifo");
                 stats.tx_dropped.add(self.tx_buffer.len() as u64);
                 self.tx_buffer.clear();
             }

--- a/vm/devices/tpm/tpm_device/src/lib.rs
+++ b/vm/devices/tpm/tpm_device/src/lib.rs
@@ -1455,7 +1455,7 @@ impl MmioIntercept for Tpm {
                     .ok() // TODO: zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
                     .and_then(|(cmd_header, _)| cmd_header.command_code.into_enum());
 
-                    tracing::debug!(
+                    tracing::trace!(
                         cmd = ?cmd_header,
                         "executing guest tpm cmd",
                     );
@@ -1483,7 +1483,7 @@ impl MmioIntercept for Tpm {
                         return IoResult::Ok;
                     }
 
-                    tracing::debug!(
+                    tracing::trace!(
                         response_code = ?tpm20proto::protocol::common::ReplyHeader::ref_from_prefix(
                         &self.tpm_engine_helper.reply_buffer,
                         )

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/services.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/services.rs
@@ -280,7 +280,7 @@ mod device_range {
                 }
 
                 fn map(&mut self, addr: $addr) {
-                    tracing::debug!(region_name = ?self.region_name, ?addr, len = ?self.len, "map");
+                    tracing::trace!(region_name = ?self.region_name, ?addr, len = ?self.len, "map");
                     self.unmap();
                     match self.ranges.register(
                         addr,
@@ -305,7 +305,7 @@ mod device_range {
                 }
 
                 fn unmap(&mut self) {
-                    tracing::debug!(region_name = ?self.region_name, addr = ?self.addr, len = ?self.len, "unmap");
+                    tracing::trace!(region_name = ?self.region_name, addr = ?self.addr, len = ?self.len, "unmap");
                     if let Some(addr) = self.addr.take() {
                         self.ranges.revoke(addr)
                     }


### PR DESCRIPTION
Lower some of the noisiest logs to trace so they don't show up in test results. Also remove the GEL from OpenVMM tests since we get the OpenHCL logs over serial already.