### PR TITLE
flowey: remove bootstrap flowey echo

### DIFF
--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -159,12 +159,6 @@ pub fn ado_yaml(
                 serde_yaml::from_str(&ado_bootstrap_template)
                     .context("malformed flowey bootstrap template")?;
 
-            ado_steps.push({
-                let mut map = serde_yaml::Mapping::new();
-                map.insert("bash".into(), "echo \"injected!\"".into());
-                map.insert("displayName".into(), "🌼🥾 Bootstrap flowey".into());
-                map.into()
-            });
             ado_steps.extend(bootstrap_steps);
         }
 


### PR DESCRIPTION
This change removes these problematic "bash echo" events which are preventing our ADO pipelines from migrating to the WS2022 image.