### PR TITLE
nvme_driver: Avoid using CancelContext on hot path

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -61,9 +61,9 @@ use zerocopy::IntoBytes;
 /// only by `NvmeDisk`! Remove any sanitization in `fuzz_nvm_driver.rs`
 /// if this struct is used anywhere else.
 #[derive(Inspect)]
-pub struct NvmeDriver<T: DeviceBacking> {
+pub struct NvmeDriver<D: DeviceBacking> {
     #[inspect(flatten)]
-    task: Option<TaskControl<DriverWorkerTask<T>, WorkerState>>,
+    task: Option<TaskControl<DriverWorkerTask<D>, WorkerState>>,
     device_id: String,
     identify: Option<Arc<spec::IdentifyController>>,
     #[inspect(skip)]
@@ -88,19 +88,19 @@ struct NamespaceHandle {
 }
 
 #[derive(Inspect)]
-struct DriverWorkerTask<T: DeviceBacking> {
+struct DriverWorkerTask<D: DeviceBacking> {
     /// The VFIO device backing this driver. For KeepAlive cases, the VFIO handle
     /// is never dropped, otherwise there is a chance that VFIO will reset the
     /// device. We don't want that.
     ///
     /// Dropped in `NvmeDriver::reset`.
-    device: ManuallyDrop<T>,
+    device: ManuallyDrop<D>,
     #[inspect(skip)]
     driver: VmTaskDriver,
-    registers: Arc<DeviceRegisters<T>>,
-    admin: Option<QueuePair<AdminAerHandler, T>>,
+    registers: Arc<DeviceRegisters<D>>,
+    admin: Option<QueuePair<AdminAerHandler, D>>,
     #[inspect(iter_by_index)]
-    io: Vec<IoQueue<T>>,
+    io: Vec<IoQueue<D>>,
     /// Prototype IO queues for restoring from saved state. These are queues
     /// that were created on the device at some point, but had no pending
     /// IOs at save/restore time. These will be promoted to full IO queues
@@ -156,13 +156,13 @@ struct ProtoIoQueue {
 }
 
 #[derive(Inspect)]
-struct IoQueue<T: DeviceBacking> {
-    queue: QueuePair<NoOpAerHandler, T>,
+struct IoQueue<D: DeviceBacking> {
+    queue: QueuePair<NoOpAerHandler, D>,
     iv: u16,
     cpu: u32,
 }
 
-impl<T: DeviceBacking> IoQueue<T> {
+impl<D: DeviceBacking> IoQueue<D> {
     pub async fn save(&self) -> anyhow::Result<IoQueueSavedState> {
         Ok(IoQueueSavedState {
             cpu: self.cpu,
@@ -174,7 +174,7 @@ impl<T: DeviceBacking> IoQueue<T> {
     pub fn restore(
         spawner: VmTaskDriver,
         interrupt: DeviceInterrupt,
-        registers: Arc<DeviceRegisters<T>>,
+        registers: Arc<DeviceRegisters<D>>,
         mem_block: MemoryBlock,
         saved_state: &IoQueueSavedState,
         bounce_buffer: bool,
@@ -224,12 +224,12 @@ enum NvmeWorkerRequest {
     Save(Rpc<Span, anyhow::Result<NvmeDriverWorkerSavedState>>),
 }
 
-impl<T: DeviceBacking> NvmeDriver<T> {
+impl<D: DeviceBacking> NvmeDriver<D> {
     /// Initializes the driver.
     pub async fn new(
         driver_source: &VmTaskDriverSource,
         cpu_count: u32,
-        device: T,
+        device: D,
         bounce_buffer: bool,
     ) -> anyhow::Result<Self> {
         let pci_id = device.id().to_owned();
@@ -258,7 +258,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
     async fn new_disabled(
         driver_source: &VmTaskDriverSource,
         cpu_count: u32,
-        mut device: T,
+        mut device: D,
         bounce_buffer: bool,
     ) -> anyhow::Result<Self> {
         let driver = driver_source.simple();
@@ -549,7 +549,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
         drop(self);
     }
 
-    fn reset(&mut self) -> impl Send + Future<Output = ()> + use<T> {
+    fn reset(&mut self) -> impl Send + Future<Output = ()> + use<D> {
         let driver = self.driver.clone();
         let id = self.device_id.clone();
         let mut task = std::mem::take(&mut self.task).unwrap();
@@ -683,7 +683,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
     /// drop the given device instance.
     pub async fn clear_existing_state(
         driver_source: &VmTaskDriverSource,
-        mut device: T,
+        mut device: D,
     ) -> anyhow::Result<()> {
         let driver = driver_source.simple();
         let bar0_mapping = device
@@ -700,7 +700,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
     pub async fn restore(
         driver_source: &VmTaskDriverSource,
         cpu_count: u32,
-        mut device: T,
+        mut device: D,
         saved_state: &NvmeDriverSavedState,
         bounce_buffer: bool,
     ) -> anyhow::Result<Self> {
@@ -859,7 +859,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             .filter(|q| {
                 q.queue_data.qid == 1 || !q.queue_data.handler_data.pending_cmds.commands.is_empty()
             })
-            .flat_map(|q| -> Result<IoQueue<T>, anyhow::Error> {
+            .flat_map(|q| -> Result<IoQueue<D>, anyhow::Error> {
                 let qid = q.queue_data.qid;
                 let cpu = q.cpu;
                 tracing::info!(qid, cpu, ?pci_id, "restoring queue");
@@ -1045,7 +1045,7 @@ async fn handle_asynchronous_events(
     }
 }
 
-impl<T: DeviceBacking> Drop for NvmeDriver<T> {
+impl<D: DeviceBacking> Drop for NvmeDriver<D> {
     fn drop(&mut self) {
         tracing::trace!(pci_id = ?self.device_id, ka = self.nvme_keepalive, task = self.task.is_some(), "dropping nvme driver");
         if self.task.is_some() {
@@ -1080,7 +1080,7 @@ impl IoIssuers {
     }
 }
 
-impl<T: DeviceBacking> AsyncRun<WorkerState> for DriverWorkerTask<T> {
+impl<D: DeviceBacking> AsyncRun<WorkerState> for DriverWorkerTask<D> {
     async fn run(
         &mut self,
         stop: &mut task_control::StopTask<'_>,
@@ -1115,7 +1115,7 @@ impl<T: DeviceBacking> AsyncRun<WorkerState> for DriverWorkerTask<T> {
     }
 }
 
-impl<T: DeviceBacking> DriverWorkerTask<T> {
+impl<D: DeviceBacking> DriverWorkerTask<D> {
     fn restore_io_issuer(&mut self, proto: ProtoIoQueue) -> anyhow::Result<()> {
         let pci_id = self.device.id().to_owned();
         let qid = proto.save_state.queue_data.qid;
@@ -1422,7 +1422,7 @@ impl<T: DeviceBacking> DriverWorkerTask<T> {
     }
 }
 
-impl<T: DeviceBacking> InspectTask<WorkerState> for DriverWorkerTask<T> {
+impl<D: DeviceBacking> InspectTask<WorkerState> for DriverWorkerTask<D> {
     fn inspect(&self, req: inspect::Request<'_>, state: Option<&WorkerState>) {
         req.respond().merge(self).merge(state);
     }


### PR DESCRIPTION
As per https://microsoft.visualstudio.com/OS/_workitems/edit/60178470, `CancelContext` as used here is polled every time the async task is woken up. This is causing high CPU usage on a hot CPU in local performance testing. This PR changes it to `TaskControl`.

The performance improvement, if any, is still being validated, but we want this change in either case.