### PR TITLE
flowey: remove echo for bootstrap flowey

### DIFF
--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -159,12 +159,6 @@ pub fn ado_yaml(
                 serde_yaml::from_str(&ado_bootstrap_template)
                     .context("malformed flowey bootstrap template")?;
 
-            ado_steps.push({
-                let mut map = serde_yaml::Mapping::new();
-                map.insert("bash".into(), "echo \"injected!\"".into());
-                map.insert("displayName".into(), "🌼🥾 Bootstrap flowey".into());
-                map.into()
-            });
             ado_steps.extend(bootstrap_steps);
         }
 


### PR DESCRIPTION
This echo isn't adding anything valuable and is actually causing some issues with our internal ADO pipelines. For some additional context we have some Windows CI images that do not have the `bash.exe` in the path, which makes this task fail. I'm working on getting those images fixed, but in the meantime, this will allow the bootstrapping to succeed on these images.