### PR TITLE
chipset_device: Allow deferred IO to error

### DIFF
--- a/vm/chipset_device/src/io.rs
+++ b/vm/chipset_device/src/io.rs
@@ -8,7 +8,7 @@ pub mod deferred;
 /// An error related to the suitability of the IO request for the device. A
 /// device should handle device-specific errors internally, and should return
 /// `IoResult::Ok` in these conditions.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, mesh::MeshPayload)]
 pub enum IoError {
     /// The requested device register is not present.
     InvalidRegister,

--- a/vm/devices/pci/pci_bus/src/lib.rs
+++ b/vm/devices/pci/pci_bus/src/lib.rs
@@ -614,7 +614,11 @@ impl PollDevice for GenericPciBus {
                     if let Poll::Ready(res) = deferred_device_read.poll_read(cx, buf.as_mut_bytes())
                     {
                         let value = match res {
-                            Ok(()) => buf,
+                            Ok(Ok(())) => buf,
+                            Ok(Err(e)) => {
+                                self.trace_error(e, "deferred read");
+                                0
+                            }
                             Err(e) => {
                                 self.trace_recv_error(e, "deferred read");
                                 0
@@ -644,7 +648,11 @@ impl PollDevice for GenericPciBus {
                     if let Poll::Ready(res) = deferred_device_read.poll_read(cx, buf.as_mut_bytes())
                     {
                         let old_value = match res {
-                            Ok(()) => buf,
+                            Ok(Ok(())) => buf,
+                            Ok(Err(e)) => {
+                                self.trace_error(e, "deferred read for write");
+                                0
+                            }
                             Err(e) => {
                                 self.trace_recv_error(e, "deferred read for write");
                                 0
@@ -689,7 +697,10 @@ impl PollDevice for GenericPciBus {
                 } => {
                     if let Poll::Ready(res) = deferred_device_write.poll_write(cx) {
                         match res {
-                            Ok(()) => {}
+                            Ok(Ok(())) => {}
+                            Ok(Err(e)) => {
+                                self.trace_error(e, "deferred write");
+                            }
                             Err(e) => {
                                 self.trace_recv_error(e, "deferred write");
                             }

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -2246,6 +2246,7 @@ mod tests {
                     deferred.poll_write(cx)
                 })
                 .await
+                .unwrap()
                 .unwrap();
             }
             _ => panic!("{:?}", r),
@@ -2339,6 +2340,7 @@ mod tests {
                     deferred.poll_write(cx)
                 })
                 .await
+                .unwrap()
                 .unwrap();
             }
             _ => panic!("{:?}", r),


### PR DESCRIPTION
In order to support remote devices we need the ability to report operation errors as well as successes. When things are remote every IO gets deferred. Previously every deferred IO would always be successful, but this may no longer be the case.