### PR TITLE
mana: return early in save() when there are no endpoints

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -133,7 +133,7 @@ pub trait LoadedVmNetworkSettings: Inspect {
     ) -> anyhow::Result<PacketCaptureParams<Socket>>;
 
     /// Save the network state for restoration after servicing.
-    async fn save(&mut self) -> Vec<ManaSavedState>;
+    async fn save(&mut self) -> Option<Vec<ManaSavedState>>;
 }
 
 /// A VM that has been loaded and can be run.
@@ -815,7 +815,7 @@ impl LoadedVm {
         let mana_state = if let Some(network_settings) = &mut self.network_settings
             && mana_keepalive_mode.is_enabled()
         {
-            Some(network_settings.save().await)
+            network_settings.save().await
         } else {
             None
         };

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1061,9 +1061,15 @@ impl LoadedVmNetworkSettings for UhVmNetworkSettings {
         Ok(params)
     }
 
-    async fn save(&mut self) -> Vec<ManaSavedState> {
+    async fn save(&mut self) -> Option<Vec<ManaSavedState>> {
         let mut vf_managers: Vec<(Guid, Arc<HclNetworkVFManager>)> =
             self.vf_managers.drain().collect();
+
+        // Nothing to save
+        if vf_managers.is_empty() {
+            return None;
+        }
+
         let (vf_managers, mut nic_channels) = self.begin_vf_teardown(&mut vf_managers, false);
 
         let mut endpoints: Vec<_> =
@@ -1097,7 +1103,7 @@ impl LoadedVmNetworkSettings for UhVmNetworkSettings {
         let state = (run_endpoints, save_vf_managers).race().await;
 
         // Discard any vf_managers that failed to return valid save state.
-        state.into_iter().flatten().collect()
+        Some(state.into_iter().flatten().collect())
     }
 }
 


### PR DESCRIPTION
#2461 found a bug in MANA's keepalive implementation, where we can race on an empty collection which results in a divide by zero in futures-concurrency. This checks for that condition and returns early if there are no endpoints configured.