### PR TITLE
Keep requested subchannels below maximum queue limit and add subchannel request error logging (#2492)

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -5403,19 +5403,12 @@ impl<T: 'static + RingMem> NetChannel<T> {
                         subchannel_count = request.num_sub_channels;
                         protocol::Status::SUCCESS
                     } else {
-                        if request.operation != protocol::SubchannelOperation::ALLOCATE {
-                            tracelimit::warn_ratelimited!(
-                                operation = ?request.operation,
-                                "Unsupported subchannel operation"
-                            );
-                        } else {
-                            tracelimit::warn_ratelimited!(
-                                operation = ?request.operation,
-                                request_sub_channels = request.num_sub_channels,
-                                max_supported_sub_channels = self.adapter.max_queues - 1,
-                                "Subchannel request failed: requested more subchannels than supported"
-                            );
-                        }
+                        tracelimit::warn_ratelimited!(
+                            operation = ?request.operation,
+                            request_sub_channels = request.num_sub_channels,
+                            max_supported_sub_channels = self.adapter.max_queues - 1,
+                            "Subchannel request failed: either operation is not supported or requested more subchannels than supported"
+                        );
                         protocol::Status::FAILURE
                     };
 


### PR DESCRIPTION
The number of requested subchannels has to stay below the maximum queue limit because one queue is always reserved for the primary channel. In other words, the subchannels plus the primary channel must fit within the max_queues value, which means subchannels + 1 ≤ max_queues, so the subchannel count must be strictly less than max_queues.

Test result:

Running: Set-NetAdapterRss -Name "Ethernet" -MaxProcessorNumber 32
produced the following warning:
[4.903119] netvsp: WARN Subchannel request failed: request operation ALLOCATE, requested 32 subchannels, the maximum number of supported subchannels is 31

Running: Set-NetAdapterRss -Name "Ethernet" -MaxProcessorNumber 63
produced the following warning:
[584.376225] netvsp: WARN Subchannel request failed: request operation ALLOCATE, requested 47 subchannels, the maximum number of supported subchannels is 31
Note: 48 is the maximum processors in a single CPU group, so netcsv trimmed 63 down to 47.

Running: Set-NetAdapterRss -Name "Ethernet" -MaxProcessorNumber 31
produced no log output.

Running: Set-NetAdapterRss -Name "Ethernet" -MaxProcessorNumber 15
produced no log output.