### PR TITLE
netvsp: tracing improvements for error triage (#2625)

### DIFF
--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -239,6 +239,24 @@ enum Vtl0Bus {
     HiddenNotPresent,
     HiddenPresent(HclVpciBusControl),
 }
+impl std::fmt::Display for Vtl0Bus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Vtl0Bus::NotPresent => write!(f, "NotPresent"),
+            Vtl0Bus::Present(bus_control) => {
+                write!(f, "Present(vtl0_vfid={})", bus_control.instance_id().data1)
+            }
+            Vtl0Bus::HiddenNotPresent => write!(f, "HiddenNotPresent"),
+            Vtl0Bus::HiddenPresent(bus_control) => {
+                write!(
+                    f,
+                    "HiddenPresent(vtl0_vfid={})",
+                    bus_control.instance_id().data1
+                )
+            }
+        }
+    }
+}
 
 #[derive(Inspect)]
 struct HclNetworkVFManagerWorker {
@@ -366,6 +384,10 @@ impl HclNetworkVFManagerWorker {
                 },
             ),
         )
+        .instrument(tracing::info_span!(
+            "connecting endpoints",
+            num_endpoints = indices.len()
+        ))
         .await?;
         let (addresses, pkt_capture_controls): (Vec<_>, Vec<_>) = result.into_iter().unzip();
         self.pkt_capture_controls = Some(pkt_capture_controls);
@@ -424,6 +446,7 @@ impl HclNetworkVFManagerWorker {
                     }
                     Ok::<(), anyhow::Error>(())
                 }))
+                .instrument(tracing::info_span!("forcing datapath to synthetic"))
                 .await
                 .into_iter()
                 .collect::<anyhow::Result<Vec<_>, _>>()
@@ -439,7 +462,7 @@ impl HclNetworkVFManagerWorker {
             }
         }
         if let Err(err) = {
-            let bus_control = if let Vtl0Bus::Present(bus_control) = &bus_control {
+            let vpci_bus_control = if let Vtl0Bus::Present(bus_control) = &bus_control {
                 bus_control
             } else {
                 let Vtl0Bus::Present(bus_control) = &self.vtl0_bus_control else {
@@ -447,11 +470,14 @@ impl HclNetworkVFManagerWorker {
                 };
                 bus_control
             };
-            bus_control.revoke_device().await
+            vpci_bus_control
+                .revoke_device()
+                .instrument(tracing::info_span!("revoking vtl0 vf", vtl0_bus = %bus_control))
+                .await
         } {
             tracing::error!(
                 err = err.as_ref() as &dyn std::error::Error,
-                "Failed to revoke VTL0 VF."
+                "Failed to revoke VTL0 VF"
             );
         }
     }
@@ -466,7 +492,10 @@ impl HclNetworkVFManagerWorker {
     pub async fn shutdown_vtl2_device(&mut self, keep_vf_alive: bool) {
         self.disconnect_all_endpoints().await;
         if let Some(device) = self.mana_device.take() {
-            let (result, device) = device.shutdown().await;
+            let (result, device) = device
+                .shutdown()
+                .instrument(tracing::info_span!("shutdown vtl2 device", keep_vf_alive))
+                .await;
             // Closing the VFIO device handle can take a long time. Leak the handle by
             // stashing it away.
             if keep_vf_alive {
@@ -499,12 +528,15 @@ impl HclNetworkVFManagerWorker {
     async fn remove_vtl0_vf(&mut self) {
         if self.guest_state.is_offered_to_guest().await {
             *self.guest_state.offered_to_guest.lock().await = false;
-            tracing::info!(
-                vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
-                "Removing VF from VTL0"
-            );
             if let Vtl0Bus::Present(vtl0_bus_control) = &self.vtl0_bus_control {
-                match vtl0_bus_control.revoke_device().await {
+                match vtl0_bus_control
+                    .revoke_device()
+                    .instrument(tracing::info_span!(
+                        "Removing VF from VTL0",
+                        vtl0_bus = %self.vtl0_bus_control
+                    ))
+                    .await
+                {
                     Ok(_) => (),
                     Err(err) => {
                         tracing::error!(
@@ -518,6 +550,7 @@ impl HclNetworkVFManagerWorker {
     }
 
     async fn disconnect_all_endpoints(&mut self) {
+        let num_endpoints = self.endpoint_controls.len();
         futures::future::join_all(self.endpoint_controls.iter_mut().map(async |control| {
             match control.disconnect().await {
                 Ok(Some(mut endpoint)) => {
@@ -533,10 +566,25 @@ impl HclNetworkVFManagerWorker {
                 }
             }
         }))
+        .instrument(tracing::info_span!(
+            "disconnecting all endpoints",
+            num_endpoints
+        ))
         .await;
     }
 
+    async fn update_vtl2_device_bind_state(&self, is_bound: bool) -> anyhow::Result<()> {
+        self.vtl2_bus_control
+            .update_vtl2_device_bind_state(is_bound)
+            .instrument(tracing::info_span!(
+                "update vtl2 device bind state",
+                is_bound
+            ))
+            .await
+    }
+
     async fn startup_vtl2_device(&mut self, update_vtl2_device_bind_state: bool) -> bool {
+        // Each async call within this function handles its own tracing.
         let mut vtl2_device_present = false;
         let device_bound = match create_mana_device(
             &self.driver_source,
@@ -567,11 +615,7 @@ impl HclNetworkVFManagerWorker {
         };
 
         if update_vtl2_device_bind_state {
-            if let Err(err) = self
-                .vtl2_bus_control
-                .update_vtl2_device_bind_state(device_bound)
-                .await
-            {
+            if let Err(err) = self.update_vtl2_device_bind_state(device_bound).await {
                 tracing::error!(
                     err = err.as_ref() as &dyn std::error::Error,
                     "Failed to report new binding state to host"
@@ -827,7 +871,10 @@ impl HclNetworkVFManagerWorker {
                         self.disconnect_all_endpoints().await;
 
                         if let Some(device) = self.mana_device.take() {
-                            let (saved_state, device) = device.save().await;
+                            let (saved_state, device) = device
+                                .save()
+                                .instrument(tracing::info_span!("saving mana device state"))
+                                .await;
 
                             // Closing the VFIO device handle can take a long time.
                             // Leak the handle by stashing it away.
@@ -878,7 +925,7 @@ impl HclNetworkVFManagerWorker {
                         continue;
                     }
 
-                    tracing::info!("reconfiguring VF");
+                    tracing::info!("VTL2 VF reconfiguration requested");
                     // Remove VTL0 VF if present
                     *self.guest_state.vtl0_vfid.lock().await = None;
                     if self.guest_state.is_offered_to_guest().await {
@@ -956,6 +1003,7 @@ impl HclNetworkVFManagerWorker {
                         vf_reconfig_backoff.is_none(),
                         "device arrival should only occur after device removal and not vf reconfiguration"
                     );
+                    tracing::info!("VTL2 VF arrived");
                     let mut ctx =
                         mesh::CancelContext::new().with_timeout(std::time::Duration::from_secs(1));
                     // Ignore error here for waiting for the PCI path and continue to create the MANA device.
@@ -966,8 +1014,6 @@ impl HclNetworkVFManagerWorker {
                     {
                         let pci_path = Path::new("/sys/bus/pci/devices").join(&self.vtl2_pci_id);
                         tracing::error!(?pci_path, "Timed out waiting for MANA PCI path");
-                    } else {
-                        tracing::info!("VTL2 VF arrived");
                     }
 
                     let update_vtl2_device_bind_state = true;
@@ -993,11 +1039,7 @@ impl HclNetworkVFManagerWorker {
                     // If the device is being removed, remove outstanding vf reconfiguration.
                     vf_reconfig_backoff = None;
 
-                    if let Err(err) = self
-                        .vtl2_bus_control
-                        .update_vtl2_device_bind_state(false)
-                        .await
-                    {
+                    if let Err(err) = self.update_vtl2_device_bind_state(false).await {
                         tracing::error!(
                             err = err.as_ref() as &dyn std::error::Error,
                             "Failed to report new binding state to host"

--- a/support/tracelimit/src/lib.rs
+++ b/support/tracelimit/src/lib.rs
@@ -361,7 +361,7 @@ macro_rules! event_ratelimited_static {
 /// ```
 /// use tracing::Level;
 /// use tracelimit::event_ratelimited;
-/// event_ratelimited!(Level::ERROR, period: 1000, limit: 5, "custome period and limit");
+/// event_ratelimited!(Level::ERROR, period: 1000, limit: 5, "custom period and limit");
 /// event_ratelimited!(Level::WARN, period: 10000, "custom period only");
 /// event_ratelimited!(Level::INFO, limit: 50, "custom limit only");
 /// event_ratelimited!(Level::TRACE, "simple message");

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -1051,8 +1051,8 @@ impl<T: DeviceBacking + Send> Queue for ManaQueue<T> {
                         return Err(TxError::TryRestart(anyhow::anyhow!("TX GDMA error")));
                     }
                     CQE_TX_INVALID_OOB => {
-                        // Invalid OOB means the metadata didn't match how the Hardware parsed the packet.
-                        // This is somewhat common, usually due to Encapsulation, and only the affects the specific packet.
+                        // Invalid OOB means the metadata didn't match how the hardware parsed the packet.
+                        // This is somewhat common, usually due to encapsulation, and only affects the specific packet.
                         self.stats.tx_errors.increment();
                         self.trace_tx(tracing::Level::WARN, cqe.params, tx_oob, done.len());
                     }


### PR DESCRIPTION
Clean cherry-pick of https://github.com/microsoft/openvmm/pull/2625

Adding tracing spans to control-path operations in VF Manager to try and help answer two questions:

1. If a VF Manager operation like ManaDeviceRemoved fails to complete in a timely fashion, which 'await' call are we stuck in? It could be `try_notify_guest_and_revoke_vtl0_vf()`, `shutdown_vtl2_device()`, or `update_vtl2_device_bind_state()` and tracing spans will provide entry and exit opcodes.
2. If a VF Manager operation like ManaDeviceRemoved starts taking longer and missing SLAs, tracing spans can help us narrow down which call is taking up additional time.

* Improves NetVSP observability by adding structured tracing spans around VF Manager operations: VTL2 device startup/shutdown, VTL0 VF arrival/removal/revoke, endpoint disconnects, bind-state updates.
* Makes NetVSP device logging more actionable by adding `instance_id` and/or `channel_idx` to queue/channel errors: open/close/restore.
* Minor consistency improvements to error tracing. `err` => `error` and making that field the first element.
* Readability improvement to state transition logic in DataPathSwitchPending handler. Turning double-nested 'if' check into a 'match(a,b)'.
* Fixes to minor typos found in comments in net_mana and tracelimit..

---------