### PR TITLE
ci: 1.7 only: use the appropriate baseline for verifying OpenHCL binary size

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -95,7 +95,7 @@ impl SimpleFlowNode for Node {
         let merge_commit = ctx.reqv(|v| git_merge_commit::Request {
             repo_path: openvmm_repo_path.clone(),
             merge_commit: v,
-            base_branch: "main".into(),
+            base_branch: "release/1.7.2511".into(),
         });
 
         let merge_run = ctx.reqv(|v| {


### PR DESCRIPTION
Our CI pipeline ensures that no single commit increase the binary size by more than 50KB from the previous baseline, which is the binary built by the head of the current branch.

This check hard codes the main branch. The merge commit for a 1.7 change and main is the commit at which 1.7 forked.

Perhaps this is intentional (and it seems like a good idea), but we've accumulated enough code in the 1.7 branch that we need to get past this. For now, use the same logic, but just use the release/1.7.2511 branch.

We will want to take a further change to parameterize this, so that we do not need to do this for every fork.