### PR TITLE
guest_mem: Add support for guest memory access wrappers for PagedRanges

### DIFF
--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1730,9 +1730,11 @@ impl GuestMemory {
             |()| {
                 // Fallback: use compare_exchange_fallback to probe write access
                 let mut current = 0u8;
-                self.inner
-                    .imp
-                    .compare_exchange_fallback(gpa, std::slice::from_mut(&mut current), &[0u8])?;
+                self.inner.imp.compare_exchange_fallback(
+                    gpa,
+                    std::slice::from_mut(&mut current),
+                    &[0u8],
+                )?;
                 Ok(())
             },
         )
@@ -2718,7 +2720,6 @@ mod tests {
         gm.read_plain::<u8>(PAGE_SIZE64 * 3 - 1).unwrap();
         gm.write_plain::<u8>(PAGE_SIZE64 * 3 - 1, &0).unwrap_err();
 
-
         // Test probe_gpn_writable_range with FaultingMapping
         // FaultingMapping layout:
         // - Page 0 (address 0 to PAGE_SIZE): unmapped, fails on access
@@ -2761,7 +2762,6 @@ mod tests {
         let range = PagedRange::empty();
         gm.probe_gpn_writable_range(&range).unwrap();
 
-
         // Test probe_gpn_readable_range with FaultingMapping
 
         // Test 8: Probe unmapped page for read - should fail
@@ -2773,7 +2773,6 @@ mod tests {
         let gpns = vec![1];
         let range = PagedRange::new(0, PAGE_SIZE, &gpns).unwrap();
         gm.probe_gpn_readable_range(&range).unwrap();
-
 
         // Test 10: Probe mixed access (writable + read-only) for read - should succeed
         let gpns = vec![1, 2];


### PR DESCRIPTION
This change adds support for checking whether the given pagedRange is readable or writable.

**Background context:**
For IDE DMA processing, we would need to check if the buffer that is going to be transferred, is within the guest address space. We would need to probe the entire buffer range to check if its readable or writable depending on the DMA type. These utilities would help in doing the same. Ref: https://github.com/microsoft/openvmm/pull/2373/files (still in draft)


**Testing details**
```
$ cargo test -p guestmem
   Compiling guestmem v0.0.0 (/home/srshekar/openvmm/vm/vmcore/guestmem)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.88s
     Running unittests src/lib.rs (/home/srshekar/openvmm/target/debug/deps/guestmem-aedc01f3e9163589)

running 5 tests
test ranges::tests::test_ranges ... ok
test tests::test_allocated ... ok
test tests::test_fault ... ok
test tests::test_multi ... ok
test tests::test_basic_read_write ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

   Doc-tests guestmem

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```