### PR TITLE
nvme_driver: update driver to use `Arc` / `Weak` semantics to enforce unique ownership for namespaces by nsid (#2657)

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager/device.rs
+++ b/openhcl/underhill_core/src/nvme_manager/device.rs
@@ -44,7 +44,7 @@ impl NvmeDevice for VfioNvmeDevice {
     async fn namespace(
         &mut self,
         nsid: u32,
-    ) -> Result<Arc<nvme_driver::Namespace>, nvme_driver::NamespaceError> {
+    ) -> Result<nvme_driver::NamespaceHandle, nvme_driver::NamespaceError> {
         self.driver.namespace(nsid).await
     }
 
@@ -324,7 +324,7 @@ enum NvmeDriverRequest {
     Inspect(Deferred),
     LoadDriver(Rpc<Span, anyhow::Result<()>>),
     /// Get an instance of the supplied namespace (an nvme `nsid`).
-    GetNamespace(Rpc<(Span, u32), Result<Arc<nvme_driver::Namespace>, NamespaceError>>),
+    GetNamespace(Rpc<(Span, u32), Result<nvme_driver::NamespaceHandle, NamespaceError>>),
     Save(Rpc<Span, anyhow::Result<NvmeDriverSavedState>>),
     /// Shutdown the NVMe driver, and the manager of that driver.
     /// Takes the span, and a set of options.
@@ -430,7 +430,7 @@ pub struct NvmeDriverManagerClient {
 }
 
 impl NvmeDriverManagerClient {
-    pub async fn get_namespace(&self, nsid: u32) -> anyhow::Result<Arc<nvme_driver::Namespace>> {
+    pub async fn get_namespace(&self, nsid: u32) -> anyhow::Result<nvme_driver::NamespaceHandle> {
         let span = tracing::info_span!(
             "nvme_device_manager_get_namespace",
             pci_id = self.pci_id,

--- a/openhcl/underhill_core/src/nvme_manager/mod.rs
+++ b/openhcl/underhill_core/src/nvme_manager/mod.rs
@@ -51,7 +51,6 @@
 
 use async_trait::async_trait;
 use inspect::Inspect;
-use std::sync::Arc;
 use thiserror::Error;
 use vmcore::vm_task::VmTaskDriverSource;
 
@@ -95,7 +94,7 @@ pub trait NvmeDevice: Inspect + Send + Sync {
     async fn namespace(
         &mut self,
         nsid: u32,
-    ) -> Result<Arc<nvme_driver::Namespace>, nvme_driver::NamespaceError>;
+    ) -> Result<nvme_driver::NamespaceHandle, nvme_driver::NamespaceError>;
     async fn save(&mut self) -> anyhow::Result<nvme_driver::save_restore::NvmeDriverSavedState>;
     async fn shutdown(mut self: Box<Self>);
     fn update_servicing_flags(&mut self, keep_alive: bool);

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -11,7 +11,7 @@ use guestmem::GuestMemory;
 use guid::Guid;
 use nvme::NvmeController;
 use nvme::NvmeControllerCaps;
-use nvme_driver::Namespace;
+use nvme_driver::NamespaceHandle;
 use nvme_driver::NvmeDriver;
 use nvme_spec::nvm::DsmRange;
 use page_pool_alloc::PagePoolAllocator;
@@ -19,7 +19,6 @@ use pal_async::DefaultDriver;
 use pci_core::msi::MsiInterruptSet;
 use scsi_buffers::OwnedRequestBuffers;
 use std::convert::TryFrom;
-use std::sync::Arc;
 use user_driver_emulated_mock::DeviceTestMemory;
 use vmcore::vm_task::SingleDriverBackend;
 use vmcore::vm_task::VmTaskDriverSource;
@@ -27,7 +26,7 @@ use vmcore::vm_task::VmTaskDriverSource;
 /// Nvme driver fuzzer
 pub struct FuzzNvmeDriver {
     driver: Option<NvmeDriver<FuzzEmulatedDevice<NvmeController, PagePoolAllocator>>>,
-    namespace: Arc<Namespace>,
+    namespace: NamespaceHandle,
     payload_mem: GuestMemory,
     cpu_count: u32,
 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/lib.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/lib.rs
@@ -15,8 +15,8 @@ mod tests;
 
 pub use self::driver::NvmeDriver;
 pub use self::driver::save_restore;
-pub use self::namespace::Namespace;
 pub use self::namespace::NamespaceError;
+pub use self::namespace::NamespaceHandle;
 pub use self::queue_pair::RequestError;
 
 use nvme_spec as spec;

--- a/vm/devices/storage/disk_nvme/src/lib.rs
+++ b/vm/devices/storage/disk_nvme/src/lib.rs
@@ -21,19 +21,18 @@ use pal::unix::affinity::get_cpu_number;
 #[cfg(windows)]
 use pal::windows::affinity::get_cpu_number;
 use std::io;
-use std::sync::Arc;
 
 #[derive(Debug, Inspect)]
 pub struct NvmeDisk {
     /// NVMe namespace mapped to the disk representation.
     #[inspect(flatten)]
-    namespace: Arc<nvme_driver::Namespace>,
+    namespace: nvme_driver::NamespaceHandle,
     #[inspect(skip)]
     block_shift: u32,
 }
 
 impl NvmeDisk {
-    pub fn new(namespace: Arc<nvme_driver::Namespace>) -> Self {
+    pub fn new(namespace: nvme_driver::NamespaceHandle) -> Self {
         Self {
             block_shift: namespace.block_size().trailing_zeros(),
             namespace,

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -893,6 +893,7 @@ impl<T: RingMem> Worker<T> {
                             _ = self.fast_select.select((self.rescan_notification.select_next_some(),)).fuse() => {
                                 if version >= Version::Win7
                                 {
+                                    tracing::debug!("rescan notification received, sending ENUMERATE_BUS");
                                     self.inner.send_packet(&mut self.queue.split().1, storvsp_protocol::Operation::ENUMERATE_BUS, storvsp_protocol::NtStatus::SUCCESS, &())?;
                                 }
                             }

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -180,8 +180,8 @@ async fn test_storage_linux(
     controller_guid: Guid,
     expected_devices: Vec<ExpectedGuestDevice>,
 ) -> anyhow::Result<()> {
-    const DEVICE_DISCOVER_RETRIES: u32 = 5;
-    const DEVICE_DISCOVER_SLEEP_SECS: u64 = 2;
+    const DEVICE_DISCOVER_RETRIES: u32 = 10;
+    const DEVICE_DISCOVER_SLEEP_SECS: u64 = 3;
 
     let sh = agent.unix_shell();
 
@@ -767,12 +767,11 @@ async fn openhcl_linux_storvsp_dvd_nvme(
 /// Test an OpenHCL Linux direct VM with several NVMe namespaces assigned to VTL2, and
 /// vmbus relay. This should expose the disks to VTL0 as SCSI via vmbus.
 /// The disks are added and removed in a loop, dynamically after VM boot rather than being there at boot time.
-// TODO: Re-enable once re-add after removal is working in OpenHCL
-// #[openvmm_test(
-//     openhcl_linux_direct_x64,
-//     openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
-// )]
-async fn _storvsp_dynamic_add_disk(
+#[openvmm_test(
+    openhcl_linux_direct_x64,
+    openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+)]
+async fn storvsp_dynamic_add_disk(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> Result<(), anyhow::Error> {
     const NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
@@ -780,7 +779,7 @@ async fn _storvsp_dynamic_add_disk(
     const FIRST_NS: u32 = 30;
     const FIRST_LUN: u32 = 0;
     const SECTOR_SIZE: u64 = 512;
-    const NUM_ITERATIONS: u32 = 5;
+    const NUM_ITERATIONS: u32 = 3;
 
     // 128MB for the first NS and 1MB extra for each subsequent NS
     const fn disk_sectors(index: u32) -> u64 {


### PR DESCRIPTION
Clean cherry pick of PR #2657

This PR fixes a couple of problems with the driver. 
## 1. `Namespace` persisting and being reused after namespace removal from the controller
![Figjamexport2](https://github.com/user-attachments/assets/3a098676-9c4d-428d-981c-6880ddaa7262).
It addresses the situation where a namespace is removed from the controller (and therefore from the disk exposed via VTL0), but the driver continues to hold a reference to that namespace. In this state, the driver would return a stale or invalid Namespace object—one that can no longer perform valid I/O.

The approach in this PR is to avoid keeping a strong Arc<Namespace> in the driver. Instead, the driver stores only a Weak<Namespace> for any namespace it hands out. When the disk is dropped, the strong reference disappears, causing the driver’s weak reference to naturally invalidate via normal Arc/Weak semantics. This eliminates the dangling reference issue without requiring additional bookkeeping.

As discussed during office hours, the window for failure with this approach is expected to be extremely narrow, as the driver relies on strict single-ownership of the Namespace object. To further enforce this single-ownership model, this PR introduces a non-cloneable wrapper around Arc<Namespace>. This wrapper exposes the same interface as Namespace and is consumed by the disk, but it prevents cloning of the underlying Arc<Namespace> anywhere along the creation path. This ensures the driver remains the sole authority over Namespace ownership and lifecycle.

## 2. `Namespace` being reused after disk removal from VTL2 settings.
<img width="7096" height="2979" alt="image" src="https://github.com/user-attachments/assets/f519db98-447c-4a95-a7a2-c70536e07ae0" />

This is the issue being described in #2656 . This PR brings back the check to verify single-ownership of the `Namespace` objects. This time around it is possible to verify using the above described `Arc`/`Weak` semantics.
