### PR TITLE
lxutil: fix copy / paste error in validate_lx_attributes

### DIFF
--- a/vm/devices/support/fs/lxutil/src/windows/fs.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/fs.rs
@@ -529,7 +529,7 @@ pub fn validate_lx_attributes(info: &mut FileSystem::FILE_STAT_LX_INFORMATION) {
         info.LxFlags &= !FileSystem::LX_FILE_METADATA_HAS_UID;
     }
 
-    if (info.LxFlags & FileSystem::LX_FILE_METADATA_HAS_GID != 0) && (info.LxUid == lx::GID_INVALID)
+    if (info.LxFlags & FileSystem::LX_FILE_METADATA_HAS_GID != 0) && (info.LxGid == lx::GID_INVALID)
     {
         info.LxFlags &= !FileSystem::LX_FILE_METADATA_HAS_GID;
     }


### PR DESCRIPTION
This pull request fixes a bug in the `validate_lx_attributes` function where the group ID (`GID`) attribute was incorrectly validated using the user ID (`UID`) field. The check now correctly uses the `LxGid` field.

This was being caught by a VirtioFS test in the WSL codebase.