### PR TITLE
disk_striped: optimize futures vectors (#2429)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,6 @@ dependencies = [
  "pal_async",
  "scsi_buffers",
  "thiserror 2.0.16",
- "tracelimit",
  "tracing",
  "vm_resource",
 ]

--- a/vm/devices/storage/disk_striped/Cargo.toml
+++ b/vm/devices/storage/disk_striped/Cargo.toml
@@ -19,7 +19,6 @@ inspect.workspace = true
 pal_async.workspace = true
 futures.workspace = true
 thiserror.workspace = true
-tracelimit.workspace = true
 tracing.workspace = true
 vm_resource.workspace = true
 


### PR DESCRIPTION
Clean cherry-pick of #2429.

Performance traces show that growing and populating the vector of
futures in `disk_striped` IO functions is expensive. Optimize this: use
`Iterator::collect` to collect directly into the `JoinAll` that we'll
await, using an iterator that implements `TrustedLen` so that the vector
can allocate its buffer once and construct the futures in place.

Also, clean up some impossible failure paths.

---------

Co-authored-by: Matt LaFayette (Kurjanowicz) <mattkur@microsoft.com>
