### PR TITLE
vmm_tests: disabling memory validation assertions on 1.7 release builds while internal repo filter is in progress

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -461,7 +461,8 @@ async fn memory_validation_release_small<T: PetriVmmBackend>(
         WaitPeriodSec::ShortWait,
         driver,
         "release",
-        true,
+        // Disabling release assertions on small VM test while internal repo filter is in progress
+        false,
     )
     .await
 }
@@ -509,7 +510,8 @@ async fn memory_validation_release_very_heavy<T: PetriVmmBackend>(
         WaitPeriodSec::LongWait,
         driver,
         "release",
-        true,
+        // Disabling release assertions on heavy VM test while internal repo filter is in progress
+        false,
     )
     .await
 }


### PR DESCRIPTION
Description:
Due to additional overhead in internal repository builds, an additional filter needs to be applied to the memory validation tests so that baseline values are strictly compared to their corresponding build. While this is being worked on, assertions will be disabled for release builds to unblock PRs in the internal repository.

Changes:
- Disable assertions on small VM release memory validation test
- Disable assertions on large VM release memory validation test