### PR TITLE
petri/hyperv: Add an escape hatch to wait_for_agent

### DIFF
--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -338,7 +338,7 @@ impl HyperVVM {
         powershell::run_set_initial_machine_configuration(&self.vmid, &self.ps_mod, imc_hive).await
     }
 
-    async fn state(&self) -> anyhow::Result<VmState> {
+    pub(crate) async fn state(&self) -> anyhow::Result<VmState> {
         hvc::hvc_state(&self.vmid).await
     }
 


### PR DESCRIPTION
We've been seeing test runs where petri gets stuck waiting for a pipette connection when the VM crashes, and that connection never arrives. Add a check that hopefully will catch this happening and break out of the loop.