### PR TITLE
initrd: respect --kernel-modules path if specified

### DIFF
--- a/flowey/flowey_lib_hvlite/src/build_openhcl_initrd.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_initrd.rs
@@ -159,13 +159,23 @@ impl FlowNode for Node {
                         v
                     };
 
-                    let kernel_modules =
-                        custom_kernel_modules.unwrap_or(kernel_package_root.join("."));
-
                     let rootfs_py_arch = match arch {
                         CommonArch::X86_64 => "x86_64",
                         CommonArch::Aarch64 => "aarch64",
                     };
+
+                    // Kernel modules use a different arch naming convention
+                    let kernel_modules_arch = match arch {
+                        CommonArch::X86_64 => "x64",
+                        CommonArch::Aarch64 => "arm64",
+                    };
+
+                    let kernel_modules = custom_kernel_modules.unwrap_or_else(|| {
+                        kernel_package_root
+                            .join("build/native/bin")
+                            .join(kernel_modules_arch)
+                            .join("modules")
+                    });
 
                     // FUTURE: to avoid making big changes to update-roots as
                     // part of the initial OSS workstream, stage the

--- a/openhcl/rootfs.config
+++ b/openhcl/rootfs.config
@@ -30,12 +30,12 @@ dir /lib/modules/000    0755 0 0
 dir /lib/modules/001    0755 0 0
 dir /lib/modules/999    0755 0 0
 
-file /lib/modules/000/pci-hyperv-intf.ko    ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/pci/controller/pci-hyperv-intf.ko  0644 0 0
-file /lib/modules/001/pci-hyperv.ko         ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/pci/controller/pci-hyperv.ko       0644 0 0
+file /lib/modules/000/pci-hyperv-intf.ko    ${OPENHCL_MODULES_PATH}/kernel/drivers/pci/controller/pci-hyperv-intf.ko  0644 0 0
+file /lib/modules/001/pci-hyperv.ko         ${OPENHCL_MODULES_PATH}/kernel/drivers/pci/controller/pci-hyperv.ko       0644 0 0
 
 # Storvsc is last because it sometimes takes a long time to load and should not
 # block other device startup.
-file /lib/modules/999/hv_storvsc.ko         ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/scsi/hv_storvsc.ko      0644 0 0
+file /lib/modules/999/hv_storvsc.ko         ${OPENHCL_MODULES_PATH}/kernel/drivers/scsi/hv_storvsc.ko      0644 0 0
 
 # These nodes are needed for early logging before devfs is mounted.
 nod /dev/null      0666 0 0 c 1  3


### PR DESCRIPTION
When testing building everything locally, I found it annoying that the `--custom-kernel-modules` parameter of the build-igvm CLI relies on matching the directory structure of our NuGet kernel (which has a different directory structure from our GitHub releases). That means that downloading our kernel from GitHub and then passing its modules folder as the `--custom-kernel-modules` parameter fails to build. There is logic in our `download_openhcl_kernel_package` flowey node [that recreates the structure of the NuGet package](https://github.com/microsoft/openvmm/blob/0a444caae48acd806ef7763c70bd89d8409bfd79/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs#L140), which wouldn't work if we downloaded the kernel package outside of flowey.

The script has been changed to set the modules folder directly. I've validated using diffoscope that the two outputs are identical before and after the change.