### PR TITLE
emuplat/nvme_manager: add pci_id to logs when failing to create/restore a vfio device

### DIFF
--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -181,12 +181,12 @@ async fn try_create_mana_device(
         VfioDevice::restore(driver_source, pci_id, true, dma_clients)
             .instrument(tracing::info_span!("restore_mana_vfio_device"))
             .await
-            .context("failed to restore device")?
+            .with_context(|| format!("failed to restore vfio device for {}", pci_id))?
     } else {
         VfioDevice::new(driver_source, pci_id, dma_clients)
             .instrument(tracing::info_span!("new_mana_vfio_device"))
             .await
-            .context("failed to open device")?
+            .with_context(|| format!("failed to open vfio device for {}", pci_id))?
     };
 
     ManaDevice::new(

--- a/openhcl/underhill_core/src/nvme_manager/device.rs
+++ b/openhcl/underhill_core/src/nvme_manager/device.rs
@@ -111,6 +111,7 @@ impl CreateNvmeDriver for VfioNvmeDriverSpawner {
             let vfio_device = VfioDevice::restore(driver_source, pci_id, true, dma_clients)
                 .instrument(tracing::info_span!("nvme_vfio_device_restore", pci_id))
                 .await
+                .with_context(|| format!("failed to restore vfio device for {}", pci_id))
                 .map_err(NvmeSpawnerError::Vfio)?;
 
             // TODO: For now, any isolation means use bounce buffering. This
@@ -213,6 +214,7 @@ impl VfioNvmeDriverSpawner {
         let device = VfioDevice::new(driver_source, pci_id, dma_clients)
             .instrument(tracing::info_span!("nvme_vfio_device_open", pci_id))
             .await
+            .with_context(|| format!("failed to create vfio device for {}", pci_id))
             .map_err(NvmeSpawnerError::Vfio)?;
 
         // TODO: For now, any isolation means use bounce buffering. This


### PR DESCRIPTION
I have seen two test failures where OpenHCL cannot restore because the vfio restore path cannot find the iommu group file.
From those logs, I think this is just a case where the kernel is async and is yet to create the path. However, I also
identified that it is not *crystal clear* which device triggered the failure. So, add those logs.
