### PR TITLE
flowey: add Nix as a FlowPlatform

### DIFF
--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -77,7 +77,7 @@ pub mod user_facing {
     /// fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
     ///     let mut version = None;
     ///     let mut ensure_installed = Vec::new();
-    ///     
+    ///
     ///     for req in requests {
     ///         match req {
     ///             Request::Version(v) => {
@@ -89,9 +89,9 @@ pub mod user_facing {
     ///             }
     ///         }
     ///     }
-    ///     
+    ///
     ///     let version = version.ok_or(anyhow::anyhow!("Missing required request: Version"))?;
-    ///     
+    ///
     ///     // ... emit steps using aggregated requests
     ///     Ok(())
     /// }
@@ -953,6 +953,8 @@ pub enum FlowPlatformLinuxDistro {
     Ubuntu,
     /// Arch Linux (including WSL2)
     Arch,
+    /// Nix environment (detected via IN_NIX_SHELL env var or having a `/nix/store` in PATH)
+    Nix,
     /// An unknown distribution
     Unknown,
 }
@@ -2597,18 +2599,18 @@ macro_rules! new_flow_node_base {
 ///
 /// impl FlowNode for Node {
 ///     type Request = Request;
-///     
+///
 ///     fn imports(ctx: &mut ImportCtx<'_>) {
 ///         // Declare node dependencies
 ///         ctx.import::<other_node::Node>();
 ///     }
-///     
+///
 ///     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
 ///         // 1. Aggregate and validate requests
 ///         let mut version = None;
 ///         let mut ensure_installed = Vec::new();
 ///         let mut get_cargo_home = Vec::new();
-///         
+///
 ///         for req in requests {
 ///             match req {
 ///                 Request::InstallRust(v) => {
@@ -2618,9 +2620,9 @@ macro_rules! new_flow_node_base {
 ///                 Request::GetCargoHome(var) => get_cargo_home.push(var),
 ///             }
 ///         }
-///         
+///
 ///         let version = version.ok_or(anyhow::anyhow!("Version not specified"))?;
-///         
+///
 ///         // 2. Emit steps to do the work
 ///         ctx.emit_rust_step("install rust", |ctx| {
 ///             let ensure_installed = ensure_installed.claim(ctx);
@@ -2637,7 +2639,7 @@ macro_rules! new_flow_node_base {
 ///                 Ok(())
 ///             }
 ///         });
-///         
+///
 ///         Ok(())
 ///     }
 /// }

--- a/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
@@ -178,7 +178,7 @@ pub struct BuildIgvmCliCustomizations {
 
     /// (experimental) Only use local dependencies to build. Keeps flowey from
     /// downloading any dependencies from the internet.
-    #[clap(long, requires_all = ["custom_openvmm_deps", "custom_protoc"])]
+    #[clap(long, requires_all = ["custom_openvmm_deps", "custom_protoc", "custom_kernel", "custom_kernel_modules", "custom_uefi"])]
     pub use_local_deps: bool,
 
     /// Use a custom openvmm_deps directory.

--- a/flowey/flowey_lib_common/src/_util/extract.rs
+++ b/flowey/flowey_lib_common/src/_util/extract.rs
@@ -39,6 +39,7 @@ pub fn extract_zip_if_new_deps(ctx: &mut NodeCtx<'_>) -> ExtractZipDeps {
                     FlowPlatformLinuxDistro::Fedora => vec!["bsdtar".into()],
                     FlowPlatformLinuxDistro::Ubuntu => vec!["libarchive-tools".into()],
                     FlowPlatformLinuxDistro::Arch => vec!["libarchive".into()],
+                    FlowPlatformLinuxDistro::Nix => vec![],
                     FlowPlatformLinuxDistro::Unknown => vec![],
                 },
                 _ => {

--- a/flowey/flowey_lib_common/src/download_azcopy.rs
+++ b/flowey/flowey_lib_common/src/download_azcopy.rs
@@ -54,6 +54,7 @@ impl FlowNode for Node {
                     FlowPlatformLinuxDistro::Fedora => vec!["bsdtar".into()],
                     FlowPlatformLinuxDistro::Ubuntu => vec!["libarchive-tools".into()],
                     FlowPlatformLinuxDistro::Arch => vec!["libarchive".into()],
+                    FlowPlatformLinuxDistro::Nix => vec![],
                     FlowPlatformLinuxDistro::Unknown => vec![],
                 },
                 _ => {

--- a/flowey/flowey_lib_common/src/install_dist_pkg.rs
+++ b/flowey/flowey_lib_common/src/install_dist_pkg.rs
@@ -63,6 +63,9 @@ impl PackageManager {
             FlowPlatformLinuxDistro::Arch => {
                 xshell::cmd!(sh, "pacman -Qq {packages_to_check...}")
             }
+            FlowPlatformLinuxDistro::Nix => {
+                anyhow::bail!("Nix environments cannot install packages")
+            }
             FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
         }
         .ignore_status()
@@ -90,6 +93,9 @@ impl PackageManager {
             FlowPlatformLinuxDistro::Fedora => xshell::cmd!(sh, "sudo dnf update").run()?,
             // Running `pacman -Sy` without a full system update can break everything; do nothing
             FlowPlatformLinuxDistro::Arch => (),
+            FlowPlatformLinuxDistro::Nix => {
+                anyhow::bail!("Nix environments cannot install packages")
+            }
             FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
         }
 
@@ -117,6 +123,9 @@ impl PackageManager {
             FlowPlatformLinuxDistro::Arch => {
                 let auto_accept = (!interactive).then_some("--noconfirm");
                 xshell::cmd!(sh, "sudo pacman -S {auto_accept...} {packages...}").run()?;
+            }
+            FlowPlatformLinuxDistro::Nix => {
+                anyhow::bail!("Nix environments cannot install packages")
             }
             FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
         }
@@ -197,6 +206,17 @@ impl FlowNode for Node {
         if !matches!(ctx.platform(), FlowPlatform::Linux(_)) {
             ctx.emit_side_effect_step([], did_install);
             return Ok(());
+        }
+
+        // Explicitly fail on installation requests in Nix environments.
+        if matches!(
+            ctx.platform(),
+            FlowPlatform::Linux(FlowPlatformLinuxDistro::Nix)
+        ) {
+            anyhow::bail!(
+                "Nix environments cannot install packages. Dependencies should be managed by Nix. Attempted to install {:?}",
+                packages
+            );
         }
 
         let pacman = PackageManager::new(ctx)?;


### PR DESCRIPTION
This PR adds Nix as a FlowPlatform. Flowey detects this platform by checking the environment variable `FLOWEY_USING_NIX`, which enables flowey to make decisions based on the fact that it's running in Nix. This allows the `install_dist_pkg` node and other places that install packages to check the platform before issuing a request, which we don't want to do when using Nix. 

The Nix files I have locally will need some work to work with cross-compilation. As such, I have the changes in this PR set up to explicitly fail cross-compilation scenarios so that I can fix them. 

This change also adds the rest of the required parameters to `cargo build xflowey build-igvm <RECIPE> --use-local-deps`. In tandem with #2654 and #2646, this gets us to compiling the x64 recipes in a Nix environment with no flowey-downloaded dependencies.