### PR TITLE
logview_new: updated the react router to 7.12.0 or above

### DIFF
--- a/petri/logview_new/package-lock.json
+++ b/petri/logview_new/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/react-virtual": "^3.13.12",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
-        "react-router-dom": "^7.9.3"
+        "react-router-dom": "^7.12.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.7",
@@ -1692,9 +1692,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.10.1.tgz",
-      "integrity": "sha512-gHL89dRa3kwlUYtRQ+m8NmxGI6CgqN+k4XyGjwcFoQwwCWF6xXpOCUlDovkXClS0d0XJN/5q7kc5W3kiFEd0Yw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -1714,12 +1714,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.10.1.tgz",
-      "integrity": "sha512-JNBANI6ChGVjA5bwsUIwJk7LHKmqB4JYnYfzFwyp2t12Izva11elds2jx7Yfoup2zssedntwU0oZ5DEmk5Sdaw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.10.1"
+        "react-router": "7.12.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/petri/logview_new/package.json
+++ b/petri/logview_new/package.json
@@ -5,7 +5,7 @@
     "@tanstack/react-virtual": "^3.13.12",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "react-router-dom": "^7.9.3"
+    "react-router-dom": "^7.12.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",


### PR DESCRIPTION
There a vulnerability found in router version < 7.12.0 which allows XSS when using SSR (Server Side Rendering) with the react router. Notably this does not impact apps using declarative mode for the router (i.e. `<BrowserRouter>`). Our app doesn't use SSR and only uses declarative mode for the router, hence should not be vulnerable. However, still updating router version to the patched version of 7.12.0 or above for cleanliness and to appease dependabot. 

Dependabot vulnerabilities that will be addressed with this PR:
* https://github.com/microsoft/openvmm/security/dependabot/8
* https://github.com/microsoft/openvmm/security/dependabot/9
* https://github.com/microsoft/openvmm/security/dependabot/10