### PR TITLE
pal_async: allow dropping overlapped files with in-flight IO

### DIFF
--- a/support/pal/pal_async/src/windows/iocp.rs
+++ b/support/pal/pal_async/src/windows/iocp.rs
@@ -566,13 +566,13 @@ impl IoOverlapped for OverlappedIo {
     fn pre_io(&self) {}
 
     unsafe fn post_io(&self, _completed: bool, _overlapped: &Overlapped) {}
-}
 
-impl Drop for OverlappedIo {
-    fn drop(&mut self) {
-        // SAFETY: the caller guarantees handle is still owned.
+    unsafe fn disassociate(&mut self) {
+        // SAFETY: the caller guarantees the handle is still owned and that no
+        // further IO will be issued.
         unsafe {
-            disassociate_completion_port(self.handle.0).unwrap();
+            disassociate_completion_port(self.handle.0)
+                .expect("caller bug: no pending IO should be in flight");
         }
     }
 }

--- a/support/pal/pal_async/src/windows/tp.rs
+++ b/support/pal/pal_async/src/windows/tp.rs
@@ -530,13 +530,13 @@ impl IoOverlapped for OverlappedIo {
             unsafe { self.tp_io.cancel_io() };
         }
     }
-}
 
-impl Drop for OverlappedIo {
-    fn drop(&mut self) {
-        // SAFETY: the caller guarantees handle is still owned.
+    unsafe fn disassociate(&mut self) {
+        // SAFETY: the caller guarantees the handle is still owned and that no
+        // further IO will be issued.
         unsafe {
-            disassociate_completion_port(self.handle.0).unwrap();
+            disassociate_completion_port(self.handle.0)
+                .expect("caller bug: no pending IO should be in flight");
         }
     }
 }

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -130,8 +130,11 @@ unsafe impl<T> IoBufMut for StaticIoctlBuffer<T> {
 
 impl VmbusProxy {
     pub fn new(driver: &dyn Driver, handle: ProxyHandle, ctx: CancelContext) -> Result<Self> {
+        // SAFETY: TODO, analyze whether we are guaranteed to follow the safety
+        // contract.
+        let file = unsafe { OverlappedFile::new(driver, handle.0)? };
         Ok(Self {
-            file: OverlappedFile::new(driver, handle.0)?,
+            file,
             guest_memory: None,
             cancel: ctx,
         })


### PR DESCRIPTION
When a `IoOverlapped` is dropped, we disassociate the underlying file from its completion port so that the file can be reused for other purposes. Windows does not support this while there is in-flight IO, so if the drop happens before all IO has completed, we panic.

However, in most use cases, we don't need to explicitly disassociate, since the `File` is going to be dropped anyway, and it _is_ generally OK to close a file handle with IO in flight. Change things around so that we only disassociate when the caller explicitly wants to reuse the file, and make the contract clear that this will panic if there is in-flight IO.

Also, make the `OverlappedFile` safety contract clearer (if not particularly easy to ensure--Windows does not make this easy).