### PR TITLE
tdx: use timer virtualization for lower VTLs (#2483)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,7 +29,7 @@ pub const NODEJS: &str = "18.x";
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.1";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.2";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.4";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -587,6 +587,7 @@ mod ioctls {
     pub const HCL_CAP_REGISTER_PAGE: u32 = 1;
     pub const HCL_CAP_VTL_RETURN_ACTION: u32 = 2;
     pub const HCL_CAP_DR6_SHARED: u32 = 3;
+    pub const HCL_CAP_LOWER_VTL_TIMER_VIRT: u32 = 4;
 
     ioctl_write_ptr!(
         /// Check for the presence of an extension capability.
@@ -1621,6 +1622,7 @@ pub struct Hcl {
     supports_vtl_ret_action: bool,
     supports_register_page: bool,
     dr6_shared: bool,
+    supports_lower_vtl_timer_virt: bool,
     isolation: IsolationType,
     snp_register_bitmap: [u8; 64],
     sidecar: Option<SidecarClient>,
@@ -1656,6 +1658,11 @@ impl Hcl {
     /// Returns true if DR6 is a shared register on this processor.
     pub fn dr6_shared(&self) -> bool {
         self.dr6_shared
+    }
+
+    /// Returns true if timer virtualization for lower VTL is supported.
+    pub fn supports_lower_vtl_timer_virt(&self) -> bool {
+        self.supports_lower_vtl_timer_virt
     }
 }
 
@@ -2339,9 +2346,12 @@ impl Hcl {
         let supports_vtl_ret_action = mshv_fd.check_extension(HCL_CAP_VTL_RETURN_ACTION)?;
         let supports_register_page = mshv_fd.check_extension(HCL_CAP_REGISTER_PAGE)?;
         let dr6_shared = mshv_fd.check_extension(HCL_CAP_DR6_SHARED)?;
+        let supports_lower_vtl_timer_virt =
+            mshv_fd.check_extension(HCL_CAP_LOWER_VTL_TIMER_VIRT)?;
         tracing::debug!(
             supports_vtl_ret_action,
             supports_register_page,
+            supports_lower_vtl_timer_virt,
             "HCL capabilities",
         );
 
@@ -2365,6 +2375,7 @@ impl Hcl {
             supports_vtl_ret_action,
             supports_register_page,
             dr6_shared,
+            supports_lower_vtl_timer_virt,
             isolation,
             snp_register_bitmap,
             sidecar,

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -11,6 +11,7 @@ use super::ProcessorRunner;
 use super::hcl_tdcall;
 use super::mshv_tdcall;
 use crate::GuestVtl;
+use crate::protocol::tdx_l2_tsc_deadline_state;
 use crate::protocol::tdx_tdg_vp_enter_exit_info;
 use crate::protocol::tdx_vp_context;
 use crate::protocol::tdx_vp_state;
@@ -169,6 +170,16 @@ impl<'a> ProcessorRunner<'a, Tdx<'a>> {
     /// Gets a mutable reference to the TDX VP entry flags.
     fn tdx_vp_entry_flags_mut(&mut self) -> &mut TdxVmFlags {
         &mut self.tdx_vp_context_mut().entry_rcx
+    }
+
+    /// Gets a reference to the TDX L2 TSC deadline state.
+    pub fn tdx_l2_tsc_deadline_state(&self) -> &tdx_l2_tsc_deadline_state {
+        &self.tdx_vp_context().l2_tsc_deadline
+    }
+
+    /// Gets a mutable reference to the TDX L2 TSC deadline state.
+    pub fn tdx_l2_tsc_deadline_state_mut(&mut self) -> &mut tdx_l2_tsc_deadline_state {
+        &mut self.tdx_vp_context_mut().l2_tsc_deadline
     }
 
     /// Reads the private registers from the kernel's shared run page into

--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -259,6 +259,20 @@ pub struct tdx_vp_state {
     pub flags: tdx_vp_state_flags,
 }
 
+/// L2 TSC deadline state for current VP.
+#[repr(C)]
+#[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct tdx_l2_tsc_deadline_state {
+    /// Timer deadline value in absolute virtual TSC units for this processor.
+    pub deadline: u64,
+    /// Controls whether the TSC deadline should be updated.
+    ///
+    /// When set to 1, the `mshv_vtl` driver will issue a `TDG.VP.WR` call to
+    /// update the TSC deadline during the next entry into lower VTL.
+    pub update_deadline: u8,
+    pub pad: [u8; 7],
+}
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct tdx_vp_context {
@@ -268,7 +282,8 @@ pub struct tdx_vp_context {
     pub pad2: [u8; 32],
     pub entry_rcx: x86defs::tdx::TdxVmFlags,
     pub gpr_list: x86defs::tdx::TdxL2EnterGuestState,
-    pub pad3: [u8; 96],
+    pub l2_tsc_deadline: tdx_l2_tsc_deadline_state,
+    pub pad3: [u8; 80],
     pub fx_state: x86defs::xsave::Fxsave,
     pub pad4: [u8; 16],
 }

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -335,6 +335,7 @@ async fn launch_workers(
         attempt_ak_cert_callback: opt.attempt_ak_cert_callback,
         enable_vpci_relay: opt.enable_vpci_relay,
         disable_proxy_redirect: opt.disable_proxy_redirect,
+        disable_lower_vtl_timer_virt: opt.disable_lower_vtl_timer_virt,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -266,6 +266,9 @@ pub struct Options {
 
     /// (OPENHCL_DISABLE_PROXY_REDIRECT=1) Disable proxy interrupt redirection.
     pub disable_proxy_redirect: bool,
+
+    /// (OPENHCL_DISABLE_LOWER_VTL_TIMER_VIRT=1) Disable lower VTL timer virtualization.
+    pub disable_lower_vtl_timer_virt: bool,
 }
 
 impl Options {
@@ -437,6 +440,7 @@ impl Options {
         let attempt_ak_cert_callback = parse_env_bool_opt("HCL_ATTEMPT_AK_CERT_CALLBACK");
         let enable_vpci_relay = parse_env_bool_opt("OPENHCL_ENABLE_VPCI_RELAY");
         let disable_proxy_redirect = parse_env_bool("OPENHCL_DISABLE_PROXY_REDIRECT");
+        let disable_lower_vtl_timer_virt = parse_env_bool("OPENHCL_DISABLE_LOWER_VTL_TIMER_VIRT");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -501,6 +505,7 @@ impl Options {
             attempt_ak_cert_callback,
             enable_vpci_relay,
             disable_proxy_redirect,
+            disable_lower_vtl_timer_virt,
         })
     }
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -310,6 +310,8 @@ pub struct UnderhillEnvCfg {
     pub enable_vpci_relay: Option<bool>,
     /// Disable proxy interrupt redirection
     pub disable_proxy_redirect: bool,
+    /// Disable lower VTL timer virtualization
+    pub disable_lower_vtl_timer_virt: bool,
 }
 
 /// Bundle of config + runtime objects for hooking into the underhill remote
@@ -1787,6 +1789,7 @@ async fn new_underhill_vm(
         intercept_debug_exceptions: env_cfg.gdbstub,
         hide_isolation,
         disable_proxy_redirect: env_cfg.disable_proxy_redirect,
+        disable_lower_vtl_timer_virt: env_cfg.disable_lower_vtl_timer_virt,
     };
 
     let proto_partition = UhProtoPartition::new(params, |cpu| tp.driver(cpu).clone())

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -274,6 +274,7 @@ pub(crate) struct BackingSharedParams<'a> {
     pub cpuid: &'a virt::CpuidLeafSet,
     pub hcl: &'a Hcl,
     pub guest_vsm_available: bool,
+    pub lower_vtl_timer_virt_available: bool,
 }
 
 /// Supported intercept message types.
@@ -482,6 +483,12 @@ pub(crate) trait HardwareIsolatedBacking: Backing {
     );
 
     fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic>;
+
+    /// Updates the timer deadline.
+    fn update_deadline(this: &mut UhProcessor<'_, Self>, ref_time_now: u64, next_ref_time: u64);
+
+    /// Clears any pending timer deadline.
+    fn clear_deadline(this: &mut UhProcessor<'_, Self>);
 }
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]

--- a/tmk/tmk_vmm/src/paravisor_vmm.rs
+++ b/tmk/tmk_vmm/src/paravisor_vmm.rs
@@ -34,6 +34,8 @@ impl RunContext<'_> {
             use_mmio_hypercalls: false,
             intercept_debug_exceptions: false,
             disable_proxy_redirect: false,
+            // TODO: match openhcl defaults when TDX is supported.
+            disable_lower_vtl_timer_virt: true,
         };
         let p = virt_mshv_vtl::UhProtoPartition::new(params, |_| self.state.driver.clone())?;
 

--- a/vm/x86/x86defs/src/vmx.rs
+++ b/vm/x86/x86defs/src/vmx.rs
@@ -34,6 +34,7 @@ open_enum! {
         GDTR_OR_IDTR = 0x2E,
         LDTR_OR_TR = 0x2F,
         EPT_VIOLATION = 0x30,
+        TIMER_EXPIRED = 0x34,
         WBINVD_INSTRUCTION = 0x36,
         XSETBV = 0x37,
         TDCALL = 0x4D,


### PR DESCRIPTION
Cherry-pick of PR #2483 to support timer virtualization for lower VTLs.
Issue - #2028 