### PR TITLE
repo: update trigger for refresh mirror pipeline

### DIFF
--- a/.github/workflows/refresh-mirror.yml
+++ b/.github/workflows/refresh-mirror.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
+    - release/1.7.2511
 
 permissions:
   id-token: write


### PR DESCRIPTION
Update the mirror pipeline to run on the newly created release branch.