### PR TITLE
Guide: markdownlint fixes

### DIFF
--- a/Guide/src/dev_guide/contrib/release.md
+++ b/Guide/src/dev_guide/contrib/release.md
@@ -26,13 +26,13 @@ choices of these dates.
 
 Releases naturally fall into several phases:
 
-| Phase             | Meaning                                                                 |
-|-------------------|-------------------------------------------------------------------------|
-| Active Development| Regular development phase where new features and fixes are added.       |
-| Stabilization     | Phase focused on stabilizing the release by fixing bugs.                |
-| Ask Mode          | Only critical fixes are allowed; changes are scrutinized. No new features. This is the last phase before a release is closed. |
-| Servicing         | Only essential fixes are made to support the release (a.k.a. maintenance mode). |
-| Out of service    | A previous release which is no longer receiving updates. |
+| Phase              | Meaning                                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Active Development | Regular development phase where new features and fixes are added.                                                              |
+| Stabilization      | Phase focused on stabilizing the release by fixing bugs.                                                                       |
+| Ask Mode           | Only critical fixes are allowed; changes are scrutinized. No new features. This is the last phase before a release is closed.  |
+| Servicing          | Only essential fixes are made to support the release (a.k.a. maintenance mode).                                                |
+| Out of service     | A previous release which is no longer receiving updates.                                                                       |
 
 ### Release branch process
 
@@ -67,12 +67,12 @@ When creating a backport PR to a release branch:
   
 ## Existing Release Branches
 
-| Release | Phase | Notes |
-|--------|-------|-------|
-| release/2411 | Out of service | |
-| release/2505 | Servicing | Supports runtime servicing from release/2411. |
-| release/1.7.2511 | Stabilization | Supports runtime servicing from release/2411 and release/2505. |
-| _tbd, in main_ | Active Development | Supports runtime servicing from release/2411 and release/2505. |
+| Release          | Phase              | Notes                                                                |
+| ---------------- | ------------------ | -------------------------------------------------------------------- |
+| release/2411     | Out of service     |                                                                      |
+| release/2505     | Servicing          | Supports runtime servicing from release/2411.                        |
+| release/1.7.2511 | Stabilization      | Supports runtime servicing from release/2411 and release/2505.       |
+| _tbd, in main_   | Active Development | Supports runtime servicing from release/2411 and release/2505.       |
 
 ## Taking a Dependency on a Release
 

--- a/Guide/src/dev_guide/contrib/save-state.md
+++ b/Guide/src/dev_guide/contrib/save-state.md
@@ -28,7 +28,7 @@ Here are the principles you must maintain when adding new save & restore code:
    default values needed for safely extending save state:
     * Arrays: if you need to add an array, consider a `vec` or `Option<[T; N]>`
       instead.
-    * Enum: if you need to add an enum, add it as `Option<MyEnum>' instead.
+    * Enum: if you need to add an enum, add it as `Option<MyEnum>` instead.
 4. **Be particularly careful when updating saved state**: See below.
 
 ### Updating (Extending) Saved State

--- a/Guide/src/dev_guide/dev_tools.md
+++ b/Guide/src/dev_guide/dev_tools.md
@@ -14,7 +14,7 @@ don't neatly fall under the `cargo` umbrella. e.g:
 The following chapter discusses some of the various dev-facing tools / utilities
 you may encounter and/or find useful when working on OpenVMM.
 
-### Rust-based Tooling
+## Rust-based Tooling
 
 As with many projects, OpenVMM initially took the simple approach of spinning up
 ad-hoc Bash/Python scripts, and hand-written YAML workflow automation.

--- a/Guide/src/dev_guide/dev_tools/xflowey.md
+++ b/Guide/src/dev_guide/dev_tools/xflowey.md
@@ -20,7 +20,6 @@ In a nutshell:
 - `cargo xflowey`: orchestrates invoking a sequence of tools/utilities, without
   doing any non-trivial data processing itself
 
-
 ```admonish warning
 While `cargo xflowey` technically has the ability to run CI pipelines locally (e.g., `cargo xflowey ci checkin-gates`), this functionality is currently broken and should not be relied upon. Use CI pipelines in their intended environments (Azure DevOps or GitHub Actions). [`GitHub issue tracking this`](https://github.com/microsoft/openvmm/issues/2322)
 ```

--- a/Guide/src/dev_guide/getting_started.md
+++ b/Guide/src/dev_guide/getting_started.md
@@ -10,7 +10,7 @@ By the end of this chapter, you will have:
 - Built local copies of both OpenVMM and OpenHCL
 - (optionally) Set up a suggested VSCode-based development environment
 
-### _Aside:_ What is HvLite? Underhill?
+## _Aside:_ What is HvLite? Underhill?
 
 As you explore the OpenVMM repo, you may find references to things called
 **HvLite** and **Underhill**.

--- a/Guide/src/dev_guide/getting_started/build_ohcl_kernel.md
+++ b/Guide/src/dev_guide/getting_started/build_ohcl_kernel.md
@@ -27,7 +27,6 @@ NTFS being non case-sensitive by default as there are few files in the Linux ker
 in their case only. To clone successfully under Windows, need a fix in `ntdll` (merged in `Ni`?),
 and a case-sensitive NTFS partition. Best to start with the default WSL2 if there is no existing working setup.
 
-
 ## Building the kernel locally
 
 The following instructions for building the kernel locally target the Ubuntu distributions.

--- a/Guide/src/dev_guide/getting_started/build_openhcl.md
+++ b/Guide/src/dev_guide/getting_started/build_openhcl.md
@@ -97,7 +97,7 @@ OpenHCL.
 If you are still running into issues, consider filing an issue on the OpenVMM
 GitHub Issue tracker.
 
-### Help! The build failed due to a missing dependency!
+### Help! The build failed due to a missing dependency
 
 If you don't mind having `xflowey` install some dependencies globally on your
 machine (i.e: via `apt install`, or `rustup toolchain add`), you can pass
@@ -109,7 +109,7 @@ to install it.
 
 If it doesn't - please file an Issue!
 
-### Help! Everything is rebuilding even though I only made a small change!
+### Help! Everything is rebuilding even though I only made a small change
 
 Cargo's target triple handling can be a bit buggy. Try running with:
 
@@ -131,11 +131,11 @@ wish to build specialized custom IGVM files for local testing.
 
 Some examples of potentially useful customization include:
 
-  * `--override-manifest`: Override the recipe's `igvmfilegen` manifest file
+- `--override-manifest`: Override the recipe's `igvmfilegen` manifest file
     via, in order to tweak different kernel command line options, different VTL0
     boot configuration, or different VTL2 memory sizes.
 
-  * `--custom-openvmm-hcl`: Specify a pre-built `openvmm_hcl` binary. This is
+- `--custom-openvmm-hcl`: Specify a pre-built `openvmm_hcl` binary. This is
     useful in case you have already built it with some custom settings, e.g.:
 
     ```bash
@@ -143,7 +143,7 @@ Some examples of potentially useful customization include:
     cargo xflowey build-igvm x64 --custom-openvmm-hcl target/x86_64-unknown-linux-musl/debug/openvmm_hcl
     ```
 
-  * Specify a custom VTL2 kernel `vmlinux` / `Image`, instead of using a
+- Specify a custom VTL2 kernel `vmlinux` / `Image`, instead of using a
     pre-packed stable/dev kernel.
 
     ```bash

--- a/Guide/src/dev_guide/getting_started/cross_compile.md
+++ b/Guide/src/dev_guide/getting_started/cross_compile.md
@@ -24,15 +24,17 @@ rustup target add x86_64-pc-windows-msvc
 
 Additional build tools must be installed as well. If your distro has LLVM 14
 available (Ubuntu 22.04 or newer):
+
 ```bash
 sudo apt install clang-tools-14 lld-14 llvm-dev
 ```
 
-Otherwise, follow the steps at https://apt.llvm.org/ to install a specific
+Otherwise, follow the steps at <https://apt.llvm.org/> to install a specific
 version, by adding the correct apt repos. Note that you must install
 `clang-tools-14` as default `clang-14` uses gcc style arguments, where
 `clang-cl-14` uses msvc style arguments. You can use their helper script as
 well:
+
 ```bash
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh

--- a/Guide/src/dev_guide/getting_started/linux.md
+++ b/Guide/src/dev_guide/getting_started/linux.md
@@ -15,11 +15,13 @@ PS> wsl --install
 This should install WSL2 using the default Ubuntu linux distribution.
 You can check that the installation completed successfully by running the
 following command in a Powershell window.
+
 ```powershell
 PS> wsl -l -v
   NAME            STATE           VERSION
 * Ubuntu          Running         2
 ```
+
 Once that command has completed, you will need to open WSL to complete the
 installation and set your password. You can open WSL by typing `wsl` or `bash`
 into Command Prompt or Powershell, or by opening the "Ubuntu" Windows Terminal
@@ -68,8 +70,8 @@ clone from Linux! It will result in serious performance issues, and may break
 certain functionality (e.g: cross-compiling Windows binaries).
 
 ```bash
-$ cd ~/src/
-$ git clone https://github.com/microsoft/openvmm.git
+cd ~/src/
+git clone https://github.com/microsoft/openvmm.git
 ```
 
 ## Next Steps

--- a/Guide/src/dev_guide/getting_started/suggested_dev_env.md
+++ b/Guide/src/dev_guide/getting_started/suggested_dev_env.md
@@ -224,7 +224,7 @@ seconds to run locally. That's far better than waiting ~20+ minutes only
 for CI to fail on your pull request.
 ```
 
-# \[WSL2] Cross Compiling from WSL2 to Windows
+## \[WSL2] Cross Compiling from WSL2 to Windows
 
 You may also want to [set up cross compiling in WSL2](./cross_compile.md)
 to you can build for both Windows and Linux in one dev environemnt.

--- a/Guide/src/dev_guide/getting_started/windows.md
+++ b/Guide/src/dev_guide/getting_started/windows.md
@@ -36,7 +36,7 @@ Please follow the [official instructions](https://www.rust-lang.org/tools/instal
 ### Visual Studio C++ Build Tools and Windows SDK
 
 If you don't already have it, you will need to install
-[Visual Studio C++ Build tools ](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+[Visual Studio C++ Build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
 or [Visual Studio](https://visualstudio.microsoft.com/vs/) with the components
 "Desktop Development for C++" and the Windows SDK. Windows 11 SDK version 26100 is the latest
 version as of this update, but you should install the newest version if there is a newer

--- a/Guide/src/dev_guide/tests/fuzzing/running.md
+++ b/Guide/src/dev_guide/tests/fuzzing/running.md
@@ -71,7 +71,6 @@ cargo xtask fuzz run fuzz_ide -- -- -help=1
 ```
 
 [cli-opts]: https://www.llvm.org/docs/LibFuzzer.html#options
-[toolchain-overrides-url]: https://rust-lang.github.io/rustup/overrides.html
 
 ## Other Fuzzing Commands
 

--- a/Guide/src/index.md
+++ b/Guide/src/index.md
@@ -9,7 +9,7 @@ currently focused on its role in the [OpenHCL paravisor][paravisor].
 The project is open-source, MIT Licensed, and developed publicly at
 [microsoft/openvmm](https://github.com/microsoft/openvmm) on GitHub.
 
-**Cross-Platform**
+## Cross-Platform
 
 OpenVMM supports a variety of host operating systems, architectures, and
 virtualization backends:
@@ -22,7 +22,7 @@ virtualization backends:
 |                     | x64           | MSHV (Microsoft Hypervisor)            |
 | macOS               | Aarch64       | Hypervisor.framework                   |
 
-**Running in the OpenHCL paravisor**
+## Running in the OpenHCL paravisor
 
 OpenVMM is the VMM that runs in the [OpenHCL paravisor][paravisor].
 
@@ -47,7 +47,7 @@ enabling several important Azure scenarios:
 - Powering [Trusted Launch VMs] - VMs that support Secure Boot, and include a
   vTPM.
 
-**Standalone VMM**
+## Standalone VMM
 
 OpenVMM can also run as a general-purpose VMM on a Windows, Linux, or macOS
 host. At the moment, this is primarily a development vehicle: most of the same
@@ -61,7 +61,7 @@ general-purpose use. We recommend you consider other Rust-based VMMs such as
 [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) for
 such use cases.
 
-***Relationship to other Rust-based VMMs***
+## Relationship to other Rust-based VMMs
 
 OpenVMM's core security principles are aligned with those of the Rust-based
 Cloud Hypervisor, Firecracker, and crosvm projects, which is why we also chose
@@ -89,7 +89,7 @@ We are indebted to the Rust VMM community for their trailblazing work. Now that
 the OpenVMM project is open source, we hope to find ways to collaborate on
 shared code while maintaining the benefits of the OpenVMM architecture.
 
-**Guest Compatibility**
+## Guest Compatibility
 
 Similar to other general-purpose VMMs (such as Hyper-V, QEMU, VirtualBox),
 OpenVMM is able to host a wide variety of both modern and legacy guest operating

--- a/Guide/src/reference/dev_feats/gdbstub.md
+++ b/Guide/src/reference/dev_feats/gdbstub.md
@@ -14,12 +14,14 @@ Hardware debugging has several benefits over using an in-guest / in-kernel debug
 ## Enabling the Debugger
 
 ### OpenVMM
+
 1. Pass the `--gdb <port>` flag at startup to enable the
 debug worker. e.g., `--gdb 9001`
 
 To pause the VM until the debugger has been attached, pass `--paused` at startup.
 
 ### OpenHCL
+
 1. Pass the `OPENHCL_GDBSTUB=1` `OPENHCL_GDBSTUB_PORT=<gdbstub port>` parameters to enable gdbstub. e.g., `Set-VmFirmwareParameters -Name UhVM -CommandLine OPENHCL_GDBSTUB=1 OPENHCL_GDBSTUB_PORT=5900`.
 2. To expose a TCP port, run `ohcldiag-dev.exe <name> vsock-tcp-relay --allow-remote --reconnect <gdbstub port> <tcp port>`.
 
@@ -127,6 +129,7 @@ except you'll need to [enable our debugger](#enabling-the-debugger) instead of
 running QEMU.
 
 It's easiest to connect through the GUI. The steps are relatively simple: Open Windbgx -> File -> Attach to kernel -> EXDI. On the form, fill out:
+
 - Target Type: `QEMU`
 - Target Architecture: `X64`
 - Target OS: `Windows`
@@ -134,10 +137,11 @@ It's easiest to connect through the GUI. The steps are relatively simple: Open W
 - Gdb server and port: `<server>:<port>` e.g., `127.0.0.1:1337` (use whatever port you set above)
 
 ### Known WinDbg Bugs
+
 - Hardware breakpoints are issued with [`ba`](https://learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/ba--break-on-access-). The `Access Size` parameter is incorrectly multiplied by 8 when sent to the stub. Consequently, it _must_ be set to 1.
 - Unlike GDB, WinDbg doesn't implicitly set software breakpoints via our offered write_addrs implementation.
----
 
+---
 
 ## Supported Features
 
@@ -157,11 +161,11 @@ everyone, consider implementing one or more of the following features:
 
 - \* reading _all_ guest registers, including fpu, xmm, and various key msrs
 - software breakpoints:
-    - Intercept guest breakpoint exceptions into VTL2
+  - Intercept guest breakpoint exceptions into VTL2
 - writing guest registers
 - exposing the OpenVMM interactive console via the
   [`MonitorCmd`](https://docs.rs/gdbstub/latest/gdbstub/target/ext/monitor_cmd/trait.MonitorCmd.html)
   interface
-    - Custom commands sent using `monitor` (gdb) / `.exdicmd` (WinDbg)
-    - e.g., being able to invoke `x device/to/inspect` directly from the debugger
+  - Custom commands sent using `monitor` (gdb) / `.exdicmd` (WinDbg)
+  - e.g., being able to invoke `x device/to/inspect` directly from the debugger
 - [any other features supported by the `gdbstub` library](https://github.com/daniel5151/gdbstub#debugging-features)

--- a/Guide/src/reference/dev_feats/kdnet.md
+++ b/Guide/src/reference/dev_feats/kdnet.md
@@ -17,10 +17,11 @@ additional flag `--net consomme`:
 - **With OpenHCL:** Ensure "UEFI Boot" and "VTL2 VMBus Support" are active
 
 ### Known Issues with KDNET on WHP
+
 - KDNET currently only works with the `consomme` networking option in OpenVMM,
   however `consomme` will create a new network adapter in the guest every time
   OpenVMM is restarted. This can be safely ignored.
-    - KDNET will also connect with `--net vmnic:<ethernet switch id>`, but hangs
+  - KDNET will also connect with `--net vmnic:<ethernet switch id>`, but hangs
       immediately after due to a yet undiagnosed bug in vmbusproxy.
 - Quitting OpenVMM without shutting down the VM first will prevent the same
   debugger instance from reconnecting to the guest on next boot. Relauch the

--- a/Guide/src/reference/openhcl/diag/cvm_restrictions.md
+++ b/Guide/src/reference/openhcl/diag/cvm_restrictions.md
@@ -25,7 +25,7 @@ Tracing statements and spans will still be sent to the host, and therefore will 
 ETW traces and Kusto. However, individual statements may opt out of being logged inside a CVM, as a
 way of protecting guest secrets.
 
-### For Developers:
+### For Developers
 
 This is done by using the `CVM_CONFIDENTIAL` constant provided by the
 `cvm_tracing` crate. `cvm_tracing` also provides a `CVM_ALLOWED` constant, to

--- a/Guide/src/reference/openhcl/diag/ohcldiag_dev.md
+++ b/Guide/src/reference/openhcl/diag/ohcldiag_dev.md
@@ -44,7 +44,9 @@ PS > .\ohcldiag-dev.exe <vm name> run -- cat /etc/kernel-build-info.json
   "build_name": "5.15.90.7-hcl.1"
 }
 ```
+
 The OpenHCL version information can be read from the filesystem, too:
+
 ```powershell
 PS > .\ohcldiag-dev.exe <vm name> run -- cat /etc/underhill-build-info.json
 {
@@ -52,6 +54,7 @@ PS > .\ohcldiag-dev.exe <vm name> run -- cat /etc/underhill-build-info.json
     "git_revision": "a7c4ba3ffcd8708346d33a608f25b9287ac89f8b"
 }
 ```
+
 ### Interactive Shell
 
 To get an interactive shell into the VM, try:
@@ -82,7 +85,7 @@ ohcldiag-dev.exe <vm name> inspect -r
 
 The kernel `kmsg` log currently contains both the kernel log output and the
 OpenHCL log output. You can see this output via the
-[console](#kernel-console), if you have it configured, or via `ohcldiag-dev`:
+[serial console](./tracing.md#enabling-serial-logging-for-openhcl), if you have it configured, or via `ohcldiag-dev`:
 
 ```powershell
 ohcldiag-dev.exe <vm name> kmsg

--- a/Guide/src/reference/openhcl/diag/ohcldiag_dev/pcap.md
+++ b/Guide/src/reference/openhcl/diag/ohcldiag_dev/pcap.md
@@ -4,6 +4,7 @@ PCAP is an industry standard format for capturing network packets. OpenHCL now
 supports PCAP based packet capture for the network packets that are going through it.
 
 ## Prerequisites
+
 * PCAP based packet capture support in OpenHCL came in around Nov 2023. The easiest
 way to check whether the OpenHCL version you are running has PCAP support or not is by
 running `ohcldiag-dev -h` and if the output shows an option for `packet-capture`, then
@@ -14,15 +15,20 @@ would like to capture the network packets for a given vNIC in OpenHCL, disable
 accelerated networking on the vNIC first.
 
 ## Packet capture options
+
 To see the options for packet capture, run the help command using:
+
 ```cmd
 ohcldiag-dev packet-capture -h
 ```
+
 The help should be self explanatory, but further below are some sample commands
 for reference purposes.
 
 ## How to stop running packet capture
+
 There are two ways of controlling how long the packet capture runs.
+
 1. Use the `-G` or `--seconds` to specify for how many seconds to run the packet capture
 for in the command line. If not specified, it runs for the default value, which you can
 see from the output of the help command above. This option can be handy for example, when
@@ -32,6 +38,7 @@ doing packet capture on the TiP node, where interacting with the console using k
 for the `-G` option. You can then stop the capture at any time using the `Ctrl+c` key.
 
 ## Packet capture traces
+
 The packet capture command will generate a pcap file for each vNIC. You can control the
 name of the pcap file generated using the `-w` option. If not specified, the default
 value for the file name is shown by the help command above. The index of the vNIC is
@@ -39,21 +46,26 @@ appended to the file name. So, for example, the pcap file for the first vNIC wou
 `<default value>-0.pcap`, the second one `<default-value>-1.pcap`, so on and so forth.
 
 ## Loading the pcap file for analysis
+
 There are many software that are available to load the pcap file. The most commonly
 used one is `wireshark`. Copy the `*.pcap` files generated on the test machine and then
 open them up on the desired software.
 
-## Example packet capture commands:
+## Example packet capture commands
+
 In all of the below commands, `$vmname` should be replaced with the actual VM name. On
 Azure, the VM name is the same as the container ID.
+
 * Most basic command; run packet capture with all defaults. This will run packet capture
 for the default values, including the default time (see the help command above for
 default values).
+
 ```cmd
 ohcldiag-dev.exe $vmname packet-capture
 ```
 
 * Run packet capture indefinitely and use Ctrl+c to stop.
+
 ```cmd
 ohcldiag-dev.exe $vmname packet-capture -G 655555
 ```
@@ -62,9 +74,11 @@ ohcldiag-dev.exe $vmname packet-capture -G 655555
 By default, the traces are captured in the current working dir. That may not always be
 desirable, especially on TiP. Let's say you want all the output pcap files
 to go to the `c:\test` folder, then you can do something like:
+
 ```cmd
 ohcldiag-dev.exe ubuntu packet-capture -w c:\test\nic
 ```
+
 The output files will be of the form `c:\test\nic-*.pcap`
 
 * Specify the length of the packet to capture using the `-s` or `--snaplen` option.
@@ -72,12 +86,14 @@ By default, the length of the packet captured can be big and can cause the size
 of the pcap files to be quite large. It is advisable to only capture the packets
 for the length that is of interest. For example, to specify only capturing 128 bytes
 of the packet (which will generally give you the TCP and IP headers), do:
+
 ```cmd
 ohcldiag-dev.exe ubuntu packet-capture -s 128
 ```
 
 * Run the packet capture for the specified duration in seconds using the `-G` option.
 For example, to capture packets for 2min, do:
+
 ```cmd
 ohcldiag-dev.exe ubuntu packet-capture -G 120
 ```

--- a/Guide/src/reference/openhcl/diag/ohcldiag_dev/perf.md
+++ b/Guide/src/reference/openhcl/diag/ohcldiag_dev/perf.md
@@ -49,6 +49,7 @@ Use perf to convert perf data to plain text and dump it to a file on host
 ```
 
 ## Visualize perf profiling data
+
 Please follow up instructions on the external page [Flame
 Graphs](https://www.brendangregg.com/perf.html#FlameGraphs) to create flame
 graph SVG file. It requires scripts from FlameGraph GitHub repo, so it is better

--- a/Guide/src/reference/openhcl/diag/tracing.md
+++ b/Guide/src/reference/openhcl/diag/tracing.md
@@ -17,7 +17,6 @@ For examples on how to enable `OPENVMM_LOG`, see [OpenVMM Logging](../../openvmm
 
 ## \[Hyper-V\] Saving traces to the Windows event log
 
-
 The OpenHCL traces can be saved to the Windows event log on the host. That is
 not meant to be a production scenario due to resource consumption concerns. By
 default, only ETW is emitted.

--- a/Guide/src/reference/openvmm/graphical_console.md
+++ b/Guide/src/reference/openvmm/graphical_console.md
@@ -10,6 +10,7 @@ contents of the VNC clipboard.
 
 Once OpenVMM starts, you can connect to the VNC server using any supported VNC
 client. The following clients have been tested working with OpenVMM:
+
 * [TightVNC](https://www.tightvnc.com/download.php)
 * [TigerVNC](https://github.com/TigerVNC/tigervnc)
 * [RealVNC](https://www.realvnc.com/en/?lai_sr=0-4&lai_sl=l)

--- a/Guide/src/reference/openvmm/logging.md
+++ b/Guide/src/reference/openvmm/logging.md
@@ -22,7 +22,7 @@ type; see the associated documentation for more details.
 
 ## Configuring OpenHCL Trace Logging
 
-If OpenHCL is used, it also supports an [`EnvFilter`](https://docs.rs/tracing-subscriber/0.2.17/tracing_subscriber/struct.EnvFilter.html) style trace logging options that can be configured using the `OPENVMM_LOG=` command line variable passed during OpenHCL startup with `-c OPENVMM_LOG=`. The `-c` argument in OpenVMM passes a string of command line arguments to OpenHCL initialization. 
+If OpenHCL is used, it also supports an [`EnvFilter`](https://docs.rs/tracing-subscriber/0.2.17/tracing_subscriber/struct.EnvFilter.html) style trace logging options that can be configured using the `OPENVMM_LOG=` command line variable passed during OpenHCL startup with `-c OPENVMM_LOG=`. The `-c` argument in OpenVMM passes a string of command line arguments to OpenHCL initialization.
 
 The environment variable configuration and style of `OPENVMM_LOG` for OpenHCL is the same for configuring tracing for OpenVMM.
 
@@ -31,16 +31,19 @@ OpenHCL tracing can also be configured and dumped at runtime with `ohcldiag-dev`
 To retrieve OpenHCL log output at runtime, an output console or file must attach to the OpenHCL logging COM port. By default, OpenHCL outputs to `COM3`.
 
 To open a new terminal window with global OpenHCL debug level tracing enabled:
+
 ```cmd
 openvmm.exe -c "OPENVMM_LOG=debug" --com3 "term,name=VTL2 OpenHCL" [...]
 ```
 
 Configure log levels of only a given module name:
+
 ```cmd
 openvmm.exe -c "OPENVMM_LOG=mesh=trace" --com3 "term,name=VTL2 OpenHCL" [...]
 ```
 
 Multiple modules can be specified by separating them with a comma:
+
 ```cmd
 openvmm.exe -c "OPENVMM_LOG=mesh=trace,nvme_driver=trace" --com3 "term,name=VTL2 OpenHCL" [...]
 ```
@@ -54,20 +57,27 @@ For more configuration examples of serial ports and the OpenVMM CLI, see the [Ru
 On Windows, OpenVMM also logs to ETW, via the Microsoft.HvLite provider.
 
 To capture the trace first need to start the session:
+
 ```cmd
 logman.exe start trace <SessionName> -ow -o FileName0.etl -p "{22bc55fe-2116-5adc-12fb-3fadfd7e360c}" 0xffffffffffffffff 0xff -nb 16 16 -bs 16 -mode 0x2 -ets
 ```
+
  > For OpenHCL traces, use `{AA5DE534-D149-487A-9053-05972BA20A7C}` as the provider GUID.
 
 To flush:
+
 ```cmd
 logman.exe update <SessionName> -ets -fd
 ```
+
 To stop:
+
 ```cmd
 logman.exe stop <SessionName> -ets
 ```
+
 To decode as CSV:
+
 ```cmd
 tracerpt.exe <FileName0>.etl -y -of csv -o <FileName1>.csv -summary <FileName2>.summary
 ```

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -30,12 +30,12 @@ as well as the generated CLI help (via `cargo run -- --help`).
 And serial devices can each be configured to be relayed to different endpoints:
 
 * `--com1/com2/virtio-serial <none|console|stderr|listen=PATH|listen=tcp:IP:PORT>`
-    * `none`: Serial output is dropped.
-    * `console`: Serial input is read and output is written to the console.
-    * `stderr`: Serial output is written to stderr.
-    * `listen=PATH`: A named pipe (on Windows) or Unix socket (on Linux) is set
+  * `none`: Serial output is dropped.
+  * `console`: Serial input is read and output is written to the console.
+  * `stderr`: Serial output is written to stderr.
+  * `listen=PATH`: A named pipe (on Windows) or Unix socket (on Linux) is set
       up to listen on the given path. Serial input and output is relayed to this
       pipe/socket.
-    * `listen=tcp:IP:PORT`: As with `listen=PATH`, but listen for TCP
+  * `listen=tcp:IP:PORT`: As with `listen=PATH`, but listen for TCP
       connections on the given IP address and port. Typically IP will be
       127.0.0.1, to restrict connections to the current host.

--- a/Guide/src/user_guide/openhcl/run/hyperv.md
+++ b/Guide/src/user_guide/openhcl/run/hyperv.md
@@ -1,46 +1,49 @@
 # Windows - Hyper-V
-Hyper-V has support for running with OpenHCL when running on Windows. This is the 
-closest configuration to what Microsoft ships in Azure VMs, the only difference 
+
+Hyper-V has support for running with OpenHCL when running on Windows. This is the
+closest configuration to what Microsoft ships in Azure VMs, the only difference
 being that Azure uses Azure Host OS (as opposed to Windows Client or Windows Server).
 
 ## Get a Windows version that has development support for OpenHCL
 
-Note that Windows Client and Windows Server do not have production support for OpenHCL VMs 
-(Microsoft does not support production workloads on OpenHCL VMs on Windows Client and 
-Windows Server), but certain versions have development support for OpenHCL VMs (they 
+Note that Windows Client and Windows Server do not have production support for OpenHCL VMs
+(Microsoft does not support production workloads on OpenHCL VMs on Windows Client and
+Windows Server), but certain versions have development support for OpenHCL VMs (they
 can be used as developer platforms for the purposes of using/testing/developing OpenHCL).
 
 ### Windows Client
 
-You can use the Windows 11 2024 Update (AKA version 24H2), the third and new major 
-update to Windows 11, as this is the first Windows version to have development 
+You can use the Windows 11 2024 Update (AKA version 24H2), the third and new major
+update to Windows 11, as this is the first Windows version to have development
 support for OpenHCL VMs.
 
-As of October 1, 2024, the Windows 11 2024 Update is available. Microsoft is taking a 
-phased approach with its rollout. If the update is available for your device, it 
-will [download and install automatically](https://learn.microsoft.com/en-us/windows/release-health/status-windows-11-24h2). 
+As of October 1, 2024, the Windows 11 2024 Update is available. Microsoft is taking a
+phased approach with its rollout. If the update is available for your device, it
+will [download and install automatically](https://learn.microsoft.com/en-us/windows/release-health/status-windows-11-24h2).
 
-Otherwise, you can get it via [Windows Insider](https://www.microsoft.com/en-us/windowsinsider) 
-by [registering](https://www.microsoft.com/en-us/windowsinsider/register) 
-with your Microsoft account and following these [instructions](https://www.microsoft.com/en-us/windowsinsider/for-business-getting-started#flight) 
-(you can choose the "Release Preview Channel"). You may have to click the 
-"Check for updates" button to download the latest Insider Preview build 
-twice, and this update may take over an hour. Finally go to Settings > About 
-to check you are on Windows 11, version 24H2 (Build 26100.1586). 
-
+Otherwise, you can get it via [Windows Insider](https://www.microsoft.com/en-us/windowsinsider)
+by [registering](https://www.microsoft.com/en-us/windowsinsider/register)
+with your Microsoft account and following these [instructions](https://www.microsoft.com/en-us/windowsinsider/for-business-getting-started#flight)
+(you can choose the "Release Preview Channel"). You may have to click the
+"Check for updates" button to download the latest Insider Preview build
+twice, and this update may take over an hour. Finally go to Settings > About
+to check you are on Windows 11, version 24H2 (Build 26100.1586).
 
 ![alt text](./_images/exampleWindows.png)
 
 ### Windows Server
+
 Instructions coming soon.
 
 ## Machine setup
 
 ### Enable Hyper-V
-Enbable [Hyper-V](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v) on your machine. 
+
+Enbable [Hyper-V](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v) on your machine.
 
 ### Enable loading from developer file
-Once you get the right Windows Version, run the following command once before starting 
+
+Once you get the right Windows Version, run the following command once before starting
 your VM.  Note that this enabled loading unsigned images, and must be done as administrator.
 
 ```powershell
@@ -48,13 +51,14 @@ Set-ItemProperty "HKLM:/Software/Microsoft/Windows NT/CurrentVersion/Virtualizat
 ```
 
 ### File access
-Ensure that your OpenHCL .bin is located somewhere that vmwp.exe in your Windows 
-host has permissions to read it (that can be in windows\system32, or another 
-directory with wide read access). 
+
+Ensure that your OpenHCL .bin is located somewhere that vmwp.exe in your Windows
+host has permissions to read it (that can be in windows\system32, or another
+directory with wide read access).
 
 ## Create a VM
 
-Save the path of the OpenHCL .bin in a var named $Path and save the VM name 
+Save the path of the OpenHCL .bin in a var named $Path and save the VM name
 you want to use in a var named $VmName.
 
 For example:
@@ -65,23 +69,27 @@ $VmName = 'myFirstVM'
 ```
 
 ### Create VM as a Trusted Launch VM
+
 Enables [Trusted Launch](https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch) for the VM.
 
 You can use this script with no additional instructions required (simplest path).
+
 ```powershell
 $vm = new-vm $VmName -generation 2 -GuestStateIsolationType TrustedLaunch
 .\openhcl\Set-OpenHCL-HyperV-VM.ps1 -VM $vm -Path $Path
 ```
 
 ### Create other VM types
+
 Instructions coming soon.
 
 ### Set up guest OS VHD
-Running a VM will be more useful if you have a guest OS image. Given that OpenHCL 
-is a compatibility layer, the goal is to support the same set of guest OS images 
+
+Running a VM will be more useful if you have a guest OS image. Given that OpenHCL
+is a compatibility layer, the goal is to support the same set of guest OS images
 that Hyper-V currently supports without a paravisor.
 
-You can pick any existing image that you have or download one from the web, such 
+You can pick any existing image that you have or download one from the web, such
 as from Ubuntu, or any other distro that is currently supported in Hyper-V.
 
 ```powershell

--- a/Guide/src/user_guide/openhcl/run/openvmm.md
+++ b/Guide/src/user_guide/openhcl/run/openvmm.md
@@ -62,8 +62,8 @@ cargo run -- --hv --vtl2 --igvm openhcl-x64.bin --com3 "term,name=VTL2 OpenHCL" 
 
 This will launch OpenVMM in VTL2 mode using [Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/install) to display the
 output of the serial ports. You can replace `term` with `term=<path to exe>` to use your
-favorite shell and by default OpenVMM will use `cmd.exe`. A vsock window can be opened 
-using the OpenVMM terminal on windows using `v 9980` or whichever hvsock port is 
+favorite shell and by default OpenVMM will use `cmd.exe`. A vsock window can be opened
+using the OpenVMM terminal on windows using `v 9980` or whichever hvsock port is
 configured to allow consoles for OpenHCL.
 
 ### Vtl2 VMBus Support

--- a/Guide/src/user_guide/openhcl/troubleshooting.md
+++ b/Guide/src/user_guide/openhcl/troubleshooting.md
@@ -13,6 +13,7 @@ VTL2/VTL0 fails to boot is when either VTL2 or VTL0 has crashed. When the crash 
 First, check `Hyper-V worker  events` at `Applications and Services Logs -> Microsoft -> Windows -> Hyper-V-Worker-Admin`
 
 Alternatively, some queries you can use to get Hyper-V-Worker logs:
+
 - Display the `{n}` most recent events -  `wevtutil qe Microsoft-Windows-Hyper-V-Worker-Admin /c:{n} /rd:true /f:text`
 - Export events to file - `wevtutil epl Microsoft-Windows-Hyper-V-Worker-Admin C:\vtl2_0_crash.evtx`
 
@@ -30,9 +31,9 @@ See [OpenHCL Tracing](../../reference/openhcl/diag/tracing.md) for more details 
 uhdiag-dev.exe linux-uhvm00 file --file-path "/sys/firmware/fdt" > uh.dtb
 ```
 
-2. Install the DeviceTree compiler and convert the blob to the textual representation:
+1. Install the DeviceTree compiler and convert the blob to the textual representation:
 
-```sh 
+```sh
 sudo apt-get install dtc
 dtc -I dtb -o uh.dts uh.dtb
 ```

--- a/Guide/src/user_guide/openvmm.md
+++ b/Guide/src/user_guide/openvmm.md
@@ -32,9 +32,9 @@ This *non-exhaustive* list provides a broad overview of some notable features,
 devices, and scenarios OpenVMM currently supports.
 
 - Boot modes
-    - UEFI - via [`microsoft/mu_msvm`](https://github.com/microsoft/mu_msvm) firmware
-    - BIOS - via the [Hyper-V PCAT BIOS](../reference/devices/firmware/pcat_bios.md) firmware
-    - Linux Direct Boot
+  - UEFI - via [`microsoft/mu_msvm`](https://github.com/microsoft/mu_msvm) firmware
+  - BIOS - via the [Hyper-V PCAT BIOS](../reference/devices/firmware/pcat_bios.md) firmware
+  - Linux Direct Boot
 - Devices
   - Paravirtualized
     - [Virtio](https://wiki.osdev.org/Virtio)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,8 +2,8 @@
 
 ## How to file issues and get help  
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates. For new issues, file your bug or 
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing
+issues before filing new issues to avoid duplicates. For new issues, file your bug or
 feature request as a new Issue.
 
 For help and questions about using this project, please reach out to us through [Github discussions](https://github.com/microsoft/openvmm/discussions).

--- a/petri/logview_new/README.md
+++ b/petri/logview_new/README.md
@@ -61,7 +61,7 @@ npx eslint .
 
 ## Project Structure
 
-```
+```text
 logview_new/
 ├── src/
 │   ├── main.tsx          # Application entry point


### PR DESCRIPTION
Fix a number of markdownlint-reported errors across the Guide. These are mostly benign, but this fixes a few broken links as well.
