### PR TITLE
petri: wait for shutdown ic before pipette

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -785,11 +785,8 @@ impl PetriVmRuntime for HyperVPetriRuntime {
             // Extend the default timeout of 2 seconds, as tests are often run
             // in parallel on a host, causing very heavy load on the overall
             // system.
-            //
-            // TODO: Until #2470 is fixed, extend the timeout even longer to 10
-            // seconds to workaround a Windows vmbus bug.
             socket
-                .set_connect_timeout(Duration::from_secs(10))
+                .set_connect_timeout(Duration::from_secs(2))
                 .context("failed to set connect timeout")?;
             socket
                 .set_high_vtl(set_high_vtl)


### PR DESCRIPTION
As a workaround for #2470 (where the guest crashes when the pipette connection timeout expires due to a vmbus bug), wait for the shutdown IC to come online first so that we probably won't time out when connecting to the agent. Undoes https://github.com/microsoft/openvmm/pull/2485 in hopes that this is sufficient.