### PR TITLE
CI: Grant the unsafe check workflow issue write permissions

### DIFF
--- a/.github/workflows/unsafe-label.yml
+++ b/.github/workflows/unsafe-label.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   check-unsafe:


### PR DESCRIPTION
This should fix the new error it's hitting. Don't you love only being able to test in production?