### PR TITLE
petri: backend-agnostic tpm configuration (#2478)

### DIFF
--- a/petri/petri_artifacts_common/src/lib.rs
+++ b/petri/petri_artifacts_common/src/lib.rs
@@ -81,9 +81,8 @@ pub mod tags {
     pub enum InitialRebootCondition {
         /// This guest always reboots on this VMM.
         Always,
-        /// This guest only reboot when using OpenHCL and UEFI on this VMM.
-        WithOpenHclUefi,
-        // TODO: add WithTpm here once with_tpm() is backend-agnostic.
+        /// This guest only reboots when the TPM is enabled.
+        WithTpm,
     }
 
     /// Quirks needed to boot a guest, allowing for differences based on backend

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1197,3 +1197,35 @@ pub async fn run_set_guest_state_isolation_mode(
     .map(|_| ())
     .context("set_guest_state_isolation_mode")
 }
+
+/// Runs Enable-VMTPM
+pub async fn run_enable_vmtpm(vmid: &Guid) -> anyhow::Result<()> {
+    run_host_cmd(
+        PowerShellBuilder::new()
+            .cmdlet("Get-VM")
+            .arg("Id", vmid)
+            .pipeline()
+            .cmdlet("Enable-VMTPM")
+            .finish()
+            .build(),
+    )
+    .await
+    .map(|_| ())
+    .context("run_enable_vmtpm")
+}
+
+/// Runs Disable-VMTPM
+pub async fn run_disable_vmtpm(vmid: &Guid) -> anyhow::Result<()> {
+    run_host_cmd(
+        PowerShellBuilder::new()
+            .cmdlet("Get-VM")
+            .arg("Id", vmid)
+            .pipeline()
+            .cmdlet("Disable-VMTPM")
+            .finish()
+            .build(),
+    )
+    .await
+    .map(|_| ())
+    .context("run_disable_vmtpm")
+}

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -594,6 +594,16 @@ impl HyperVVM {
     ) -> anyhow::Result<()> {
         powershell::run_set_guest_state_isolation_mode(&self.vmid, &self.ps_mod, mode).await
     }
+
+    /// Enable the TPM
+    pub async fn enable_tpm(&self) -> anyhow::Result<()> {
+        powershell::run_enable_vmtpm(&self.vmid).await
+    }
+
+    /// Disable the TPM
+    pub async fn disable_tpm(&self) -> anyhow::Result<()> {
+        powershell::run_disable_vmtpm(&self.vmid).await
+    }
 }
 
 impl Drop for HyperVVM {

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -133,8 +133,8 @@ pub struct PetriVmConfig {
     pub vmgs: PetriVmgsResource,
     /// The boot device type for the VM
     pub boot_device_type: BootDeviceType,
-    /// Configure TPM state persistence
-    pub tpm_state_persistence: bool,
+    /// TPM configuration
+    pub tpm: Option<TpmConfig>,
 }
 
 /// Resources used by a Petri VM during contruction and runtime
@@ -285,7 +285,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 agent_image: artifacts.agent_image,
                 openhcl_agent_image: artifacts.openhcl_agent_image,
                 vmgs: PetriVmgsResource::Ephemeral,
-                tpm_state_persistence: true,
+                tpm: None,
                 guest_crash_disk,
             },
             modify_vmm_config: None,
@@ -354,22 +354,24 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
     }
 
     fn expect_reset(&self) -> bool {
-        // TODO: use presence of TPM here once with_tpm() backend-agnostic.
         self.override_expect_reset
             || matches!(
                 (
                     self.guest_quirks.initial_reboot,
                     self.expected_boot_event,
                     &self.config.firmware,
+                    &self.config.tpm,
                 ),
                 (
                     Some(InitialRebootCondition::Always),
                     Some(FirmwareEvent::BootSuccess | FirmwareEvent::BootAttempt),
                     _,
+                    _,
                 ) | (
-                    Some(InitialRebootCondition::WithOpenHclUefi),
+                    Some(InitialRebootCondition::WithTpm),
                     Some(FirmwareEvent::BootSuccess | FirmwareEvent::BootAttempt),
-                    Firmware::OpenhclUefi { .. },
+                    _,
+                    Some(_),
                 )
             )
     }
@@ -747,9 +749,23 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         self
     }
 
+    /// Enable the TPM for the VM.
+    pub fn with_tpm(mut self, enable: bool) -> Self {
+        if enable {
+            self.config.tpm.get_or_insert_default();
+        } else {
+            self.config.tpm = None;
+        }
+        self
+    }
+
     /// Enable or disable the TPM state persistence for the VM.
     pub fn with_tpm_state_persistence(mut self, tpm_state_persistence: bool) -> Self {
-        self.config.tpm_state_persistence = tpm_state_persistence;
+        self.config
+            .tpm
+            .as_mut()
+            .expect("TPM persistence requires a TPM")
+            .no_persistent_secrets = !tpm_state_persistence;
         self
     }
 
@@ -1346,6 +1362,21 @@ impl Default for OpenHclConfig {
             command_line: None,
             log_levels: OpenHclLogConfig::TestDefault,
             vtl2_base_address_type: None,
+        }
+    }
+}
+
+/// TPM configuration
+#[derive(Debug)]
+pub struct TpmConfig {
+    /// Use ephemeral TPM state (do not persist to VMGS)
+    pub no_persistent_secrets: bool,
+}
+
+impl Default for TpmConfig {
+    fn default() -> Self {
+        Self {
+            no_persistent_secrets: true,
         }
     }
 }

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -352,12 +352,10 @@ pub mod artifacts {
             const OS_FLAVOR: OsFlavor = OsFlavor::Linux;
             const ARCH: MachineArch = MachineArch::X86_64;
             fn quirks() -> GuestQuirks {
-                let mut quirks = GuestQuirks::for_all_backends(GuestQuirksInner {
+                GuestQuirks::for_all_backends(GuestQuirksInner {
                     hyperv_shutdown_ic_sleep: Some(std::time::Duration::from_secs(20)),
-                    ..Default::default()
-                });
-                quirks.hyperv.initial_reboot = Some(InitialRebootCondition::WithOpenHclUefi);
-                quirks
+                    initial_reboot: Some(InitialRebootCondition::WithTpm),
+                })
             }
         }
 
@@ -375,12 +373,10 @@ pub mod artifacts {
             const OS_FLAVOR: OsFlavor = OsFlavor::Linux;
             const ARCH: MachineArch = MachineArch::X86_64;
             fn quirks() -> GuestQuirks {
-                let mut quirks = GuestQuirks::for_all_backends(GuestQuirksInner {
+                GuestQuirks::for_all_backends(GuestQuirksInner {
                     hyperv_shutdown_ic_sleep: Some(std::time::Duration::from_secs(20)),
-                    ..Default::default()
-                });
-                quirks.hyperv.initial_reboot = Some(InitialRebootCondition::WithOpenHclUefi);
-                quirks
+                    initial_reboot: Some(InitialRebootCondition::WithTpm),
+                })
             }
         }
 
@@ -398,12 +394,10 @@ pub mod artifacts {
             const OS_FLAVOR: OsFlavor = OsFlavor::Linux;
             const ARCH: MachineArch = MachineArch::Aarch64;
             fn quirks() -> GuestQuirks {
-                let mut quirks = GuestQuirks::for_all_backends(GuestQuirksInner {
+                GuestQuirks::for_all_backends(GuestQuirksInner {
                     hyperv_shutdown_ic_sleep: Some(std::time::Duration::from_secs(20)),
-                    ..Default::default()
-                });
-                quirks.hyperv.initial_reboot = Some(InitialRebootCondition::WithOpenHclUefi);
-                quirks
+                    initial_reboot: Some(InitialRebootCondition::WithTpm),
+                })
             }
         }
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -28,6 +28,8 @@ mod memstat;
 mod openhcl_servicing;
 /// PCIe emulation tests.
 mod pcie;
+/// Tests involving TPM functionality
+mod tpm;
 /// Tests of vmbus relay functionality.
 mod vmbus_relay;
 /// Tests involving VMGS functionality

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -6,7 +6,6 @@
 mod openhcl_linux_direct;
 mod openhcl_uefi;
 mod storage;
-mod tpm;
 
 use anyhow::Context;
 use hvlite_defs::config::DeviceVtl;


### PR DESCRIPTION
Adds backend-agnostic tpm configuration to Petri.