### PR TITLE
loader: refactor page table library to be usable in nostd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5349,6 +5349,8 @@ name = "page_table"
 version = "0.0.0"
 dependencies = [
  "bitfield-struct 0.11.0",
+ "static_assertions",
+ "thiserror 2.0.16",
  "tracing",
  "zerocopy 0.8.25",
 ]

--- a/vm/loader/Cargo.toml
+++ b/vm/loader/Cargo.toml
@@ -11,7 +11,7 @@ aarch64defs.workspace = true
 igvm.workspace = true
 loader_defs.workspace = true
 memory_range.workspace = true
-page_table.workspace = true
+page_table = {workspace = true, features = ["tracing"] }
 hvdef.workspace = true
 vm_topology.workspace = true
 x86defs.workspace = true

--- a/vm/loader/page_table/Cargo.toml
+++ b/vm/loader/page_table/Cargo.toml
@@ -8,7 +8,15 @@ rust-version.workspace = true
 
 [dependencies]
 bitfield-struct.workspace = true
-tracing.workspace = true
+thiserror.workspace = true
+static_assertions.workspace = true
+tracing = { workspace = true, optional = true }
 zerocopy.workspace = true
+
+[features]
+default = ["tracing", "std"]
+tracing = ["dep:tracing", "std"]
+std = []
+
 [lints]
 workspace = true

--- a/vm/loader/page_table/src/lib.rs
+++ b/vm/loader/page_table/src/lib.rs
@@ -3,11 +3,47 @@
 
 //! Methods to construct page tables.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+//TODO docs are missing on pub page table functions for aarch64
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
 
 pub mod aarch64;
 pub mod x64;
+
+use thiserror::Error;
+
+/// Errors returned by the Page Table Builder
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum Error {
+    /// The PageTableBuilder bytes buffer does not match the size of the struct buffer
+    #[error(
+        "PageTableBuilder bytes buffer size {bytes_buf} does not match the struct buffer size [{struct_buf}]"
+    )]
+    BadBufferSize { bytes_buf: usize, struct_buf: usize },
+
+    /// The constructed page tables are larger than the amount memory given for construction by the caller
+    #[error(
+        "constructed page tables are larger than the amount memory given for construction by the caller"
+    )]
+    NotEnoughMemory,
+
+    /// The page table builder mapping ranges are not sorted
+    #[error("the page table builder was invoked with unsorted mapping ranges")]
+    UnsortedMappings,
+
+    /// The page table builder was given an invalid range
+    #[error("page table builder range.end() < range.start()")]
+    InvalidRange,
+
+    /// The page table builder is generating overlapping mappings
+    #[error("the page table builder was invoked with overlapping mappings")]
+    OverlappingMappings,
+
+    /// The page table builder tried to overwrite a leaf mapping
+    #[error("the page table builder attempted to overwite a leaf mapping")]
+    AttemptedEntryOverwrite,
+}
 
 /// Size of the initial identity map
 #[derive(Debug, Copy, Clone)]

--- a/vm/loader/page_table/src/x64.rs
+++ b/vm/loader/page_table/src/x64.rs
@@ -3,9 +3,9 @@
 
 //! Methods to construct page tables on x64.
 
+use crate::Error;
 use crate::IdentityMapSize;
 use zerocopy::FromBytes;
-use zerocopy::FromZeros;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
@@ -17,6 +17,7 @@ const X64_PTE_DIRTY: u64 = 1 << 6;
 const X64_PTE_LARGE_PAGE: u64 = 1 << 7;
 
 const PAGE_TABLE_ENTRY_COUNT: usize = 512;
+const PAGE_TABLE_ENTRY_SIZE: usize = 8;
 
 const X64_PAGE_SHIFT: u64 = 12;
 const X64_PTE_BITS: u64 = 9;
@@ -30,18 +31,69 @@ pub const X64_LARGE_PAGE_SIZE: u64 = 0x200000;
 /// Number of bytes in a 1GB page for X64.
 pub const X64_1GB_PAGE_SIZE: u64 = 0x40000000;
 
+/// An upper bound on the number of page tables that will be built for an x64 identity
+/// map. The builder will greedily map the largest possible page size, a cap of 20 tables
+/// is more than enough for mapping a few gigabytes with mostly large pages, which is
+/// sufficient for all of the current use cases of the identity map builder
+pub const PAGE_TABLE_MAX_COUNT: usize = 20;
+
+static_assertions::const_assert_eq!(
+    PAGE_TABLE_ENTRY_SIZE * PAGE_TABLE_ENTRY_COUNT,
+    X64_PAGE_SIZE as usize
+);
+const PAGE_TABLE_SIZE: usize = PAGE_TABLE_ENTRY_COUNT * PAGE_TABLE_ENTRY_SIZE;
+
+/// Maximum number of bytes needed to store an x64 identity map
+pub const PAGE_TABLE_MAX_BYTES: usize = PAGE_TABLE_MAX_COUNT * X64_PAGE_SIZE as usize;
+
 #[derive(Copy, Clone, PartialEq, Eq, IntoBytes, Immutable, KnownLayout, FromBytes)]
 #[repr(transparent)]
+/// An x64 page table entry
 pub struct PageTableEntry {
     pub(crate) entry: u64,
 }
 
-impl std::fmt::Debug for PageTableEntry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+/// A memory range to be mapped in a page table, and the associated permissions
+/// The default permissions bits are present, R/W, executable
+#[derive(Copy, Clone, Debug)]
+pub struct MappedRange {
+    start: u64,
+    end: u64,
+    permissions: u64,
+}
+
+impl MappedRange {
+    /// Create a new mapped range, with default permissions
+    pub fn new(start: u64, end: u64) -> Self {
+        Self {
+            start,
+            end,
+            permissions: X64_PTE_PRESENT | X64_PTE_ACCESSED | X64_PTE_READ_WRITE,
+        }
+    }
+
+    /// The start address of the mapped range
+    pub fn start(&self) -> u64 {
+        self.start
+    }
+
+    /// The end address of the mapped range
+    pub fn end(&self) -> u64 {
+        self.end
+    }
+
+    /// Consumes a mapped range, and returns the range without the writable bit set
+    pub fn read_only(mut self) -> Self {
+        self.permissions &= !X64_PTE_READ_WRITE;
+        self
+    }
+}
+
+impl core::fmt::Debug for PageTableEntry {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PageTableEntry")
             .field("entry", &self.entry)
             .field("is_present", &self.is_present())
-            .field("is_large_page", &self.is_large_page())
             .field("gpa", &self.gpa())
             .finish()
     }
@@ -49,80 +101,63 @@ impl std::fmt::Debug for PageTableEntry {
 
 #[derive(Debug, Copy, Clone)]
 pub enum PageTableEntryType {
+    /// 1GB page in a PDPT
     Leaf1GbPage(u64),
+    /// 2MB page in a PD
     Leaf2MbPage(u64),
+    /// 4K page in a PT
     Leaf4kPage(u64),
+    /// A link to a lower level page table in a PML4, PDPT, or PD
     Pde(u64),
 }
 
-pub trait PteOps {
-    fn get_addr_mask(&self) -> u64;
-    fn get_confidential_mask(&self) -> u64;
+/// The depth of an x64 page table
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum EntryLevel {
+    Pml4 = 3,
+    Pdpt = 2,
+    Pd = 1,
+    Pt = 0,
+}
 
-    fn build_pte(entry_type: PageTableEntryType) -> PageTableEntry {
-        let mut entry: u64 = X64_PTE_PRESENT | X64_PTE_ACCESSED | X64_PTE_READ_WRITE;
-
-        match entry_type {
-            PageTableEntryType::Leaf1GbPage(address) => {
-                // Must be 1GB aligned.
-                assert!(address % X64_1GB_PAGE_SIZE == 0);
-                entry |= address;
-                entry |= X64_PTE_LARGE_PAGE | X64_PTE_DIRTY;
-            }
-            PageTableEntryType::Leaf2MbPage(address) => {
-                // Leaf entry, set like UEFI does for 2MB pages. Must be 2MB aligned.
-                assert!(address % X64_LARGE_PAGE_SIZE == 0);
-                entry |= address;
-                entry |= X64_PTE_LARGE_PAGE | X64_PTE_DIRTY;
-            }
-            PageTableEntryType::Leaf4kPage(address) => {
-                // Must be 4K aligned.
-                assert!(address % X64_PAGE_SIZE == 0);
-                entry |= address;
-                entry |= X64_PTE_DIRTY;
-            }
-            PageTableEntryType::Pde(address) => {
-                // Points to another pagetable.
-                assert!(address % X64_PAGE_SIZE == 0);
-                entry |= address;
-            }
-        }
-
-        PageTableEntry { entry }
-    }
-
-    fn is_pte_present(pte: &PageTableEntry) -> bool {
-        pte.is_present()
-    }
-
-    fn is_pte_large_page(pte: &PageTableEntry) -> bool {
-        pte.is_large_page()
-    }
-
-    fn get_gpa_from_pte(&self, pte: &PageTableEntry) -> Option<u64> {
-        if pte.is_present() {
-            Some(self.get_addr_from_pte(pte))
-        } else {
-            None
+impl EntryLevel {
+    /// The amount of memory that can be mapped by an entry in a page table.
+    /// If the entry is a leaf, this value represents the size of the entry,
+    /// otherwise it represents the maximum amount of physical memory space
+    /// that can be mapped if all mappings below this entry are used
+    pub fn mapping_size(self) -> u64 {
+        match self {
+            Self::Pml4 => X64_1GB_PAGE_SIZE * 512,
+            Self::Pdpt => X64_1GB_PAGE_SIZE,
+            Self::Pd => X64_LARGE_PAGE_SIZE,
+            Self::Pt => X64_PAGE_SIZE,
         }
     }
 
-    fn get_addr_from_pte(&self, pte: &PageTableEntry) -> u64 {
-        pte.entry & self.get_addr_mask()
-    }
-
-    fn set_addr_in_pte(&self, pte: &mut PageTableEntry, address: u64) {
-        let mask = self.get_addr_mask();
-        pte.entry = (pte.entry & !mask) | (address & mask);
-    }
-
-    fn set_pte_confidentiality(&self, pte: &mut PageTableEntry, confidential: bool) {
-        let mask = self.get_confidential_mask();
-        if confidential {
-            pte.entry |= mask;
-        } else {
-            pte.entry &= !mask;
+    /// Returns a leaf entry for a virtual address in this level
+    pub fn leaf(self, va: u64) -> PageTableEntryType {
+        match self {
+            Self::Pml4 => panic!("cannot insert a leaf entry into a PML4 table"),
+            Self::Pdpt => PageTableEntryType::Leaf1GbPage(va),
+            Self::Pd => PageTableEntryType::Leaf2MbPage(va),
+            Self::Pt => PageTableEntryType::Leaf4kPage(va),
         }
+    }
+
+    fn pa_mask(self) -> u64 {
+        match self {
+            Self::Pml4 => 0x000f_ffff_c000_0000,
+            Self::Pdpt => 0x000f_ffff_ffe0_0000,
+            Self::Pd => 0x000f_ffff_ffff_f000,
+            Self::Pt => 0x000f_ffff_ffff_f000,
+        }
+    }
+
+    /// Returns the physical address of the directory entry for a va at this level
+    /// Assumes that the directory is part of an identity mapping
+    pub fn directory_pa(self, va: u64) -> u64 {
+        va & self.pa_mask()
     }
 }
 
@@ -130,7 +165,7 @@ impl PageTableEntry {
     const VALID_BITS: u64 = 0x000f_ffff_ffff_f000;
 
     /// Set an AMD64 PDE to either represent a leaf 2MB page or PDE.
-    /// This sets the PTE to preset, accessed, dirty, read write execute.
+    /// This sets the PTE to present, accessed, dirty, read write execute.
     pub fn set_entry(&mut self, entry_type: PageTableEntryType) {
         self.entry = X64_PTE_PRESENT | X64_PTE_ACCESSED | X64_PTE_READ_WRITE;
 
@@ -161,14 +196,12 @@ impl PageTableEntry {
         }
     }
 
+    /// Checks if a page table entry is marked as present
     pub fn is_present(&self) -> bool {
         self.entry & X64_PTE_PRESENT == X64_PTE_PRESENT
     }
 
-    pub fn is_large_page(&self) -> bool {
-        self.entry & X64_PTE_LARGE_PAGE == X64_PTE_LARGE_PAGE
-    }
-
+    /// Returns the GPA pointed to by a mapping, if it is present
     pub fn gpa(&self) -> Option<u64> {
         if self.is_present() {
             // bits 51 to 12 describe the gpa of the next page table
@@ -178,6 +211,7 @@ impl PageTableEntry {
         }
     }
 
+    /// Clears the address in an entry, and replaces it with the provided address
     pub fn set_addr(&mut self, addr: u64) {
         assert!(addr & !Self::VALID_BITS == 0);
 
@@ -186,26 +220,26 @@ impl PageTableEntry {
         self.entry |= addr;
     }
 
+    /// Get the address pointed to by a page table entry, regardless of whether the entry is present
     pub fn get_addr(&self) -> u64 {
         self.entry & Self::VALID_BITS
     }
 
+    /// Clear all bits of a page table entry
     pub fn clear(&mut self) {
         self.entry = 0;
     }
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Clone, PartialEq, Eq, IntoBytes, Immutable, KnownLayout, FromBytes)]
+/// A single page table at any level of the page table hierarchy
 pub struct PageTable {
     entries: [PageTableEntry; PAGE_TABLE_ENTRY_COUNT],
 }
 
 impl PageTable {
-    // fn iter(&self) -> impl Iterator<Item = &PageTableEntry> {
-    //     self.entries.iter()
-    // }
-
+    /// Returns a page table as a mutable iterator of page table entries
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut PageTableEntry> {
         self.entries.iter_mut()
     }
@@ -217,7 +251,7 @@ impl PageTable {
     }
 }
 
-impl std::ops::Index<usize> for PageTable {
+impl core::ops::Index<usize> for PageTable {
     type Output = PageTableEntry;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -225,7 +259,7 @@ impl std::ops::Index<usize> for PageTable {
     }
 }
 
-impl std::ops::IndexMut<usize> for PageTable {
+impl core::ops::IndexMut<usize> for PageTable {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.entries[index]
     }
@@ -275,16 +309,24 @@ pub fn calculate_pde_table_count(start_gpa: u64, size: u64) -> u64 {
 }
 
 #[derive(Debug, Clone)]
-pub struct PageTableBuilder {
+struct PageTableBuilderInner {
     page_table_gpa: u64,
-    start_gpa: u64,
-    size: u64,
-    local_map: Option<(u64, u64)>,
     confidential_bit: Option<u32>,
-    map_reset_vector: bool,
 }
 
-impl PteOps for PageTableBuilder {
+/// A builder for an x64 identity-mapped page table
+pub struct PageTableBuilder<'a> {
+    /// parameters to the page table builder, stored seperately s.t. they can be easily cloned and copied
+    inner: PageTableBuilderInner,
+    /// a reference to a mutable slice of PageTables, used as working memory for constructing the page table
+    page_table: &'a mut [PageTable],
+    /// a reference to a mutable slice of u8s, used to store and return the final page table bytes
+    flattened_page_table: &'a mut [u8],
+    /// a reference to a slice of ranges to map in the page table
+    ranges: &'a [MappedRange],
+}
+
+impl PageTableBuilderInner {
     fn get_addr_mask(&self) -> u64 {
         const ALL_ADDR_BITS: u64 = 0x000f_ffff_ffff_f000;
         ALL_ADDR_BITS & !self.get_confidential_mask()
@@ -297,291 +339,388 @@ impl PteOps for PageTableBuilder {
             0
         }
     }
+
+    fn build_pte(&self, entry_type: PageTableEntryType, permissions: u64) -> PageTableEntry {
+        let mut entry: u64 = permissions;
+
+        match entry_type {
+            PageTableEntryType::Leaf1GbPage(address) => {
+                // Must be 1GB aligned.
+                assert_eq!(address % X64_1GB_PAGE_SIZE, 0);
+                entry |= address;
+                entry |= X64_PTE_LARGE_PAGE | X64_PTE_DIRTY;
+            }
+            PageTableEntryType::Leaf2MbPage(address) => {
+                // Leaf entry, set like UEFI does for 2MB pages. Must be 2MB aligned.
+                assert_eq!(address % X64_LARGE_PAGE_SIZE, 0);
+                entry |= address;
+                entry |= X64_PTE_LARGE_PAGE | X64_PTE_DIRTY;
+            }
+            PageTableEntryType::Leaf4kPage(address) => {
+                // Must be 4K aligned.
+                assert_eq!(address % X64_PAGE_SIZE, 0);
+                entry |= address;
+                entry |= X64_PTE_DIRTY;
+            }
+            PageTableEntryType::Pde(address) => {
+                // Points to another pagetable.
+                assert_eq!(address % X64_PAGE_SIZE, 0);
+                entry |= address;
+            }
+        }
+
+        let mask = self.get_confidential_mask();
+        if self.confidential_bit.is_some() {
+            entry |= mask;
+        } else {
+            entry &= !mask;
+        }
+
+        PageTableEntry { entry }
+    }
+
+    fn get_addr_from_pte(&self, pte: &PageTableEntry) -> u64 {
+        pte.entry & self.get_addr_mask()
+    }
 }
 
-impl PageTableBuilder {
-    pub fn new(page_table_gpa: u64) -> Self {
-        PageTableBuilder {
-            page_table_gpa,
-            start_gpa: 0,
-            size: 0,
-            local_map: None,
-            confidential_bit: None,
-            map_reset_vector: false,
-        }
-    }
-
-    pub fn with_mapped_region(mut self, start_gpa: u64, size: u64) -> Self {
-        self.start_gpa = start_gpa;
-        self.size = size;
-        self
-    }
-
-    pub fn with_local_map(mut self, start_va: u64, size: u64) -> Self {
-        self.local_map = Some((start_va, size));
-        self
-    }
-
-    pub fn with_confidential_bit(mut self, bit_position: u32) -> Self {
-        self.confidential_bit = Some(bit_position);
-        self
-    }
-
-    /// Map the reset vector at page 0xFFFFF with a single page.
-    pub fn with_reset_vector(mut self, map_reset_vector: bool) -> Self {
-        self.map_reset_vector = map_reset_vector;
-        self
-    }
-
-    /// Build a set of X64 page tables identity mapping the given region. `size` must be less than 512GB.
-    /// This creates up to 3+N page tables: 1 PML4E and up to 2 PDPTE tables, and N page tables counted at 1 per GB of size,
-    /// for 2MB mappings.
-    pub fn build(self) -> Vec<u8> {
-        const SIZE_512_GB: u64 = 0x8000000000;
-
-        if self.size == 0 {
-            panic!("size not set");
-        }
-
-        if self.size > SIZE_512_GB {
-            panic!("more than 512 gb size not supported");
-        }
-
-        if !self.size.is_multiple_of(X64_LARGE_PAGE_SIZE) {
-            panic!("size not 2mb aligned");
-        }
-
-        // start_gpa and size must be 2MB aligned.
-        if !self.start_gpa.is_multiple_of(X64_LARGE_PAGE_SIZE) {
-            panic!("start_gpa not 2mb aligned");
-        }
-
-        let start_va = self.start_gpa;
-        let end_va = start_va + self.size;
-        let page_table_gpa = self.page_table_gpa;
-
-        if let Some((local_map_start, local_map_size)) = self.local_map {
-            if local_map_start % X64_LARGE_PAGE_SIZE != 0 {
-                panic!("local map address not 2 mb aligned");
-            }
-
-            if local_map_size % X64_LARGE_PAGE_SIZE != 0 {
-                panic!("local map size not 2 mb aligned");
-            }
-
-            if local_map_size == 0 {
-                panic!("local map size cannot be 0");
-            }
-
-            let local_map_end = local_map_start + local_map_size;
-            if local_map_end > start_va && local_map_start < end_va {
-                panic!("local map overlaps with mapped region");
-            }
-        }
-
-        // Allocate single PML4E page table.
-        let mut page_table: Vec<PageTable> = Vec::new();
-        page_table.push(PageTable::new_zeroed());
-        let pml4_table_index = 0;
-        let confidential = self.confidential_bit.is_some();
-
-        let mut link_tables = |start_va: u64, end_va: u64, use_large_pages: bool| {
-            let mut current_va = start_va;
-            while current_va < end_va {
-                tracing::trace!(current_va);
-
-                let pdpte_table_index = {
-                    let next_index = page_table.len();
-                    let pml4_entry = page_table[pml4_table_index].entry(current_va, 3);
-                    if !pml4_entry.is_present() {
-                        // Allocate and link PDPTE table.
-                        let output_address = page_table_gpa + next_index as u64 * X64_PAGE_SIZE;
-                        let mut new_entry =
-                            Self::build_pte(PageTableEntryType::Pde(output_address));
-                        self.set_pte_confidentiality(&mut new_entry, confidential);
-                        *pml4_entry = new_entry;
-                        page_table.push(PageTable::new_zeroed());
-
-                        next_index
-                    } else {
-                        ((self.get_addr_from_pte(pml4_entry) - page_table_gpa) / X64_PAGE_SIZE)
-                            .try_into()
-                            .expect("Valid page table index")
-                    }
-                };
-
-                tracing::trace!(pdpte_table_index);
-
-                let pde_table_index = {
-                    let next_index = page_table.len();
-                    let pdpte_entry = page_table[pdpte_table_index].entry(current_va, 2);
-                    if !pdpte_entry.is_present() {
-                        // Allocate and link PDE table.
-                        let output_address = page_table_gpa + next_index as u64 * X64_PAGE_SIZE;
-                        let mut new_entry =
-                            Self::build_pte(PageTableEntryType::Pde(output_address));
-                        self.set_pte_confidentiality(&mut new_entry, confidential);
-                        *pdpte_entry = new_entry;
-                        page_table.push(PageTable::new_zeroed());
-
-                        next_index
-                    } else {
-                        ((self.get_addr_from_pte(pdpte_entry) - page_table_gpa) / X64_PAGE_SIZE)
-                            .try_into()
-                            .expect("Valid page table index")
-                    }
-                };
-
-                tracing::trace!(pde_table_index);
-
-                let next_index = page_table.len();
-                let pde_entry = page_table[pde_table_index].entry(current_va, 1);
-                assert!(!pde_entry.is_present());
-
-                if use_large_pages {
-                    assert!(!pde_entry.is_present());
-
-                    let mut new_entry =
-                        Self::build_pte(PageTableEntryType::Leaf2MbPage(current_va));
-                    self.set_pte_confidentiality(&mut new_entry, confidential);
-                    *pde_entry = new_entry;
-                    current_va += X64_LARGE_PAGE_SIZE;
-                } else {
-                    let pt_table_index = if !pde_entry.is_present() {
-                        // Allocate and link page table.
-                        let output_address = page_table_gpa + next_index as u64 * X64_PAGE_SIZE;
-                        let mut new_entry =
-                            Self::build_pte(PageTableEntryType::Pde(output_address));
-                        self.set_pte_confidentiality(&mut new_entry, confidential);
-                        *pde_entry = new_entry;
-                        page_table.push(PageTable::new_zeroed());
-
-                        next_index
-                    } else {
-                        ((self.get_addr_from_pte(pde_entry) - page_table_gpa) / X64_PAGE_SIZE)
-                            .try_into()
-                            .expect("Valid page table index")
-                    };
-
-                    tracing::trace!(pt_table_index);
-
-                    let pt_entry = page_table[pt_table_index].entry(current_va, 0);
-                    let mut new_entry = Self::build_pte(PageTableEntryType::Leaf4kPage(current_va));
-                    self.set_pte_confidentiality(&mut new_entry, confidential);
-                    *pt_entry = new_entry;
-                    current_va += X64_PAGE_SIZE;
+impl<'a> PageTableBuilder<'a> {
+    /// Creates a new instance of the page table builder. The [PageTable] slice is working memory
+    /// for constructing the page table, and the [u8] slice is the memory used to output the
+    /// final bytes of the page table
+    ///
+    /// The working memory and output memory are taken as parameters to allow for the caller
+    /// to flexibly choose their allocation strategy, to support usage in no_std environments
+    /// like openhcl_boot
+    ///
+    pub fn new(
+        page_table_gpa: u64,
+        page_table: &'a mut [PageTable],
+        flattened_page_table: &'a mut [u8],
+        ranges: &'a [MappedRange],
+    ) -> Result<Self, Error> {
+        // TODO: When const generic expressions are supported, the builder can take arrays
+        // instead of slices, and this validation can be moved to the types
+        if flattened_page_table.len() != (page_table.len() * PAGE_TABLE_SIZE) {
+            Err(Error::BadBufferSize {
+                bytes_buf: flattened_page_table.len(),
+                struct_buf: page_table.len() * PAGE_TABLE_SIZE,
+            })
+        } else {
+            for range in ranges.iter() {
+                if range.start() > range.end() {
+                    return Err(Error::InvalidRange);
                 }
             }
+
+            for window in ranges.windows(2) {
+                let (l, r) = (&window[0], &window[1]);
+
+                if r.start() < l.start() {
+                    return Err(Error::UnsortedMappings);
+                }
+
+                if l.end() > r.start() {
+                    return Err(Error::OverlappingMappings);
+                }
+            }
+            Ok(PageTableBuilder {
+                inner: PageTableBuilderInner {
+                    page_table_gpa,
+                    confidential_bit: None,
+                },
+                page_table,
+                flattened_page_table,
+                ranges,
+            })
+        }
+    }
+
+    /// Builds the page tables with the confidential bit set
+    pub fn with_confidential_bit(mut self, bit_position: u32) -> Self {
+        self.inner.confidential_bit = Some(bit_position);
+        self
+    }
+
+    /// Build a set of X64 page tables identity mapping the given regions.
+    /// This creates up to 3+N page tables: 1 PML4E and up to 2 PDPTE tables, and N page tables counted at 1 per GB of size,
+    /// for 2MB mappings.
+    pub fn build(self) -> Result<&'a [u8], Error> {
+        let PageTableBuilder {
+            page_table,
+            flattened_page_table,
+            ranges,
+            inner,
+        } = self;
+
+        // Allocate single PML4E page table.
+        let (mut page_table_index, pml4_table_index) = (0, 0);
+
+        // Allocate and link table
+        let mut link_tables = |start_va: u64, end_va: u64, permissions: u64| -> Result<(), Error> {
+            let mut current_va = start_va;
+            let mut get_or_insert_entry = |table_index: usize,
+                                           entry_level: EntryLevel,
+                                           current_va: &mut u64|
+             -> Result<Option<usize>, Error> {
+                // If the current mapping can be inserted at this level as a leaf entry, do so
+                if (*current_va).is_multiple_of(entry_level.mapping_size())
+                    && (*current_va + entry_level.mapping_size() <= end_va)
+                {
+                    let entry = page_table[table_index].entry(*current_va, entry_level as u8);
+                    if entry.is_present() {
+                        // This error should be unreachable - something has gone horribly wrong
+                        return Err(Error::AttemptedEntryOverwrite);
+                    }
+
+                    #[cfg(feature = "tracing")]
+                    tracing::trace!(
+                        "inserting entry for va: {:#X} at level {:?}",
+                        current_va,
+                        entry_level
+                    );
+
+                    let new_entry = inner.build_pte(entry_level.leaf(*current_va), permissions);
+                    *entry = new_entry;
+                    *current_va += entry_level.mapping_size();
+
+                    Ok(None)
+                }
+                // The current mapping cannot be inserted as a leaf at this level
+                //
+                // Find or create the appropriate directory at this hierarchy level, and
+                // return the index
+                else {
+                    let directory_pa = entry_level.directory_pa(*current_va);
+                    let len = page_table.len();
+                    let entry = page_table[table_index].entry(directory_pa, entry_level as u8);
+
+                    if !entry.is_present() {
+                        page_table_index += 1;
+
+                        if page_table_index >= len {
+                            return Err(Error::NotEnoughMemory);
+                        }
+                        // Allocate and link a page directory
+                        let output_address =
+                            inner.page_table_gpa + page_table_index as u64 * X64_PAGE_SIZE;
+
+                        // Create the directory entry. Directory entries can be shared amongst
+                        // MappedRanges with different sets of permissions, so give a wide set of
+                        // permissions in the directory, and apply the MappedRange permissions in
+                        // the leaf entry
+                        let new_entry = inner.build_pte(
+                            PageTableEntryType::Pde(output_address),
+                            X64_PTE_PRESENT | X64_PTE_ACCESSED | X64_PTE_READ_WRITE,
+                        );
+
+                        #[cfg(feature = "tracing")]
+                        tracing::trace!(
+                            "creating directory for va: {:#X} at level {:?}",
+                            directory_pa,
+                            entry_level
+                        );
+                        *entry = new_entry;
+
+                        Ok(Some(page_table_index))
+                    } else {
+                        Ok(Some(
+                            ((inner.get_addr_from_pte(entry) - inner.page_table_gpa)
+                                / X64_PAGE_SIZE)
+                                .try_into()
+                                .expect("Valid page table index"),
+                        ))
+                    }
+                }
+            };
+
+            while current_va < end_va {
+                #[cfg(feature = "tracing")]
+                tracing::trace!("creating entry for va: {:#X}", current_va);
+                // For the current_va, insert entires as needed into the page table hierarchy,
+                // terminating when a leaf entry is inserted
+                let pdpt_table_index =
+                    get_or_insert_entry(pml4_table_index, EntryLevel::Pml4, &mut current_va)?;
+                if let Some(pdpt_table_index) = pdpt_table_index {
+                    let pd_table_index =
+                        get_or_insert_entry(pdpt_table_index, EntryLevel::Pdpt, &mut current_va)?;
+                    if let Some(pd_table_index) = pd_table_index {
+                        let pt_table_index =
+                            get_or_insert_entry(pd_table_index, EntryLevel::Pd, &mut current_va)?;
+                        if let Some(pt_table_index) = pt_table_index {
+                            get_or_insert_entry(pt_table_index, EntryLevel::Pt, &mut current_va)?;
+                        }
+                    }
+                }
+            }
+
+            Ok(())
         };
 
-        link_tables(start_va, end_va, true);
-
-        // Create local map area if present.
-        if let Some((local_map_start, local_map_size)) = self.local_map {
-            link_tables(local_map_start, local_map_start + local_map_size, true);
+        for range in ranges {
+            link_tables(range.start, range.end, range.permissions)?;
         }
 
-        if self.map_reset_vector {
-            // Map the reset vector pfn of 0xFFFFF
-            tracing::trace!("identity mapping reset page 0xFFFFF");
-            let reset_vector_addr = 0xFFFFF * X64_PAGE_SIZE;
-            link_tables(reset_vector_addr, reset_vector_addr + X64_PAGE_SIZE, false);
-        }
-
-        // Flatten page table vec into u8 vec
-        flatten_page_table(page_table)
+        // flatten the [page_table] into a [u8]
+        Ok(flatten_page_table(
+            page_table,
+            flattened_page_table,
+            page_table_index + 1,
+        ))
     }
 }
 
-/// Build a set of X64 page tables identity mapping the bottom address
-/// space with an optional address bias.
-///
-/// An optional PML4E entry may be linked, with arguments being (link_target_gpa, linkage_gpa).
-/// link_target_gpa represents the GPA of the PML4E to link into the built page table.
-/// linkage_gpa represents the GPA at which the linked PML4E should be linked.
-pub fn build_page_tables_64(
+#[derive(Debug, Clone)]
+struct IdentityMapBuilderParams {
     page_table_gpa: u64,
-    address_bias: u64,
     identity_map_size: IdentityMapSize,
+    address_bias: u64,
     pml4e_link: Option<(u64, u64)>,
-) -> Vec<u8> {
-    // Allocate page tables. There are up to 6 total page tables:
-    //      1 PML4E (Level 4) (omitted if the address bias is non-zero)
-    //      1 PDPTE (Level 3)
-    //      4 or 8 PDE tables (Level 2)
-    // Note that there are no level 1 page tables, as 2MB pages are used.
-    let leaf_page_table_count = match identity_map_size {
-        IdentityMapSize::Size4Gb => 4,
-        IdentityMapSize::Size8Gb => 8,
-    };
-    let page_table_count = leaf_page_table_count + if address_bias == 0 { 2 } else { 1 };
-    let mut page_table: Vec<PageTable> = vec![PageTable::new_zeroed(); page_table_count];
-    let mut page_table_allocator = page_table.iter_mut().enumerate();
+}
 
-    // Allocate single PDPTE table.
-    let pdpte_table = if address_bias == 0 {
-        // Allocate single PML4E page table.
-        let (_, pml4e_table) = page_table_allocator
-            .next()
-            .expect("pagetable should always be available, code bug if not");
+/// An IdentityMap Builder, which builds either a 4GB or 8GB identity map of the lower address space
+/// FUTURE: This logic can merged with the PageTableBuilder, rather than maintaining two implementations
+pub struct IdentityMapBuilder<'a> {
+    params: IdentityMapBuilderParams,
+    /// a reference to a mutable slice of PageTables, used as working memory for constructing the page table
+    page_table: &'a mut [PageTable],
+    /// a reference to a mutable slice of u8s, used to store and return the final page table bytes
+    flattened_page_table: &'a mut [u8],
+}
 
-        // PDPTE table is the next pagetable.
-        let (pdpte_table_index, pdpte_table) = page_table_allocator
-            .next()
-            .expect("pagetable should always be available, code bug if not");
-
-        // Set PML4E entry linking PML4E to PDPTE.
-        let output_address = page_table_gpa + pdpte_table_index as u64 * X64_PAGE_SIZE;
-        pml4e_table[0].set_entry(PageTableEntryType::Pde(output_address));
-
-        // Set PML4E entry to link the additional entry if specified.
-        if let Some((link_target_gpa, linkage_gpa)) = pml4e_link {
-            assert!((linkage_gpa & 0x7FFFFFFFFF) == 0);
-            pml4e_table[linkage_gpa as usize >> 39]
-                .set_entry(PageTableEntryType::Pde(link_target_gpa));
-        }
-
-        pdpte_table
-    } else {
-        // PDPTE table is the first table, if no PML4E.
-        page_table_allocator
-            .next()
-            .expect("pagetable should always be available, code bug if not")
-            .1
-    };
-
-    // Build PDEs that point to 2 MB pages.
-    let top_address = match identity_map_size {
-        IdentityMapSize::Size4Gb => 0x100000000u64,
-        IdentityMapSize::Size8Gb => 0x200000000u64,
-    };
-    let mut current_va = 0;
-
-    while current_va < top_address {
-        // Allocate a new PDE table
-        let (pde_table_index, pde_table) = page_table_allocator
-            .next()
-            .expect("pagetable should always be available, code bug if not");
-
-        // Link PDPTE table to PDE table (L3 to L2)
-        let pdpte_index = get_amd64_pte_index(current_va, 2);
-        let output_address = page_table_gpa + pde_table_index as u64 * X64_PAGE_SIZE;
-        let pdpte_entry = &mut pdpte_table[pdpte_index as usize];
-        assert!(!pdpte_entry.is_present());
-        pdpte_entry.set_entry(PageTableEntryType::Pde(output_address));
-
-        // Set all 2MB entries in this PDE table.
-        for entry in pde_table.iter_mut() {
-            entry.set_entry(PageTableEntryType::Leaf2MbPage(current_va + address_bias));
-            current_va += X64_LARGE_PAGE_SIZE;
+impl<'a> IdentityMapBuilder<'a> {
+    /// Creates a new instance of the IdentityMapBuilder. The [PageTable] slice is working memory
+    /// for constructing the page table, and the [u8] slice is the memory used to output the
+    /// final bytes of the page table
+    ///
+    /// The working memory and output memory are taken as parameters to allow for the caller
+    /// to flexibly choose their allocation strategy, to support usage in no_std environments
+    /// like openhcl_boot
+    pub fn new(
+        page_table_gpa: u64,
+        identity_map_size: IdentityMapSize,
+        page_table: &'a mut [PageTable],
+        flattened_page_table: &'a mut [u8],
+    ) -> Result<Self, Error> {
+        if flattened_page_table.len() != (page_table.len() * PAGE_TABLE_SIZE) {
+            Err(Error::BadBufferSize {
+                bytes_buf: flattened_page_table.len(),
+                struct_buf: page_table.len() * PAGE_TABLE_SIZE,
+            })
+        } else {
+            Ok(IdentityMapBuilder {
+                params: IdentityMapBuilderParams {
+                    page_table_gpa,
+                    identity_map_size,
+                    address_bias: 0,
+                    pml4e_link: None,
+                },
+                page_table,
+                flattened_page_table,
+            })
         }
     }
 
-    // All pagetables should be used, code bug if not.
-    assert!(page_table_allocator.next().is_none());
+    /// Builds the page tables with an address bias, a fixed offset between the virtual
+    /// and physical addresses in the identity map
+    pub fn with_address_bias(mut self, address_bias: u64) -> Self {
+        self.params.address_bias = address_bias;
+        self
+    }
 
-    // Flatten page table vec into u8 vec
-    flatten_page_table(page_table)
+    /// An optional PML4E entry may be linked, with arguments being (link_target_gpa, linkage_gpa).
+    /// link_target_gpa represents the GPA of the PML4E to link into the built page table.
+    /// linkage_gpa represents the GPA at which the linked PML4E should be linked.
+    pub fn with_pml4e_link(mut self, pml4e_link: (u64, u64)) -> Self {
+        self.params.pml4e_link = Some(pml4e_link);
+        self
+    }
+
+    /// Build a set of X64 page tables identity mapping the bottom address
+    /// space with an optional address bias.
+    pub fn build(self) -> &'a [u8] {
+        let IdentityMapBuilder {
+            page_table,
+            flattened_page_table,
+            params,
+        } = self;
+
+        // Allocate page tables. There are up to 6 total page tables:
+        //      1 PML4E (Level 4) (omitted if the address bias is non-zero)
+        //      1 PDPTE (Level 3)
+        //      4 or 8 PDE tables (Level 2)
+        // Note that there are no level 1 page tables, as 2MB pages are used.
+        let leaf_page_table_count = match params.identity_map_size {
+            IdentityMapSize::Size4Gb => 4,
+            IdentityMapSize::Size8Gb => 8,
+        };
+        let page_table_count = leaf_page_table_count + if params.address_bias == 0 { 2 } else { 1 };
+        let mut page_table_allocator = page_table.iter_mut().enumerate();
+
+        // Allocate single PDPTE table.
+        let pdpte_table = if params.address_bias == 0 {
+            // Allocate single PML4E page table.
+            let (_, pml4e_table) = page_table_allocator
+                .next()
+                .expect("pagetable should always be available, code bug if not");
+
+            // PDPTE table is the next pagetable.
+            let (pdpte_table_index, pdpte_table) = page_table_allocator
+                .next()
+                .expect("pagetable should always be available, code bug if not");
+
+            // Set PML4E entry linking PML4E to PDPTE.
+            let output_address = params.page_table_gpa + pdpte_table_index as u64 * X64_PAGE_SIZE;
+            pml4e_table.entries[0].set_entry(PageTableEntryType::Pde(output_address));
+
+            // Set PML4E entry to link the additional entry if specified.
+            if let Some((link_target_gpa, linkage_gpa)) = params.pml4e_link {
+                assert!((linkage_gpa & 0x7FFFFFFFFF) == 0);
+                pml4e_table.entries[linkage_gpa as usize >> 39]
+                    .set_entry(PageTableEntryType::Pde(link_target_gpa));
+            }
+
+            pdpte_table
+        } else {
+            // PDPTE table is the first table, if no PML4E.
+            page_table_allocator
+                .next()
+                .expect("pagetable should always be available, code bug if not")
+                .1
+        };
+
+        // Build PDEs that point to 2 MB pages.
+        let top_address = match params.identity_map_size {
+            IdentityMapSize::Size4Gb => 0x100000000u64,
+            IdentityMapSize::Size8Gb => 0x200000000u64,
+        };
+        let mut current_va = 0;
+
+        while current_va < top_address {
+            // Allocate a new PDE table
+            let (pde_table_index, pde_table) = page_table_allocator
+                .next()
+                .expect("pagetable should always be available, code bug if not");
+
+            // Link PDPTE table to PDE table (L3 to L2)
+            let pdpte_index = get_amd64_pte_index(current_va, 2);
+            let output_address = params.page_table_gpa + pde_table_index as u64 * X64_PAGE_SIZE;
+            let pdpte_entry = &mut pdpte_table.entries[pdpte_index as usize];
+            assert!(!pdpte_entry.is_present());
+            pdpte_entry.set_entry(PageTableEntryType::Pde(output_address));
+
+            // Set all 2MB entries in this PDE table.
+            for entry in pde_table.iter_mut() {
+                entry.set_entry(PageTableEntryType::Leaf2MbPage(
+                    current_va + params.address_bias,
+                ));
+                current_va += X64_LARGE_PAGE_SIZE;
+            }
+        }
+
+        // Flatten [page_table] into [u8]
+        flatten_page_table(page_table, flattened_page_table, page_table_count)
+    }
 }
 
 /// Align an address up to the start of the next page.
@@ -599,21 +738,39 @@ pub fn align_up_to_1_gb_page_size(address: u64) -> u64 {
     (address + X64_1GB_PAGE_SIZE - 1) & !(X64_1GB_PAGE_SIZE - 1)
 }
 
-fn flatten_page_table(page_table: Vec<PageTable>) -> Vec<u8> {
-    let mut flat_tables = Vec::with_capacity(page_table.len() * X64_PAGE_SIZE as usize);
-    for table in page_table {
-        flat_tables.extend_from_slice(table.as_bytes());
+fn flatten_page_table<'a>(
+    page_table: &mut [PageTable],
+    flattened_page_table: &'a mut [u8],
+    page_table_count: usize,
+) -> &'a [u8] {
+    for (page_table, dst) in page_table
+        .iter()
+        .take(page_table_count)
+        .zip(flattened_page_table.chunks_mut(PAGE_TABLE_SIZE))
+    {
+        let src = page_table.as_bytes();
+        dst.copy_from_slice(src);
     }
 
-    flat_tables
+    &flattened_page_table[0..PAGE_TABLE_SIZE * page_table_count]
 }
 
 #[cfg(test)]
 mod tests {
+    use std;
+    use std::vec;
+
+    use super::Error;
+    use super::MappedRange;
+    use super::PAGE_TABLE_MAX_BYTES;
+    use super::PAGE_TABLE_MAX_COUNT;
+    use super::PageTable;
+    use super::PageTableBuilder;
     use super::X64_1GB_PAGE_SIZE;
     use super::align_up_to_large_page_size;
     use super::align_up_to_page_size;
     use super::calculate_pde_table_count;
+    use zerocopy::FromZeros;
 
     #[test]
     fn test_align_up() {
@@ -647,5 +804,120 @@ mod tests {
             calculate_pde_table_count(X64_1GB_PAGE_SIZE, X64_1GB_PAGE_SIZE * 3),
             3
         );
+    }
+
+    fn check_page_table_count(ranges: &[MappedRange], count: usize) {
+        let mut page_table_work_buffer: Vec<PageTable> =
+            vec![PageTable::new_zeroed(); PAGE_TABLE_MAX_COUNT];
+        let mut page_table: Vec<u8> = vec![0; PAGE_TABLE_MAX_BYTES];
+
+        let page_table_builder = PageTableBuilder::new(
+            0,
+            page_table_work_buffer.as_mut_slice(),
+            page_table.as_mut_slice(),
+            ranges,
+        )
+        .expect("page table builder initialization should succeed");
+
+        let page_table = page_table_builder.build().expect("building should succeed");
+        assert_eq!(page_table.len(), count);
+    }
+
+    fn page_table_builder_error(ranges: &[MappedRange]) -> Option<Error> {
+        let mut page_table_work_buffer: Vec<PageTable> =
+            vec![PageTable::new_zeroed(); PAGE_TABLE_MAX_COUNT];
+        let mut page_table: Vec<u8> = vec![0; PAGE_TABLE_MAX_BYTES];
+
+        PageTableBuilder::new(
+            0,
+            page_table_work_buffer.as_mut_slice(),
+            page_table.as_mut_slice(),
+            ranges,
+        )
+        .err()
+    }
+
+    #[test]
+    fn test_page_table_entry_sizing() {
+        const ONE_GIG: u64 = 1024 * 1024 * 1024;
+        const TWO_MB: u64 = 1024 * 1024 * 2;
+        const FOUR_KB: u64 = 4096;
+
+        check_page_table_count(&[MappedRange::new(0, ONE_GIG)], 4096 * 2);
+        check_page_table_count(&[MappedRange::new(0, TWO_MB)], 4096 * 3);
+        check_page_table_count(&[MappedRange::new(0, FOUR_KB)], 4096 * 4);
+        check_page_table_count(&[MappedRange::new(FOUR_KB, ONE_GIG)], 4096 * 4);
+        check_page_table_count(&[MappedRange::new(TWO_MB, ONE_GIG)], 4096 * 3);
+        check_page_table_count(&[MappedRange::new(TWO_MB, ONE_GIG + FOUR_KB)], 4096 * 5);
+        check_page_table_count(&[MappedRange::new(TWO_MB, ONE_GIG + TWO_MB)], 4096 * 4);
+    }
+
+    #[test]
+    fn test_page_table_builder_overlapping_range() {
+        const ONE_GIG: u64 = 1024 * 1024 * 1024;
+        const TWO_MB: u64 = 1024 * 1024 * 2;
+        const FOUR_KB: u64 = 4096;
+
+        let err = page_table_builder_error(&[
+            MappedRange::new(FOUR_KB, ONE_GIG),
+            MappedRange::new(TWO_MB, ONE_GIG),
+        ])
+        .expect("must fail");
+        assert!(matches!(err, Error::OverlappingMappings));
+    }
+
+    #[test]
+    fn test_page_table_builder_invalid_range() {
+        const ONE_GIG: u64 = 1024 * 1024 * 1024;
+        const FOUR_KB: u64 = 4096;
+
+        let err =
+            page_table_builder_error(&[MappedRange::new(ONE_GIG, FOUR_KB)]).expect("must fail");
+        assert!(matches!(err, Error::InvalidRange));
+    }
+
+    #[test]
+    fn test_page_table_builder_oom() {
+        const ONE_GIG: u64 = 1024 * 1024 * 1024;
+
+        let mut page_table_work_buffer: Vec<PageTable> = vec![PageTable::new_zeroed(); 1];
+        let mut page_table: Vec<u8> = vec![0; 4096];
+
+        let err = PageTableBuilder::new(
+            0,
+            page_table_work_buffer.as_mut_slice(),
+            page_table.as_mut_slice(),
+            &[MappedRange::new(0, ONE_GIG)],
+        )
+        .expect("page table builder initialization should succeed")
+        .build()
+        .expect_err("building page tables should fail");
+
+        assert!(matches!(err, Error::NotEnoughMemory));
+    }
+
+    #[test]
+    fn test_page_table_builder_mismatched_buffers() {
+        const ONE_GIG: u64 = 1024 * 1024 * 1024;
+
+        let mut page_table_work_buffer: Vec<PageTable> = vec![PageTable::new_zeroed(); 4];
+        let mut page_table: Vec<u8> = vec![0; 4096 * 5];
+
+        let err = PageTableBuilder::new(
+            0,
+            page_table_work_buffer.as_mut_slice(),
+            page_table.as_mut_slice(),
+            &[MappedRange::new(0, ONE_GIG)],
+        )
+        .err()
+        .expect("building page tables should fail");
+
+        assert!(matches!(
+            err,
+            Error::BadBufferSize {
+                bytes_buf: _,
+                struct_buf: _
+            }
+        ));
     }
 }

--- a/vm/loader/src/linux.rs
+++ b/vm/loader/src/linux.rs
@@ -21,9 +21,12 @@ use bitfield_struct::bitfield;
 use hvdef::HV_PAGE_SIZE;
 use loader_defs::linux as defs;
 use page_table::IdentityMapSize;
+use page_table::x64::IdentityMapBuilder;
+use page_table::x64::PAGE_TABLE_MAX_BYTES;
+use page_table::x64::PAGE_TABLE_MAX_COUNT;
+use page_table::x64::PageTable;
 use page_table::x64::align_up_to_large_page_size;
 use page_table::x64::align_up_to_page_size;
-use page_table::x64::build_page_tables_64;
 use std::ffi::CString;
 use thiserror::Error;
 use vm_topology::memory::MemoryLayout;
@@ -126,6 +129,8 @@ pub enum Error {
     UnalignedAddress(u64),
     #[error("importer error")]
     Importer(#[source] anyhow::Error),
+    #[error("PageTableBuilder: {0}")]
+    PageTableBuilder(#[from] page_table::Error),
 }
 
 pub struct AcpiConfig<'a> {
@@ -331,12 +336,16 @@ pub fn load_config(
     check_address_alignment(registers.gdt_address)?;
     import_default_gdt(importer, registers.gdt_address / HV_PAGE_SIZE).map_err(Error::Importer)?;
     check_address_alignment(registers.page_table_address)?;
-    let page_table = build_page_tables_64(
+    let mut page_table_work_buffer: Vec<PageTable> =
+        vec![PageTable::new_zeroed(); PAGE_TABLE_MAX_COUNT];
+    let mut page_table: Vec<u8> = vec![0; PAGE_TABLE_MAX_BYTES];
+    let page_table_builder = IdentityMapBuilder::new(
         registers.page_table_address,
-        0,
         IdentityMapSize::Size4Gb,
-        None,
-    );
+        page_table_work_buffer.as_mut_slice(),
+        page_table.as_mut_slice(),
+    )?;
+    let page_table = page_table_builder.build();
     assert!((page_table.len() as u64).is_multiple_of(HV_PAGE_SIZE));
     importer
         .import_pages(
@@ -344,7 +353,7 @@ pub fn load_config(
             page_table.len() as u64 / HV_PAGE_SIZE,
             "linux-pagetables",
             BootPageAcceptance::Exclusive,
-            &page_table,
+            page_table,
         )
         .map_err(Error::Importer)?;
 

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -35,6 +35,10 @@ use memory_range::MemoryRange;
 use page_table::aarch64::Arm64PageSize;
 use page_table::aarch64::MemoryAttributeEl1;
 use page_table::aarch64::MemoryAttributeIndirectionEl1;
+use page_table::x64::MappedRange;
+use page_table::x64::PAGE_TABLE_MAX_BYTES;
+use page_table::x64::PAGE_TABLE_MAX_COUNT;
+use page_table::x64::PageTable;
 use page_table::x64::PageTableBuilder;
 use page_table::x64::X64_LARGE_PAGE_SIZE;
 use page_table::x64::align_up_to_large_page_size;
@@ -86,6 +90,8 @@ pub enum Error {
     NotEnoughMemory(u64),
     #[error("importer error")]
     Importer(#[from] anyhow::Error),
+    #[error("PageTableBuilder: {0}")]
+    PageTableBuilder(#[from] page_table::Error),
 }
 
 /// Kernel Command line type.
@@ -448,29 +454,48 @@ where
 
     tracing::debug!(page_table_region_start, page_table_region_size);
 
-    let mut page_table_builder = PageTableBuilder::new(page_table_region_start)
-        .with_mapped_region(memory_start_address, page_table_mapping_size);
+    // Construct the memory ranges that will be identity mapped
+    let mut ranges: Vec<MappedRange> = Vec::new();
+
+    ranges.push(MappedRange::new(
+        memory_start_address,
+        memory_start_address + page_table_mapping_size,
+    ));
 
     if let Some((local_map_start, size)) = local_map {
-        page_table_builder = page_table_builder.with_local_map(local_map_start, size);
+        ranges.push(MappedRange::new(local_map_start, local_map_start + size));
     }
 
-    match isolation_type {
-        IsolationType::Snp => {
-            page_table_builder = page_table_builder.with_confidential_bit(51);
-        }
-        IsolationType::Tdx => {
-            page_table_builder = page_table_builder.with_reset_vector(true);
-        }
-        _ => {}
+    if isolation_type == IsolationType::Tdx {
+        const RESET_VECTOR_ADDR: u64 = 0xffff_f000;
+        ranges.push(MappedRange::new(
+            RESET_VECTOR_ADDR,
+            RESET_VECTOR_ADDR + page_table::x64::X64_PAGE_SIZE,
+        ));
     }
 
-    let page_table = page_table_builder.build();
+    ranges.sort_by_key(|r| r.start());
+
+    // Initialize the page table builder, and build the page table
+    let mut page_table_work_buffer: Vec<PageTable> =
+        vec![PageTable::new_zeroed(); PAGE_TABLE_MAX_COUNT];
+    let mut page_table: Vec<u8> = vec![0; PAGE_TABLE_MAX_BYTES];
+    let mut page_table_builder = PageTableBuilder::new(
+        page_table_region_start,
+        page_table_work_buffer.as_mut_slice(),
+        page_table.as_mut_slice(),
+        ranges.as_slice(),
+    )?;
+
+    if isolation_type == IsolationType::Snp {
+        page_table_builder = page_table_builder.with_confidential_bit(51);
+    }
+
+    let page_table = page_table_builder.build()?;
 
     assert!((page_table.len() as u64).is_multiple_of(HV_PAGE_SIZE));
     let page_table_page_base = page_table_region_start / HV_PAGE_SIZE;
     assert!(page_table.len() as u64 <= page_table_region_size);
-
     let offset = offset;
 
     if with_relocation {
@@ -560,7 +585,7 @@ where
         page_table_page_count,
         "underhill-page-tables",
         BootPageAcceptance::Exclusive,
-        &page_table,
+        page_table,
     )?;
 
     // Set selectors and control registers
@@ -1239,12 +1264,13 @@ where
         MemoryAttributeEl1::Device_nGnRnE,
         MemoryAttributeEl1::Device_nGnRnE,
     ]);
+    let mut page_tables: Vec<u8> = vec![0; page_table_region_size as usize];
     let page_tables = page_table::aarch64::build_identity_page_tables_aarch64(
         page_table_region_start,
         memory_start_address,
         memory_size,
         memory_attribute_indirection,
-        page_table_region_size as usize,
+        page_tables.as_mut_slice(),
     );
     assert!((page_tables.len() as u64).is_multiple_of(HV_PAGE_SIZE));
     let page_table_page_base = page_table_region_start / HV_PAGE_SIZE;
@@ -1278,7 +1304,7 @@ where
         page_table_page_count,
         "underhill-page-tables",
         BootPageAcceptance::Exclusive,
-        &page_tables,
+        page_tables,
     )?;
 
     tracing::trace!("Importing register state");

--- a/vm/loader/src/uefi/mod.rs
+++ b/vm/loader/src/uefi/mod.rs
@@ -334,6 +334,8 @@ pub enum Error {
     InvalidConfigType(String),
     #[error("Importer error")]
     Importer(#[source] anyhow::Error),
+    #[error("PageTableBuilder: {0}")]
+    PageTableBuilder(#[from] page_table::Error),
 }
 
 #[derive(Debug)]
@@ -371,8 +373,11 @@ pub mod x86_64 {
     use crate::uefi::get_sec_entry_point_offset;
     use hvdef::HV_PAGE_SIZE;
     use page_table::IdentityMapSize;
+    use page_table::x64::IdentityMapBuilder;
+    use page_table::x64::PAGE_TABLE_MAX_BYTES;
+    use page_table::x64::PAGE_TABLE_MAX_COUNT;
+    use page_table::x64::PageTable;
     use page_table::x64::align_up_to_page_size;
-    use page_table::x64::build_page_tables_64;
     use zerocopy::FromZeros;
     use zerocopy::IntoBytes;
 
@@ -404,6 +409,17 @@ pub mod x86_64 {
         //        to map the bottom 4GB of memory with shared visibility.
         //      - Otherwise, build the standard UEFI page tables. Bottom 4GB of address space,
         //        identity mapped with 2 MB pages.
+        let mut page_table_work_buffer: Vec<PageTable> =
+            vec![PageTable::new_zeroed(); PAGE_TABLE_MAX_COUNT];
+        let mut page_tables: Vec<u8> = vec![0; PAGE_TABLE_MAX_BYTES];
+        let page_table_builder = IdentityMapBuilder::new(
+            PAGE_TABLE_GPA_BASE,
+            IdentityMapSize::Size4Gb,
+            page_table_work_buffer.as_mut_slice(),
+            page_tables.as_mut_slice(),
+        )?;
+        let mut shared_vis_page_table_work_buffer: Vec<PageTable> = Vec::new();
+        let mut shared_vis_page_tables: Vec<u8> = Vec::new();
         let (page_tables, shared_vis_page_tables) =
             if isolation.isolation_type == IsolationType::Snp && !isolation.paravisor_present {
                 if let ConfigType::ConfigBlob(_) = config {
@@ -418,28 +434,29 @@ pub mod x86_64 {
                     .ok_or(Error::InvalidSharedGpaBoundary)?;
                 let shared_gpa_boundary = 1 << shared_gpa_boundary_bits;
 
+                shared_vis_page_table_work_buffer
+                    .resize(PAGE_TABLE_MAX_COUNT, PageTable::new_zeroed());
+                shared_vis_page_tables.resize(PAGE_TABLE_MAX_BYTES, 0);
+                let shared_vis_builder = IdentityMapBuilder::new(
+                    shared_vis_page_table_gpa,
+                    IdentityMapSize::Size4Gb,
+                    shared_vis_page_table_work_buffer.as_mut_slice(),
+                    shared_vis_page_tables.as_mut_slice(),
+                )?
+                .with_address_bias(shared_gpa_boundary);
+
                 // The extra page tables are placed after the first config blob
                 // page.  They will be accounted for when the IGVM parameters are
                 // built.
-                let shared_vis_page_tables = build_page_tables_64(
-                    shared_vis_page_table_gpa,
-                    shared_gpa_boundary,
-                    IdentityMapSize::Size4Gb,
-                    None,
-                );
+                let shared_vis_page_tables = shared_vis_builder.build();
 
-                let page_tables = build_page_tables_64(
-                    PAGE_TABLE_GPA_BASE,
-                    0,
-                    IdentityMapSize::Size4Gb,
-                    Some((shared_vis_page_table_gpa, shared_gpa_boundary)),
-                );
+                let page_tables = page_table_builder
+                    .with_pml4e_link((shared_vis_page_table_gpa, shared_gpa_boundary))
+                    .build();
 
                 (page_tables, Some(shared_vis_page_tables))
             } else {
-                let page_tables =
-                    build_page_tables_64(PAGE_TABLE_GPA_BASE, 0, IdentityMapSize::Size4Gb, None);
-
+                let page_tables = page_table_builder.build();
                 (page_tables, None)
             };
 
@@ -466,7 +483,7 @@ pub mod x86_64 {
                 PAGE_TABLE_SIZE / HV_PAGE_SIZE,
                 "uefi-page-tables",
                 BootPageAcceptance::Exclusive,
-                &page_tables,
+                page_tables,
             )
             .map_err(Error::Importer)?;
 


### PR DESCRIPTION
Backporting #2423

Updates the page table builder in the loader to be no_std, and to accept a generic buffer for its working memory

