### PR TITLE
nvme_driver: additional instrumentation in the nvme driver save path

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -648,8 +648,8 @@ impl<T: DeviceBacking> NvmeDriver<T> {
                 tracing::info!(
                     namespaces = self
                         .namespaces
-                        .iter()
-                        .map(|(nsid, _)| nsid.to_string())
+                        .keys()
+                        .map(|nsid| nsid.to_string())
                         .collect::<Vec<_>>()
                         .join(", "),
                     "saving namespaces",


### PR DESCRIPTION
In production tests I see that entering `nvme_driver_save` is the last span before a save timeout. It is a mystery to me why this would hang. Add some additional logs to help parse through why. Since I wish for these logs in my tests, I think they should go into mainline.
