### PR TITLE
CI: Fix petri log upload free space cleaner

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # Azure CLI is considered a large package
+          large-packages: false
 
       - name: Authenticate to Azure
         uses: azure/login@v1


### PR DESCRIPTION
In https://github.com/microsoft/openvmm/pull/2394 I added this new action to our log upload script, as if there are many crash dumps present during a test run the uploader can run out of disk space. However since this script only runs out of main I couldn't test the changes. Turns out the cleaner removes azure cli, which we kinda need. Fix that.