### PR TITLE
CI: Build openhcl_boot, sidecar, tmks with our custom target (#2521)

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -5608,12 +5608,6 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 8 flowey_lib_hvlite::download_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
     - name: cargo build openhcl_boot
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 1
@@ -5629,6 +5623,13 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::download_openhcl_kernel_package 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 8 flowey_lib_hvlite::download_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_hcl
@@ -5952,7 +5953,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
         flowey e 9 flowey_lib_hvlite::run_cargo_build 11
         flowey e 9 flowey_lib_hvlite::run_cargo_build 12
       shell: bash
@@ -5966,7 +5967,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
         flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_sidecar 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 2
         flowey e 9 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
@@ -5992,7 +5993,7 @@ jobs:
     - name: extract X64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
@@ -6013,7 +6014,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 4
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6157,7 +6158,7 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
@@ -6173,7 +6174,7 @@ jobs:
     - name: copying openhcl build to publish dir
       run: |-
         flowey e 9 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build pipette
       run: |-
@@ -6186,7 +6187,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 10
         flowey e 9 flowey_lib_hvlite::build_pipette 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build tmk_vmm
       run: |-

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -5615,12 +5615,6 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 8 flowey_lib_hvlite::download_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
     - name: cargo build openhcl_boot
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 1
@@ -5636,6 +5630,13 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::download_openhcl_kernel_package 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 8 flowey_lib_hvlite::download_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
@@ -5935,7 +5936,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
@@ -5949,7 +5950,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 9 flowey_lib_hvlite::run_cargo_build 12
         flowey e 9 flowey_lib_hvlite::build_sidecar 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 2
         flowey e 9 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
@@ -5975,7 +5976,7 @@ jobs:
     - name: extract X64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
@@ -5996,7 +5997,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 4
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6140,7 +6141,7 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build pipette
       run: |-
@@ -6153,7 +6154,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 8
         flowey e 9 flowey_lib_hvlite::build_pipette 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build tmk_vmm
       run: |-

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -511,7 +511,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 4
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 9
         flowey e 10 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
@@ -525,7 +525,7 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 10 flowey_lib_hvlite::run_cargo_build 12
         flowey e 10 flowey_lib_hvlite::build_sidecar 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 5
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
@@ -551,7 +551,7 @@ jobs:
     - name: extract X64 sysroot.tar.gz
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
@@ -572,7 +572,7 @@ jobs:
         flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 4
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -716,7 +716,7 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build pipette
       run: |-
@@ -729,7 +729,7 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_cargo_build 8
         flowey e 10 flowey_lib_hvlite::build_pipette 0
         flowey e 10 flowey_core::pipeline::artifact::publish 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build tmk_vmm
       run: |-
@@ -6331,12 +6331,6 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 8 flowey_lib_hvlite::download_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
     - name: cargo build openhcl_boot
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 1
@@ -6352,6 +6346,13 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::download_openhcl_kernel_package 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 8 flowey_lib_hvlite::download_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
@@ -56,21 +56,14 @@ impl FlowNode for Node {
             });
 
         for (OpenhclBootBuildParams { arch, profile }, openhcl_boot) in requests {
-            let target = match arch {
-                CommonArch::X86_64 => target_lexicon::Triple {
-                    architecture: arch.as_arch(),
-                    operating_system: target_lexicon::OperatingSystem::None_,
-                    environment: target_lexicon::Environment::Unknown,
-                    vendor: target_lexicon::Vendor::Unknown,
-                    binary_format: target_lexicon::BinaryFormat::Unknown,
-                },
-                CommonArch::Aarch64 => target_lexicon::Triple {
-                    architecture: arch.as_arch(),
-                    operating_system: target_lexicon::OperatingSystem::Linux,
-                    environment: target_lexicon::Environment::Musl,
-                    vendor: target_lexicon::Vendor::Unknown,
-                    binary_format: target_lexicon::BinaryFormat::Elf,
-                },
+            let target = target_lexicon::Triple {
+                architecture: arch.as_arch(),
+                operating_system: target_lexicon::OperatingSystem::None_,
+                environment: target_lexicon::Environment::Unknown,
+                vendor: target_lexicon::Vendor::Custom(target_lexicon::CustomVendor::Static(
+                    "minimal_rt",
+                )),
+                binary_format: target_lexicon::BinaryFormat::Unknown,
             };
 
             // We use special profiles for boot, convert from the standard ones:
@@ -88,7 +81,7 @@ impl FlowNode for Node {
                 target,
                 no_split_dbg_info: false,
                 extra_env: Some(ReadVar::from_static(
-                    [("MINIMAL_RT_BUILD".to_string(), "1".to_string())]
+                    [("RUSTC_BOOTSTRAP".to_string(), "1".to_string())]
                         .into_iter()
                         .collect(),
                 )),

--- a/flowey/flowey_lib_hvlite/src/build_sidecar.rs
+++ b/flowey/flowey_lib_hvlite/src/build_sidecar.rs
@@ -56,21 +56,14 @@ impl FlowNode for Node {
             });
 
         for (SidecarBuildParams { arch, profile }, sidecar) in requests {
-            let target = match arch {
-                CommonArch::X86_64 => target_lexicon::Triple {
-                    architecture: arch.as_arch(),
-                    operating_system: target_lexicon::OperatingSystem::None_,
-                    environment: target_lexicon::Environment::Unknown,
-                    vendor: target_lexicon::Vendor::Unknown,
-                    binary_format: target_lexicon::BinaryFormat::Unknown,
-                },
-                CommonArch::Aarch64 => target_lexicon::Triple {
-                    architecture: arch.as_arch(),
-                    operating_system: target_lexicon::OperatingSystem::Linux,
-                    environment: target_lexicon::Environment::Musl,
-                    vendor: target_lexicon::Vendor::Unknown,
-                    binary_format: target_lexicon::BinaryFormat::Elf,
-                },
+            let target = target_lexicon::Triple {
+                architecture: arch.as_arch(),
+                operating_system: target_lexicon::OperatingSystem::None_,
+                environment: target_lexicon::Environment::Unknown,
+                vendor: target_lexicon::Vendor::Custom(target_lexicon::CustomVendor::Static(
+                    "minimal_rt",
+                )),
+                binary_format: target_lexicon::BinaryFormat::Unknown,
             };
 
             // We use special profiles for boot, convert from the standard ones:
@@ -88,7 +81,7 @@ impl FlowNode for Node {
                 target,
                 no_split_dbg_info: false,
                 extra_env: Some(ReadVar::from_static(
-                    [("MINIMAL_RT_BUILD".to_string(), "1".to_string())]
+                    [("RUSTC_BOOTSTRAP".to_string(), "1".to_string())]
                         .into_iter()
                         .collect(),
                 )),

--- a/openhcl/minimal_rt/aarch64-config.toml
+++ b/openhcl/minimal_rt/aarch64-config.toml
@@ -13,7 +13,7 @@
 target = "minimal_rt/aarch64-minimal_rt-none.json"
 
 [unstable]
-build-std = ["core"]
+build-std = ["core", "alloc"]
 
 [env]
 MINIMAL_RT_BUILD = "1"

--- a/openhcl/openhcl_boot/src/arch/aarch64/entry.S
+++ b/openhcl/openhcl_boot/src/arch/aarch64/entry.S
@@ -47,10 +47,10 @@ _start:
     // NOTE: the stack space is allocated in BSS, and one can't use function calls yet
     // as the return address will be wiped out.
 
-    adrp    x0,  __bss_start__
-    add     x0, x0, :lo12:__bss_start__ // X0 contains the BSS start
-    adrp    x1, __bss_end__
-    add     x1, x1, :lo12:__bss_end__
+    adrp    x0,  __bss_start
+    add     x0, x0, :lo12:__bss_start // X0 contains the BSS start
+    adrp    x1, _end
+    add     x1, x1, :lo12:_end
     sub     x1, x1, x0                  // X2 contains the BSS length
 1:
     cbz     x1, 2f


### PR DESCRIPTION
This PR unifies the build settings across these three binaries, which need to run in a no-std no-os environment. This should fix the rust_eh_personality linker errors we've been seeing on arm recently.

Clean cherrypick