### PR TITLE
flowey: Remove support for building tests with panic-abort-tests

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -894,7 +894,6 @@ impl IntoPipeline for CheckinGatesCli {
                             fail_job_on_test_fail: true,
                             target: target.clone(),
                             profile: CommonProfile::from_release(release),
-                            unstable_panic_abort_tests: None,
                             artifact_dir: pub_unit_test_junit_xml.map(|x| ctx.publish_artifact(x)),
                             done: ctx.new_done_handle(),
                         }

--- a/flowey/flowey_lib_common/src/run_cargo_nextest_archive.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_archive.rs
@@ -51,7 +51,6 @@ impl FlowNode for Node {
                     packages,
                     features,
                     no_default_features,
-                    unstable_panic_abort_tests,
                     target,
                     profile,
                     extra_env,
@@ -90,7 +89,6 @@ impl FlowNode for Node {
                                 target,
                                 packages,
                                 features,
-                                unstable_panic_abort_tests,
                                 no_default_features,
                                 extra_env,
                             );

--- a/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
@@ -21,16 +21,6 @@ pub mod build_params {
     use flowey::node::prelude::*;
     use std::collections::BTreeMap;
 
-    #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
-    pub enum PanicAbortTests {
-        /// Assume the current rust toolchain is nightly
-        // FUTURE: current flowey infrastructure doesn't actually have a path for
-        // multi-toolchain drifting
-        UsingNightly,
-        /// Build with `RUSTC_BOOTSTRAP=1` set
-        UsingRustcBootstrap,
-    }
-
     /// Types of things that can be documented
     #[derive(Serialize, Deserialize)]
     pub enum TestPackages {
@@ -54,8 +44,6 @@ pub mod build_params {
         pub features: CargoFeatureSet,
         /// Whether to disable default features
         pub no_default_features: bool,
-        /// Whether to build tests with unstable `-Zpanic-abort-tests` flag
-        pub unstable_panic_abort_tests: Option<PanicAbortTests>,
         /// Build tests for the specified target
         pub target: target_lexicon::Triple,
         /// Build tests with the specified cargo profile
@@ -402,7 +390,6 @@ impl build_params::NextestBuildParams {
             packages,
             features,
             no_default_features,
-            unstable_panic_abort_tests,
             target,
             profile,
             extra_env,
@@ -412,7 +399,6 @@ impl build_params::NextestBuildParams {
             packages: packages.claim(ctx),
             features,
             no_default_features,
-            unstable_panic_abort_tests,
             target,
             profile,
             extra_env: extra_env.claim(ctx),

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs
@@ -7,7 +7,6 @@ use crate::build_nextest_unit_tests::BuildNextestUnitTestMode;
 use crate::run_cargo_build::common::CommonProfile;
 use crate::run_cargo_nextest_run::NextestProfile;
 use flowey::node::prelude::*;
-use flowey_lib_common::run_cargo_nextest_run::build_params::PanicAbortTests;
 use std::collections::BTreeMap;
 
 flowey_request! {
@@ -18,8 +17,6 @@ flowey_request! {
         pub target: target_lexicon::Triple,
         /// Build and run unit tests with the specified cargo profile
         pub profile: CommonProfile,
-        /// Whether to build tests with unstable `-Zpanic-abort-tests` flag
-        pub unstable_panic_abort_tests: Option<PanicAbortTests>,
         /// Nextest profile to use when running the source code
         pub nextest_profile: NextestProfile,
 
@@ -46,7 +43,6 @@ impl SimpleFlowNode for Node {
             junit_test_label,
             target,
             profile,
-            unstable_panic_abort_tests,
             nextest_profile,
             fail_job_on_test_fail,
             artifact_dir,
@@ -56,7 +52,6 @@ impl SimpleFlowNode for Node {
         let results = ctx.reqv(|v| crate::build_nextest_unit_tests::Request {
             profile,
             target,
-            unstable_panic_abort_tests,
             build_mode: BuildNextestUnitTestMode::ImmediatelyRun {
                 nextest_profile,
                 results: v,

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -17,7 +17,6 @@ use flowey::node::prelude::*;
 use flowey_lib_common::run_cargo_build::CargoBuildProfile;
 use flowey_lib_common::run_cargo_build::CargoFeatureSet;
 use flowey_lib_common::run_cargo_nextest_run::TestResults;
-use flowey_lib_common::run_cargo_nextest_run::build_params::PanicAbortTests;
 use flowey_lib_common::run_cargo_nextest_run::build_params::TestPackages;
 
 /// Type-safe wrapper around a built nextest archive containing unit tests
@@ -47,8 +46,6 @@ flowey_request! {
         pub target: target_lexicon::Triple,
         /// Build and run unit tests with the specified cargo profile
         pub profile: CommonProfile,
-        /// Whether to build tests with unstable `-Zpanic-abort-tests` flag
-        pub unstable_panic_abort_tests: Option<PanicAbortTests>,
         /// Build mode to use when building the nextest unit tests
         pub build_mode: BuildNextestUnitTestMode,
     }
@@ -154,7 +151,6 @@ impl FlowNode for Node {
         for Request {
             target,
             profile,
-            unstable_panic_abort_tests,
             build_mode,
         } in requests
         {
@@ -207,7 +203,6 @@ impl FlowNode for Node {
                     packages: test_packages.clone(),
                     features,
                     no_default_features: false,
-                    unstable_panic_abort_tests,
                     target: target.clone(),
                     profile: match profile {
                         CommonProfile::Release => CargoBuildProfile::Release,

--- a/flowey/flowey_lib_hvlite/src/build_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_vmm_tests.rs
@@ -120,7 +120,6 @@ impl FlowNode for Node {
                     }),
                     features: Default::default(),
                     no_default_features: false,
-                    unstable_panic_abort_tests: None, // don't run VMM tests on musl hvlite
                     target: target.clone(),
                     profile: match profile {
                         CommonProfile::Release => CargoBuildProfile::Release,


### PR DESCRIPTION
This removes yet another use of RUSTC_BOOTSTRAP from our CI, which is something we should be striving towards. We don't even use this feature anymore in this repo. There was one use in the internal repo, however a test run I did there seems to indicate that this is no longer needed since we switched to nextest. So we can safely get rid of it.