### PR TITLE
Repo: Take the Rust 1.92 compat changes without the version bump

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -89,6 +89,9 @@ rustflags = [
   "-Ctarget-feature=+crt-static",
   # Use RELR relocation format, which is considerably smaller.
   "-Clink-arg=-Wl,-z,pack-relative-relocs",
+  # Disable unwind tables to reduce binary size.
+  # TODO: It would be nice to have this enabled for debug builds
+  "-Cforce-unwind-tables=no",
 ]
 
 [target.'cfg(all(target_arch = "aarch64", target_env = "musl"))']

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -36,6 +36,7 @@ macro_rules! bitops_base {
     };
 }
 
+#[cfg(target_arch = "x86_64")]
 pub(crate) use bitops_base;
 
 macro_rules! bitops {
@@ -69,6 +70,7 @@ macro_rules! bitops {
     };
 }
 
+#[cfg(target_arch = "x86_64")]
 pub(crate) use bitops;
 
 #[repr(C)]


### PR DESCRIPTION
Supercedes https://github.com/microsoft/openvmm/pull/2562. Takes the non-version-bump-related changes from that PR so that we can have a clean version bump PR in the future, whether that's to 1.92 or 1.93.