### PR TITLE
REPO: Raise checkin bar for 1.7 branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # File containing policy for file ownership
 
 # Reviewers for all files in the repository
-* @microsoft/openvmm-reviewers
+* @microsoft/openvmm-maintain
 
 # Any CI changes require special approval
 /ci/ @microsoft/openvmm-ci-reviewers


### PR DESCRIPTION
This change switches the CODEOWNERS from openvmm-reviewers to openvmm-maintain to increase the checkin bar for the release branch.