### PR TITLE
CI: Fully fix the unsafe check by going back to pull_request_target and rewriting

### DIFF
--- a/.github/workflows/unsafe-label.yml
+++ b/.github/workflows/unsafe-label.yml
@@ -8,8 +8,7 @@ name: "Unsafe Check"
 # This eliminates filesystem-based attacks (symlinks, large files, race conditions)
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request_target
 
 permissions:
   contents: read


### PR DESCRIPTION
Was hoping this wouldn't be necessary, as it allows more permissions than we'd like, but it seems to be the only way to really have write access to make comments and modify labels. Rewrite the script to fetch content via github's API, instead of checking out to the filesystem, to avoid any filesystem-based attacks.