### PR TITLE
nvme_driver: Remove the handle_in_use check from the Namespace references held by the nvme driver

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -573,16 +573,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
     /// Gets the namespace with namespace ID `nsid`.
     pub async fn namespace(&mut self, nsid: u32) -> Result<Arc<Namespace>, NamespaceError> {
         if let Some(namespace) = self.namespaces.get(&nsid) {
-            // Check if this is the only reference to the namespace
-            if Arc::strong_count(namespace) == 1 {
-                return Ok(namespace.clone());
-            }
-
-            // Prevent multiple references to the same Namespace.
-            // Allowing this could lead to undefined behavior if multiple components
-            // concurrently read or write to the same namespace. To avoid this,
-            // return an error if the namespace is already requested.
-            return Err(NamespaceError::DuplicateRequest { nsid });
+            return Ok(namespace.clone());
         }
 
         let (send, recv) = mesh::channel::<()>();

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/namespace.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/namespace.rs
@@ -41,8 +41,6 @@ pub enum NamespaceError {
     Request(#[source] RequestError),
     #[error("maximum data transfer size too small: 2^{0} pages")]
     MdtsInvalid(u8),
-    #[error("namespace ID {nsid} already exists")]
-    DuplicateRequest { nsid: u32 },
 }
 
 /// An NVMe namespace.


### PR DESCRIPTION
first of two changes addressing incorrect disk removal behavior when VTL2 settings are updated to remove a LUN from VTL0. Currently, even after a disk is removed at the VTL2 layer, the underlying namespace reference continues to exist on the controller.
We've observed a bug where adding, removing, and then re‑adding a disk via VTL2 updates results in a DuplicateRequest error (Verified by @alandau). This issue originates from namespace handle‑count checks in the driver. This PR removes that handle validation and shifts the responsibility for ensuring a one‑namespace‑per‑disk invariant back to the storage controller, where it historically used to be as well.

Design Note
I considered re‑implementing the handle_in_use logic by checking the Arc strong count == 1. While functional, that approach would impose an unusual and fragile constraint on the Arc—one that could be accidentally violated by unrelated code. To keep this first part simple and robust, this PR returns the most recent namespace object each time one is requested, without relying on usage‑count semantics.

![Figjamexport](https://github.com/user-attachments/assets/e970e2c7-a7c6-48b7-ac63-6fca829bd8d6)

