### PR TITLE
netvsp: always wait for coordinator to process messages from the primary worker

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -27,6 +27,7 @@ use buffers::sub_allocation_size_for_mtu;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::channel::mpsc;
+use futures::channel::mpsc::TrySendError;
 use futures_concurrency::future::Race;
 use guestmem::AccessError;
 use guestmem::GuestMemory;
@@ -197,6 +198,7 @@ impl<T: RingMem + 'static + Sync> InspectTaskMut<Worker<T>> for NetQueue {
                     WorkerState::Init(None) => "version",
                     WorkerState::Init(Some(_)) => "init",
                     WorkerState::Ready(_) => "ready",
+                    WorkerState::WaitingForCoordinator(_) => "waiting for coordinator",
                 },
             )
             .field("ring", &worker.channel.queue)
@@ -230,10 +232,10 @@ impl<T: RingMem + 'static + Sync> InspectTaskMut<Worker<T>> for NetQueue {
     }
 }
 
-#[expect(clippy::large_enum_variant)]
 enum WorkerState {
     Init(Option<InitState>),
     Ready(ReadyState),
+    WaitingForCoordinator(Option<ReadyState>),
 }
 
 impl WorkerState {
@@ -1443,6 +1445,7 @@ impl Nic {
                 active_packet_filter: restoring
                     .map(|r| r.active_packet_filter)
                     .unwrap_or(rndisprot::NDIS_PACKET_TYPE_NONE),
+                sleep_deadline: None,
             },
         );
     }
@@ -1690,7 +1693,7 @@ impl Nic {
                         }),
                     })
                 }
-                WorkerState::Ready(ready) => {
+                WorkerState::WaitingForCoordinator(Some(ready)) | WorkerState::Ready(ready) => {
                     let primary = ready.state.primary.as_ref().unwrap();
 
                     let rndis_state = match primary.rndis_state {
@@ -1856,6 +1859,9 @@ impl Nic {
                         packet_filter: Some(worker_0_packet_filter),
                     })
                 }
+                WorkerState::WaitingForCoordinator(None) => {
+                    unreachable!("valid ready state")
+                }
             };
 
             let state = saved_state::OpenState { primary };
@@ -1916,6 +1922,8 @@ enum WorkerError {
     BufferRevoked,
     #[error("endpoint requires queue restart: {0}")]
     EndpointRequiresQueueRestart(#[source] anyhow::Error),
+    #[error("Failed to send message to coordinator")]
+    CoordinatorMessageSendFailed(#[source] TrySendError<CoordinatorMessage>),
 }
 
 impl From<task_control::Cancelled> for WorkerError {
@@ -3682,6 +3690,7 @@ struct Coordinator {
     buffers: Option<Arc<ChannelBuffers>>,
     num_queues: u16,
     active_packet_filter: u32,
+    sleep_deadline: Option<Instant>,
 }
 
 /// Removing the VF may result in the guest sending messages to switch the data
@@ -3790,7 +3799,6 @@ impl Coordinator {
         stop: &mut StopTask<'_>,
         state: &mut CoordinatorState,
     ) -> Result<(), task_control::Cancelled> {
-        let mut sleep_duration: Option<Instant> = None;
         loop {
             if self.restart {
                 stop.until_stopped(self.stop_workers()).await?;
@@ -3823,6 +3831,13 @@ impl Coordinator {
             for worker in &mut self.workers[1..] {
                 worker.start();
             }
+            if !self.workers[0].is_running()
+                && self.workers[0].state().is_none_or(|worker| {
+                    !matches!(worker.state, WorkerState::WaitingForCoordinator(_))
+                })
+            {
+                self.workers[0].start();
+            }
 
             enum Message {
                 Internal(CoordinatorMessage),
@@ -3837,23 +3852,6 @@ impl Coordinator {
                 state.pending_vf_state,
                 CoordinatorStatePendingVfState::Pending
             ) {
-                // The primary worker is allowed to run, but as no
-                // notifications are being processed, if it is waiting for an
-                // action then it should remain stopped until this completes
-                // and the regular message processing logic resumes. Currently
-                // the only message that requires processing is
-                // DataPathSwitchPending, so check for that here.
-                if !self.workers[0].is_running()
-                    && self.primary_mut().is_none_or(|primary| {
-                        !matches!(
-                            primary.guest_vf_state,
-                            PrimaryChannelGuestVfState::DataPathSwitchPending { result: None, .. }
-                        )
-                    })
-                {
-                    self.workers[0].start();
-                }
-
                 // guest_ready_for_device is not restartable, so do not poll on
                 // stop.
                 state
@@ -3865,9 +3863,9 @@ impl Coordinator {
                 Message::PendingVfStateComplete
             } else {
                 let timer_sleep = async {
-                    if let Some(sleep_duration) = sleep_duration {
+                    if let Some(deadline) = self.sleep_deadline {
                         let mut timer = PolledTimer::new(&state.adapter.driver);
-                        timer.sleep_until(sleep_duration).await;
+                        timer.sleep_until(deadline).await;
                     } else {
                         pending::<()>().await;
                     }
@@ -3915,16 +3913,12 @@ impl Coordinator {
                     }
                 };
 
-                let mut wait_for_message = std::pin::pin!(wait_for_message);
-                match (&mut wait_for_message).now_or_never() {
-                    Some(message) => message,
-                    None => {
-                        self.workers[0].start();
-                        stop.until_stopped(wait_for_message).await?
-                    }
-                }
+                stop.until_stopped(wait_for_message).await?
             };
             match message {
+                Message::Internal(msg) => {
+                    self.handle_coordinator_message(msg, state).await;
+                }
                 Message::UpdateFromVf(rpc) => {
                     rpc.handle(async |_| {
                         self.update_guest_vf_state(state).await;
@@ -3949,36 +3943,13 @@ impl Coordinator {
                 }
                 Message::TimerExpired => {
                     // Kick the worker as requested.
-                    if self.workers[0].is_running() {
-                        self.workers[0].stop().await;
-                        if let Some(primary) = self.primary_mut() {
-                            if let PendingLinkAction::Delay(up) = primary.pending_link_action {
-                                primary.pending_link_action = PendingLinkAction::Active(up);
-                            }
+                    self.workers[0].stop().await;
+                    if let Some(primary) = self.primary_mut() {
+                        if let PendingLinkAction::Delay(up) = primary.pending_link_action {
+                            primary.pending_link_action = PendingLinkAction::Active(up);
                         }
                     }
-                    sleep_duration = None;
-                }
-                Message::Internal(CoordinatorMessage::Update(update_type)) => {
-                    if update_type.filter_state {
-                        self.stop_workers().await;
-                        self.active_packet_filter =
-                            self.workers[0].state().unwrap().channel.packet_filter;
-                        self.workers.iter_mut().skip(1).for_each(|worker| {
-                            if let Some(state) = worker.state_mut() {
-                                state.channel.packet_filter = self.active_packet_filter;
-                                tracing::debug!(
-                                    packet_filter = ?self.active_packet_filter,
-                                    channel_idx = state.channel_idx,
-                                    "update packet filter"
-                                );
-                            }
-                        });
-                    }
-
-                    if update_type.guest_vf_state {
-                        self.update_guest_vf_state(state).await;
-                    }
+                    self.sleep_deadline = None;
                 }
                 Message::UpdateFromEndpoint(EndpointAction::RestartRequired) => self.restart = true,
                 Message::UpdateFromEndpoint(EndpointAction::LinkStatusNotify(connect)) => {
@@ -3996,13 +3967,7 @@ impl Coordinator {
                     }
 
                     // If there is any existing sleep timer running, cancel it out.
-                    sleep_duration = None;
-                }
-                Message::Internal(CoordinatorMessage::Restart) => self.restart = true,
-                Message::Internal(CoordinatorMessage::StartTimer(duration)) => {
-                    sleep_duration = Some(duration);
-                    // Restart primary task.
-                    self.workers[0].stop().await;
+                    self.sleep_deadline = None;
                 }
                 Message::ChannelDisconnected => {
                     break;
@@ -4010,6 +3975,51 @@ impl Coordinator {
             };
         }
         Ok(())
+    }
+
+    async fn handle_coordinator_message(
+        &mut self,
+        msg: CoordinatorMessage,
+        state: &mut CoordinatorState,
+    ) {
+        self.workers[0].stop().await;
+        if let Some(worker) = self.workers[0].state_mut() {
+            if matches!(worker.state, WorkerState::WaitingForCoordinator(_)) {
+                let WorkerState::WaitingForCoordinator(Some(ready)) =
+                    std::mem::replace(&mut worker.state, WorkerState::WaitingForCoordinator(None))
+                else {
+                    unreachable!("valid ready state")
+                };
+                let _ = std::mem::replace(&mut worker.state, WorkerState::Ready(ready));
+            }
+        }
+        match msg {
+            CoordinatorMessage::Update(update_type) => {
+                if update_type.filter_state {
+                    self.stop_workers().await;
+                    self.active_packet_filter =
+                        self.workers[0].state().unwrap().channel.packet_filter;
+                    self.workers.iter_mut().skip(1).for_each(|worker| {
+                        if let Some(state) = worker.state_mut() {
+                            state.channel.packet_filter = self.active_packet_filter;
+                            tracing::debug!(
+                                packet_filter = ?self.active_packet_filter,
+                                channel_idx = state.channel_idx,
+                                "update packet filter"
+                            );
+                        }
+                    });
+                }
+
+                if update_type.guest_vf_state {
+                    self.update_guest_vf_state(state).await;
+                }
+            }
+            CoordinatorMessage::StartTimer(deadline) => {
+                self.sleep_deadline = Some(deadline);
+            }
+            CoordinatorMessage::Restart => self.restart = true,
+        }
     }
 
     async fn stop_workers(&mut self) {
@@ -4139,6 +4149,7 @@ impl Coordinator {
                 }
                 PrimaryChannelGuestVfState::Initializing
                 | PrimaryChannelGuestVfState::Unavailable
+                | PrimaryChannelGuestVfState::UnavailableFromAvailable
                 | PrimaryChannelGuestVfState::Restoring(saved_state::GuestVfState::NoState) => {
                     PrimaryChannelGuestVfState::Available { vfid: guest_vf_id }
                 }
@@ -4482,11 +4493,7 @@ impl<T: RingMem + 'static> Worker<T> {
         loop {
             match &mut self.state {
                 WorkerState::Init(initializing) => {
-                    if self.channel_idx != 0 {
-                        // Still waiting for the coordinator to provide receive
-                        // buffers. The task will be restarted when they are available.
-                        stop.until_stopped(pending()).await?
-                    }
+                    assert_eq!(self.channel_idx, 0);
 
                     tracelimit::info_ratelimited!("network accepted");
 
@@ -4504,7 +4511,13 @@ impl<T: RingMem + 'static> Worker<T> {
                     let _ = self.coordinator_send.try_send(CoordinatorMessage::Restart);
 
                     tracelimit::info_ratelimited!("network initialized");
-                    self.state = WorkerState::Ready(state);
+                    self.state = WorkerState::WaitingForCoordinator(Some(state));
+                }
+                WorkerState::WaitingForCoordinator(_) => {
+                    assert_eq!(self.channel_idx, 0);
+                    // Waiting for the coordinator to process a message and
+                    // restart the primary worker.
+                    stop.until_stopped(pending()).await?
                 }
                 WorkerState::Ready(state) => {
                     let queue_state = if let Some(queue_state) = &mut queue.queue_state {
@@ -4527,29 +4540,34 @@ impl<T: RingMem + 'static> Worker<T> {
                     };
 
                     let result = self.channel.main_loop(stop, state, queue_state).await;
-                    match result {
+                    let msg = match result {
                         Ok(restart) => {
                             assert_eq!(self.channel_idx, 0);
-                            let _ = self.coordinator_send.try_send(restart);
+                            restart
                         }
                         Err(WorkerError::EndpointRequiresQueueRestart(err)) => {
                             tracelimit::warn_ratelimited!(
                                 err = %err,
                                 "Endpoint requires queues to restart",
                             );
-                            if let Err(try_send_err) =
-                                self.coordinator_send.try_send(CoordinatorMessage::Restart)
-                            {
-                                tracing::error!(
-                                    try_send_err = %try_send_err,
-                                    "failed to restart queues"
-                                );
-                                return Err(WorkerError::Endpoint(err));
-                            }
+                            CoordinatorMessage::Restart
                         }
                         Err(err) => return Err(err),
-                    }
+                    };
 
+                    let WorkerState::Ready(ready) = std::mem::replace(
+                        &mut self.state,
+                        WorkerState::WaitingForCoordinator(None),
+                    ) else {
+                        unreachable!("must be running in ready state")
+                    };
+                    let _ = std::mem::replace(
+                        &mut self.state,
+                        WorkerState::WaitingForCoordinator(Some(ready)),
+                    );
+                    self.coordinator_send
+                        .try_send(msg)
+                        .map_err(WorkerError::CoordinatorMessageSendFailed)?;
                     stop.until_stopped(pending()).await?
                 }
             }


### PR DESCRIPTION
There have been several issues with starting the primary worker before the last message was processed (specifically the message to switch the data path). These have been resolved as discovered, but there is still at least one race, and generally this should be made harder to get wrong. Change the protocol to put the primary worker in a "waiting" state, and only after the message has been processed is it returned to 'ready'. The state is used to determine if it should be restarted, so it should never actually start running in the 'waiting' state, but just in case that will pend instead of running the main_loop.

I was not able to hit the latest race condition via unit test, but the test code has been updated with fixes and behavior updates that more closely match real devices.

CP from #2370