### PR TITLE
ci/github: update release labeler yaml for new release branch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,3 +7,6 @@ release_2411:
 
 release_2505:
  - base-branch: 'release/2505'
+
+release_1.7.2511:
+ - base-branch: 'release/1.7.2511'


### PR DESCRIPTION
Update the yaml to reflect the new release branch. 