### PR TITLE
vmm_test: increase memory_page_count

### DIFF
--- a/vm/loader/manifests/openhcl-aarch64-dev.json
+++ b/vm/loader/manifests/openhcl-aarch64-dev.json
@@ -7,7 +7,7 @@
             "isolation_type": "none",
             "image": {
                 "openhcl": {
-                    "memory_page_count": 126976,
+                    "memory_page_count": 131072,
                     "command_line": "console=null OPENHCL_IGVM_VTL2_GPA_POOL_CONFIG=debug",
                     "uefi": true
                 }

--- a/vm/loader/manifests/openhcl-x64-dev.json
+++ b/vm/loader/manifests/openhcl-x64-dev.json
@@ -8,7 +8,7 @@
             "image": {
                 "openhcl": {
                     "command_line": "OPENHCL_BOOT_LOG=com3 OPENHCL_IGVM_VTL2_GPA_POOL_CONFIG=debug",
-                    "memory_page_count": 126976,
+                    "memory_page_count": 131072,
                     "uefi": true
                 }
             }


### PR DESCRIPTION
A few PRs and some CI runs are starting to hit an initramfs unpacking error on `boot_heavy` tests. A PR I have open (#2123) was consistently failing those tests and increasing to this value has stopped those tests from failing. Should we increase it by more than this? I tried to stay conservative about the increase.