### PR TITLE
vmgs: Make VmgsClient MeshPayload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9228,7 +9228,6 @@ dependencies = [
  "guestmem",
  "inspect",
  "inspect_counters",
- "mesh",
  "mesh_protobuf",
  "openssl",
  "pal_async",
@@ -9264,7 +9263,6 @@ version = "0.0.0"
 dependencies = [
  "bitfield-struct 0.11.0",
  "inspect",
- "mesh",
  "open_enum",
  "static_assertions",
  "zerocopy 0.8.27",

--- a/vm/vmgs/vmgs/Cargo.toml
+++ b/vm/vmgs/vmgs/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 
 inspect = ["vmgs_format/inspect", "dep:inspect", "dep:inspect_counters"]
 save_restore = ["dep:mesh_protobuf"]
-mesh = ["dep:mesh"]
+mesh = ["dep:mesh_protobuf"]
 
 # Use native windows crypto APIs
 encryption_win = ["dep:windows"]
@@ -29,7 +29,6 @@ vmgs_format.workspace = true
 inspect = { workspace = true, optional = true }
 inspect_counters = { workspace = true, optional = true }
 mesh_protobuf = { workspace = true, optional = true }
-mesh = { workspace = true, optional = true }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -47,7 +47,7 @@ enum LogOpType {
 
 /// Info about a specific VMGS file.
 #[derive(Debug)]
-#[cfg_attr(feature = "mesh", derive(mesh::MeshPayload))]
+#[cfg_attr(feature = "mesh", derive(mesh_protobuf::Protobuf))]
 pub struct VmgsFileInfo {
     /// Number of bytes allocated in the file.
     pub allocated_bytes: u64,

--- a/vm/vmgs/vmgs_broker/Cargo.toml
+++ b/vm/vmgs/vmgs_broker/Cargo.toml
@@ -15,7 +15,7 @@ encryption_win = ["vmgs/encryption_win"]
 encryption_ossl = ["vmgs/encryption_ossl"]
 
 [dependencies]
-vmgs_format = { workspace = true, features = ["mesh"] }
+vmgs_format.workspace = true
 vmgs_resources.workspace = true
 vmgs = { workspace = true, features = ["inspect", "save_restore", "mesh"] }
 vm_resource.workspace = true

--- a/vm/vmgs/vmgs_broker/src/client.rs
+++ b/vm/vmgs/vmgs_broker/src/client.rs
@@ -30,7 +30,6 @@ pub enum VmgsClientError {
 impl From<RpcError> for VmgsClientError {
     fn from(value: RpcError) -> Self {
         match value {
-            RpcError::Call(_) => unreachable!(),
             RpcError::Channel(e) => VmgsClientError::BrokerOffline(RpcError::Channel(e)),
         }
     }
@@ -58,7 +57,7 @@ impl VmgsClient {
     pub async fn get_file_info(&self, file_id: FileId) -> Result<VmgsFileInfo, VmgsClientError> {
         let res = self
             .control
-            .call_failable(VmgsBrokerRpc::GetFileInfo, file_id)
+            .call_failable(VmgsBrokerRpc::GetFileInfo, file_id.into())
             .await?;
 
         Ok(res)
@@ -69,7 +68,7 @@ impl VmgsClient {
     pub async fn read_file(&self, file_id: FileId) -> Result<Vec<u8>, VmgsClientError> {
         let res = self
             .control
-            .call_failable(VmgsBrokerRpc::ReadFile, file_id)
+            .call_failable(VmgsBrokerRpc::ReadFile, file_id.into())
             .await?;
 
         Ok(res)
@@ -82,7 +81,7 @@ impl VmgsClient {
     #[instrument(skip_all, fields(file_id))]
     pub async fn write_file(&self, file_id: FileId, buf: Vec<u8>) -> Result<(), VmgsClientError> {
         self.control
-            .call_failable(VmgsBrokerRpc::WriteFile, (file_id, buf))
+            .call_failable(VmgsBrokerRpc::WriteFile, (file_id.into(), buf))
             .await?;
 
         Ok(())
@@ -99,7 +98,7 @@ impl VmgsClient {
         buf: Vec<u8>,
     ) -> Result<(), VmgsClientError> {
         self.control
-            .call_failable(VmgsBrokerRpc::WriteFileEncrypted, (file_id, buf))
+            .call_failable(VmgsBrokerRpc::WriteFileEncrypted, (file_id.into(), buf))
             .await?;
 
         Ok(())

--- a/vm/vmgs/vmgs_format/Cargo.toml
+++ b/vm/vmgs/vmgs_format/Cargo.toml
@@ -6,13 +6,9 @@ name = "vmgs_format"
 edition.workspace = true
 rust-version.workspace = true
 
-[features]
-mesh = ["dep:mesh"]
-
 [dependencies]
-inspect = { workspace = true, optional = true }
-mesh = { workspace = true, optional = true }
 open_enum.workspace = true
+inspect = { workspace = true, optional = true }
 
 bitfield-struct.workspace = true
 static_assertions.workspace = true

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -32,7 +32,6 @@ open_enum! {
     /// VMGS fixed file IDs
     #[cfg_attr(feature = "inspect", derive(Inspect))]
     #[cfg_attr(feature = "inspect", inspect(debug))]
-    #[cfg_attr(feature = "mesh", derive(mesh::MeshPayload))]
     pub enum FileId: u32 {
         FILE_TABLE     = 0,
         BIOS_NVRAM     = 1,


### PR DESCRIPTION
As part of my work to support running ChipsetDevices in another process, I ran into needing certain resources to be MeshPayload. The VmgsClient is the second of these.