### PR TITLE
vmgs: Write a diagnostic marker when provisioning the VMGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7562,6 +7562,7 @@ name = "tpm_protocol"
 version = "0.0.0"
 dependencies = [
  "bitfield-struct 0.11.0",
+ "open_enum",
  "thiserror 2.0.16",
  "zerocopy 0.8.27",
 ]
@@ -8008,6 +8009,7 @@ dependencies = [
  "thiserror 2.0.16",
  "time",
  "tpm_device",
+ "tpm_protocol",
  "tpm_resources",
  "tracelimit",
  "tracing",
@@ -8043,6 +8045,7 @@ dependencies = [
  "vmcore",
  "vmgs",
  "vmgs_broker",
+ "vmgs_format",
  "vmgs_resources",
  "vmm_core",
  "vmm_core_defs",
@@ -9268,6 +9271,7 @@ dependencies = [
  "inspect",
  "open_enum",
  "static_assertions",
+ "tpm_protocol",
  "zerocopy 0.8.27",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8045,7 +8045,6 @@ dependencies = [
  "vmcore",
  "vmgs",
  "vmgs_broker",
- "vmgs_format",
  "vmgs_resources",
  "vmm_core",
  "vmm_core_defs",
@@ -9271,7 +9270,6 @@ dependencies = [
  "inspect",
  "open_enum",
  "static_assertions",
- "tpm_protocol",
  "zerocopy 0.8.27",
 ]
 

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -130,7 +130,6 @@ vmcore.workspace = true
 vm_resource.workspace = true
 vmgs = { workspace = true, features = ["encryption_ossl", "save_restore"] }
 vmgs_broker = { workspace = true, features = ["encryption_ossl"] }
-vmgs_format.workspace = true
 vmgs_resources.workspace = true
 x86defs.workspace = true
 

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -83,6 +83,7 @@ serial_16550_resources.workspace = true
 storage_string.workspace = true
 storvsp.workspace = true
 storvsp_resources.workspace = true
+tpm_protocol.workspace = true
 tpm_resources.workspace = true
 tpm_device = { workspace = true, features = ["tpm"] }
 tracelimit.workspace = true
@@ -129,6 +130,7 @@ vmcore.workspace = true
 vm_resource.workspace = true
 vmgs = { workspace = true, features = ["encryption_ossl", "save_restore"] }
 vmgs_broker = { workspace = true, features = ["encryption_ossl"] }
+vmgs_format.workspace = true
 vmgs_resources.workspace = true
 x86defs.workspace = true
 

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -74,10 +74,42 @@ use pal_async::task::Spawn;
 use profiler_worker::ProfilerWorker;
 #[cfg(feature = "profiler")]
 use profiler_worker::ProfilerWorkerParameters;
+use serde::Deserialize;
+use serde::Serialize;
 use std::time::Duration;
 use vmsocket::VmAddress;
 use vmsocket::VmListener;
 use vnc_worker_defs::VncParameters;
+
+// TODO: serde rename
+#[derive(Debug, Serialize, Deserialize)]
+pub enum VmgsProvisioner {
+    Unknown,
+    HCL,
+    OpenHCL,
+    CpsVmgstoolCvm,
+    CpsVmgstoolTvm,
+    HclPostProvisioning,
+}
+
+// TODO: serde rename
+#[derive(Debug, Serialize, Deserialize)]
+pub enum VmgsProvisioningReason {
+    Empty,
+    Failure,
+    Request,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProvisioningMarker {
+    pub provisioner: VmgsProvisioner,
+    pub reason: VmgsProvisioningReason,
+    pub tpm_version: String,
+    pub tpm_nvram_size: usize,
+    pub akcert_size: usize,
+    pub akcert_attrs: String,
+    pub hcl_version: String,
+}
 
 fn new_underhill_remote_console_cfg(
     framebuffer_gpa_base: Option<u64>,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1751,9 +1751,14 @@ async fn new_underhill_vm(
 
     if let Some((_, ref mut vmgs)) = vmgs {
         if vmgs.was_provisioned_this_boot() {
+            let mut rev: [u8; 40] = [0; 40];
+            let rev_bytes = build_info::get().scm_revision().as_bytes();
+            let rev_len = rev_bytes.len().min(40);
+            rev[..rev_len].copy_from_slice(&rev_bytes[..rev_len]);
+
             let marker = ProvisioningMarker {
                 marker_version: vmgs_format::PROVISIONING_MARKER_CURRENT_VERSION,
-                provisioner: VmgsProvisioner::HCL,
+                provisioner: VmgsProvisioner::OPENHCL,
                 reset_by_gsl_flag: (matches!(
                     dps.general.guest_state_lifetime,
                     GuestStateLifetime::Reprovision
@@ -1765,6 +1770,7 @@ async fn new_underhill_vm(
                 vtpm_nvram_size: tpm_protocol::TPM_DEFAULT_SIZE,
                 vtpm_akcert_size: tpm_protocol::TPM_DEFAULT_AKCERT_SIZE,
                 vtpm_akcert_attrs: tpm_protocol::platform_akcert_attributes().into(),
+                hcl_version: rev,
                 ..FromZeros::new_zeroed()
             };
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1756,7 +1756,9 @@ async fn new_underhill_vm(
         if vmgs.was_provisioned_this_boot() {
             let reason = if dps.general.guest_state_lifetime == GuestStateLifetime::Reprovision {
                 VmgsProvisioningReason::Request
-            } else if dps.general.guest_state_lifetime == GuestStateLifetime::ReprovisionOnFailure && vmgs.was_formatted_on_failure() {
+            } else if dps.general.guest_state_lifetime == GuestStateLifetime::ReprovisionOnFailure
+                && vmgs.was_formatted_on_failure()
+            {
                 VmgsProvisioningReason::Failure
             } else {
                 VmgsProvisioningReason::Empty
@@ -1769,7 +1771,10 @@ async fn new_underhill_vm(
                 tpm_nvram_size: tpm_protocol::TPM_DEFAULT_SIZE,
                 akcert_size: tpm_protocol::TPM_DEFAULT_AKCERT_SIZE,
                 // TODO: make sure it gets "0x"
-                akcert_attrs: format!("{:x}", Into::<u32>::into(tpm_protocol::platform_akcert_attributes())),
+                akcert_attrs: format!(
+                    "{:x}",
+                    Into::<u32>::into(tpm_protocol::platform_akcert_attributes())
+                ),
                 hcl_version: build_info::get().scm_revision().to_string(),
             };
 
@@ -1799,8 +1804,11 @@ async fn new_underhill_vm(
             //    ..FromZeros::new_zeroed()
             //};
 
-            vmgs.write_file(vmgs::FileId::PROVISIONING_MARKER, serde_json::to_string(&marker)?.as_bytes())
-                .await?;
+            vmgs.write_file(
+                vmgs::FileId::PROVISIONING_MARKER,
+                serde_json::to_string(&marker)?.as_bytes(),
+            )
+            .await?;
         }
     }
 

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -93,7 +93,7 @@ pub enum PcatBootDevice {
 }
 
 /// Guest state lifetime
-#[derive(Debug, Copy, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, Default, PartialEq)]
 pub enum GuestStateLifetime {
     #[default]
     Default,

--- a/vm/devices/tpm/tpm_protocol/Cargo.toml
+++ b/vm/devices/tpm/tpm_protocol/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 bitfield-struct.workspace = true
+open_enum.workspace = true
 thiserror.workspace = true
 zerocopy.workspace = true
 

--- a/vm/devices/tpm/tpm_protocol/src/lib.rs
+++ b/vm/devices/tpm/tpm_protocol/src/lib.rs
@@ -7,12 +7,18 @@
 
 pub mod tpm20proto;
 
+use open_enum::open_enum;
 use tpm20proto::NV_INDEX_RANGE_BASE_PLATFORM_MANUFACTURER;
 use tpm20proto::NV_INDEX_RANGE_BASE_TCG_ASSIGNED;
 use tpm20proto::ReservedHandle;
 use tpm20proto::TPM20_HT_PERSISTENT;
+use tpm20proto::TpmaNvBits;
 use tpm20proto::TpmaObject;
 use tpm20proto::TpmaObjectBits;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
 
 // --- Reserved handles for Storage Primary Key ranges from 0x81000000 – 0x810000ff ---
 
@@ -55,3 +61,34 @@ pub fn expected_ak_attributes() -> TpmaObject {
         .with_sign_encrypt(true)
         .into()
 }
+
+/// Expected NVRAM index attributes for a platform-created AKCert index.
+pub fn platform_akcert_attributes() -> TpmaNvBits {
+    TpmaNvBits::new()
+        .with_nv_authread(true)
+        .with_nv_authwrite(true)
+        .with_nv_ownerread(true)
+        .with_nv_platformcreate(true)
+        .with_nv_no_da(true)
+}
+
+open_enum! {
+    /// vTPM versions whose state can be provisioned in a new VMGS file. Note that
+    /// these constants are part of the VMGS diagnostic provisioning marker format
+    /// defined in vmgs_format.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum TpmVersion: u32 {
+        /// TPM version 1.38
+        VER_138 = 1,
+    }
+}
+
+/// Default vTPM version provisioned for a new VMGS.
+pub const TPM_DEFAULT_VERSION: TpmVersion = TpmVersion::VER_138;
+
+/// Default vTPM NVRAM size provisioned for a new VMGS.
+pub const TPM_DEFAULT_SIZE: u32 = 32768;
+
+// TODO: combine this with MAX_NV_INDEX_SIZE
+/// Default NVRAM index size provisioned for AKCert.
+pub const TPM_DEFAULT_AKCERT_SIZE: u32 = 4096;

--- a/vm/devices/tpm/tpm_protocol/src/lib.rs
+++ b/vm/devices/tpm/tpm_protocol/src/lib.rs
@@ -72,23 +72,23 @@ pub fn platform_akcert_attributes() -> TpmaNvBits {
         .with_nv_no_da(true)
 }
 
-open_enum! {
-    /// vTPM versions whose state can be provisioned in a new VMGS file. Note that
-    /// these constants are part of the VMGS diagnostic provisioning marker format
-    /// defined in vmgs_format.
-    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
-    pub enum TpmVersion: u32 {
-        /// TPM version 1.38
-        VER_138 = 1,
-    }
-}
+//open_enum! {
+//    /// vTPM versions whose state can be provisioned in a new VMGS file. Note that
+//    /// these constants are part of the VMGS diagnostic provisioning marker format
+//    /// defined in vmgs_format.
+//    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+//    pub enum TpmVersion: u32 {
+//        /// TPM version 1.38
+//        VER_138 = 1,
+//    }
+//}
 
 /// Default vTPM version provisioned for a new VMGS.
-pub const TPM_DEFAULT_VERSION: TpmVersion = TpmVersion::VER_138;
+pub const TPM_DEFAULT_VERSION: &'static str = "1.38";
 
 /// Default vTPM NVRAM size provisioned for a new VMGS.
-pub const TPM_DEFAULT_SIZE: u32 = 32768;
+pub const TPM_DEFAULT_SIZE: usize = 32768;
 
 // TODO: combine this with MAX_NV_INDEX_SIZE
 /// Default NVRAM index size provisioned for AKCert.
-pub const TPM_DEFAULT_AKCERT_SIZE: u32 = 4096;
+pub const TPM_DEFAULT_AKCERT_SIZE: usize = 4096;

--- a/vm/vmgs/vmgs/Cargo.toml
+++ b/vm/vmgs/vmgs/Cargo.toml
@@ -34,11 +34,11 @@ anyhow.workspace = true
 async-trait.workspace = true
 cfg-if.workspace = true
 crc32fast.workspace = true
+cvm_tracing.workspace = true
 getrandom.workspace = true
 openssl = { optional = true, features = ["vendored"], workspace = true }
 thiserror.workspace = true
 tracing.workspace = true
-cvm_tracing.workspace = true
 zerocopy.workspace = true
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/vm/vmgs/vmgs_format/Cargo.toml
+++ b/vm/vmgs/vmgs_format/Cargo.toml
@@ -12,6 +12,7 @@ inspect = { workspace = true, optional = true }
 
 bitfield-struct.workspace = true
 static_assertions.workspace = true
+tpm_protocol.workspace = true
 zerocopy.workspace = true
 [lints]
 workspace = true

--- a/vm/vmgs/vmgs_format/Cargo.toml
+++ b/vm/vmgs/vmgs_format/Cargo.toml
@@ -12,7 +12,6 @@ inspect = { workspace = true, optional = true }
 
 bitfield-struct.workspace = true
 static_assertions.workspace = true
-tpm_protocol.workspace = true
 zerocopy.workspace = true
 [lints]
 workspace = true

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -233,6 +233,9 @@ open_enum! {
 /// Current version of the VMGS provisioning diagnostic marker.
 pub const PROVISIONING_MARKER_CURRENT_VERSION: u32 = 1;
 
+/// Length of HCL version field.
+pub const HCL_VERSION_LENGTH: usize = 40;
+
 /// Diagnostic marker that describes how a VMGS file was provisioned.
 #[repr(C, packed)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -245,7 +248,8 @@ pub struct ProvisioningMarker {
     pub vtpm_nvram_size: u32,
     pub vtpm_akcert_size: u32,
     pub vtpm_akcert_attrs: u32,
-    pub hcl_version: [u8; 40], // OpenHCL: string representation of commit hash
+    // provisioner == OPENHCL: string representation of commit hash; otherwise undefined
+    pub hcl_version: [u8; HCL_VERSION_LENGTH],
     pub _reserved2: [u8; 956],
 }
 

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -14,7 +14,7 @@ use core::ops::IndexMut;
 use inspect::Inspect;
 use open_enum::open_enum;
 use static_assertions::const_assert;
-use tpm_protocol::TpmVersion;
+//use tpm_protocol::TpmVersion;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -244,13 +244,13 @@ pub struct ProvisioningMarker {
     pub provisioner: VmgsProvisioner,
     pub reset_by_gsl_flag: u8,
     pub _reserved1: [u8; 3],
-    pub vtpm_version: TpmVersion,
+    //pub vtpm_version: TpmVersion,
     pub vtpm_nvram_size: u32,
     pub vtpm_akcert_size: u32,
     pub vtpm_akcert_attrs: u32,
     // provisioner == OPENHCL: string representation of commit hash; otherwise undefined
     pub hcl_version: [u8; HCL_VERSION_LENGTH],
-    pub _reserved2: [u8; 956],
+    pub _reserved2: [u8; 960],
 }
 
 // Size of the provisioning marker.

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -222,10 +222,11 @@ open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
     pub enum VmgsProvisioner: u32 {
         HCL = 1,
-        HOST_AGENT_VMGSTOOL = 2,
-        CPS_VMGSTOOL_CVM = 3,
-        CPS_VMGSTOOL_TVM = 4,
-        HCL_POST_PROVISIONING = 5,
+        OPENHCL = 2,
+        HOST_AGENT_VMGSTOOL = 3,
+        CPS_VMGSTOOL_CVM = 4,
+        CPS_VMGSTOOL_TVM = 5,
+        HCL_POST_PROVISIONING = 6,
     }
 }
 
@@ -244,7 +245,8 @@ pub struct ProvisioningMarker {
     pub vtpm_nvram_size: u32,
     pub vtpm_akcert_size: u32,
     pub vtpm_akcert_attrs: u32,
-    pub _reserved2: [u8; 996],
+    pub hcl_version: [u8; 40], // OpenHCL: string representation of commit hash
+    pub _reserved2: [u8; 956],
 }
 
 // Size of the provisioning marker.


### PR DESCRIPTION
We want to leave a marker in a VMGS file that indicates that it was provisioned originally by HCL, with some diagnostic details (vTPM version, etc.) This is intended to be information-only.