### PR TITLE
petri/hyperv: Re-increase the pipette timeout (#2580)

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -785,8 +785,11 @@ impl PetriVmRuntime for HyperVPetriRuntime {
             // Extend the default timeout of 2 seconds, as tests are often run
             // in parallel on a host, causing very heavy load on the overall
             // system.
+            //
+            // TODO: Until #2470 is fixed, extend the timeout even longer to 10
+            // seconds to workaround a Windows vmbus bug.
             socket
-                .set_connect_timeout(Duration::from_secs(2))
+                .set_connect_timeout(Duration::from_secs(10))
                 .context("failed to set connect timeout")?;
             socket
                 .set_high_vtl(set_high_vtl)


### PR DESCRIPTION
To help mitigate the impact of #2470, re-increase the hyper-v pipette timeout to 10 seconds. #2527 helped but wasn't quite enough to make the issue completely go away.

Clean cherry-pick