### PR TITLE
net_mana: adding test of RX CQE error handling

### DIFF
--- a/vm/devices/net/gdma/src/bnic.rs
+++ b/vm/devices/net/gdma/src/bnic.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use self::bnic_defs::CQE_RX_TRUNCATED;
 use self::bnic_defs::CQE_TX_GDMA_ERR;
 use self::bnic_defs::CQE_TX_OKAY;
 use self::bnic_defs::MANA_CQE_COMPLETION;
@@ -85,7 +86,11 @@ impl BufferAccess for GuestBuffers {
     fn write_data(&mut self, id: RxId, mut data: &[u8]) {
         let mut addrs = self.rx_packets[id.0 as usize].segments.iter();
         while !data.is_empty() {
-            let addr = addrs.next().expect("packet too large");
+            let Some(addr) = addrs.next() else {
+                // Packet exceeds buffer capacity; will be reported as
+                // CQE_RX_TRUNCATED by write_header.
+                break;
+            };
             let len = data.len().min(addr.len as usize);
             let (this, next) = data.split_at(len);
             if let Err(err) = self.gm.write_at(addr.gpa, this) {
@@ -135,9 +140,16 @@ impl BufferAccess for GuestBuffers {
         }
 
         let packet = &mut self.rx_packets[id.0 as usize];
+
+        let cqe_type = if metadata.len > packet.len as usize {
+            CQE_RX_TRUNCATED
+        } else {
+            CQE_RX_OKAY
+        };
+
         packet.oob = ManaRxcompOob {
             cqe_hdr: ManaCqeHeader::new()
-                .with_cqe_type(CQE_RX_OKAY)
+                .with_cqe_type(cqe_type)
                 .with_client_type(MANA_CQE_COMPLETION),
             rx_wqe_offset: packet.wqe_offset,
             flags,
@@ -173,8 +185,8 @@ impl InspectMut for Vport {
             .field_mut("endpoint", self.endpoint.as_mut())
             .field("tx_wq", self.queue_cfg.tx.map(|(wq, _cq)| wq))
             .field("tx_cq", self.queue_cfg.tx.map(|(_wq, cq)| cq))
-            .field("rx_wq", self.queue_cfg.tx.map(|(wq, _cq)| wq))
-            .field("rx_cq", self.queue_cfg.tx.map(|(_wq, cq)| cq))
+            .field("rx_wq", self.queue_cfg.rx.map(|(wq, _cq)| wq))
+            .field("rx_cq", self.queue_cfg.rx.map(|(_wq, cq)| cq))
             .merge(&mut self.task);
     }
 }

--- a/vm/devices/net/net_mana/src/test.rs
+++ b/vm/devices/net/net_mana/src/test.rs
@@ -573,6 +573,33 @@ async fn test_vport_with_query_filter_state(driver: DefaultDriver) {
     let _ = thing.new_vport(0, None, &dev_config).await.unwrap();
 }
 
+#[async_test]
+async fn test_rx_error_handling(driver: DefaultDriver) {
+    // Send a packet larger than the 2048-byte RX buffer, causing the GDMA BNIC emulator
+    // to return CQE_RX_TRUNCATED, exercising the rx_poll error path.
+    let expected_num_tx_packets = 1;
+    let expected_num_rx_packets = 0;
+    let num_segments = 1;
+    let packet_len = 4096; // Exceeds the 2048-byte RX buffer
+
+    let mut pkt_builder = TxPacketBuilder::new();
+    build_tx_segments(packet_len, num_segments, false, &mut pkt_builder);
+
+    let stats = test_endpoint(
+        driver,
+        GuestDmaMode::DirectDma,
+        &pkt_builder,
+        expected_num_tx_packets,
+        expected_num_rx_packets,
+        ManaTestConfiguration::default(),
+    )
+    .await;
+
+    assert_eq!(stats.rx_errors.get(), 1, "rx_errors should increase");
+    assert_eq!(stats.rx_packets.get(), 0, "rx_packets should stay the same");
+    assert_eq!(stats.tx_packets.get(), 1, "tx_packets should increase");
+}
+
 async fn send_test_packet(
     driver: DefaultDriver,
     dma_mode: GuestDmaMode,
@@ -620,8 +647,8 @@ async fn send_test_packet_multi(
         driver,
         dma_mode,
         pkt_builder,
-        expected_stats.rx_packets.get() as usize,
         expected_stats.tx_packets.get() as usize,
+        expected_stats.rx_packets.get() as usize,
         test_config,
     )
     .await;
@@ -763,7 +790,14 @@ async fn test_endpoint(
     let mut rx_packets_n = 0;
     let mut tx_done = vec![TxId(0); expected_num_send_packets.max(2)];
     let mut tx_done_n = 0;
-    while rx_packets_n == 0 {
+
+    // Wait until both expected RX and TX completions are satisfied.
+    // When an expected count is 0, its condition is immediately true.
+    let done = |rx_n: usize, tx_n: usize| -> bool {
+        rx_n >= expected_num_received_packets && tx_n >= expected_num_send_packets
+    };
+
+    loop {
         let mut context = CancelContext::new().with_timeout(Duration::from_secs(1));
         match context
             .until_cancelled(poll_fn(|cx| queues[0].poll_ready(cx, &mut pool)))
@@ -783,11 +817,12 @@ async fn test_endpoint(
         tx_done_n += queues[0]
             .tx_poll(&mut pool, &mut tx_done[tx_done_n..])
             .unwrap_or(0);
-        if expected_num_received_packets == 0 {
+        if done(rx_packets_n, tx_done_n) {
             break;
         }
     }
     assert_eq!(rx_packets_n, expected_num_received_packets);
+    assert_eq!(tx_done_n, expected_num_send_packets);
 
     if expected_num_received_packets == 0 {
         // If no packets were received, exit.
@@ -797,8 +832,6 @@ async fn test_endpoint(
         return stats;
     }
 
-    // Check tx
-    assert_eq!(tx_done_n, expected_num_send_packets);
     // GDMA emulator always returns TxId(1) for completed packets.
     for done in tx_done.iter().take(expected_num_send_packets) {
         assert_eq!(done.0, 1);


### PR DESCRIPTION
Adding a test to validate that net_mana handles RX CQE errors. `QueueStats` `rx_errors` should be incremented. `QueueStates` `rx_packets` should not increase. net_mana already has a test to validate proper TX CQE error handline. Ex: `test_lso_segment_coalescing_only_header()`

- BNIC emulator updated to return CQE_RX_TRUNCATED on oversized packets instead of panicing. This is closer to actual BNIC behvaior.
- New test added 'test_rx_error_handling' sends oversized packet and validates queue stats.
- Minor improvements in test_endpoint polling loop to account for zero-rx cases.