### PR TITLE
logview_new: safely set inspect links in the log viewer

### DIFF
--- a/petri/logview_new/src/data_defs.tsx
+++ b/petri/logview_new/src/data_defs.tsx
@@ -61,12 +61,14 @@ export interface LogEntry {
 
 export interface LogMessage {
   message: string;
+  link_string: string;  // This is a space-separated string of link texts for searching/sorting
   links: LogLink[];
 }
 
 export interface LogLink {
   text: string;
   url: string;
+  inspect: boolean;
 }
 
 // Concurrency settings when fetching test results

--- a/petri/logview_new/src/fetch/fetch_logs_data.tsx
+++ b/petri/logview_new/src/fetch/fetch_logs_data.tsx
@@ -162,6 +162,7 @@ export async function fetchProcessedLog(
     message = sevExtract.message;
     severity = sevExtract.severity;
     let logLinks: LogLink[] = [];
+    let links_text = "";
 
     let screenshot: string | null = null;
     if (rec.attachment) {
@@ -176,6 +177,7 @@ export async function fetchProcessedLog(
         entries[entries.length - 1].screenshot = attachmentUrl;
         continue; // don't emit separate row
       }
+
       // Inspect attachment gets two links (inspect + raw); others single link
       if (rec.attachment.includes("inspect")) {
         // Add two links:
@@ -186,16 +188,24 @@ export async function fetchProcessedLog(
         logLinks.push({
           text: rec.attachment,
           url: attachmentUrl,
+          inspect: true,
         });
+
         logLinks.push({
           text: "[raw]",
           url: attachmentUrl,
+          inspect: false,
         });
+
+        links_text += rec.attachment + " [raw] ";
       } else {
         logLinks.push({
           text: rec.attachment,
           url: attachmentUrl,
+          inspect: false,
         });
+
+        links_text += rec.attachment + " ";
       }
     }
 
@@ -207,6 +217,7 @@ export async function fetchProcessedLog(
       source,
       logMessage: {
         message: message,
+        link_string: links_text.trim(),
         links: logLinks,
       },
       screenshot,

--- a/petri/logview_new/src/log_viewer.tsx
+++ b/petri/logview_new/src/log_viewer.tsx
@@ -226,7 +226,7 @@ export function LogViewer(): React.JSX.Element {
                         const severityClass = `severity-${row.original.severity}`;
                         return `${severityClass} ${isSelected ? 'selected' : ''}`;
                     }}
-                    overscan={300}
+                    overscan={100}
                     onRowClick={(row, event) => {
                         const logId = `log-${row.original.index}`;
                         handleRowClick(
@@ -460,18 +460,21 @@ function filterLog(logs: LogEntry[] | undefined, query: string): LogEntry[] {
         return tokens.every(token => {
             const [prefix, ...rest] = token.split(':');
             const term = rest.join(':').toLowerCase();
+            const columnSearching = token.includes(':');
 
-            if (prefix === 'source') {
+            if (columnSearching && prefix === 'source') {
                 return log.source.toLowerCase().includes(term);
-            } else if (prefix === 'severity') {
+            } else if (columnSearching && prefix === 'severity') {
                 return log.severity.toLowerCase().includes(term);
-            } else if (prefix === 'message') {
-                return log.logMessage.message.toLowerCase().includes(term);
+            } else if (columnSearching && prefix === 'message') {
+                return log.logMessage.message.toLowerCase().includes(term)
+                    || log.logMessage.link_string.toLowerCase().includes(term);
             } else {
                 return (
                     log.source.toLowerCase().includes(token.toLowerCase()) ||
                     log.severity.toLowerCase().includes(token.toLowerCase()) ||
-                    log.logMessage.message.toLowerCase().includes(token.toLowerCase())
+                    log.logMessage.message.toLowerCase().includes(token.toLowerCase()) ||
+                    log.logMessage.link_string.toLowerCase().includes(token.toLowerCase())
                 );
             }
         });

--- a/petri/logview_new/src/table_defs/log_viewer.tsx
+++ b/petri/logview_new/src/table_defs/log_viewer.tsx
@@ -53,7 +53,7 @@ export function createColumns(
                             className="attachment"
                             target="_blank"
                             rel="noopener noreferrer"
-                            data-inspect="true"
+                            data-inspect={link.inspect}
                             style={{ marginLeft: 8 }}
                         >
                             {link.text}
@@ -61,7 +61,7 @@ export function createColumns(
                     ))}
                 </>
             ),
-            enableSorting: false, // Disable sorting for complex HTML content
+            enableSorting: false, // Sorting by full message text is not useful
         },
         {
             id: 'screenshot',


### PR DESCRIPTION
Previously we would treat the entire message as HTML so that it can display links to the inspect viewer. This PR fixes it by separating the links from the actual message. As a side effect it also fixes an issue where highlighted text would get refreshed/unhighlighted when the page was scrolled.