### PR TITLE
Renew AKCert if platform-defined and vTPM blob is 32k (#2316)

### DIFF
--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -156,8 +156,9 @@ open_enum! {
 pub struct ManagementVtlFeatures {
     pub strict_encryption_policy: bool,
     pub _reserved1: bool,
+    pub control_ak_cert_provisioning: bool,
     pub attempt_ak_cert_callback: bool,
-    #[bits(61)]
+    #[bits(60)]
     pub _reserved2: u64,
 }
 

--- a/vm/devices/tpm/tpm_device/src/lib.rs
+++ b/vm/devices/tpm/tpm_device/src/lib.rs
@@ -16,6 +16,7 @@ pub mod ak_cert;
 pub mod logger;
 mod recover;
 pub mod resolver;
+use tpm_lib::AllocateNvIndicesParams;
 use tpm_lib::CommandDebugInfo;
 use tpm_lib::TpmCommandError;
 use tpm_lib::TpmEngine;
@@ -95,8 +96,11 @@ const AK_CERT_RENEW_PERIOD: std::time::Duration = std::time::Duration::new(24 * 
 // 2 seconds
 const REPORT_TIMER_PERIOD: std::time::Duration = std::time::Duration::new(2, 0);
 
-// 16kB: vtpmservice provisions a 16kB blob for the vTPM; HCL/OpenHCL provisions a 32k blob
-const LEGACY_VTPM_SIZE: usize = 16384;
+// 16kB and 32kB: These are the sizes of the blob that gets provisioned for the
+// vTPM state. vtpmservice provisions a 16kB blob; HCL/OpenHCL provision a 32kB
+// blob.
+const LEGACY_VTPM_SIZE: usize = 16 * 1024;
+const STANDARD_VTPM_SIZE: usize = 32 * 1024;
 
 /// Operation types for provisioning telemetry.
 #[expect(clippy::enum_variant_names)]
@@ -259,6 +263,7 @@ pub struct Tpm {
     #[inspect(skip)]
     mmio_region: Vec<(&'static str, RangeInclusive<u64>)>,
     allow_ak_cert_renewal: bool,
+    handle_ak_cert_renewal: bool,
 
     // For logging
     bios_guid: Guid,
@@ -331,8 +336,6 @@ pub enum TpmErrorKind {
     CreateAkPublic(#[source] tpm_lib::Error),
     #[error("failed to create ek public")]
     CreateEkPublic(#[source] tpm_lib::Error),
-    #[error("failed to allocate guest attestation nv indices")]
-    AllocateGuestAttestationNvIndices(#[source] tpm_lib::Error),
     #[error("failed to read from nv index")]
     ReadFromNvIndex(#[source] tpm_lib::Error),
     #[error("failed to write to nv index")]
@@ -437,6 +440,7 @@ impl Tpm {
             io_region,
             mmio_region,
             allow_ak_cert_renewal: false,
+            handle_ak_cert_renewal: false,
             bios_guid,
             ak_pub_hash: [0; SHA_256_OUTPUT_SIZE_BYTES],
 
@@ -494,12 +498,15 @@ impl Tpm {
         is_confidential_vm: bool,
     ) -> Result<(), TpmError> {
         use ms_tpm_20_ref::NvError;
-        let mut force_ak_regen = false;
-        let fixup_16k_ak_cert;
+        struct TpmQuirks {
+            force_ak_regen: bool,
+            large_vtpm_blob: bool,
+            fixup_16k_ak_cert: bool,
+        }
 
-        // Check whether or not we need to pave-over the blank TPM with our
-        // existing nvmem state.
-        {
+        let quirks = {
+            // Check whether or not we need to pave-over the blank TPM with our
+            // existing nvmem state.
             let existing_nvmem_blob = (self.rt.nvram_store)
                 .restore()
                 .await
@@ -527,19 +534,37 @@ impl Tpm {
                     return Err(TpmErrorKind::ResetTpmWithState(e).into());
                 }
 
-                // If this is a confidential VM or has a vTPM blob size that indicates that it was
-                // HCL-provisioned, regenerate the AK from TPM seeds. This prevents an attack where
-                // the VTL0 admin can replace the AK and get an AKCert for it.
-                force_ak_regen =
-                    self.refresh_tpm_seeds || blob.len() != LEGACY_VTPM_SIZE || is_confidential_vm;
+                TpmQuirks {
+                    // If this is a confidential VM or has a vTPM blob size that indicates that it was
+                    // HCL-provisioned, regenerate the AK from TPM seeds. This prevents an attack where
+                    // the VTL0 admin can replace the AK and get an AKCert for it.
+                    force_ak_regen: self.refresh_tpm_seeds
+                        || blob.len() != LEGACY_VTPM_SIZE
+                        || is_confidential_vm,
 
-                // If this is a small vTPM blob, potentially fixup the AK cert.
-                fixup_16k_ak_cert = blob.len() == LEGACY_VTPM_SIZE;
+                    // If this is a small vTPM blob, potentially fixup the AK cert.
+                    fixup_16k_ak_cert: blob.len() == LEGACY_VTPM_SIZE,
+
+                    large_vtpm_blob: blob.len() >= STANDARD_VTPM_SIZE,
+                }
             } else {
-                // No fixup is required, because there is no existing NVRAM blob.
-                fixup_16k_ak_cert = false;
+                TpmQuirks {
+                    // Don't need to force-regen the AK if there is no existing NVRAM.
+                    force_ak_regen: false,
+                    // No fixup is required, because there is no existing NVRAM blob.
+                    fixup_16k_ak_cert: false,
+                    // This is a brand-new vTPM and will get provisioned with at
+                    // least 32kB of storage.
+                    large_vtpm_blob: true,
+                }
             }
-        }
+        };
+
+        let TpmQuirks {
+            force_ak_regen,
+            fixup_16k_ak_cert,
+            large_vtpm_blob,
+        } = quirks;
 
         self.tpm_engine_helper
             .initialize_tpm_engine()
@@ -692,18 +717,50 @@ impl Tpm {
             // `TPM_RC_HIERARCHY` (0c0290285) error code would return.
             // It means the Nvram index space needs to be allocated before clearing the
             // tpm hierarchy control. NV index value can be rewritten later.
-            self.tpm_engine_helper
+            if let Err(e) = self
+                .tpm_engine_helper
                 .allocate_guest_attestation_nv_indices(
                     auth_value,
-                    !self.refresh_tpm_seeds, // Preserve AK cert if TPM seeds are not refreshed
-                    self.ak_cert_type.attested(),
-                    fixup_16k_ak_cert,
+                    AllocateNvIndicesParams {
+                        preserve_ak_cert: !self.refresh_tpm_seeds, // Preserve AK cert if TPM seeds are not refreshed
+                        support_attestation_report: self.ak_cert_type.attested(),
+                        mitigate_legacy_akcert: fixup_16k_ak_cert,
+                        create_if_missing: large_vtpm_blob,
+                    },
                 )
-                .map_err(TpmErrorKind::AllocateGuestAttestationNvIndices)?;
+            {
+                tracing::error!(
+                    CVM_ALLOWED,
+                    err = &e as &dyn std::error::Error,
+                    "error defining guest attestation NV indices"
+                );
+            }
 
-            // Initialize `TPM_NV_INDEX_AIK_CERT` if `ak_cert_type` requires AK cert and the cert is not pre-provisioned.
-            if !matches!(self.ak_cert_type, TpmAkCertType::TrustedPreProvisionedOnly) {
+            // Determine whether OpenHCL should handle renewing the AKCert.
+            self.handle_ak_cert_renewal = match self.ak_cert_type {
+                TpmAkCertType::Trusted(_, Some(should_handle)) => {
+                    // If TpmAkCertType::Trusted has the optional bool that
+                    // controls AKCert renewal, follow that.
+                    should_handle
+                }
+                TpmAkCertType::Trusted(_, _) => {
+                    // Otherwise, if the existing AKCert index is platform-
+                    // defined and this appears to be an HCL-provisioned
+                    // vTPM, then handle AKCert renewal from OpenHCL.
+                    self.tpm_engine_helper.has_platform_akcert_index() && large_vtpm_blob
+                }
+                // If there's no AKCert, then don't handle renewal.
+                TpmAkCertType::None => false,
+                // If TpmAkCertType is one that should always be handled by
+                // OpenHCL, then handle AKCert renewal.
+                TpmAkCertType::HwAttested(_) | TpmAkCertType::SwAttested(_) => true,
+            };
+
+            if self.handle_ak_cert_renewal {
+                tracing::info!(CVM_ALLOWED, "handling AKCert renewal");
                 self.get_ak_cert(false)?;
+            } else {
+                tracing::info!(CVM_ALLOWED, "will not handle AKCert renewal");
             }
 
             // Initialize `TPM_NV_INDEX_ATTESTATION_REPORT` if `ak_cert_type` supports attestation
@@ -1460,12 +1517,7 @@ impl MmioIntercept for Tpm {
                         "executing guest tpm cmd",
                     );
 
-                    if matches!(
-                        self.ak_cert_type,
-                        TpmAkCertType::Trusted(_)
-                            | TpmAkCertType::HwAttested(_)
-                            | TpmAkCertType::SwAttested(_)
-                    ) {
+                    if self.handle_ak_cert_renewal {
                         if let Some(CommandCodeEnum::NV_Read) = cmd_header {
                             self.refresh_device_attestation_data_on_nv_read()
                         }
@@ -2015,7 +2067,7 @@ mod tests {
             monotonic_timer,
             false,
             false,
-            TpmAkCertType::Trusted(Arc::new(TestRequestAkCertHelper)),
+            TpmAkCertType::Trusted(Arc::new(TestRequestAkCertHelper), Some(true)),
             None,
             None,
             false,

--- a/vm/devices/tpm/tpm_device/src/resolver.rs
+++ b/vm/devices/tpm/tpm_device/src/resolver.rs
@@ -79,16 +79,14 @@ impl AsyncResolveResource<ChipsetDeviceHandleKind, TpmDeviceHandle> for TpmDevic
                     .map_err(ResolveTpmError::ResolveRequestAkCert)?
                     .0,
             ),
-            TpmAkCertTypeResource::Trusted(request_ak_cert) => TpmAkCertType::Trusted(
+            TpmAkCertTypeResource::Trusted(request_ak_cert, handle) => TpmAkCertType::Trusted(
                 resolver
                     .resolve(request_ak_cert, &())
                     .await
                     .map_err(ResolveTpmError::ResolveRequestAkCert)?
                     .0,
+                handle,
             ),
-            TpmAkCertTypeResource::TrustedPreProvisionedOnly => {
-                TpmAkCertType::TrustedPreProvisionedOnly
-            }
             TpmAkCertTypeResource::None => TpmAkCertType::None,
         };
 

--- a/vm/devices/tpm_resources/src/lib.rs
+++ b/vm/devices/tpm_resources/src/lib.rs
@@ -53,12 +53,10 @@ impl ResourceKind for RequestAkCertKind {
 pub enum TpmAkCertTypeResource {
     /// No Ak cert.
     None,
-    /// Expects an AK cert that is not hardware-attested
-    /// to be pre-provisioned. Used by TVM
-    TrustedPreProvisionedOnly,
-    /// Authorized AK cert that is not hardware-attested.
+    /// Authorized AK cert that is not hardware-attested. Optional bool controls
+    /// whether OpenHCL handles renewal.
     /// Used by TVM
-    Trusted(Resource<RequestAkCertKind>),
+    Trusted(Resource<RequestAkCertKind>, Option<bool>),
     /// Authorized and hardware-attested AK cert (backed by
     /// a TEE attestation report).
     /// Used by CVM

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/tpm.rs
@@ -198,7 +198,6 @@ async fn tpm_ak_cert_persisted<T>(
 ) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
     let config = config
-        .with_openhcl_command_line("HCL_ATTEMPT_AK_CERT_CALLBACK=1")
         .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
         .modify_backend(|b| {
             b.with_tpm()
@@ -263,7 +262,6 @@ async fn tpm_ak_cert_retry<T>(
 ) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
     let config = config
-        .with_openhcl_command_line("HCL_ATTEMPT_AK_CERT_CALLBACK=1")
         .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
         .modify_backend(|b| {
             b.with_tpm()


### PR DESCRIPTION
HCL-provisioned vTPMs have a platform-defined AKCert index and the AKCert has to be renewed by OpenHCL. We were planning on using control flags (see, e.g., PR #2036) to control whether OpenHCL will renew the AKCert, but it needs to run on older host OS versions that don't support these flags.

As an alternative, we can detect that the existing vTPM has a platform-defined AKCert index and is 32kB in size, which indicates that the vTPM was provisioned by HCL and that OpenHCL should handle renewing the AKCert.

This change also adds handling for a power-fail-robustness case, where the VM comes up without an AKCert index at all. In that case, HCL should try to create it if the vTPM is at least 32kB.