### PR TITLE
openhcl_boot: improve diagnostics on private pool allocation failure

### DIFF
--- a/openhcl/openhcl_boot/src/host_params/dt/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt/mod.rs
@@ -566,17 +566,18 @@ fn topology_from_host_dt(
                     // for diagnostics. Keep the string relatively small, as the
                     // enlightened panic message can only contain 1 page (4096)
                     // bytes of output.
-                    let mut free_ranges = off_stack!(ArrayString<512>, ArrayString::new_const());
+                    let mut free_ranges = off_stack!(ArrayString<2048>, ArrayString::new_const());
                     for range in address_space.free_ranges(vnode) {
-                        let _ = write!(
-                            free_ranges,
-                            "s: {:#x?}, e: {:#x?}; ",
-                            range.start(),
-                            range.end()
-                        );
+                        if write!(free_ranges, "[{:#x?}, {:#x?}) ", range.start(), range.end())
+                            .is_err()
+                        {
+                            let _ = write!(free_ranges, "...");
+                            break;
+                        }
                     }
+                    let highest_numa_node = vtl2_ram.iter().map(|e| e.vnode).max().unwrap_or(0);
                     panic!(
-                        "failed to allocate VTL2 pool of size {pool_size_bytes:#x} bytes (enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, device_dma_page_count={device_dma_page_count:#x?}, vp_count={vp_count}, mem_size={mem_size:#x}), free_ranges=[{}]",
+                        "failed to allocate VTL2 pool of size {pool_size_bytes:#x} bytes (enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, device_dma_page_count={device_dma_page_count:#x?}, vp_count={vp_count}, mem_size={mem_size:#x}), highest_numa_node={highest_numa_node}, free_ranges=[ {}]",
                         free_ranges.as_str()
                     );
                 }

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -657,6 +657,9 @@ mod tests {
             )
             .unwrap();
         assert_eq!(range.range, MemoryRange::new(0x12000..0x13000));
+
+        let free_ranges: Vec<MemoryRange> = address_space.free_ranges(0).collect();
+        assert_eq!(free_ranges, vec![MemoryRange::new(0x13000..0x1D000)]);
     }
 
     #[test]


### PR DESCRIPTION
When private pool allocation fails, we have no indication of why without additional private changes. Add additional information containing the free ranges in numa node 0, along with the highest numa node. 