### PR TITLE
ohcl_boot: Fix handling of static command line (#2561)

### DIFF
--- a/openhcl/openhcl_boot/src/host_params/dt/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt/mod.rs
@@ -835,12 +835,21 @@ impl PartitionInfo {
         )
         .map_err(|_| DtError::CommandLineSize)?;
 
-        // Depending on policy, write what the host specified in the chosen node.
-        if can_trust_host && command_line.policy == CommandLinePolicy::APPEND_CHOSEN {
-            // Parse in extra options from the host provided command line.
-            options.parse(&parsed.command_line);
-            write!(storage.cmdline, " {}", &parsed.command_line)
-                .map_err(|_| DtError::CommandLineSize)?;
+        match command_line.policy {
+            CommandLinePolicy::STATIC => {
+                // Nothing to do, we already wrote the measured command line.
+            }
+            CommandLinePolicy::APPEND_CHOSEN if can_trust_host => {
+                // Check the host-provided command line for options for ourself,
+                // and pass it along to the kernel.
+                options.parse(&parsed.command_line);
+                write!(storage.cmdline, " {}", &parsed.command_line)
+                    .map_err(|_| DtError::CommandLineSize)?;
+            }
+            CommandLinePolicy::APPEND_CHOSEN if !can_trust_host => {
+                // Nothing to do, we ignore the host provided command line.
+            }
+            _ => unreachable!(),
         }
 
         init_heap(params);

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -314,21 +314,21 @@ fn build_kernel_command_line(
         write!(cmdline, "{} ", sidecar.kernel_command_line())?;
     }
 
-    // HACK: Set the vmbus connection id via kernel commandline.
-    //
-    // This code will be removed when the kernel supports setting connection id
-    // via device tree.
-    write!(
-        cmdline,
-        "hv_vmbus.message_connection_id=0x{:x} ",
-        partition_info.vmbus_vtl2.connection_id
-    )?;
-
-    // If we're isolated we can't trust the host-provided cmdline
-    if can_trust_host {
-        // Prepend the computed parameters to the original command line.
-        cmdline.write_str(&partition_info.cmdline)?;
+    if !cmdline.contains("hv_vmbus.message_connection_id") {
+        // HACK: Set the vmbus connection id via kernel commandline if we haven't
+        // gotten one from elsewhere.
+        //
+        // This code will be removed when the kernel supports setting connection id
+        // via device tree.
+        write!(
+            cmdline,
+            "hv_vmbus.message_connection_id=0x{:x} ",
+            partition_info.vmbus_vtl2.connection_id
+        )?;
     }
+
+    // Prepend the computed parameters to the original command line.
+    cmdline.write_str(&partition_info.cmdline)?;
 
     Ok(())
 }


### PR DESCRIPTION
Due to checking can_trust_host twice, we accidentally were ignoring the safe-to-trust measured portion of the command line for CVMs. Clean up our command line handling in general and fix this.

Clean cherry-pick