### PR TITLE
Rename pub_key field in telemetry (#2503)

### DIFF
--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -634,7 +634,7 @@ impl Tpm {
                 op_type = ?LogOpType::VtpmKeysProvision,
                 key_type = ?KeyType::AkPub,
                 bios_guid = %self.bios_guid,
-                akpub_hash = self.ak_pub_str(),
+                ak_pub_hash = self.ak_pub_str(),
                 success = true,
                 latency = std::time::SystemTime::now()
                     .duration_since(start_time)
@@ -1016,7 +1016,7 @@ impl Tpm {
             CVM_ALLOWED,
             op_type = ?LogOpType::BeginAkCertProvision,
             is_renew,
-            akpub_hash = self.ak_pub_str(),
+            ak_pub_hash = self.ak_pub_str(),
             bios_guid = %self.bios_guid,
             "Request AK cert renewal"
         );
@@ -1084,7 +1084,7 @@ impl Tpm {
                             CVM_ALLOWED,
                             op_type = ?LogOpType::AkCertProvision,
                             bios_guid = %self.bios_guid,
-                            akpub_hash = self.ak_pub_str(),
+                            ak_pub_hash = self.ak_pub_str(),
                             is_renew,
                             got_cert = 0,
                             latency = latency.map_or(0, |d| d.as_millis()),
@@ -1105,7 +1105,7 @@ impl Tpm {
                             CVM_ALLOWED,
                             op_type = ?LogOpType::AkCertProvision,
                             bios_guid = %self.bios_guid,
-                            akpub_hash = self.ak_pub_str(),
+                            ak_pub_hash = self.ak_pub_str(),
                             is_renew,
                             got_cert = 0,
                             latency = latency.map_or(0, |d| d.as_millis()),
@@ -1141,7 +1141,7 @@ impl Tpm {
                     CVM_ALLOWED,
                     op_type = ?LogOpType::AkCertProvision,
                     bios_guid = %self.bios_guid,
-                    akpub_hash = self.ak_pub_str(),
+                    ak_pub_hash = self.ak_pub_str(),
                     is_renew,
                     got_cert = 1,
                     size = response.len(),


### PR DESCRIPTION
The pub_key field in the OpenHCL telemetry is raising false-positive alerts for credential disclosure. Rename it to something that won't trigger alerts.