### PR TITLE
vmm_tests: slow GET_LOG_PAGE command before servicing

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -416,8 +416,8 @@ async fn _servicing_keepalive_with_missed_get_log_page(
         .with_timeout(Duration::from_secs(30))
         .until_cancelled(identify_verify_recv)
         .await
-        .expect("IDENTIFY command was NOT observed within 30 seconds of vm restore after servicing with namespace change")
-        .expect("IDENTIFY verification completed");
+        .expect("IDENTIFY should be observed within 30 seconds of vm restore after servicing with namespace change")
+        .expect("IDENTIFY verification should pass and return a valid result.");
 
     fault_start_updater.set(false).await;
     agent.ping().await?;


### PR DESCRIPTION
Currently the AER Handler in the nvme_driver crate is modeled as a simple task function which we then call `cancel()` on during save time. However, this leads us to situations where the AER could be "missed" when GET_LOG_PAGE was slow to respond.
This is a formalized version of the above mentioned scenario. Sure enough, currently it fails (I verified that the test passes as expected when there is no servicing).
I am working on a solution to this problem by making the AER handler more cooperative during save time. For now this test can remain dormant but will be used to verify correctness later.