### PR TITLE
[nvme_test] Can now apply completion queue faults to AER completions

### DIFF
--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -1110,7 +1110,7 @@ impl AdminHandler {
         if state.asynchronous_event_requests.len() >= MAX_ASYNC_EVENT_REQUESTS as usize {
             return Err(spec::Status::ASYNCHRONOUS_EVENT_REQUEST_LIMIT_EXCEEDED.into());
         }
-        state.asynchronous_event_requests.push(command.clone());
+        state.asynchronous_event_requests.push(*command);
         Ok(None)
     }
 


### PR DESCRIPTION
This change moves the completion queue fault logic to it's own function that is now also invoked from the `process_events` function. This allows applying a completion queue fault to the AER/AEN flow.