### PR TITLE
flowey: Consistently add skipped jobs to the skipped jobs list

### DIFF
--- a/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
@@ -125,6 +125,7 @@ fn direct_run_do_work(
             (FlowArch::X86_64, FlowArch::X86_64) | (FlowArch::Aarch64, FlowArch::Aarch64) => (),
             _ => {
                 log::error!("mismatch between job arch and local arch. skipping job...");
+                skipped_jobs.insert(idx);
                 continue;
             }
         }
@@ -331,6 +332,7 @@ fn direct_run_do_work(
 
             if !should_run {
                 log::warn!("job condition was false - skipping job...");
+                skipped_jobs.insert(idx);
                 continue;
             }
         }


### PR DESCRIPTION
When running locally we keep track of jobs that have been skipped so we can avoid running jobs that depend on them. However we were inconsistently adding jobs to the skipped list, only doing it half of the time. Fix this oversight.