### PR TITLE
tdx: support proxy interrupt redirection for VTL0 owned devices

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,7 +29,7 @@ pub const NODEJS: &str = "18.x";
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.1";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.1";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.2";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -334,6 +334,7 @@ async fn launch_workers(
         strict_encryption_policy: opt.strict_encryption_policy,
         attempt_ak_cert_callback: opt.attempt_ak_cert_callback,
         enable_vpci_relay: opt.enable_vpci_relay,
+        disable_proxy_redirect: opt.disable_proxy_redirect,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -254,6 +254,9 @@ pub struct Options {
 
     /// (OPENHCL_ENABLE_VPCI_RELAY=1) Enable the VPCI relay.
     pub enable_vpci_relay: Option<bool>,
+
+    /// (OPENHCL_DISABLE_PROXY_REDIRECT=1) Disable proxy interrupt redirection.
+    pub disable_proxy_redirect: bool,
 }
 
 impl Options {
@@ -411,6 +414,7 @@ impl Options {
         let strict_encryption_policy = parse_env_bool_opt("HCL_STRICT_ENCRYPTION_POLICY");
         let attempt_ak_cert_callback = parse_env_bool_opt("HCL_ATTEMPT_AK_CERT_CALLBACK");
         let enable_vpci_relay = parse_env_bool_opt("OPENHCL_ENABLE_VPCI_RELAY");
+        let disable_proxy_redirect = parse_env_bool("OPENHCL_DISABLE_PROXY_REDIRECT");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -474,6 +478,7 @@ impl Options {
             strict_encryption_policy,
             attempt_ak_cert_callback,
             enable_vpci_relay,
+            disable_proxy_redirect,
         })
     }
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -308,6 +308,8 @@ pub struct UnderhillEnvCfg {
     pub attempt_ak_cert_callback: Option<bool>,
     /// Enable the VPCI relay
     pub enable_vpci_relay: Option<bool>,
+    /// Disable proxy interrupt redirection
+    pub disable_proxy_redirect: bool,
 }
 
 /// Bundle of config + runtime objects for hooking into the underhill remote
@@ -1762,6 +1764,7 @@ async fn new_underhill_vm(
         use_mmio_hypercalls,
         intercept_debug_exceptions: env_cfg.gdbstub,
         hide_isolation,
+        disable_proxy_redirect: env_cfg.disable_proxy_redirect,
     };
 
     let proto_partition = UhProtoPartition::new(params, |cpu| tp.driver(cpu).clone())

--- a/tmk/tmk_vmm/src/paravisor_vmm.rs
+++ b/tmk/tmk_vmm/src/paravisor_vmm.rs
@@ -33,6 +33,7 @@ impl RunContext<'_> {
             no_sidecar_hotplug: false,
             use_mmio_hypercalls: false,
             intercept_debug_exceptions: false,
+            disable_proxy_redirect: false,
         };
         let p = virt_mshv_vtl::UhProtoPartition::new(params, |_| self.state.driver.clone())?;
 

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -1055,12 +1055,14 @@ pub mod hypercall {
     pub struct HvInterruptTargetFlags {
         pub multicast: bool,
         pub processor_set: bool,
-        #[bits(30)]
+        pub proxy_redirect: bool,
+        #[bits(29)]
         pub reserved: u32,
     }
 
     pub const HV_DEVICE_INTERRUPT_TARGET_MULTICAST: u32 = 1;
     pub const HV_DEVICE_INTERRUPT_TARGET_PROCESSOR_SET: u32 = 2;
+    pub const HV_DEVICE_INTERRUPT_TARGET_PROXY_REDIRECT: u32 = 4;
 
     pub const HV_GENERIC_SET_SPARSE_4K: u64 = 0;
     pub const HV_GENERIC_SET_ALL: u64 = 1;
@@ -3151,8 +3153,11 @@ pub struct HvRegisterVsmCapabilities {
     pub install_intercept_ex: bool,
     /// Only available in VTL2.
     pub intercept_system_reset_available: bool,
-    #[bits(31)]
-    pub reserved: u64,
+    #[bits(1)]
+    pub reserved1: u8,
+    pub proxy_interrupt_redirect_available: bool,
+    #[bits(29)]
+    pub reserved2: u64,
 }
 
 #[bitfield(u64)]


### PR DESCRIPTION
Clean cherry-pick of PR #384 to enable support for proxy interrupt redirection for VTL0 owned devices
Issue - https://github.com/microsoft/openvmm/issues/362
