### PR TITLE
user_driver: backoff 250ms in set_keep_alive, just like open_device (#2480)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8329,6 +8329,7 @@ dependencies = [
  "bitfield-struct 0.11.0",
  "libc",
  "nix 0.30.1",
+ "pal_async",
  "tracing",
  "vfio-bindings",
 ]

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -130,13 +130,14 @@ impl VfioDevice {
             anyhow::bail!("group is not viable");
         }
 
+        let driver = driver_source.simple();
         container.set_iommu(IommuType::NoIommu)?;
         if keepalive {
             // Prevent physical hardware interaction when restoring.
-            group.set_keep_alive(pci_id)?;
+            group.set_keep_alive(pci_id, &driver).await?;
         }
         tracing::debug!(pci_id, "about to open device");
-        let device = group.open_device(pci_id)?;
+        let device = group.open_device(pci_id, &driver).await?;
         let msix_info = device.irq_info(vfio_bindings::bindings::vfio::VFIO_PCI_MSIX_IRQ_INDEX)?;
         if msix_info.flags.noresize() {
             anyhow::bail!("unsupported: kernel does not support dynamic msix allocation");

--- a/vm/devices/user_driver/vfio_sys/Cargo.toml
+++ b/vm/devices/user_driver/vfio_sys/Cargo.toml
@@ -7,6 +7,8 @@ edition.workspace = true
 rust-version.workspace = true
 
 [target.'cfg(unix)'.dependencies]
+pal_async.workspace = true
+
 anyhow.workspace = true
 bitfield-struct.workspace = true
 libc.workspace = true

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -9,6 +9,8 @@
 use anyhow::Context;
 use bitfield_struct::bitfield;
 use libc::c_void;
+use pal_async::driver::Driver;
+use pal_async::timer::PolledTimer;
 use std::ffi::CString;
 use std::fs;
 use std::fs::File;
@@ -149,7 +151,11 @@ impl Group {
         Ok(group)
     }
 
-    pub fn open_device(&self, device_id: &str) -> anyhow::Result<Device> {
+    pub async fn open_device(
+        &self,
+        device_id: &str,
+        driver: &(impl ?Sized + Driver),
+    ) -> anyhow::Result<Device> {
         let id = CString::new(device_id)?;
         // SAFETY: The file descriptor is valid and the string is null-terminated.
         let file = unsafe {
@@ -160,8 +166,10 @@ impl Group {
             // sleep.
             let fd = match fd {
                 Err(nix::errno::Errno::ENODEV) => {
-                    std::thread::sleep(std::time::Duration::from_millis(250));
-                    tracing::warn!("Retrying vfio open_device after delay");
+                    tracing::warn!(pci_id = device_id, "Retrying vfio open_device after delay");
+                    PolledTimer::new(driver)
+                        .sleep(std::time::Duration::from_millis(250))
+                        .await;
                     ioctl::vfio_group_get_device_fd(self.file.as_raw_fd(), id.as_ptr())
                 }
                 _ => fd,
@@ -198,14 +206,40 @@ impl Group {
     /// Skip VFIO device reset when kernel is reloaded during servicing.
     /// This feature is non-upstream version of our kernel and will be
     /// eventually replaced with iommufd.
-    pub fn set_keep_alive(&self, device_id: &str) -> anyhow::Result<()> {
+    pub async fn set_keep_alive(
+        &self,
+        device_id: &str,
+        driver: &(impl ?Sized + Driver),
+    ) -> anyhow::Result<()> {
         // SAFETY: The file descriptor is valid and a correctly constructed struct is being passed.
         unsafe {
-            let id = CString::new(device_id.to_owned())?;
-            ioctl::vfio_group_set_keep_alive(self.file.as_raw_fd(), id.as_ptr())
-                .with_context(|| format!("failed to set keep-alive for device {device_id}"))?;
+            let id = CString::new(device_id)?;
+            let r = ioctl::vfio_group_set_keep_alive(self.file.as_raw_fd(), id.as_ptr());
+            match r {
+                Ok(_) => Ok(()),
+                Err(nix::errno::Errno::ENODEV) => {
+                    // There is a small race window in the kernel between when the
+                    // vfio device is visible to userspace, and when it is added to its
+                    // internal list. Try one more time on ENODEV failure after a brief
+                    // sleep.
+                    tracing::warn!(
+                        pci_id = device_id,
+                        "vfio keepalive got ENODEV, retrying after delay"
+                    );
+                    PolledTimer::new(driver)
+                        .sleep(std::time::Duration::from_millis(250))
+                        .await;
+                    ioctl::vfio_group_set_keep_alive(self.file.as_raw_fd(), id.as_ptr())
+                        .with_context(|| {
+                            format!("failed to set keep-alive after delay for {device_id}")
+                        })
+                        .map(|_| ())
+                }
+                Err(_) => r
+                    .with_context(|| format!("failed to set keep-alive for {device_id}"))
+                    .map(|_| ()),
+            }
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
VFIO's `open_device` method already waits 250ms when it sees `ENODEV`. Since `set_keep_alive` is called before `open_device`, it stands to reason that `set_keep_alive` would be impacted by the same race condition. So, add the same 250ms backoff.

This also changes the sleep in `open_device` from one that will block the executor to one that will allow other async tasks to continue. Hopefully this lessens the impact on overall VM startup or restore in these degenerate cases.

Clean cherry pick of #2480 