### PR TITLE
vmbus_server: add equality operators to saved state types

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -833,7 +833,7 @@ impl MonitorPageRequest {
     }
 }
 
-#[derive(Debug, Copy, PartialEq, Eq, Clone, Protobuf)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Protobuf)]
 #[mesh(package = "vmbus.server.channels")]
 pub struct SignalInfo {
     #[mesh(1)]


### PR DESCRIPTION
This change adds implementations of `PartialEq` and `Eq` to some of the VMBus saved state types. This will be used by unit tests in internal code.