### PR TITLE
SNP: Test and set guest busy bit atomically.

### DIFF
--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -99,6 +99,16 @@ impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
             | ((self.set_u64((v >> 64) as u64, offset + 8) as u128) << 64)
     }
 
+    /// Gets an atomic reference to the v_intr_cntrl field.
+    /// # Safety
+    /// v_intr_cntrl must not be accessed by other VPs.
+    unsafe fn v_intr_cntrl_atomic(&mut self) -> &AtomicU64 {
+        // SAFETY: the vintr control field is on the VMSA which is per-VP per-VTL.
+        // As VPs cannot run on multiple processors at the same time there is a
+        // limited need for synchronization on the vintr control field.
+        unsafe { &*(core::ptr::from_ref(&self.vmsa.v_intr_cntrl).cast::<AtomicU64>()) }
+    }
+
     /// Create a new VMSA
     pub fn reset(&mut self, vmsa_reg_prot: bool) {
         *self.vmsa = FromZeros::new_zeroed();
@@ -161,17 +171,11 @@ impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
         }
     }
 
-    /// Gets an atomic reference to the v_intr_cntrl field.
-    pub fn v_intr_cntrl_atomic(&self) -> &AtomicU64 {
-        // SAFETY: caller responsible for synchronizing with any non-atomic access.
-        unsafe { &*(core::ptr::from_ref(&self.vmsa.v_intr_cntrl) as *const AtomicU64) }
-    }
-
     /// Atomically test and set the guest busy bit in v_intr_cntrl.
     pub fn guest_busy_bit_test_and_set(&mut self) -> bool {
         const VINTR_GUEST_BUSYBIT_MASK: u64 = 1u64 << 63;
-        let prev = self
-            .v_intr_cntrl_atomic()
+        // SAFETY: v_intr_cntrl is only accessed by this VP.
+        let prev = unsafe { self.v_intr_cntrl_atomic() }
             .fetch_or(VINTR_GUEST_BUSYBIT_MASK, Ordering::SeqCst);
         (prev & VINTR_GUEST_BUSYBIT_MASK) != 0
     }

--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -99,16 +99,6 @@ impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
             | ((self.set_u64((v >> 64) as u64, offset + 8) as u128) << 64)
     }
 
-    /// Gets an atomic reference to the v_intr_cntrl field.
-    /// # Safety
-    /// v_intr_cntrl must not be accessed by other VPs.
-    unsafe fn v_intr_cntrl_atomic(&mut self) -> &AtomicU64 {
-        // SAFETY: the vintr control field is on the VMSA which is per-VP per-VTL.
-        // As VPs cannot run on multiple processors at the same time there is a
-        // limited need for synchronization on the vintr control field.
-        unsafe { &*(core::ptr::from_ref(&self.vmsa.v_intr_cntrl).cast::<AtomicU64>()) }
-    }
-
     /// Create a new VMSA
     pub fn reset(&mut self, vmsa_reg_prot: bool) {
         *self.vmsa = FromZeros::new_zeroed();
@@ -174,9 +164,15 @@ impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
     /// Atomically test and set the guest busy bit in v_intr_cntrl.
     pub fn guest_busy_bit_test_and_set(&mut self) -> bool {
         const VINTR_GUEST_BUSYBIT_MASK: u64 = 1u64 << 63;
-        // SAFETY: v_intr_cntrl is only accessed by this VP.
-        let prev = unsafe { self.v_intr_cntrl_atomic() }
-            .fetch_or(VINTR_GUEST_BUSYBIT_MASK, Ordering::SeqCst);
+        // SAFETY: `v_intr_cntrl` is in the per-VP per-VTL VMSA. The `&mut self`
+        // guarantees no other Rust reference to this field exists, and this code
+        // only runs on the owning VP's thread. The atomic is needed because the
+        // untrusted hypervisor's hardware may concurrently access this field via
+        // VMRUN on another physical CPU.
+        let prev = unsafe {
+            &*(core::ptr::from_ref(&self.vmsa.v_intr_cntrl).cast::<AtomicU64>())
+        }
+        .fetch_or(VINTR_GUEST_BUSYBIT_MASK, Ordering::SeqCst);
         (prev & VINTR_GUEST_BUSYBIT_MASK) != 0
     }
 }

--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -170,10 +170,11 @@ impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
     /// Atomically test and set the guest busy bit in v_intr_cntrl.
     pub fn guest_busy_bit_test_and_set(&mut self) -> bool {
         const VINTR_GUEST_BUSYBIT_MASK: u64 = 1u64 << 63;
-        let prev = self.v_intr_cntrl_atomic().fetch_or(VINTR_GUEST_BUSYBIT_MASK, Ordering::SeqCst);
+        let prev = self
+            .v_intr_cntrl_atomic()
+            .fetch_or(VINTR_GUEST_BUSYBIT_MASK, Ordering::SeqCst);
         (prev & VINTR_GUEST_BUSYBIT_MASK) != 0
     }
-
 }
 
 /// Check bitmap to see if a register is included in masking.

--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -7,6 +7,8 @@
 use std::array;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use x86defs::snp::SecureAvicControl;
 use x86defs::snp::SevEventInjectInfo;
 use x86defs::snp::SevFeatures;
@@ -158,6 +160,20 @@ impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
             self.vmsa.x87_registers[i] = val;
         }
     }
+
+    /// Gets an atomic reference to the v_intr_cntrl field.
+    pub fn v_intr_cntrl_atomic(&self) -> &AtomicU64 {
+        // SAFETY: caller responsible for synchronizing with any non-atomic access.
+        unsafe { &*(core::ptr::from_ref(&self.vmsa.v_intr_cntrl) as *const AtomicU64) }
+    }
+
+    /// Atomically test and set the guest busy bit in v_intr_cntrl.
+    pub fn guest_busy_bit_test_and_set(&mut self) -> bool {
+        const VINTR_GUEST_BUSYBIT_MASK: u64 = 1u64 << 63;
+        let prev = self.v_intr_cntrl_atomic().fetch_or(VINTR_GUEST_BUSYBIT_MASK, Ordering::SeqCst);
+        (prev & VINTR_GUEST_BUSYBIT_MASK) != 0
+    }
+
 }
 
 /// Check bitmap to see if a register is included in masking.

--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -169,10 +169,8 @@ impl<T: DerefMut<Target = SevVmsa>> VmsaWrapper<'_, T> {
         // only runs on the owning VP's thread. The atomic is needed because the
         // untrusted hypervisor's hardware may concurrently access this field via
         // VMRUN on another physical CPU.
-        let prev = unsafe {
-            &*(core::ptr::from_ref(&self.vmsa.v_intr_cntrl).cast::<AtomicU64>())
-        }
-        .fetch_or(VINTR_GUEST_BUSYBIT_MASK, Ordering::SeqCst);
+        let prev = unsafe { &*(core::ptr::from_ref(&self.vmsa.v_intr_cntrl).cast::<AtomicU64>()) }
+            .fetch_or(VINTR_GUEST_BUSYBIT_MASK, Ordering::SeqCst);
         (prev & VINTR_GUEST_BUSYBIT_MASK) != 0
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -106,7 +106,7 @@ enum SnpGhcbError {
 
 #[derive(Debug, Error)]
 enum SnpRunVpError {
-    #[error("Guest AVIC backing page is not validated or cannot be accessed.")]
+    #[error("guest AVIC backing page is not validated or cannot be accessed")]
     VpNotRestartableError,
     #[error("failed to run")]
     RunVpError(#[source] hcl::ioctl::Error),
@@ -1547,13 +1547,13 @@ impl UhProcessor<'_, SnpBacked> {
             let sev_error_code = SevExitCode(vmsa.guest_error_code());
             match sev_error_code {
                 SevExitCode::NOT_RESTARTABLE => {
-                    // The guest APIC backing page is not validated in the RMP.
+                    // The guest AVIC backing page is not validated in the RMP.
                     return Err(dev.fatal_error(SnpRunVpError::VpNotRestartableError.into()));
                 }
                 SevExitCode::NPF => {
                     let exit_info = SevNpfInfo::from(vmsa.exit_info1());
                     if exit_info.not_restartable() {
-                        // An access to the guest's APIC backing page by AVIC hardware resulted
+                        // An access to the guest AVIC backing page by hardware resulted
                         // in a nested page fault.
                         return Err(dev.fatal_error(SnpRunVpError::VpNotRestartableError.into()));
                     }
@@ -2051,7 +2051,7 @@ impl UhProcessor<'_, SnpBacked> {
                 tracing::error!(
                     CVM_CONFIDENTIAL,
                     "SEV exit code {sev_error_code:x?} sev features {:x?} v_intr_control {:x?} event inject {:x?} \
-                    vmpl {:x?} cpl {:x?} exit_info1 {:x?} exit_info2 {:x?} exit_int_info {:x?}  virtual_tom {:x?} \
+                    vmpl {:x?} cpl {:x?} exit_info1 {:x?} exit_info2 {:x?} exit_int_info {:x?} virtual_tom {:x?} \
                     efer {:x?} cr4 {:x?} cr3 {:x?} cr0 {:x?} rflag {:x?} rip {:x?} next rip {:x?}",
                     vmsa.sev_features(),
                     vmsa.v_intr_cntrl(),

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -105,7 +105,6 @@ enum SnpGhcbError {
 }
 
 #[derive(Debug, Error)]
-#[error("failed to run")]
 enum SnpRunVpError {
     #[error("Guest AVIC backing page is not validated or cannot be accessed.")]
     VpNotRestartableError,
@@ -1584,14 +1583,14 @@ impl UhProcessor<'_, SnpBacked> {
                     _ => Some(exit_int_info),
                 };
 
+                if let Some(inject) = inject {
+                    vmsa.set_event_inject(inject);
+                }
+
                 // Since the exit interrupt information was processed, it must be
                 // cleared so that it is not examined again on a subsequent reentry to
                 // the HCL.
                 vmsa.set_exit_int_info(0);
-
-                if let Some(inject) = inject {
-                    vmsa.set_event_inject(inject);
-                }
             } else {
                 // Any previously injected event has been consumed.
             }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1532,21 +1532,12 @@ impl UhProcessor<'_, SnpBacked> {
 
         let entered_from_vtl = next_vtl;
         let (avic_page, mut vmsa) = self.runner.secure_avic_page_vmsa_mut(entered_from_vtl);
-        let exit_int_info_trace = SevEventInjectInfo::from(vmsa.exit_int_info());
 
         // Atomically test and set the guest busy bit. This prevents the untrusted
         // hypervisor from re-entering the VMSA on another physical CPU while VTL2
-        // is processing the exit. The return value indicates whether the hardware
-        // had already set the busy bit on exit (e.g., for APIC-related exits with
-        // secure AVIC, or injection failures with alternate injection).
-        #[cfg(not(feature = "disable_secure_avic"))]
-        if !vmsa.sev_features().alternate_injection() {
-            assert!(
-                vmsa.sev_features().secure_avic(),
-                "secure AVIC must be enabled"
-            );
-        }
+        // is processing the exit.
         let was_busy = vmsa.guest_busy_bit_test_and_set();
+        let exit_int_info_trace = SevEventInjectInfo::from(vmsa.exit_int_info());
 
         if was_busy {
             self.backing.general_stats[entered_from_vtl]
@@ -1571,8 +1562,6 @@ impl UhProcessor<'_, SnpBacked> {
             }
         }
 
-        // Handle exit interrupt info re-injection (alternate injection only).
-        // Secure AVIC manages event injection through the APIC backing page.
         if vmsa.sev_features().alternate_injection() {
             // Software interrupts/exceptions cannot be automatically re-injected, but RIP still
             // points to the instruction and the event should be re-generated when the
@@ -1605,7 +1594,14 @@ impl UhProcessor<'_, SnpBacked> {
                 // cleared so that it is not examined again on a subsequent reentry to
                 // the HCL.
                 vmsa.set_exit_int_info(0);
+            } else {
+                // Any previously injected event has been consumed.
             }
+        } else {
+            assert!(
+                cfg!(feature = "disable_secure_avic") || vmsa.sev_features().secure_avic(),
+                "secure AVIC must be enabled"
+            );
         }
 
         if last_interrupt_ctrl.irq() && !vmsa.v_intr_cntrl().irq() {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1534,33 +1534,46 @@ impl UhProcessor<'_, SnpBacked> {
         let (avic_page, mut vmsa) = self.runner.secure_avic_page_vmsa_mut(entered_from_vtl);
         let exit_int_info_trace = SevEventInjectInfo::from(vmsa.exit_int_info());
 
-        if vmsa.sev_features().alternate_injection() {
-            let was_busy = vmsa.guest_busy_bit_test_and_set();
-            if was_busy {
-                self.backing.general_stats[entered_from_vtl]
-                    .guest_busy
-                    .increment();
+        // Atomically test and set the guest busy bit. This prevents the untrusted
+        // hypervisor from re-entering the VMSA on another physical CPU while VTL2
+        // is processing the exit. The return value indicates whether the hardware
+        // had already set the busy bit on exit (e.g., for APIC-related exits with
+        // secure AVIC, or injection failures with alternate injection).
+        #[cfg(not(feature = "disable_secure_avic"))]
+        if !vmsa.sev_features().alternate_injection() {
+            assert!(
+                vmsa.sev_features().secure_avic(),
+                "secure AVIC must be enabled"
+            );
+        }
+        let was_busy = vmsa.guest_busy_bit_test_and_set();
 
-                let sev_error_code = SevExitCode(vmsa.guest_error_code());
-                match sev_error_code {
-                    SevExitCode::NOT_RESTARTABLE => {
-                        // The guest APIC backing page is not validated in the RMP.
+        if was_busy {
+            self.backing.general_stats[entered_from_vtl]
+                .guest_busy
+                .increment();
+
+            let sev_error_code = SevExitCode(vmsa.guest_error_code());
+            match sev_error_code {
+                SevExitCode::NOT_RESTARTABLE => {
+                    // The guest APIC backing page is not validated in the RMP.
+                    return Err(dev.fatal_error(SnpRunVpError::VpNotRestartableError.into()));
+                }
+                SevExitCode::NPF => {
+                    let exit_info = SevNpfInfo::from(vmsa.exit_info1());
+                    if exit_info.not_restartable() {
+                        // An access to the guest's APIC backing page by AVIC hardware resulted
+                        // in a nested page fault.
                         return Err(dev.fatal_error(SnpRunVpError::VpNotRestartableError.into()));
                     }
-                    SevExitCode::NPF => {
-                        let exit_info = SevNpfInfo::from(vmsa.exit_info1());
-                        if exit_info.not_restartable() {
-                            // An access to the guest's APIC backing page by AVIC hardware resulted
-                            // in a nested page fault.
-                            return Err(
-                                dev.fatal_error(SnpRunVpError::VpNotRestartableError.into())
-                            );
-                        }
-                    }
-                    _ => {}
                 }
+                _ => {}
             }
+        }
 
+        // Handle exit interrupt info re-injection (alternate injection only).
+        // Secure AVIC manages event injection through the APIC backing page.
+        if vmsa.sev_features().alternate_injection() {
             // Software interrupts/exceptions cannot be automatically re-injected, but RIP still
             // points to the instruction and the event should be re-generated when the
             // instruction is re-executed. Note that hardware does not provide instruction
@@ -1592,17 +1605,8 @@ impl UhProcessor<'_, SnpBacked> {
                 // cleared so that it is not examined again on a subsequent reentry to
                 // the HCL.
                 vmsa.set_exit_int_info(0);
-            } else {
-                // Any previously injected event has been consumed.
             }
-        } else {
-            #[cfg(not(feature = "disable_secure_avic"))]
-            assert!(
-                vmsa.sev_features().secure_avic(),
-                "secure AVIC must be enabled"
-            );
-            None
-        };
+        }
 
         if last_interrupt_ctrl.irq() && !vmsa.v_intr_cntrl().irq() {
             self.backing.general_stats[entered_from_vtl]

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1532,6 +1532,7 @@ impl UhProcessor<'_, SnpBacked> {
 
         let entered_from_vtl = next_vtl;
         let (avic_page, mut vmsa) = self.runner.secure_avic_page_vmsa_mut(entered_from_vtl);
+        let exit_int_info_trace = SevEventInjectInfo::from(vmsa.exit_int_info());
 
         if vmsa.sev_features().alternate_injection() {
             let was_busy = vmsa.guest_busy_bit_test_and_set();
@@ -2050,7 +2051,7 @@ impl UhProcessor<'_, SnpBacked> {
                 tracing::error!(
                     CVM_CONFIDENTIAL,
                     "SEV exit code {sev_error_code:x?} sev features {:x?} v_intr_control {:x?} event inject {:x?} \
-                    vmpl {:x?} cpl {:x?} exit_info1 {:x?} exit_info2 {:x?} exit_int_info {:x?} virtual_tom {:x?} \
+                    vmpl {:x?} cpl {:x?} exit_info1 {:x?} exit_info2 {:x?} exit_int_info {:x?}  virtual_tom {:x?} \
                     efer {:x?} cr4 {:x?} cr3 {:x?} cr0 {:x?} rflag {:x?} rip {:x?} next rip {:x?}",
                     vmsa.sev_features(),
                     vmsa.v_intr_cntrl(),
@@ -2059,7 +2060,7 @@ impl UhProcessor<'_, SnpBacked> {
                     vmsa.cpl(),
                     vmsa.exit_info1(),
                     vmsa.exit_info2(),
-                    vmsa.exit_int_info(),
+                    exit_int_info_trace,
                     vmsa.virtual_tom(),
                     vmsa.efer(),
                     vmsa.cr4(),

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1529,26 +1529,46 @@ impl UhProcessor<'_, SnpBacked> {
         let entered_from_vtl = next_vtl;
         let (avic_page, mut vmsa) = self.runner.secure_avic_page_vmsa_mut(entered_from_vtl);
 
-        // TODO SNP: The guest busy bit needs to be tested and set atomically.
-        let inject = if vmsa.sev_features().alternate_injection() {
-            if vmsa.v_intr_cntrl().guest_busy() {
+        if vmsa.sev_features().alternate_injection() {
+            let was_busy = vmsa.guest_busy_bit_test_and_set();
+            if was_busy {
                 self.backing.general_stats[entered_from_vtl]
                     .guest_busy
                     .increment();
-                // Software interrupts/exceptions cannot be automatically re-injected, but RIP still
-                // points to the instruction and the event should be re-generated when the
-                // instruction is re-executed. Note that hardware does not provide instruction
-                // length in this case so it's impossible to directly re-inject a software event if
-                // delivery generates an intercept.
-                //
-                // TODO SNP: Handle ICEBP.
-                let exit_int_info = SevEventInjectInfo::from(vmsa.exit_int_info());
-                assert!(
-                    exit_int_info.valid(),
-                    "event inject info should be valid {exit_int_info:x?}"
-                );
 
-                match exit_int_info.interruption_type() {
+                let sev_error_code = SevExitCode(vmsa.guest_error_code());
+                match sev_error_code {
+                    SevExitCode::NOT_RESTARTABLE => {
+                        // The guest APIC backing page is not validated in the RMP.
+                        return Err(VpHaltReason::TripleFault {
+                            vtl: entered_from_vtl.into(),
+                        });
+                    }
+                    SevExitCode::NPF => {
+                        let exit_info = SevNpfInfo::from(vmsa.exit_info1());
+                        if exit_info.not_restartable() {
+                            // An access to the guest's APIC backing page by AVIC hardware resulted
+                            // in a nested page fault.
+                            return Err(VpHaltReason::TripleFault {
+                                vtl: entered_from_vtl.into(),
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // Software interrupts/exceptions cannot be automatically re-injected, but RIP still
+            // points to the instruction and the event should be re-generated when the
+            // instruction is re-executed. Note that hardware does not provide instruction
+            // length in this case so it's impossible to directly re-inject a software event if
+            // delivery generates an intercept.
+            //
+            // TODO SNP: Handle ICEBP.
+            let exit_int_info = SevEventInjectInfo::from(vmsa.exit_int_info());
+
+            if exit_int_info.valid() {
+                let inject = match exit_int_info.interruption_type() {
                     x86defs::snp::SEV_INTR_TYPE_EXCEPT => {
                         if exit_int_info.vector() != 3 && exit_int_info.vector() != 4 {
                             // If the event is an exception, we can inject it.
@@ -1559,9 +1579,15 @@ impl UhProcessor<'_, SnpBacked> {
                     }
                     x86defs::snp::SEV_INTR_TYPE_SW => None,
                     _ => Some(exit_int_info),
+                };
+
+                vmsa.set_exit_int_info(0);
+
+                if let Some(inject) = inject {
+                    vmsa.set_event_inject(inject);
                 }
             } else {
-                None
+                // Any previously injected event has been consumed.
             }
         } else {
             #[cfg(not(feature = "disable_secure_avic"))]
@@ -1571,13 +1597,6 @@ impl UhProcessor<'_, SnpBacked> {
             );
             None
         };
-
-        if let Some(inject) = inject {
-            vmsa.set_event_inject(inject);
-        }
-        if vmsa.sev_features().alternate_injection() {
-            vmsa.v_intr_cntrl_mut().set_guest_busy(true);
-        }
 
         if last_interrupt_ctrl.irq() && !vmsa.v_intr_cntrl().irq() {
             self.backing.general_stats[entered_from_vtl]

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -106,7 +106,12 @@ enum SnpGhcbError {
 
 #[derive(Debug, Error)]
 #[error("failed to run")]
-struct SnpRunVpError(#[source] hcl::ioctl::Error);
+enum SnpRunVpError {
+    #[error("Guest AVIC backing page is not validated or cannot be accessed.")]
+    VpNotRestartableError,
+    #[error("failed to run")]
+    RunVpError(#[source] hcl::ioctl::Error),
+}
 
 /// A backing for SNP partitions.
 #[derive(InspectMut)]
@@ -1524,7 +1529,7 @@ impl UhProcessor<'_, SnpBacked> {
         let mut has_intercept = self
             .runner
             .run()
-            .map_err(|e| dev.fatal_error(SnpRunVpError(e).into()))?;
+            .map_err(|e| dev.fatal_error(SnpRunVpError::RunVpError(e).into()))?;
 
         let entered_from_vtl = next_vtl;
         let (avic_page, mut vmsa) = self.runner.secure_avic_page_vmsa_mut(entered_from_vtl);
@@ -1540,18 +1545,16 @@ impl UhProcessor<'_, SnpBacked> {
                 match sev_error_code {
                     SevExitCode::NOT_RESTARTABLE => {
                         // The guest APIC backing page is not validated in the RMP.
-                        return Err(VpHaltReason::TripleFault {
-                            vtl: entered_from_vtl.into(),
-                        });
+                        return Err(dev.fatal_error(SnpRunVpError::VpNotRestartableError.into()));
                     }
                     SevExitCode::NPF => {
                         let exit_info = SevNpfInfo::from(vmsa.exit_info1());
                         if exit_info.not_restartable() {
                             // An access to the guest's APIC backing page by AVIC hardware resulted
                             // in a nested page fault.
-                            return Err(VpHaltReason::TripleFault {
-                                vtl: entered_from_vtl.into(),
-                            });
+                            return Err(
+                                dev.fatal_error(SnpRunVpError::VpNotRestartableError.into())
+                            );
                         }
                     }
                     _ => {}
@@ -1581,6 +1584,9 @@ impl UhProcessor<'_, SnpBacked> {
                     _ => Some(exit_int_info),
                 };
 
+                // Since the exit interrupt information was processed, it must be
+                // cleared so that it is not examined again on a subsequent reentry to
+                // the HCL.
                 vmsa.set_exit_int_info(0);
 
                 if let Some(inject) = inject {

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -217,7 +217,7 @@ pub struct SevNpfInfo {
     pub vmpl_violation: bool,
     pub npt_supervisor_shadow_stack: bool,
     #[bits(25)]
-    rsvd38_63: u64,
+    rsvd38_62: u64,
     pub not_restartable: bool,
 }
 

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -216,8 +216,9 @@ pub struct SevNpfInfo {
     pub rmp_size_mismatch: bool,
     pub vmpl_violation: bool,
     pub npt_supervisor_shadow_stack: bool,
-    #[bits(26)]
+    #[bits(25)]
     rsvd38_63: u64,
+    pub not_restartable: bool,
 }
 
 /// SEV secure AVIC control register
@@ -968,6 +969,7 @@ open_enum::open_enum! {
         AVIC_NOACCEL = 0x402,
         VMGEXIT = 0x403,
         PAGE_NOT_VALIDATED = 0x404,
+        NOT_RESTARTABLE = 0x406,
 
         // SEV-ES software-defined exit codes
         SNP_GUEST_REQUEST = 0x80000011,


### PR DESCRIPTION
When running an SNP guest VP, test and set the guest busy bit atomically. Handle cases where the VP is not able to be restarted due to access issues with the guest APIC backing page. The guest busy bit is used for both secure AVIC and alternate injection scenarios.