### PR TITLE
nix: commit nix files to enable running the build from a `nix-shell --pure`

### DIFF
--- a/Guide/src/SUMMARY.md
+++ b/Guide/src/SUMMARY.md
@@ -42,6 +42,7 @@
     - [`Nodes`](./dev_guide/dev_tools/flowey/nodes.md)
     - [`Artifacts`](./dev_guide/dev_tools/flowey/artifacts.md)
     - [`Pipelines`](./dev_guide/dev_tools/flowey/pipelines.md)
+    - [`Nix`](./dev_guide/dev_tools/flowey/nix.md)
   - [`cargo xtask`](./dev_guide/dev_tools/xtask.md)
   - [`cargo xflowey`](./dev_guide/dev_tools/xflowey.md)
   - [VmgsTool](./dev_guide/dev_tools/vmgstool.md)

--- a/Guide/src/dev_guide/dev_tools/flowey/nix.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/nix.md
@@ -1,0 +1,31 @@
+# Nix
+
+In order to enable reproducible builds, experimental flowey features are being built to utilize the [Nix package manager](https://nixos.org/) for dependency management and environment isolation.
+The root of the nix configuration lives in `shell.nix`. If you're unsure where the Nix definition is for a dependency, you should be able to track it down from there.
+
+## Updating Nix Packages
+
+Nix dependencies require a hash of their contents to ensure integrity and reproducibility. When updating a dependency, you'll need to update the release that's being pulled and its corresponding hash.
+
+For instance, let's say we have a new release of the OpenHCL Kernel and we want to update it in our Nix configuration:
+
+1. Go to the corresponding `.nix` file (in this case, `openhcl_kernel.nix`)
+2. Clear the hash to an empty string
+3. Update the version
+4. Run `nix-shell --pure` and use the printed error to get the new hash
+
+> **Warning:** Because Nix caches dependencies based on the hash, if you don't clear the hash to an empty string before updating the version, `nix-shell --pure` will run without error even though the dependency hasn't actually been updated.
+
+Here's an example of what the error will look like when done correctly:
+
+```bash
+error: hash mismatch in fixed-output derivation '/nix/store/cc7hhyslx1dnw01nmjx11zqim2l50awp-source.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-wUDWFazJM80oztKqpuRwj8Wvto2Uo/OuVGvhpszIw+A=
+error: Cannot build '/nix/store/spg5vbm6mzmsxpg5v2ibg97qrz8khc70-openhcl-kernel-x64-6.12.52.4.drv'.
+       Reason: 1 dependency failed.
+       Output paths:
+         /nix/store/kv8s7pld70yvzxzd77swz9hb3pygkrhl-openhcl-kernel-x64-6.12.52.4
+```
+
+Given this error, you would update the corresponding hash to `sha256-An1N76i1MPb+rrQ1nBpoiuxnNeD0E+VuwqXdkPzaZn0=` in the `openhcl_kernel.nix` file.

--- a/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
@@ -197,6 +197,12 @@ impl FlowNode for Node {
                     for (_, arch) in local_reqs {
                         let (kernel_path, modules_path) = local_paths.get(&arch).unwrap();
 
+                        log::info!(
+                            "using local kernel at {:?} and modules at {:?}",
+                            kernel_path,
+                            modules_path
+                        );
+
                         // Write kernel paths for all kinds matching this arch
                         for kind in [
                             OpenhclKernelPackageKind::Main,

--- a/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
+++ b/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
@@ -49,7 +49,7 @@ impl SimpleFlowNode for Node {
                     FlowPlatformLinuxDistro::Arch => {
                         match_arch!(host_arch, FlowArch::X86_64, (Some("binutils"), "objcopy"))
                     }
-                    FlowPlatformLinuxDistro::Nix => (None, "objcopy"),
+                    FlowPlatformLinuxDistro::Nix => (None, "x86_64-linux-gnu-objcopy"),
                     FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
                 },
                 _ => anyhow::bail!("Unsupported platform"),

--- a/nix/mdbook.nix
+++ b/nix/mdbook.nix
@@ -1,0 +1,29 @@
+{ system, stdenv, fetchzip, }:
+
+let
+  version = "0.4.40";
+  arch = if system == "aarch64-linux" then "aarch64-unknown-linux-musl" else "x86_64-unknown-linux-gnu";
+  hash = {
+    "x86_64-linux" = "sha256-ijQbAOvEcmKaoPMe+eZELxY8iCJvrMnk4R07+d5lGtQ=";
+    "aarch64-linux" = "sha256-YhPCIdU8F84fZ7zDvbPP57MnPXR3DL2T9GjXDV5akz8=";
+  }.${system};
+
+in stdenv.mkDerivation {
+  pname = "mdbook";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/rust-lang/mdBook/releases/download/v${version}/mdbook-v${version}-${arch}.tar.gz";
+    inherit hash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp mdbook $out/bin/
+    runHook postInstall
+  '';
+}

--- a/nix/mdbook_admonish.nix
+++ b/nix/mdbook_admonish.nix
@@ -1,0 +1,29 @@
+{ system, stdenv, fetchzip, }:
+
+let
+  version = "1.18.0";
+  arch = if system == "aarch64-linux" then "aarch64-unknown-linux-musl" else "x86_64-unknown-linux-gnu";
+  hash = {
+    "x86_64-linux" = "sha256-L7Vt3a1vz1aO4ItCSpKqn+413JGZZ9R+ukqgsE38fMc=";
+    "aarch64-linux" = "sha256-Ytvmmgjd0F2icVWufuHHKHyjsgkj0MtWVkIyb09vBwA=";
+  }.${system};
+
+in stdenv.mkDerivation {
+  pname = "mdbook-admonish";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/tommilligan/mdbook-admonish/releases/download/v${version}/mdbook-admonish-v${version}-${arch}.tar.gz";
+    inherit hash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp mdbook-admonish $out/bin/
+    runHook postInstall
+  '';
+}

--- a/nix/mdbook_mermaid.nix
+++ b/nix/mdbook_mermaid.nix
@@ -1,0 +1,29 @@
+{ system, stdenv, fetchzip, }:
+
+let
+  version = "0.17.0";
+  arch = if system == "aarch64-linux" then "aarch64-unknown-linux-musl" else "x86_64-unknown-linux-gnu";
+  hash = {
+    "x86_64-linux" = "sha256-eqO3OU9VPCSN+1zfqK0aOkAvJ7tmB7W/ieDLPejJYV4=";
+    "aarch64-linux" = "sha256-3TSbAzUZfX/oEut0AVLuAHQlahoJaonZp2lTpBkg2q0=";
+  }.${system};
+
+in stdenv.mkDerivation {
+  pname = "mdbook-mermaid";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/badboy/mdbook-mermaid/releases/download/v${version}/mdbook-mermaid-v${version}-${arch}.tar.gz";
+    inherit hash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp mdbook-mermaid $out/bin/
+    runHook postInstall
+  '';
+}

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,0 +1,71 @@
+{ system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
+
+let
+  version = if is_dev then "6.12.52.4" else "6.12.52.4";
+  # Allow explicit override of architecture, otherwise derive from host system
+  # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
+  arch = if targetArch == "x86_64" then "x64"
+         else if targetArch == "aarch64" then "arm64"
+         else if system == "aarch64-linux" then "arm64"
+         else "x64";
+  branch = if is_dev then "hcl-dev" else "hcl-main";
+  build_type = if is_cvm then "cvm" else "std";
+  # See https://github.com/microsoft/OHCL-Linux-Kernel/releases
+  url =
+    "https://github.com/microsoft/OHCL-Linux-Kernel/releases/download/rolling-lts/${branch}/${version}/Microsoft.OHCL.Kernel${
+      if is_dev then ".Dev" else ""
+    }.${version}-${if is_cvm then "cvm-" else ""}${arch}.tar.gz";
+  hashes = {
+    hcl-main = {
+      std = {
+        x64 = "";
+        arm64 = "sha256-qdJtqTGGWGnaNbjmEopx8YTVP7K7ZaknW9U043EJyvk=";
+      };
+      cvm = {
+        x64 = "sha256-9aEQdbWVSRHfPNRHPkUUWqH+YxEDnqc59yB2dx8bYiI=";
+        arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
+      };
+    };
+    hcl-dev = {
+      std = {
+        x64 = "sha256-m2fAkpX/7y0Oj2exyJbj7mQqinY2RiQX30DqEi7rg+g=";
+        arm64 = "sha256-pD63MvgHEnZxYfYq9NepdGe8DcqnK2vmPH2utHO7GTM=";
+      };
+      cvm = {
+        x64 = "sha256-xQm1DtnQYOC3kRrwnX+EBMR4nEYpZpKQwSdMmI0nsB4=";
+        arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
+      };
+    };
+  };
+  hash = hashes.${branch}.${build_type}.${arch};
+
+  # Build a descriptive pname that includes variant info
+  variant = "${if is_cvm then "-cvm" else ""}${if is_dev then "-dev" else ""}";
+
+in stdenv.mkDerivation {
+  pname = "openhcl-kernel-${arch}${variant}";
+  inherit version;
+  src = fetchzip {
+    inherit url;
+    stripRoot = false;
+    inherit hash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/modules
+    # x64 uses vmlinux, arm64 uses Image
+    if [ -f vmlinux ]; then
+      cp vmlinux* $out/
+    fi
+    if [ -f Image ]; then
+      cp Image $out/
+    fi
+    cp -r modules/* $out/modules/
+    cp kernel_build_metadata.json $out/
+    runHook postInstall
+  '';
+}

--- a/nix/openvmm_deps.nix
+++ b/nix/openvmm_deps.nix
@@ -1,0 +1,42 @@
+{ system, stdenv, fetchzip, gnutar, gzip, targetArch ? null }:
+
+let
+  # Allow explicit override of architecture, otherwise derive from host system
+  arch = if targetArch != null then targetArch
+         else if system == "aarch64-linux" then "aarch64"
+         else "x86_64";
+  hash = {
+    "aarch64" = "sha256-yLGLoQrzA07jrG4G1HMb2P3fcmnGS3KF5H/4AtzDO4w=";
+    "x86_64" = "sha256-uDCEo4wbHya3KEYVgFHxr+/OOkzyMCUwhLNX7kppojQ=";
+  }.${arch};
+
+in stdenv.mkDerivation {
+  pname = "openvmm-deps-${arch}";
+  version = "0.1.0-20250403.3";
+
+  src = fetchzip {
+    url =
+      "https://github.com/microsoft/openvmm-deps/releases/download/0.1.0-20250403.3/openvmm-deps.${arch}.0.1.0-20250403.3.tar.bz2";
+    stripRoot = false;
+    inherit hash;
+  };
+
+  nativeBuildInputs = [ gnutar gzip ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+
+    # Copy all original files (including sysroot.tar.gz for flowey compatibility)
+    cp -r * $out/
+
+    # Also extract sysroot.tar.gz so that $out is a valid sysroot path
+    # (lib/, include/, etc. at top level for the linker wrapper)
+    tar -xzf sysroot.tar.gz -C $out
+
+    runHook postInstall
+  '';
+}

--- a/nix/protoc.nix
+++ b/nix/protoc.nix
@@ -1,0 +1,31 @@
+{ system, stdenv, fetchzip, }:
+
+let
+  version = "27.1";
+  arch = if system == "aarch64-linux" then "linux-aarch_64" else "linux-x86_64";
+  hash = {
+    "x86_64-linux" = "sha256-jk1VHYxOMo7C6mr1EVL97I2+osYz7lRtQLULv91gFH4=";
+    "aarch64-linux" = "sha256-ozZBHlgEiRycPiYH1aLb9QkvGmO3qY3+cLmsC/OrZB4=";
+  }.${system};
+
+in stdenv.mkDerivation {
+  pname = "protoc";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-${arch}.zip";
+    stripRoot = false;
+    inherit hash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp bin/protoc $out/bin/
+    cp -r include $out
+    runHook postInstall
+  '';
+}

--- a/nix/uefi_mu_msvm.nix
+++ b/nix/uefi_mu_msvm.nix
@@ -1,0 +1,35 @@
+{ system, stdenv, fetchzip, targetArch ? null }:
+
+let
+  # Allow explicit override of architecture, otherwise derive from host system
+  # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"AARCH64"
+  arch = if targetArch == "x86_64" then "x64"
+         else if targetArch == "aarch64" then "AARCH64"
+         else if system == "aarch64-linux" then "AARCH64"
+         else "x64";
+  hash = {
+    "AARCH64" = "sha256-C0NgBSZ0+CQXpopPiLKbSawD+FISEIlMApXTeEEw2J4=";
+    "x64" = "sha256-lWLFJezfDRgWg+uI7ELKFAGWNsg33kCNjuqGjNa9sOY=";
+  }.${arch};
+
+in stdenv.mkDerivation {
+  pname = "uefi-mu-msvm-${arch}";
+  version = "25.1.9";
+
+  src = fetchzip {
+    url =
+      "https://github.com/microsoft/mu_msvm/releases/download/v25.1.9/RELEASE-${arch}-artifacts.zip";
+    stripRoot = false;
+    inherit hash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir $out
+    cp FV/MSVM.fd $out
+    runHook postInstall
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,197 @@
+let
+  # Pinned nixpkgs in 25.11 branch
+  nixpkgs = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/50ab793786d9de88ee30ec4e4c24fb4236fc2674.tar.gz";
+    sha256 = "1s2gr5rcyqvpr58vxdcb095mdhblij9bfzaximrva2243aal3dgx";
+  };
+  # Pinned rust-overlay from stable branch
+  rust_overlay = import (builtins.fetchTarball {
+    url = "https://github.com/oxalica/rust-overlay/archive/2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2.tar.gz";
+    sha256 = "138a0p83qzflw8wj4a7cainqanjmvjlincx8imr3yq1b924lg9cz";
+  });
+  pkgs = import nixpkgs { overlays = [ rust_overlay ]; };
+
+  # Detect host architecture
+  hostArch = if pkgs.system == "aarch64-linux" then "aarch64" else "x86_64";
+
+  # Host tools
+  mdbook = pkgs.callPackage ./nix/mdbook.nix { };
+  mdbook_admonish = pkgs.callPackage ./nix/mdbook_admonish.nix { };
+  mdbook_mermaid = pkgs.callPackage ./nix/mdbook_mermaid.nix { };
+  protoc = pkgs.callPackage ./nix/protoc.nix { };
+
+  # Helper to get openvmm_deps and uefi_mu_msvm by architecture
+  mkBaseDepsForArch = arch: {
+    openvmm_deps = pkgs.callPackage ./nix/openvmm_deps.nix { targetArch = arch; };
+    uefi_mu_msvm = pkgs.callPackage ./nix/uefi_mu_msvm.nix { targetArch = arch; };
+  };
+
+  # Helper to get kernel package for specific arch and variant
+  mkKernel = { arch, is_dev ? false, is_cvm ? false }: pkgs.callPackage ./nix/openhcl_kernel.nix {
+    targetArch = arch;
+    inherit is_dev is_cvm;
+  };
+
+  # Base deps for both architectures
+  x64BaseDeps = mkBaseDepsForArch "x86_64";
+  aarch64BaseDeps = mkBaseDepsForArch "aarch64";
+
+  # Kernel variants for x64
+  x64Kernel = mkKernel { arch = "x86_64"; };
+  x64KernelCvm = mkKernel { arch = "x86_64"; is_cvm = true; };
+  x64KernelDev = mkKernel { arch = "x86_64"; is_dev = true; };
+  x64KernelCvmDev = mkKernel { arch = "x86_64"; is_dev = true; is_cvm = true; };
+
+  # Kernel variants for aarch64
+  aarch64Kernel = mkKernel { arch = "aarch64"; };
+  aarch64KernelDev = mkKernel { arch = "aarch64"; is_dev = true; };
+
+  # Cross-compilers based on host architecture
+  # On x64 host: provide aarch64 cross-compiler
+  # On aarch64 host: provide x64 cross-compiler
+  aarch64CrossGcc = pkgs.pkgsCross.aarch64-multiplatform.buildPackages.gcc;
+  x64CrossGcc = pkgs.pkgsCross.gnu64.buildPackages.gcc;
+
+  # Native gcc (for native architecture builds)
+  nativeGcc = pkgs.gcc;
+
+  crossCompilers =
+    if hostArch == "x86_64" then [ aarch64CrossGcc ]
+    else [ x64CrossGcc ];
+
+  # Rust configuration
+  overrides = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
+  rustVersionFromCargo = overrides.workspace.package.rust-version;
+  # Cargo.toml uses "X.Y", rust-overlay uses "X.Y.Z"
+  # Find the latest patch version available for the given MAJOR.MINOR
+  availableVersions = builtins.attrNames pkgs.rust-bin.stable;
+  matchingVersions = builtins.filter
+    (v: pkgs.lib.hasPrefix "${rustVersionFromCargo}." v)
+    availableVersions;
+  rustVersion =
+    if builtins.length matchingVersions == 0
+    then throw "No rust version matching ${rustVersionFromCargo}.* found in rust-overlay"
+    else builtins.head (builtins.sort (a: b: builtins.compareVersions a b > 0) matchingVersions);
+
+  rust = pkgs.rust-bin.stable.${rustVersion}.default.override {
+    extensions = [
+      "rust-src" # for rust-analyzer
+      "rust-analyzer"
+    ];
+    # Include both musl targets for cross-compilation
+    targets = [
+      "x86_64-unknown-linux-musl"
+      "x86_64-unknown-none"
+      "aarch64-unknown-linux-musl"
+      "aarch64-unknown-none"
+    ];
+  };
+
+  # Build CARGO_BUILD_ARGS for specific architecture and kernel
+  # x86_64 uses vmlinux, aarch64 uses Image
+  mkCargoBuildArgs = { arch, baseDeps, kernel }:
+    let kernelFile = if arch == "x86_64" then "vmlinux" else "Image";
+    in "--use-local-deps --custom-openvmm-deps ${baseDeps.openvmm_deps} --custom-uefi=${baseDeps.uefi_mu_msvm}/MSVM.fd --custom-kernel ${kernel}/${kernelFile} --custom-kernel-modules ${kernel}/modules --custom-protoc ${protoc}";
+
+in pkgs.mkShell {
+  nativeBuildInputs = [
+    rust
+    mdbook
+    mdbook_admonish
+    mdbook_mermaid
+    protoc
+    nativeGcc
+  ] ++ crossCompilers ++ (with pkgs; [
+    libarchive
+    git
+    perl
+    python3
+    pkg-config
+    binutils
+  ]);
+
+  buildInputs = [
+    pkgs.openssl.dev
+  ];
+
+  # Sysroot paths for linker wrappers (used by build_support/underhill_cross/*-underhill-musl-gcc)
+  X86_64_SYSROOT = "${x64BaseDeps.openvmm_deps}";
+  AARCH64_SYSROOT = "${aarch64BaseDeps.openvmm_deps}";
+
+  # x64 recipe variants
+  CARGO_BUILD_ARGS_X64 = mkCargoBuildArgs {
+    arch = "x86_64";
+    baseDeps = x64BaseDeps;
+    kernel = x64Kernel;
+  };
+  CARGO_BUILD_ARGS_X64_CVM = mkCargoBuildArgs {
+    arch = "x86_64";
+    baseDeps = x64BaseDeps;
+    kernel = x64KernelCvm;
+  };
+  CARGO_BUILD_ARGS_X64_DEVKERN = mkCargoBuildArgs {
+    arch = "x86_64";
+    baseDeps = x64BaseDeps;
+    kernel = x64KernelDev;
+  };
+  CARGO_BUILD_ARGS_X64_CVM_DEVKERN = mkCargoBuildArgs {
+    arch = "x86_64";
+    baseDeps = x64BaseDeps;
+    kernel = x64KernelCvmDev;
+  };
+
+  # aarch64 recipe variants
+  CARGO_BUILD_ARGS_AARCH64 = mkCargoBuildArgs {
+    arch = "aarch64";
+    baseDeps = aarch64BaseDeps;
+    kernel = aarch64Kernel;
+  };
+  CARGO_BUILD_ARGS_AARCH64_DEVKERN = mkCargoBuildArgs {
+    arch = "aarch64";
+    baseDeps = aarch64BaseDeps;
+    kernel = aarch64KernelDev;
+  };
+
+  # Expose deps for reference in update-rootfs.py
+  OPENVMM_DEPS_X64 = x64BaseDeps.openvmm_deps;
+  OPENVMM_DEPS_AARCH64 = aarch64BaseDeps.openvmm_deps;
+
+  RUST_BACKTRACE = 1;
+  SOURCE_DATE_EPOCH = 12345;
+
+  shellHook = ''
+    # Create a temp bin directory with symlinks using the expected gcc names.
+    # The linker wrappers (build_support/underhill_cross/*-underhill-musl-gcc) expect
+    # aarch64-linux-gnu-gcc and x86_64-linux-gnu-gcc, but nixpkgs provides
+    # aarch64-unknown-linux-gnu-gcc and x86_64-unknown-linux-gnu-gcc (for cross)
+    # and just gcc (for native). objcopy is needed by run_split_debug_info.rs.
+    export NIX_CC_WRAPPER_DIR=$(mktemp -d)
+    ${if hostArch == "x86_64" then ''
+    # On x64 host: native x64 + cross aarch64
+    ln -sf ${nativeGcc}/bin/gcc $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-gcc
+    ln -sf ${pkgs.binutils}/bin/objcopy $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-objcopy
+    ln -sf ${aarch64CrossGcc}/bin/aarch64-unknown-linux-gnu-gcc $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-gcc
+    ln -sf ${aarch64CrossGcc}/bin/aarch64-unknown-linux-gnu-objcopy $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-objcopy
+    '' else ''
+    # On aarch64 host: native aarch64 + cross x64
+    ln -sf ${nativeGcc}/bin/gcc $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-gcc
+    ln -sf ${pkgs.binutils}/bin/objcopy $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-objcopy
+    ln -sf ${x64CrossGcc}/bin/x86_64-unknown-linux-gnu-gcc $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-gcc
+    ln -sf ${x64CrossGcc}/bin/x86_64-unknown-linux-gnu-objcopy $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-objcopy
+    ''}
+    export PATH="$NIX_CC_WRAPPER_DIR:$PATH"
+
+    echo "OpenVMM Nix Shell"
+    echo "================="
+    echo "Host architecture: ${hostArch}"
+    echo ""
+    echo "Build commands:"
+    echo "  cargo xflowey build-igvm x64 \$CARGO_BUILD_ARGS_X64"
+    echo "  cargo xflowey build-igvm x64-cvm \$CARGO_BUILD_ARGS_X64_CVM"
+    echo "  cargo xflowey build-igvm x64-devkern \$CARGO_BUILD_ARGS_X64_DEVKERN"
+    echo "  cargo xflowey build-igvm x64-cvm-devkern \$CARGO_BUILD_ARGS_X64_CVM_DEVKERN"
+    echo "  cargo xflowey build-igvm aarch64 \$CARGO_BUILD_ARGS_AARCH64"
+    echo "  cargo xflowey build-igvm aarch64-devkern \$CARGO_BUILD_ARGS_AARCH64_DEVKERN"
+    echo ""
+  '';
+}


### PR DESCRIPTION
This adds a `shell.nix` and other `.nix` files related to dependencies needed to build OpenHCL inside a `nix-shell --pure`. If you install nix and run `nix-shell --pure`, you'll be greeted with the following text:

```
justuscamp@DESKTOP-J6M7TP0:~/openvmm$ nix-shell --pure
OpenVMM Nix Shell
=================
Host architecture: x86_64

Build commands:
  cargo xflowey build-igvm x64 $CARGO_BUILD_ARGS_X64
  cargo xflowey build-igvm x64-cvm $CARGO_BUILD_ARGS_X64_CVM
  cargo xflowey build-igvm x64-devkern $CARGO_BUILD_ARGS_X64_DEVKERN
  cargo xflowey build-igvm x64-cvm-devkern $CARGO_BUILD_ARGS_X64_CVM_DEVKERN
  cargo xflowey build-igvm aarch64 $CARGO_BUILD_ARGS_AARCH64
  cargo xflowey build-igvm aarch64-devkern $CARGO_BUILD_ARGS_AARCH64_DEVKERN


[nix-shell:~/openvmm]$
```

You can then run any of the given build commands to run an "all-local" version of the build that uses the dependencies downloaded by Nix. This isn't the intended UX for this, but committing these files now is necessary to start trying to use Nix in CI. 