### PR TITLE
nvme_driver: split the mesh channel to the queue handler between commands and requests

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -761,7 +761,8 @@ struct PendingCommand {
 }
 
 // "ControlPlane" requests sent to the QueueHandler. These can be processed at
-// any time; regardless of whether submission queue is full or not.
+// any time; regardless of whether submission queue is full or not and will be
+// prioritized over IO completions to keep the save path responsive.
 enum Req {
     Save(Rpc<(), Result<QueueHandlerSavedState, anyhow::Error>>),
     Inspect(inspect::Deferred),


### PR DESCRIPTION
Currently, in QueueHandler::poll_fn, we register a waker with the receiving channel only when there is space available in the submission queue (SQ). This channel multiplexes two kinds of traffic: requests that write to the submission queue, and control‑plane requests for the handler.
When the submission queue is full, poll_fn does not register a waker with recv. Instead, it relies entirely on incoming completions and interrupts to wake the task. As a result, if completions are slow, not only is command submission affected, but control‑plane operations such as Save, Inspect, and NextAen are also delayed—even though they are unrelated to SQ writes.
With this change, the run loop now listens on three separate channels:

1. A command channel for requests that write to the submission queue
2. A control‑plane channel for operations like Save and Inspect
3. A completion channel

This separation ensures that control‑plane operations can continue to make progress even when the submission queue is full and completions are slow. In particular, Save() should no longer be blocked by SQ backpressure.
Note: I am still working on a VMM test to validate behavior when the submission queue is full.