### PR TITLE
enable default_boot_always_attempt for non-TL VMs

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1433,8 +1433,8 @@ async fn new_underhill_vm(
     // with the OS disk for these VMs in Azure (and in any case on-prem),
     // causing the VM to fail to boot after an OS swap.
     //
-    // TODO: remove this once host changes are saturated
-    if !hardware_isolated
+    // TODO: remove this (and petri workaround) once host changes are saturated
+    if !isolation.is_isolated()
         && !dps.general.secure_boot_enabled
         && !dps.general.tpm_enabled
         && !dps.general.default_boot_always_attempt


### PR DESCRIPTION
Always enable default boot always attempt for non-Trusted Launch VMs. This is roughly equivalent to not having secure boot or TPM enabled. This is necessary because the VMGS is not swapped with the OS disk for these VMs in Azure (and in any case on-prem), causing the VM to fail to boot after an OS swap.