### PR TITLE
Add more logs to debug nvme servicing CI failures (#2482)

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager/manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager/manager.rs
@@ -68,6 +68,12 @@ impl NvmeManager {
         saved_state: Option<NvmeSavedState>,
         nvme_driver_spawner: Arc<dyn CreateNvmeDriver>,
     ) -> Self {
+        tracing::info!(
+            vp_count,
+            save_restore_supported,
+            saved_state = saved_state.is_some(),
+            "starting nvme manager"
+        );
         let (send, recv) = mesh::channel();
         let driver = driver_source.simple();
         let mut worker = NvmeManagerWorker {
@@ -94,6 +100,8 @@ impl NvmeManager {
                     );
                 }
             };
+
+            tracing::debug!("nvme manager entering main loop");
             worker.run(recv).await
         });
         Self {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2188,6 +2188,12 @@ async fn new_underhill_vm(
             }),
         );
 
+        tracing::debug!(
+            CVM_ALLOWED,
+            nvme_vfio = true,
+            save_restore_supported,
+            "NVMe VFIO manager initialized, setting up resolver"
+        );
         resolver.add_async_resolver::<DiskHandleKind, _, NvmeDiskConfig, _>(NvmeDiskResolver::new(
             manager.client().clone(),
         ));


### PR DESCRIPTION
Clean cherry pick of PR #2482

- **user_driver: backoff 250ms in set_keep_alive, just like
open_device**
- **copilot pr feedback**
- **nvme_manager: re-enable multi-device servicing test, add some more
logs to try and track down the problem**
- **more logs**
