### PR TITLE
vmbus_proxy: dissociate the IOCP when VmbusProxy is dropped

### DIFF
--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -142,8 +142,8 @@ unsafe impl<T> IoBufMut for StaticIoctlBuffer<T> {
 
 impl VmbusProxy {
     pub fn new(driver: &dyn Driver, handle: ProxyHandle, ctx: CancelContext) -> Result<Self> {
-        // SAFETY: While the handle is cloned from the vdev, VmbusProxy is the only place where
-        // async IO is performed using this file object.
+        // SAFETY: This handle is duplicated and can be shared with other devices, so safety depends
+        // on this being the only user of the handle for overlapped IO.
         let file = unsafe { OverlappedFile::new(driver, handle.0)? };
         Ok(Self {
             file: ManuallyDrop::new(file),


### PR DESCRIPTION
In #2406, `OverlappedFile` was changed to no longer automatically dissociate the I/O completion port when the object is dropped. `VmbusProxy` relied on that behavior to ensure the handle could be reused.

This change adds a `Drop` implementation to `VmbusProxy` to ensure the IOCP is dissociated.