### PR TITLE
virt_kvm: Fix debug asserts on a modern AMD cpu

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -475,15 +475,15 @@ impl AccessVpState for KvmVpStateAccess<'_> {
     }
 
     fn cet_ss(&mut self) -> Result<vp::CetSs, Self::Error> {
-        // KVM does not appear to support CET_SS and in particular does not have
+        // TODO: KVM does not appear to support CET_SS and in particular does not have
         // an API to get the SSP register yet.
-        unimplemented!()
+        Ok(Default::default())
     }
 
     fn set_cet_ss(&mut self, _value: &vp::CetSs) -> Result<(), Self::Error> {
-        // KVM does not appear to support CET_SS and in particular does not have
+        // TODO: KVM does not appear to support CET_SS and in particular does not have
         // an API to get the SSP register yet.
-        unimplemented!()
+        Ok(())
     }
 
     fn tsc_aux(&mut self) -> Result<vp::TscAux, Self::Error> {


### PR DESCRIPTION
My personal machine's Ryzen 5800X reports that cet_ss is present in its capabilities. This causes us to try to validate their state at initialization, which hits these panics. Just report the defaults instead, seems to work.