### PR TITLE
netvsp: handle eqe 135 followup (#2684)

### DIFF
--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -550,9 +550,10 @@ impl HclNetworkVFManagerWorker {
         .await
         {
             Ok(mut device) => {
+                // Subscribe to VF reconfigure events before starting notification task
+                self.vf_reconfig_receiver = Some(device.subscribe_vf_reconfig().await);
                 // Resubscribe to notifications from the MANA device.
                 device.start_notification_task(&self.driver_source).await;
-                self.vf_reconfig_receiver = Some(device.subscribe_vf_reconfig().await);
 
                 self.mana_device = Some(device);
                 self.connect_endpoints().await.is_ok()
@@ -875,6 +876,12 @@ impl HclNetworkVFManagerWorker {
                     if self.is_shutdown_active
                         || matches!(vtl2_device_state, Vtl2DeviceState::Missing)
                     {
+                        tracing::debug!(
+                            is_shutdown_active = self.is_shutdown_active,
+                            vtl2_device_state_missing =
+                                matches!(vtl2_device_state, Vtl2DeviceState::Missing),
+                            "Skipping VF reconfiguration during shutdown or when device is missing"
+                        );
                         continue;
                     }
 
@@ -1200,8 +1207,9 @@ impl HclNetworkVFManager {
         // Now that the endpoints are connected, start the device notification task that will
         // listen for and relay endpoint actions.
         let device = worker.mana_device.as_mut().unwrap();
-        device.start_notification_task(driver_source).await;
+        // Subscribe to VF reconfig events before starting notification task
         worker.vf_reconfig_receiver = Some(device.subscribe_vf_reconfig().await);
+        device.start_notification_task(driver_source).await;
         let endpoints = endpoints
             .into_iter()
             .zip(mac_addresses)

--- a/vm/devices/net/gdma/src/hwc.rs
+++ b/vm/devices/net/gdma/src/hwc.rs
@@ -304,8 +304,9 @@ impl HwControl {
                 0
             }
             GdmaRequestType::GDMA_GENERATE_RECONFIG_VF_EVENT => {
-                let req: GdmaGenerateTestEventReq =
-                    read.read_plain().context("reading test eqe request")?;
+                let req: GdmaGenerateTestEventReq = read
+                    .read_plain()
+                    .context("reading test vf reconfig request")?;
                 self.state
                     .queues
                     .post_eq(req.queue_index, GDMA_EQE_HWC_RECONFIG_VF, &[]);

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -523,6 +523,10 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             anyhow::bail!("cannot save/restore after HWC failure");
         }
 
+        if self.vf_reconfiguration_pending {
+            anyhow::bail!("cannot save/restore with VF reconfiguration pending");
+        }
+
         self.state_saved = true;
 
         let doorbell = self.bar0.save(Some(self.db_id as u64));
@@ -543,7 +547,6 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             num_msix: self.num_msix,
             min_queue_avail: self.min_queue_avail,
             link_toggle: self.link_toggle.clone(),
-            vf_reconfiguration_pending: self.vf_reconfiguration_pending,
         })
     }
 
@@ -669,7 +672,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             hwc_failure: false,
             state_saved: false,
             db_id: db_id as u32,
-            vf_reconfiguration_pending: saved_state.vf_reconfiguration_pending,
+            vf_reconfiguration_pending: false,
         };
 
         this.eq.arm();

--- a/vm/devices/net/mana_driver/src/save_restore.rs
+++ b/vm/devices/net/mana_driver/src/save_restore.rs
@@ -77,10 +77,6 @@ pub struct GdmaDriverSavedState {
     /// Link status by vport index
     #[mesh(12)]
     pub link_toggle: Vec<(u32, bool)>,
-
-    /// Whether a VF reconfiguration event is pending
-    #[mesh(13)]
-    pub vf_reconfiguration_pending: bool,
 }
 
 /// The saved state of a completion queue or event queue for restoration


### PR DESCRIPTION
Clean cherry-pick of https://github.com/microsoft/openvmm/pull/2684

Follow-up to https://github.com/microsoft/openvmm/pull/2576

* Reorder the reconfigure subscription to before starting notifications.
* Adding debug tracing to skipped VF reconfiguration events.
* Fixing text in HWC test code.
* Removing pending VF reconfiguration from GDMA saved state. Modifying save state to fail when reconfiguration is pending.
