### PR TITLE
vmm_tests/underhill_core: allow command line to specify settings / config timeout, and make it 30s for many devices test

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -197,6 +197,7 @@ pub(crate) struct LoadedVm {
     pub mana_keep_alive: KeepAliveConfig,
     pub test_configuration: Option<TestScenarioConfig>,
     pub dma_manager: OpenhclDmaManager,
+    pub config_timeout_in_seconds: u64,
 }
 
 pub struct LoadedVmState<T> {
@@ -235,6 +236,7 @@ impl LoadedVm {
                 device_config_send,
                 self.get_client.clone(),
                 self.device_interfaces.take().unwrap(),
+                self.config_timeout_in_seconds,
             );
 
             threadpool.spawn("VTL2 settings services", {

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -336,6 +336,7 @@ async fn launch_workers(
         enable_vpci_relay: opt.enable_vpci_relay,
         disable_proxy_redirect: opt.disable_proxy_redirect,
         disable_lower_vtl_timer_virt: opt.disable_lower_vtl_timer_virt,
+        config_timeout_in_seconds: opt.config_timeout_in_seconds,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -269,6 +269,11 @@ pub struct Options {
 
     /// (OPENHCL_DISABLE_LOWER_VTL_TIMER_VIRT=1) Disable lower VTL timer virtualization.
     pub disable_lower_vtl_timer_virt: bool,
+
+    /// (OPENHCL_CONFIG_TIMEOUT_IN_SECONDS=\<number\>) (default: 5)
+    /// Timeout in seconds for VM configuration operations, both initial
+    /// configuration and subsequent modifications.
+    pub config_timeout_in_seconds: u64,
 }
 
 impl Options {
@@ -441,6 +446,8 @@ impl Options {
         let enable_vpci_relay = parse_env_bool_opt("OPENHCL_ENABLE_VPCI_RELAY");
         let disable_proxy_redirect = parse_env_bool("OPENHCL_DISABLE_PROXY_REDIRECT");
         let disable_lower_vtl_timer_virt = parse_env_bool("OPENHCL_DISABLE_LOWER_VTL_TIMER_VIRT");
+        let config_timeout_in_seconds =
+            parse_legacy_env_number("OPENHCL_CONFIG_TIMEOUT_IN_SECONDS")?.unwrap_or(5);
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -506,6 +513,7 @@ impl Options {
             enable_vpci_relay,
             disable_proxy_redirect,
             disable_lower_vtl_timer_virt,
+            config_timeout_in_seconds,
         })
     }
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -312,6 +312,9 @@ pub struct UnderhillEnvCfg {
     pub disable_proxy_redirect: bool,
     /// Disable lower VTL timer virtualization
     pub disable_lower_vtl_timer_virt: bool,
+    /// The timeout in seconds for VM config operations, both the initial configuration
+    /// and then subsequent modifications.
+    pub config_timeout_in_seconds: u64,
 }
 
 /// Bundle of config + runtime objects for hooking into the underhill remote
@@ -2118,6 +2121,7 @@ async fn new_underhill_vm(
         env_cfg.nvme_vfio,
         is_restoring,
         default_io_queue_depth,
+        env_cfg.config_timeout_in_seconds,
     )
     .instrument(tracing::info_span!("new_initial_controllers", CVM_ALLOWED))
     .await
@@ -3564,6 +3568,7 @@ async fn new_underhill_vm(
         mana_keep_alive: env_cfg.mana_keep_alive,
         test_configuration: env_cfg.test_configuration,
         dma_manager,
+        config_timeout_in_seconds: env_cfg.config_timeout_in_seconds,
     };
 
     Ok(loaded_vm)

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -105,7 +105,7 @@ async fn many_nvme_devices_servicing_very_heavy(
             ("OPENVMM_SHOW_SPANS".to_owned(), "true".to_owned()),
         ].into()))
         .with_openhcl_command_line(
-            "OPENHCL_ENABLE_VTL2_GPA_POOL=16384 dyndbg=\"module vfio_pci +p; module pci_hyperv +p\" udev.log_priority=debug",
+            "OPENHCL_ENABLE_VTL2_GPA_POOL=16384 dyndbg=\"module vfio_pci +p; module pci_hyperv +p\" udev.log_priority=debug OPENHCL_CONFIG_TIMEOUT_IN_SECONDS=30",
         ) // 64MB of private pool for VTL2 NVMe devices, debug logging for vfio-pci driver.
         .with_memory(MemoryConfig {
             startup_bytes: 8 * 1024 * 1024 * 1024, // 8GB


### PR DESCRIPTION
We see that, under load, it takes quite a while for OpenHCL to enumerate the vPCI devices. Work around this by allowing tests to configure a timeout.
