### PR TITLE
kernel: update dev kernel to 6.12.52.4 (#2578)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -28,7 +28,7 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.1";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.4";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.4";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";


### PR DESCRIPTION
Mirror the CVM TDX changes from HCL kernel main to dev branch. TDX changes are captured in this commit:

https://github.com/microsoft/openvmm/commit/01987f4a7bfc113a6a7b44217e2c66a5c0aaa2fc