### PR TITLE
repo: update trigger for mirror refresh workflow to include release branches

### DIFF
--- a/.github/workflows/refresh-mirror.yml
+++ b/.github/workflows/refresh-mirror.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - release/*
 
 permissions:
   id-token: write


### PR DESCRIPTION
This will mean one less file to be manually updated next time we fork a release branch.