### PR TITLE
flowey: Fix running multi-step pipelines locally on windows

### DIFF
--- a/flowey/flowey_cli/src/cli/exec_snippet.rs
+++ b/flowey/flowey_cli/src/cli/exec_snippet.rs
@@ -163,6 +163,9 @@ impl ExecSnippet {
             }
         }
 
+        // Leave the last snippet's working dir so it can be deleted by later steps
+        std::env::set_current_dir(working_dir)?;
+
         Ok(())
     }
 }

--- a/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
@@ -379,6 +379,9 @@ fn direct_run_do_work(
                 log::info!(""); // log a newline, for the pretty
             }
         }
+
+        // Leave the last node's working dir so it can be deleted by later steps
+        std::env::set_current_dir(&out_dir)?;
     }
 
     Ok(())


### PR DESCRIPTION
When running a pipeline locally, flowey will create temporary working directories for each step and move the process's working directory into them. Later on, flowey may try to delete these temporary directories. This is fine on Linux, but on Windows processes hold a handle to their working directory, so this fails. Fix this by just leaving the last step's working directory after it's done.