### PR TITLE
Revert "vmm_tests: disabling memory validation assertions on 1.7 release builds while internal repo filter is in progress (#2514)"

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -461,8 +461,7 @@ async fn memory_validation_release_small<T: PetriVmmBackend>(
         WaitPeriodSec::ShortWait,
         driver,
         "release",
-        // Disabling release assertions on small VM test while internal repo filter is in progress
-        false,
+        true,
     )
     .await
 }
@@ -510,8 +509,7 @@ async fn memory_validation_release_very_heavy<T: PetriVmmBackend>(
         WaitPeriodSec::LongWait,
         driver,
         "release",
-        // Disabling release assertions on heavy VM test while internal repo filter is in progress
-        false,
+        true,
     )
     .await
 }


### PR DESCRIPTION
This reverts the PR since the filter has been added to the internal repository, enabling memory validation assertions on release builds of underhill 1.7.