### PR TITLE
Reserve VMGS file IDs for provenance data (#2484)

### DIFF
--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -47,6 +47,8 @@ open_enum! {
         HW_KEY_PROTECTOR = 11,
         GUEST_SECRET_KEY = 13,
         HIBERNATION_FIRMWARE = 14,
+        PLATFORM_SEED = 15,
+        PROVENANCE_DOC = 16,
 
         EXTENDED_FILE_TABLE = 63,
     }


### PR DESCRIPTION
A future project will be adding signed provenance data to the VMGS file. This change reserves file IDs.