### PR TITLE
GET: Increase our start failure timeout (#2647)

### DIFF
--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -539,7 +539,7 @@ impl GuestEmulationTransportClient {
                 // Currently known host timeouts:
                 // Vdev/VF removal: 1 minute
                 mesh::CancelContext::new()
-                    .with_timeout(std::time::Duration::from_mins(2))
+                    .with_timeout(std::time::Duration::from_secs(120))
                     .until_cancelled(std::future::pending::<()>())
                     .await
                     .unwrap_or_else(|_| {


### PR DESCRIPTION
In cases where attached devices are in a bad state, and OpenHCL reports a start failure, the worker process can get stuck trying to clean up the devices and will wait on a timeout. That timeout is currently longer than OpenHCL's, which results in us firing a crash and recording an ICM for no valid reason. Increase our timeout to be longer than this host-side case to ensure we only crash in cases that are truly stuck forever.

Mostly clean cherry-pick of #2647