### PR TITLE
[nvme_driver] minor: update failure message wording

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -19,7 +19,6 @@ use guestmem::GuestMemory;
 use guestmem::GuestMemoryError;
 use guestmem::ranges::PagedRange;
 use inspect::Inspect;
-use inspect::Request;
 use inspect_counters::Counter;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcError;


### PR DESCRIPTION
minor-fix: Updates the wording of the `expect()` calls when request for memory fails to be more clear. "capacity" instead of "cap". This failure should also probably return an error instead of panic-ing but that is an update for the future as it needs some more thought/consideration.