### PR TITLE
petri/pipette: extend timeout for connect to workaround windows vmbus bug (#2485)

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -765,10 +765,14 @@ impl PetriVmRuntime for HyperVPetriRuntime {
     async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient> {
         let client_core = async || {
             let socket = VmSocket::new().context("failed to create AF_HYPERV socket")?;
-            // Extend the default timeout of 2 seconds, as tests are often run in
-            // parallel on a host, causing very heavy load on the overall system.
+            // Extend the default timeout of 2 seconds, as tests are often run
+            // in parallel on a host, causing very heavy load on the overall
+            // system.
+            //
+            // TODO: Until #2470 is fixed, extend the timeout even longer to 10
+            // seconds to workaround a Windows vmbus bug.
             socket
-                .set_connect_timeout(Duration::from_secs(5))
+                .set_connect_timeout(Duration::from_secs(10))
                 .context("failed to set connect timeout")?;
             socket
                 .set_high_vtl(set_high_vtl)


### PR DESCRIPTION
On CVMs, there's a Windows guest bug where a revoked hvsock with a listener inside the guest will cause a crash. Until this bug is fixed in public builds, attempt to workaround the issue by extending the connection time to allow the guest to boot and the agent to start listening.

If this still doesn't work, we may need to try a slightly different strategy. See #2470.

Clean cherry pick of #2485