### PR TITLE
vmm_tests: updating memory validation baselines and re-enabling tests

### DIFF
--- a/vmm_tests/vmm_tests/test_data/memstat_baseline.json
+++ b/vmm_tests/vmm_tests/test_data/memstat_baseline.json
@@ -4,80 +4,80 @@
             "vtl2_total": 524288,
             "2vp": {
                 "usage": {
-                    "base": 59510,
+                    "base": 59928,
                     "threshold": 1024
                 },
                 "reservation": {
-                    "base": 18440,
+                    "base": 30732,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 1171,
+                        "base": 1070,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 290,
+                        "base": 303,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 10775,
+                        "base": 11204,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 1388,
+                        "base": 1346,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 21567,
+                        "base": 22507,
                         "threshold": 1024
                     },
                     "Pss_Anon": {
-                        "base": 4734,
+                        "base": 5447,
                         "threshold": 1024
                     }
                 }
             },
             "64vp": {
                 "usage": {
-                    "base": 118732,
+                    "base": 120011,
                     "threshold": 3072
                 },
                 "reservation": {
-                    "base": 23964,
+                    "base": 56736,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 1173,
+                        "base": 1072,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 3760,
+                        "base": 306,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 10757,
+                        "base": 11203,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 1370,
+                        "base": 1350,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 36105,
+                        "base": 37437,
                         "threshold": 3072
                     },
                     "Pss_Anon": {
-                        "base": 16976,
+                        "base": 18076,
                         "threshold": 3072
                     }
                 }
@@ -87,80 +87,80 @@
             "vtl2_total": 524288,
             "2vp": {
                 "usage": {
-                    "base": 232418,
+                    "base": 232210,
                     "threshold": 1024
                 },
                 "reservation": {
-                    "base": 17668,
+                    "base": 30044,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 4553,
+                        "base": 4635,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 3767,
+                        "base": 3857,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 16541,
+                        "base": 15191,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 4824,
+                        "base": 4897,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 32801,
+                        "base": 30455,
                         "threshold": 1024
                     },
                     "Pss_Anon": {
-                        "base": 8951,
+                        "base": 9526,
                         "threshold": 1024
                     }
                 }
             },
             "32vp": {
                 "usage": {
-                    "base": 255386,
+                    "base": 253692,
                     "threshold": 3072
                 },
                 "reservation": {
-                    "base": 24668,
+                    "base": 49328,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 4543,
+                        "base": 4627,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 3767,
+                        "base": 3850,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 16116,
+                        "base": 15036,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 4811,
+                        "base": 4861,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 41883,
+                        "base": 39073,
                         "threshold": 3072
                     },
                     "Pss_Anon": {
-                        "base": 16628,
+                        "base": 17252,
                         "threshold": 3072
                     }
                 }
@@ -170,80 +170,80 @@
             "vtl2_total": 655360,
             "2vp": {
                 "usage": {
-                    "base": 231175,
+                    "base": 237570,
                     "threshold": 1024
                 },
                 "reservation": {
-                    "base": 29036,
+                    "base": 29052,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 4525,
+                        "base": 4609,
                         "threshold":512
                     },
                     "Pss_Anon": {
-                        "base": 3760,
+                        "base": 3851,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 14940,
+                        "base": 15090,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 4774,
+                        "base": 4872,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 29554,
+                        "base": 36284,
                         "threshold": 1024
                     },
                     "Pss_Anon": {
-                        "base": 9312,
+                        "base": 15481,
                         "threshold": 1024
                     }
                 }
             },
             "64vp": {
                 "usage": {
-                    "base": 307455,
+                    "base": 314922,
                     "threshold": 3072
                 },
                 "reservation": {
-                    "base": 41764,
+                    "base": 41780,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 4530,
+                        "base": 4604,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 3755,
+                        "base": 3848,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 14933,
+                        "base": 15014,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 4798,
+                        "base": 4878,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 58375,
+                        "base": 66907,
                         "threshold": 3072
                     },
                     "Pss_Anon": {
-                        "base": 35983,
+                        "base": 43592,
                         "threshold": 3072
                     }
                 }
@@ -253,80 +253,80 @@
             "vtl2_total": 655360,
             "2vp": {
                 "usage": {
-                    "base": 233704,
+                    "base": 237356,
                     "threshold": 1024
                 },
                 "reservation": {
-                    "base": 28972,
+                    "base": 28976,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 4516,
+                        "base": 4602,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 3760,
+                        "base": 3846,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 15061,
+                        "base": 15036,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 4799,
+                        "base": 4856,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 31812,
+                        "base": 36163,
                         "threshold": 1024
                     },
                     "Pss_Anon": {
-                        "base": 11730,
+                        "base": 15216,
                         "threshold": 1024
                     }
                 }
             },
             "64vp": {
                 "usage": {
-                    "base": 310880,
+                    "base": 314924,
                     "threshold": 3072
                 },
                 "reservation": {
-                    "base": 42440,
+                    "base": 42448,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 4514,
+                        "base": 4618,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 3759,
+                        "base": 3844,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 14992,
+                        "base": 15011,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 4787,
+                        "base": 4864,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 57297,
+                        "base": 61570,
                         "threshold": 3072
                     },
                     "Pss_Anon": {
-                        "base": 34598,
+                        "base": 38098,
                         "threshold": 3072
                     }
                 }
@@ -338,80 +338,80 @@
             "vtl2_total": 524288,
             "2vp": {
                 "usage": {
-                    "base": 32768,
+                    "base": 32176,
                     "threshold": 1024
                 },
                 "reservation": {
-                    "base": 18360,
+                    "base": 34828,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 1214,
+                        "base": 1187,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 283,
+                        "base": 302,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 3815,
+                        "base": 4073,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 1164,
+                        "base": 1168,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 9906,
+                        "base": 10623,
                         "threshold": 1024
                     },
                     "Pss_Anon": {
-                        "base": 3153,
+                        "base": 3760,
                         "threshold": 1024
                     }
                 }
             },
             "64vp": {
                 "usage": {
-                    "base": 89076,
+                    "base": 88612,
                     "threshold": 3072
                 },
                 "reservation": {
-                    "base": 23884,
+                    "base": 58784,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 1222,
+                        "base": 1177,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 288,
+                        "base": 292,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 3806,
+                        "base": 4044,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 1176,
+                        "base": 1171,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 21768,
+                        "base": 22275,
                         "threshold": 3072
                     },
                     "Pss_Anon": {
-                        "base": 12767,
+                        "base": 13156,
                         "threshold": 3072
                     }
                 }
@@ -421,80 +421,80 @@
             "vtl2_total": 524288,
             "2vp": {
                 "usage": {
-                    "base": 40562,
+                    "base": 39482,
                     "threshold": 1024
                 },
                 "reservation": {
-                    "base": 17644,
+                    "base": 34116,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 2719,
+                        "base": 2676,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 1716,
+                        "base": 1658,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 5212,
+                        "base": 5404,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 2564,
+                        "base": 2538,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 13096,
+                        "base": 13208,
                         "threshold": 1024
                     },
                     "Pss_Anon": {
-                        "base": 5283,
+                        "base": 5572,
                         "threshold": 1024
                     }
                 }
             },
             "32vp": {
                 "usage": {
-                    "base": 60320,
+                    "base": 58929,
                     "threshold": 3072
                 },
                 "reservation": {
-                    "base": 24644,
+                    "base": 65688,
                     "threshold": 512
                 },
                 "underhill_init": {
                     "Pss": {
-                        "base": 2723,
+                        "base": 2659,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 1711,
+                        "base": 1658,
                         "threshold": 512
                     }
                 },
                 "openvmm_hcl": {
                     "Pss": {
-                        "base": 5242,
+                        "base": 5305,
                         "threshold": 512
                     },
                     "Pss_Anon": {
-                        "base": 2574,
+                        "base": 2488,
                         "threshold": 512
                     }
                 },
                 "underhill_vm": {
                     "Pss": {
-                        "base": 19046,
+                        "base": 19567,
                         "threshold": 3072
                     },
                     "Pss_Anon": {
-                        "base": 10448,
+                        "base": 11003,
                         "threshold": 3072
                     }
                 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -461,8 +461,7 @@ async fn memory_validation_release_small<T: PetriVmmBackend>(
         WaitPeriodSec::ShortWait,
         driver,
         "release",
-        // Disabling test for now to investigate higher memory usage on intel GP and intel TDX tests
-        false,
+        true,
     )
     .await
 }
@@ -488,8 +487,7 @@ async fn memory_validation_debug_small<T: PetriVmmBackend>(
         WaitPeriodSec::ShortWait,
         driver,
         "debug",
-        // Disabling test for now to investigate higher memory usage on intel GP and intel TDX tests
-        false,
+        true,
     )
     .await
 }
@@ -511,8 +509,7 @@ async fn memory_validation_release_very_heavy<T: PetriVmmBackend>(
         WaitPeriodSec::LongWait,
         driver,
         "release",
-        // Disabling test for now to investigate higher memory usage on intel GP and intel TDX tests
-        false,
+        true,
     )
     .await
 }
@@ -538,8 +535,7 @@ async fn memory_validation_debug_very_heavy<T: PetriVmmBackend>(
         WaitPeriodSec::LongWait,
         driver,
         "debug",
-        // Disabling test for now to investigate higher memory usage on intel GP and intel TDX tests
-        false,
+        true,
     )
     .await
 }


### PR DESCRIPTION
To re-enable memory validation checks, baseline values have been updated to pass for the memory usage of current underhill builds.

Changes:
- Updated all memory validation baselines to pass for the latest memory usage
- Enable memory validation checks in the CI/CD pipeline