### PR TITLE
GET: Increase our start failure timeout

### DIFF
--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -538,10 +538,13 @@ impl GuestEmulationTransportClient {
 
             if let Some(error_msg) = error_msg {
                 // If we sent an error to the host, Underhill expects to be
-                // terminated/halted. If this doesn't occur in 30 seconds, then
-                // surface a panic to force a guest crash.
+                // terminated/halted. If this doesn't occur in 2 minutes, then
+                // surface a panic to force a guest crash. Make sure our timeout
+                // is longer than any host-side timeouts to avoid false positives.
+                // Currently known host timeouts:
+                // Vdev/VF removal: 1 minute
                 mesh::CancelContext::new()
-                    .with_timeout(std::time::Duration::from_secs(30))
+                    .with_timeout(std::time::Duration::from_mins(2))
                     .until_cancelled(std::future::pending::<()>())
                     .await
                     .unwrap_or_else(|_| {


### PR DESCRIPTION
In cases where attached devices are in a bad state, and OpenHCL reports a start failure, the worker process can get stuck trying to clean up the devices and will wait on a timeout. That timeout is currently longer than OpenHCL's, which results in us firing a crash and recording an ICM for no valid reason. Increase our timeout to be longer than this host-side case to ensure we only crash in cases that are truly stuck forever.