### PR TITLE
openhcl: keep logging levels and emit them in usermode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7120,6 +7120,7 @@ dependencies = [
 name = "string_page_buf"
 version = "0.0.0"
 dependencies = [
+ "log",
  "thiserror 2.0.16",
  "zerocopy 0.8.27",
 ]

--- a/support/string_page_buf/Cargo.toml
+++ b/support/string_page_buf/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+log.workspace = true
 thiserror.workspace = true
 zerocopy.workspace = true
 

--- a/support/string_page_buf/src/lib.rs
+++ b/support/string_page_buf/src/lib.rs
@@ -351,7 +351,7 @@ impl<'a> StringBuffer<'a> {
     pub fn append_log(
         &mut self,
         level: Level,
-        args: fmt::Arguments<'_>,
+        args: &fmt::Arguments<'_>,
     ) -> Result<bool, StringBufferError> {
         // Check if we have at least space for the entry header
         if self.remaining_capacity() < ENTRY_HEADER_SIZE {
@@ -650,27 +650,27 @@ mod tests {
         // Test append_log with different levels
         assert!(
             buffer
-                .append_log(Level::Error, format_args!("error msg"))
+                .append_log(Level::Error, &format_args!("error msg"))
                 .is_ok()
         );
         assert!(
             buffer
-                .append_log(Level::Warn, format_args!("warn msg"))
+                .append_log(Level::Warn, &format_args!("warn msg"))
                 .is_ok()
         );
         assert!(
             buffer
-                .append_log(Level::Info, format_args!("info msg"))
+                .append_log(Level::Info, &format_args!("info msg"))
                 .is_ok()
         );
         assert!(
             buffer
-                .append_log(Level::Debug, format_args!("debug msg"))
+                .append_log(Level::Debug, &format_args!("debug msg"))
                 .is_ok()
         );
         assert!(
             buffer
-                .append_log(Level::Trace, format_args!("trace msg"))
+                .append_log(Level::Trace, &format_args!("trace msg"))
                 .is_ok()
         );
 
@@ -722,7 +722,7 @@ mod tests {
         let name = "test";
         assert!(
             buffer
-                .append_log(Level::Info, format_args!("value={}, name={}", value, name))
+                .append_log(Level::Info, &format_args!("value={}, name={}", value, name))
                 .is_ok()
         );
 
@@ -738,7 +738,7 @@ mod tests {
         let mut buffer = StringBuffer::new(&mut storage).unwrap();
 
         // Empty format should succeed but not store anything
-        assert!(buffer.append_log(Level::Info, format_args!("")).is_ok());
+        assert!(buffer.append_log(Level::Info, &format_args!("")).is_ok());
         assert_eq!(collect_entries(&buffer).len(), 0);
     }
 

--- a/support/string_page_buf/src/lib.rs
+++ b/support/string_page_buf/src/lib.rs
@@ -7,13 +7,18 @@
 #![no_std]
 #![forbid(unsafe_code)]
 
+use core::fmt;
+use core::fmt::Write;
 use core::str;
 use core::str::Utf8Error;
+use log::Level;
 use thiserror::Error;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
+use zerocopy::Unaligned;
+use zerocopy::little_endian::U16 as U16Le;
 
 const PAGE_SIZE_4K: usize = 4096;
 
@@ -31,16 +36,19 @@ struct Header {
 ///
 /// Format:
 /// - Header (6 bytes total)
-///   - u16: total length in bytes of the data region (capacity usable for UTF-8
-///     data)
+///   - u16: total length in bytes of the data region (capacity usable for
+///     entries)
 ///   - u16: next insertion offset (number of valid bytes currently used)
 ///   - u16: number of messages that were dropped because there was insufficient
 ///     space
-/// - Data region: UTF-8 bytes
+/// - Data region: sequence of log entries, each consisting of:
+///   - 1 byte: log level (0=Error, 1=Warn, 2=Info, 3=Debug, 4=Trace)
+///   - 2 bytes: message length (u16 little-endian)
+///   - N bytes: UTF-8 string data
 ///
 /// Invariants:
 /// - next_insert <= data_len
-/// - Data bytes [0, next_insert) always form valid UTF-8
+/// - Data bytes in string portions of entries always form valid UTF-8
 /// - Appends never partially write data
 /// - On insufficient space, the append is dropped and `dropped` is incremented
 ///
@@ -53,6 +61,91 @@ pub struct StringBuffer<'a> {
     header: &'a mut Header,
     /// Reference to the rest of the data
     data: &'a mut [u8],
+}
+
+/// Header for each log entry in the buffer.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned)]
+struct EntryHeader {
+    /// Log level encoded as a byte (0=Error, 1=Warn, 2=Info, 3=Debug, 4=Trace)
+    level: u8,
+    /// Length of the message in bytes (little-endian, unaligned)
+    msg_len: U16Le,
+}
+
+const ENTRY_HEADER_SIZE: usize = size_of::<EntryHeader>();
+
+/// Converts a `log::Level` to a single byte for storage.
+#[inline]
+fn level_to_byte(level: Level) -> u8 {
+    match level {
+        Level::Error => 0,
+        Level::Warn => 1,
+        Level::Info => 2,
+        Level::Debug => 3,
+        Level::Trace => 4,
+    }
+}
+
+/// Converts a stored byte back to a `log::Level`.
+///
+/// Returns `None` if the byte is not a valid log level.
+#[inline]
+pub fn byte_to_level(byte: u8) -> Option<Level> {
+    match byte {
+        0 => Some(Level::Error),
+        1 => Some(Level::Warn),
+        2 => Some(Level::Info),
+        3 => Some(Level::Debug),
+        4 => Some(Level::Trace),
+        _ => None,
+    }
+}
+
+/// A single log entry containing a level and message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LogEntry<'a> {
+    /// The log level of this entry.
+    pub level: Level,
+    /// The message content.
+    pub message: &'a str,
+}
+
+/// Iterator over log entries in a StringBuffer.
+///
+/// Each entry consists of a log level and a message string.
+pub struct LogEntryIter<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Iterator for LogEntryIter<'a> {
+    type Item = LogEntry<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos + ENTRY_HEADER_SIZE > self.data.len() {
+            return None;
+        }
+
+        let header_bytes = &self.data[self.pos..self.pos + ENTRY_HEADER_SIZE];
+        let entry_header = EntryHeader::ref_from_bytes(header_bytes).ok()?;
+
+        let level = byte_to_level(entry_header.level)?;
+        let msg_len = entry_header.msg_len.get() as usize;
+
+        let msg_start = self.pos + ENTRY_HEADER_SIZE;
+        let msg_end = msg_start + msg_len;
+
+        if msg_end > self.data.len() {
+            return None;
+        }
+
+        let message_bytes = &self.data[msg_start..msg_end];
+        let message = str::from_utf8(message_bytes).ok()?;
+        self.pos = msg_end;
+
+        Some(LogEntry { level, message })
+    }
 }
 
 /// Error types that can occur when working with the string buffer.
@@ -132,26 +225,65 @@ impl<'a> StringBuffer<'a> {
             return Err(StringBufferError::InvalidHeaderNextInsert);
         }
 
-        // Validate utf8 data is valid
+        // Validate entries are valid
         let used = &data[..next_insert];
-        str::from_utf8(used).map_err(StringBufferError::InvalidUtf8)?;
+        Self::validate_entries(used)?;
 
         Ok(Self { header, data })
     }
 
-    /// Appends a string to the buffer.
+    /// Validates that the given data slice contains valid log entries.
     ///
-    /// The string is appended directly as UTF-8 bytes to the end of the current
-    /// data payload (no delimiters).
+    /// Each entry must have: level byte (0-4) + u16 length + valid UTF-8 data.
+    fn validate_entries(data: &[u8]) -> Result<(), StringBufferError> {
+        let mut pos = 0;
+        while pos < data.len() {
+            // Need at least ENTRY_HEADER_SIZE bytes for an entry header
+            if pos + ENTRY_HEADER_SIZE > data.len() {
+                return Err(StringBufferError::InvalidHeaderNextInsert);
+            }
+
+            // Read the entry header using zerocopy
+            let header_bytes = &data[pos..pos + ENTRY_HEADER_SIZE];
+            let entry_header = EntryHeader::ref_from_bytes(header_bytes)
+                .map_err(|_| StringBufferError::InvalidHeaderNextInsert)?;
+
+            // Validate level byte
+            if byte_to_level(entry_header.level).is_none() {
+                return Err(StringBufferError::InvalidHeaderNextInsert);
+            }
+
+            let msg_len = entry_header.msg_len.get() as usize;
+            let msg_start = pos + ENTRY_HEADER_SIZE;
+            let msg_end = msg_start + msg_len;
+
+            if msg_end > data.len() {
+                return Err(StringBufferError::InvalidHeaderNextInsert);
+            }
+
+            // Validate UTF-8
+            let msg_bytes = &data[msg_start..msg_end];
+            str::from_utf8(msg_bytes).map_err(StringBufferError::InvalidUtf8)?;
+
+            pos = msg_end;
+        }
+        Ok(())
+    }
+
+    /// Appends a string to the buffer with the specified log level.
+    ///
+    /// The entry is stored as a 3-byte header (level + u16 length) followed by
+    /// the UTF-8 string bytes.
     ///
     /// # Arguments
+    /// * `level` - The log level for this entry
     /// * `s` - The string to append
     ///
     /// # Returns
     /// `Ok(true)` if the string was successfully added. `Ok(false)` if the
     /// string is valid to add, but was dropped due to not enough space
     /// remaining.
-    pub fn append(&mut self, s: &str) -> Result<bool, StringBufferError> {
+    fn append_with_level(&mut self, level: Level, s: &str) -> Result<bool, StringBufferError> {
         if s.is_empty() {
             // Do not store empty strings.
             return Ok(true);
@@ -161,23 +293,120 @@ impl<'a> StringBuffer<'a> {
             return Err(StringBufferError::StringTooLong);
         }
 
-        let required_space = s.len();
-        if required_space > self.remaining_capacity() {
+        // Total length includes entry header (level + length) + string bytes
+        let total_len = ENTRY_HEADER_SIZE + s.len();
+        if total_len > self.remaining_capacity() {
             self.header.dropped = self.header.dropped.saturating_add(1);
             return Ok(false);
         }
-        let start = self.header.next_insert as usize;
-        let end = start + required_space;
-        self.data[start..end].copy_from_slice(s.as_bytes());
 
-        self.header.next_insert += required_space as u16;
+        let start = self.header.next_insert as usize;
+
+        let entry_header = EntryHeader {
+            level: level_to_byte(level),
+            msg_len: U16Le::new(s.len() as u16),
+        };
+        self.data[start..start + ENTRY_HEADER_SIZE].copy_from_slice(entry_header.as_bytes());
+
+        // Write string data
+        let str_start = start + ENTRY_HEADER_SIZE;
+        let str_end = str_start + s.len();
+        self.data[str_start..str_end].copy_from_slice(s.as_bytes());
+
+        self.header.next_insert += total_len as u16;
 
         Ok(true)
     }
 
-    /// Returns the concatenated UTF-8 contents stored so far.
-    pub fn contents(&self) -> &str {
-        str::from_utf8(&self.data[..self.header.next_insert as usize]).unwrap()
+    /// Appends a string to the buffer with `Info` log level.
+    ///
+    /// The entry is stored as a 3-byte header (Info level + u16 length)
+    /// followed by the UTF-8 string bytes.
+    ///
+    /// # Arguments
+    /// * `s` - The string to append
+    ///
+    /// # Returns
+    /// `Ok(true)` if the string was successfully added. `Ok(false)` if the
+    /// string is valid to add, but was dropped due to not enough space
+    /// remaining.
+    pub fn append(&mut self, s: &str) -> Result<bool, StringBufferError> {
+        self.append_with_level(Level::Info, s)
+    }
+
+    /// Appends a formatted log message to the buffer.
+    ///
+    /// This method accepts `fmt::Arguments` directly, allowing efficient
+    /// formatting without intermediate allocations. The entry is stored as a
+    /// 3-byte header (level + u16 length) followed by the formatted UTF-8
+    /// string bytes.
+    ///
+    /// # Arguments
+    /// * `level` - The log level for this entry
+    /// * `args` - The format arguments to write
+    ///
+    /// # Returns
+    /// `Ok(true)` if the message was successfully added. `Ok(false)` if the
+    /// message was dropped due to not enough space remaining.
+    pub fn append_log(
+        &mut self,
+        level: Level,
+        args: fmt::Arguments<'_>,
+    ) -> Result<bool, StringBufferError> {
+        // Check if we have at least space for the entry header
+        if self.remaining_capacity() < ENTRY_HEADER_SIZE {
+            self.header.dropped = self.header.dropped.saturating_add(1);
+            return Ok(false);
+        }
+
+        let start = self.header.next_insert as usize;
+
+        // Reserve space for header, write directly after it
+        let str_start = start + ENTRY_HEADER_SIZE;
+        let mut writer = SliceWriter {
+            buf: &mut self.data[str_start..],
+            pos: 0,
+        };
+
+        // Format directly into the buffer
+        if write!(writer, "{}", args).is_err() {
+            // Not enough space - don't update next_insert, increment dropped
+            self.header.dropped = self.header.dropped.saturating_add(1);
+            return Ok(false);
+        }
+
+        let bytes_written = writer.pos;
+        if bytes_written == 0 {
+            // Empty message - don't store anything
+            return Ok(true);
+        }
+
+        if bytes_written > u16::MAX as usize {
+            self.header.dropped = self.header.dropped.saturating_add(1);
+            return Err(StringBufferError::StringTooLong);
+        }
+
+        // Message written, now write the header
+        let entry_header = EntryHeader {
+            level: level_to_byte(level),
+            msg_len: U16Le::new(bytes_written as u16),
+        };
+        self.data[start..start + ENTRY_HEADER_SIZE].copy_from_slice(entry_header.as_bytes());
+
+        let total_len = ENTRY_HEADER_SIZE + bytes_written;
+        self.header.next_insert += total_len as u16;
+
+        Ok(true)
+    }
+
+    /// Returns an iterator over log entries in the buffer.
+    ///
+    /// Each entry contains a log level and a message string.
+    pub fn entries(&self) -> LogEntryIter<'_> {
+        LogEntryIter {
+            data: &self.data[..self.header.next_insert as usize],
+            pos: 0,
+        }
     }
 
     /// Returns the number of bytes remaining in the buffer.
@@ -191,14 +420,46 @@ impl<'a> StringBuffer<'a> {
     }
 }
 
+/// A writer that writes directly to a byte slice without allocation.
+///
+/// This is used internally to format `fmt::Arguments` directly into the buffer.
+struct SliceWriter<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+}
+
+impl Write for SliceWriter<'_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
+        let remaining = self.buf.len() - self.pos;
+        if bytes.len() > remaining {
+            return Err(fmt::Error);
+        }
+        self.buf[self.pos..self.pos + bytes.len()].copy_from_slice(bytes);
+        self.pos += bytes.len();
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     extern crate alloc;
     use alloc::vec;
+    use alloc::vec::Vec;
     use core::mem::size_of;
 
     const TEST_BUFFER_SIZE: usize = 4096; // 4K page
+
+    /// Helper to collect all entry messages into a Vec
+    fn collect_messages<'a>(buffer: &'a StringBuffer<'_>) -> Vec<&'a str> {
+        buffer.entries().map(|e| e.message).collect()
+    }
+
+    /// Helper to collect all entries
+    fn collect_entries<'a>(buffer: &'a StringBuffer<'_>) -> Vec<LogEntry<'a>> {
+        buffer.entries().collect()
+    }
 
     #[test]
     fn test_new_buffer() {
@@ -210,7 +471,7 @@ mod tests {
         let expected_remaining = TEST_BUFFER_SIZE - header_size;
         assert_eq!(buffer.remaining_capacity(), expected_remaining);
         assert_eq!(buffer.dropped_messages(), 0);
-        assert_eq!(buffer.contents(), "");
+        assert_eq!(collect_messages(&buffer).len(), 0);
     }
 
     #[test]
@@ -219,7 +480,10 @@ mod tests {
         let mut buffer = StringBuffer::new(&mut storage).unwrap();
         let test_string = "Hello, World!";
         assert!(buffer.append(test_string).is_ok());
-        assert_eq!(buffer.contents(), test_string);
+        let entries = collect_entries(&buffer);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].message, test_string);
+        assert_eq!(entries[0].level, Level::Info);
     }
 
     #[test]
@@ -230,8 +494,8 @@ mod tests {
         for s in &strings {
             assert!(buffer.append(s).is_ok());
         }
-        let expected = strings.join("");
-        assert_eq!(buffer.contents(), expected);
+        let messages = collect_messages(&buffer);
+        assert_eq!(messages, strings);
     }
 
     #[test]
@@ -242,11 +506,13 @@ mod tests {
         let large_string = "x".repeat(70000);
         let result = buffer.append(&large_string);
         assert!(matches!(result, Err(StringBufferError::StringTooLong)));
-        // Fill remaining capacity exactly
+        // Fill remaining capacity (accounting for entry header)
         let space = buffer.remaining_capacity();
-        let max_string = "x".repeat(space);
+        // Each entry needs ENTRY_HEADER_SIZE (3) bytes for the header
+        let max_string = "x".repeat(space - ENTRY_HEADER_SIZE);
         assert!(matches!(buffer.append(&max_string), Ok(true)));
-        assert_eq!(buffer.remaining_capacity(), 0);
+        // Now there's only ENTRY_HEADER_SIZE-1 bytes left, not enough for any entry
+        assert!(buffer.remaining_capacity() < ENTRY_HEADER_SIZE + 1);
         // Try to append another string (should be dropped, Ok(false))
         let result = buffer.append("test");
         assert!(matches!(result, Ok(false)));
@@ -261,7 +527,7 @@ mod tests {
             let _buf = StringBuffer::new(&mut storage).unwrap();
         }
         let reopened = StringBuffer::from_existing(&mut storage).unwrap();
-        assert_eq!(reopened.contents(), "");
+        assert_eq!(collect_messages(&reopened).len(), 0);
     }
 
     #[test]
@@ -271,14 +537,16 @@ mod tests {
         assert!(matches!(buffer.append("Hello"), Ok(true)));
         // Reconstruct using from_existing
         let buffer2 = StringBuffer::from_existing(&mut storage).unwrap();
-        assert!(buffer2.contents().contains("Hello"));
+        let messages = collect_messages(&buffer2);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0], "Hello");
     }
 
     #[test]
-    fn test_contents_empty() {
+    fn test_entries_empty() {
         let mut storage = [0u8; TEST_BUFFER_SIZE];
         let buffer = StringBuffer::new(&mut storage).unwrap();
-        assert_eq!(buffer.contents(), "");
+        assert_eq!(collect_messages(&buffer).len(), 0);
     }
 
     #[test]
@@ -331,10 +599,14 @@ mod tests {
         let header_size = size_of::<Header>();
         let data_len = (TEST_BUFFER_SIZE - header_size) as u16;
         storage[0..2].copy_from_slice(&data_len.to_le_bytes());
-        // next_insert = 1 (one byte used)
-        storage[2..4].copy_from_slice(&1u16.to_le_bytes());
+        // Create a valid entry header: level=Info(2), length=1
+        storage[header_size] = 2; // Info level
+        storage[header_size + 1] = 1; // length low byte
+        storage[header_size + 2] = 0; // length high byte
+        // next_insert = 4 (header + 1 byte message)
+        storage[2..4].copy_from_slice(&4u16.to_le_bytes());
         // dropped = 0 (already zeroed)
-        storage[header_size] = 0xFF; // invalid UTF-8
+        storage[header_size + 3] = 0xFF; // invalid UTF-8 message byte
         let res = StringBuffer::from_existing(&mut storage);
         assert!(matches!(res, Err(StringBufferError::InvalidUtf8(_))));
     }
@@ -343,11 +615,12 @@ mod tests {
     fn test_append_multiple_drops_increment() {
         let mut storage = [0u8; TEST_BUFFER_SIZE];
         let mut buffer = StringBuffer::new(&mut storage).unwrap();
-        // Fill the buffer completely
+        // Fill the buffer completely (accounting for entry header)
         let space = buffer.remaining_capacity();
-        let filler = "x".repeat(space);
+        let filler = "x".repeat(space - ENTRY_HEADER_SIZE);
         assert!(matches!(buffer.append(&filler), Ok(true)));
-        assert_eq!(buffer.remaining_capacity(), 0);
+        // Buffer is now full (only has 0 bytes left, not enough for any entry)
+        assert!(buffer.remaining_capacity() < ENTRY_HEADER_SIZE + 1);
         // Multiple failed appends increment dropped each time
         assert!(matches!(buffer.append("a"), Ok(false)));
         assert_eq!(buffer.dropped_messages(), 1);
@@ -365,7 +638,215 @@ mod tests {
         for s in &strings {
             assert!(matches!(buffer.append(s), Ok(true)));
         }
-        let expected = strings.join("");
-        assert_eq!(buffer.contents(), expected);
+        let messages = collect_messages(&buffer);
+        assert_eq!(messages, strings);
+    }
+
+    #[test]
+    fn test_append_log_with_level() {
+        let mut storage = [0u8; TEST_BUFFER_SIZE];
+        let mut buffer = StringBuffer::new(&mut storage).unwrap();
+
+        // Test append_log with different levels
+        assert!(
+            buffer
+                .append_log(Level::Error, format_args!("error msg"))
+                .is_ok()
+        );
+        assert!(
+            buffer
+                .append_log(Level::Warn, format_args!("warn msg"))
+                .is_ok()
+        );
+        assert!(
+            buffer
+                .append_log(Level::Info, format_args!("info msg"))
+                .is_ok()
+        );
+        assert!(
+            buffer
+                .append_log(Level::Debug, format_args!("debug msg"))
+                .is_ok()
+        );
+        assert!(
+            buffer
+                .append_log(Level::Trace, format_args!("trace msg"))
+                .is_ok()
+        );
+
+        let entries = collect_entries(&buffer);
+        assert_eq!(entries.len(), 5);
+        assert_eq!(
+            entries[0],
+            LogEntry {
+                level: Level::Error,
+                message: "error msg"
+            }
+        );
+        assert_eq!(
+            entries[1],
+            LogEntry {
+                level: Level::Warn,
+                message: "warn msg"
+            }
+        );
+        assert_eq!(
+            entries[2],
+            LogEntry {
+                level: Level::Info,
+                message: "info msg"
+            }
+        );
+        assert_eq!(
+            entries[3],
+            LogEntry {
+                level: Level::Debug,
+                message: "debug msg"
+            }
+        );
+        assert_eq!(
+            entries[4],
+            LogEntry {
+                level: Level::Trace,
+                message: "trace msg"
+            }
+        );
+    }
+
+    #[test]
+    fn test_append_log_formatted() {
+        let mut storage = [0u8; TEST_BUFFER_SIZE];
+        let mut buffer = StringBuffer::new(&mut storage).unwrap();
+
+        let value = 42;
+        let name = "test";
+        assert!(
+            buffer
+                .append_log(Level::Info, format_args!("value={}, name={}", value, name))
+                .is_ok()
+        );
+
+        let entries = collect_entries(&buffer);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].level, Level::Info);
+        assert_eq!(entries[0].message, "value=42, name=test");
+    }
+
+    #[test]
+    fn test_append_log_empty() {
+        let mut storage = [0u8; TEST_BUFFER_SIZE];
+        let mut buffer = StringBuffer::new(&mut storage).unwrap();
+
+        // Empty format should succeed but not store anything
+        assert!(buffer.append_log(Level::Info, format_args!("")).is_ok());
+        assert_eq!(collect_entries(&buffer).len(), 0);
+    }
+
+    #[test]
+    fn test_raw_append_uses_info_level() {
+        let mut storage = [0u8; TEST_BUFFER_SIZE];
+        let mut buffer = StringBuffer::new(&mut storage).unwrap();
+
+        assert!(buffer.append("raw string").is_ok());
+
+        let entries = collect_entries(&buffer);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].level, Level::Info);
+        assert_eq!(entries[0].message, "raw string");
+    }
+
+    #[test]
+    fn test_level_byte_conversion() {
+        assert_eq!(level_to_byte(Level::Error), 0);
+        assert_eq!(level_to_byte(Level::Warn), 1);
+        assert_eq!(level_to_byte(Level::Info), 2);
+        assert_eq!(level_to_byte(Level::Debug), 3);
+        assert_eq!(level_to_byte(Level::Trace), 4);
+
+        assert_eq!(byte_to_level(0), Some(Level::Error));
+        assert_eq!(byte_to_level(1), Some(Level::Warn));
+        assert_eq!(byte_to_level(2), Some(Level::Info));
+        assert_eq!(byte_to_level(3), Some(Level::Debug));
+        assert_eq!(byte_to_level(4), Some(Level::Trace));
+        assert_eq!(byte_to_level(5), None);
+        assert_eq!(byte_to_level(255), None);
+    }
+
+    #[test]
+    fn test_validate_entries_empty() {
+        // Empty data is valid
+        assert!(StringBuffer::validate_entries(&[]).is_ok());
+    }
+
+    #[test]
+    fn test_validate_entries_truncated_header() {
+        // Only 1 byte - not enough for entry header (needs 3)
+        assert!(StringBuffer::validate_entries(&[2]).is_err());
+        // Only 2 bytes - still not enough
+        assert!(StringBuffer::validate_entries(&[2, 0]).is_err());
+    }
+
+    #[test]
+    fn test_validate_entries_invalid_level() {
+        // Level byte = 5 is invalid (valid range is 0-4)
+        let data = [5, 0, 0]; // level=5, msg_len=0
+        assert!(StringBuffer::validate_entries(&data).is_err());
+
+        // Level byte = 255 is invalid
+        let data = [255, 0, 0]; // level=255, msg_len=0
+        assert!(StringBuffer::validate_entries(&data).is_err());
+    }
+
+    #[test]
+    fn test_validate_entries_msg_len_overflow() {
+        // Valid header but msg_len points past end of data
+        let data = [2, 10, 0]; // level=Info, msg_len=10, but no message bytes
+        assert!(StringBuffer::validate_entries(&data).is_err());
+    }
+
+    #[test]
+    fn test_validate_entries_invalid_utf8() {
+        // Valid header but invalid UTF-8 in message
+        let data = [2, 1, 0, 0xFF]; // level=Info, msg_len=1, message=0xFF (invalid UTF-8)
+        assert!(matches!(
+            StringBuffer::validate_entries(&data),
+            Err(StringBufferError::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_entries_single_valid() {
+        // Valid entry: level=Info, msg_len=5, message="hello"
+        let data = [2, 5, 0, b'h', b'e', b'l', b'l', b'o'];
+        assert!(StringBuffer::validate_entries(&data).is_ok());
+    }
+
+    #[test]
+    fn test_validate_entries_multiple_valid() {
+        // Two valid entries
+        let mut data = vec![];
+        // Entry 1: level=Error, msg_len=2, message="hi"
+        data.extend_from_slice(&[0, 2, 0, b'h', b'i']);
+        // Entry 2: level=Warn, msg_len=3, message="bye"
+        data.extend_from_slice(&[1, 3, 0, b'b', b'y', b'e']);
+        assert!(StringBuffer::validate_entries(&data).is_ok());
+    }
+
+    #[test]
+    fn test_validate_entries_second_entry_invalid() {
+        // First entry valid, second entry has invalid level
+        let mut data = vec![];
+        // Entry 1: level=Info, msg_len=2, message="hi"
+        data.extend_from_slice(&[2, 2, 0, b'h', b'i']);
+        // Entry 2: level=99 (invalid), msg_len=0
+        data.extend_from_slice(&[99, 0, 0]);
+        assert!(StringBuffer::validate_entries(&data).is_err());
+    }
+
+    #[test]
+    fn test_validate_entries_zero_length_message() {
+        // Valid entry with zero-length message
+        let data = [2, 0, 0]; // level=Info, msg_len=0
+        assert!(StringBuffer::validate_entries(&data).is_ok());
     }
 }

--- a/support/string_page_buf/src/lib.rs
+++ b/support/string_page_buf/src/lib.rs
@@ -11,7 +11,6 @@ use core::fmt;
 use core::fmt::Write;
 use core::str;
 use core::str::Utf8Error;
-use log::Level;
 use thiserror::Error;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
@@ -19,6 +18,9 @@ use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 use zerocopy::Unaligned;
 use zerocopy::little_endian::U16 as U16Le;
+
+// Re-export log::Level for consumers who need it for LogEntry
+pub use log::Level;
 
 const PAGE_SIZE_4K: usize = 4096;
 


### PR DESCRIPTION
After switching to the log crate, we now have log levels associated with each log call. Persist them by updating the `string_page_buf` structure to store a log level with the log entry, and update callers to use that info. 