### PR TITLE
ovmm_entry: Fix compiling with no-default-features

### DIFF
--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -3,6 +3,8 @@
 
 //! Worker for the prototype gRPC/ttrpc management endpoint.
 
+#![cfg(any(feature = "ttrpc", feature = "grpc"))]
+
 use self::vmservice::nic_config::Backend;
 use crate::serial_io::bind_serial;
 use anyhow::Context;


### PR DESCRIPTION
This lets the whole codebase be cargo-hack clean on linux (with excluding encryption_win).