### PR TITLE
petri/pipette: extend timeout for connect to workaround windows vmbus bug

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -770,7 +770,7 @@ impl PetriVmRuntime for HyperVPetriRuntime {
             // system.
             //
             // TODO: Until #2470 is fixed, extend the timeout even longer to 10
-            // seconds workaround a Windows vmbus bug.
+            // seconds to workaround a Windows vmbus bug.
             socket
                 .set_connect_timeout(Duration::from_secs(10))
                 .context("failed to set connect timeout")?;


### PR DESCRIPTION
On CVMs, there's a Windows guest bug where a revoked hvsock with a listener inside the guest will cause a crash. Until this bug is fixed in public builds, attempt to workaround the issue by extending the connection time to allow the guest to boot and the agent to start listening. 

If this still doesn't work, we may need to try a slightly different strategy. See #2470. 