### PR TITLE
vpci_relay: fix GDMA devices having an incorrect filter (#2419)

### DIFF
--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -164,7 +164,7 @@ pub mod hwid {
             MASS_STORAGE_CONTROLLER_NON_VOLATILE_MEMORY_NVME = 0x02,
 
             // Ethernet Controller (Class code: 0x02, Subclass: 0x00)
-            NETWORK_CONTROLLER_ETHERNET_GDMA = 0x01,
+            NETWORK_CONTROLLER_ETHERNET_GDMA = 0x00,
         }
     }
 

--- a/vm/devices/pci/vpci_relay/src/lib.rs
+++ b/vm/devices/pci/vpci_relay/src/lib.rs
@@ -272,7 +272,18 @@ impl VpciRelay {
         if !self.allowed_devices.is_empty()
             && !self.allowed_devices.iter().any(|d| d.allows(hw_ids))
         {
-            tracing::warn!(%instance_id, vendor_id = hw_ids.vendor_id, device_id = hw_ids.device_id, "device not allowed on VPCI bus");
+            let prog_if = hw_ids.prog_if;
+            let sub_class = hw_ids.sub_class;
+            let base_class = hw_ids.base_class;
+            tracing::warn!(
+                %instance_id,
+                vendor_id = hw_ids.vendor_id,
+                device_id = hw_ids.device_id,
+                ?prog_if,
+                ?sub_class,
+                ?base_class,
+                "device not allowed on VPCI bus"
+            );
             return Ok(());
         }
 


### PR DESCRIPTION
Due to a spec definition bug that has been there forever, when running with real hardware the vpci_relay will filter GDMA devices incorrectly. Fix this bug.

Clean cherry pick of #2419 