### PR TITLE
netvsp: handle eqe 135 and reconfigure vf

### DIFF
--- a/vm/devices/net/gdma/src/hwc.rs
+++ b/vm/devices/net/gdma/src/hwc.rs
@@ -10,6 +10,7 @@ use anyhow::anyhow;
 use gdma_defs::GDMA_EQE_HWC_INIT_DATA;
 use gdma_defs::GDMA_EQE_HWC_INIT_DONE;
 use gdma_defs::GDMA_EQE_HWC_INIT_EQ_ID_DB;
+use gdma_defs::GDMA_EQE_HWC_RECONFIG_VF;
 use gdma_defs::GDMA_EQE_TEST_EVENT;
 use gdma_defs::GdmaChangeMsixVectorIndexForEq;
 use gdma_defs::GdmaCreateDmaRegionReq;
@@ -300,6 +301,14 @@ impl HwControl {
                     .queues
                     .post_eq(req.queue_index, GDMA_EQE_TEST_EVENT, &[]);
 
+                0
+            }
+            GdmaRequestType::GDMA_GENERATE_RECONFIG_VF_EVENT => {
+                let req: GdmaGenerateTestEventReq =
+                    read.read_plain().context("reading test eqe request")?;
+                self.state
+                    .queues
+                    .post_eq(req.queue_index, GDMA_EQE_HWC_RECONFIG_VF, &[]);
                 0
             }
             GdmaRequestType::GDMA_VERIFY_VF_DRIVER_VERSION => {

--- a/vm/devices/net/gdma_defs/src/lib.rs
+++ b/vm/devices/net/gdma_defs/src/lib.rs
@@ -260,6 +260,8 @@ pub const GDMA_EQE_HWC_INIT_EQ_ID_DB: u8 = 129;
 pub const GDMA_EQE_HWC_INIT_DATA: u8 = 130;
 pub const GDMA_EQE_HWC_INIT_DONE: u8 = 131;
 pub const GDMA_EQE_HWC_RECONFIG_DATA: u8 = 133;
+// Sent on the event of a SoC Crash or certain Firmware updates.
+pub const GDMA_EQE_HWC_RECONFIG_VF: u8 = 135;
 
 #[bitfield(u32)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -306,6 +308,7 @@ open_enum! {
         GDMA_REGISTER_DEVICE = 4,
         GDMA_DEREGISTER_DEVICE = 5,
         GDMA_GENERATE_TEST_EQE = 10,
+        GDMA_GENERATE_RECONFIG_VF_EVENT = 11,
         GDMA_CREATE_QUEUE = 12,
         GDMA_DISABLE_QUEUE = 13,
         GDMA_CREATE_DMA_REGION = 25,

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -25,6 +25,7 @@ use gdma_defs::GDMA_EQE_HWC_INIT_DATA;
 use gdma_defs::GDMA_EQE_HWC_INIT_DONE;
 use gdma_defs::GDMA_EQE_HWC_INIT_EQ_ID_DB;
 use gdma_defs::GDMA_EQE_HWC_RECONFIG_DATA;
+use gdma_defs::GDMA_EQE_HWC_RECONFIG_VF;
 use gdma_defs::GDMA_EQE_TEST_EVENT;
 use gdma_defs::GDMA_MESSAGE_V1;
 use gdma_defs::GDMA_PAGE_TYPE_4K;
@@ -72,6 +73,7 @@ use gdma_defs::SmcProtoHdr;
 use inspect::Inspect;
 use pal_async::driver::Driver;
 use std::collections::HashMap;
+use std::mem;
 use std::mem::ManuallyDrop;
 use std::sync::Arc;
 use std::time::Duration;
@@ -160,6 +162,7 @@ pub struct GdmaDriver<T: DeviceBacking> {
     hwc_failure: bool,
     db_id: u32,
     state_saved: bool,
+    vf_reconfiguration_pending: bool,
 }
 
 const EQ_PAGE: usize = 0;
@@ -490,6 +493,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             hwc_failure: false,
             state_saved: false,
             db_id,
+            vf_reconfiguration_pending: false,
         };
 
         this.push_rqe();
@@ -539,6 +543,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             num_msix: self.num_msix,
             min_queue_avail: self.min_queue_avail,
             link_toggle: self.link_toggle.clone(),
+            vf_reconfiguration_pending: self.vf_reconfiguration_pending,
         })
     }
 
@@ -664,6 +669,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             hwc_failure: false,
             state_saved: false,
             db_id: db_id as u32,
+            vf_reconfiguration_pending: saved_state.vf_reconfiguration_pending,
         };
 
         this.eq.arm();
@@ -770,6 +776,10 @@ impl<T: DeviceBacking> GdmaDriver<T> {
 
     pub fn get_link_toggle_list(&mut self) -> Vec<(u32, bool)> {
         self.link_toggle.drain(..).collect()
+    }
+
+    pub fn get_vf_reconfiguration_pending(&mut self) -> bool {
+        mem::take(&mut self.vf_reconfiguration_pending)
     }
 
     pub fn device(&self) -> &T {
@@ -1002,6 +1012,11 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                         unknown => tracing::error!(unknown, "unknown reconfig data type"),
                     }
                 }
+                GDMA_EQE_HWC_RECONFIG_VF => {
+                    // No data is supplied for VF reconfiguration events.
+                    tracing::info!("HWC VF reconfiguration event");
+                    self.vf_reconfiguration_pending = true;
+                }
                 ty => tracing::error!(ty, "unknown eq event"),
             }
             self.eq.ack();
@@ -1186,6 +1201,20 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                 )
             })?;
         }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    #[tracing::instrument(skip(self), level = "debug", err)]
+    pub async fn generate_reconfig_vf_event(&mut self) -> anyhow::Result<()> {
+        self.request::<_, ()>(
+            GdmaRequestType::GDMA_GENERATE_RECONFIG_VF_EVENT.0,
+            HWC_DEV_ID,
+            GdmaGenerateTestEventReq {
+                queue_index: self.eq.id(),
+            },
+        )
+        .await?;
         Ok(())
     }
 

--- a/vm/devices/net/mana_driver/src/save_restore.rs
+++ b/vm/devices/net/mana_driver/src/save_restore.rs
@@ -77,6 +77,10 @@ pub struct GdmaDriverSavedState {
     /// Link status by vport index
     #[mesh(12)]
     pub link_toggle: Vec<(u32, bool)>,
+
+    /// Whether a VF reconfiguration event is pending
+    #[mesh(13)]
+    pub vf_reconfiguration_pending: bool,
 }
 
 /// The saved state of a completion queue or event queue for restoration


### PR DESCRIPTION
Clean cherry pick of PR #2576

For netvsp to recover from SoC crash and NMC servicing, it must detect EQE 135 from MANA and reconfigure the Virtual Function.

* `GDMA_EQE_HWC_RECONFIG_VF` added to events handled by the GDMA driver
* `vf_reconfiguration_pending` bool added the GDMA driver. Set when the EQE is received, read by the MANA driver when processing all EQ events.
* `vf_reconfig_sender` added to MANA driver to signal Netvsp VF Manager when it sees 'pending' is true
* `vf_reconfig_receiver` added to Netvsp HclNetworkVFManagerWorker to send `VFReconfig` message when signaled
* `VfReconfig` message added to Netvsp VF Manager, which removes the old VF and then creates a new VF

Smaller changes:
* `GDMA_GENERATE_TEST_EQE` and `GDMA_GENERATE_RECONFIG_VF_EVENT` added in order to create a unit test, `test_gdma_reconfig_vf()`
* The logic of `NextWorkItem::ManaDeviceArrived` refactored into `startup_vtl2_device()` so the logic can be shared with `VfReconfig`

Testing:
* Unit tests pass
* Tested on a lab machine with SoC MANA privates which allowed EQE 135 to be generated by command. Netvsp is able to see the EQE and VfReconfig is called. Before and after sending the EQE, ping and ntttcp traffic succeed.

Observed in testing: when the reconfiguration is in `startup_vtl2_device()` it sees a failure in `update_vtl2_device_bind_state()` (see below). From code inspection, netvsp treats any errors from updating bind state as ignorable.
```
[8439.658408] underhill_core::emuplat::netvsp: ERROR  Failed to report new binding state to host err=vpci operation error: INVALID_REQUEST
```
