### PR TITLE
openhcl_boot: disable acpi runtime support (#2441)

### DIFF
--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -193,6 +193,9 @@ fn build_kernel_command_line(
         "hv_storvsc.storvsc_ringbuffer_size=0x8000",
         // Disable eager mimalloc commit to prevent core dumps from being overly large
         "MIMALLOC_ARENA_EAGER_COMMIT=0",
+        // Disable acpi runtime support. Unused in underhill, but some support
+        // is compiled in for the kernel (ie TDX mailbox protocol).
+        "acpi=off",
     ];
 
     const X86_KERNEL_PARAMETERS: &[&str] = &[


### PR DESCRIPTION
An upcoming kernel change will compile in some limited acpi routines for TDX AP startup. Disable ACPI runtime functions as they are unwanted.

Clean cherry pick of #2441 