### PR TITLE
ci: update node version to 24

### DIFF
--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -572,7 +572,7 @@ jobs:
     - id: flowey_lib_common__install_nodejs__0
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 24.x
       name: Install nodejs
     - name: build test-results website
       run: flowey e 3 flowey_lib_hvlite::_jobs::build_test_results_website 0

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const RUSTUP_TOOLCHAIN: &str = "1.91.1";
 pub const MU_MSVM: &str = "25.1.9";
 pub const NEXTEST: &str = "0.9.101";
-pub const NODEJS: &str = "18.x";
+pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.


### PR DESCRIPTION
We need a more up to date node version because we see errors in test results website build. And the existing version (18) has met it's End-Of-Life