### PR TITLE
CI: add mdbook test to validate guide in PRs

### DIFF
--- a/Guide/book.toml
+++ b/Guide/book.toml
@@ -3,7 +3,6 @@
 
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "The OpenVMM Guide"
 

--- a/Guide/src/dev_guide/dev_tools/flowey/artifacts.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/artifacts.md
@@ -7,7 +7,7 @@ Artifacts enable typed data transfer between jobs with automatic dependency mana
 **Typed artifacts (recommended)** provide type-safe artifact handling by defining
 a custom type that implements the `Artifact` trait:
 
-```rust
+```rust,ignore
 #[derive(Serialize, Deserialize)]
 struct MyArtifact {
     #[serde(rename = "output.bin")]
@@ -23,7 +23,7 @@ let (pub_artifact, use_artifact) = pipeline.new_typed_artifact("my-files");
 
 **Untyped artifacts** provide simple directory-based artifacts for simpler cases:
 
-```rust
+```rust,ignore
 let (pub_artifact, use_artifact) = pipeline.new_artifact("my-files");
 ```
 
@@ -31,7 +31,7 @@ For detailed examples of defining and using artifacts, see the [Artifact trait d
 
 Both `pipeline.new_typed_artifact("name")` and `pipeline.new_artifact("name")` return a tuple of handles: `(pub_artifact, use_artifact)`. When defining a job you convert them with the job context:
 
-```rust
+```rust,ignore
 // In a producing job:
 let artifact_out = ctx.publish_artifact(pub_artifact);
 // artifact_out : WriteVar<MyArtifact>   (typed)

--- a/Guide/src/dev_guide/dev_tools/flowey/nodes.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/nodes.md
@@ -36,7 +36,7 @@ The key advantage of FlowNode is its ability to accept configuration from differ
 
 Consider an "install Rust toolchain" node with an enum Request:
 
-```rust
+```rust,ignore
 enum Request {
     SetVersion { version: String },
     GetToolchain { toolchain_path: WriteVar<PathBuf> },

--- a/Guide/src/dev_guide/dev_tools/flowey/pipelines.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/pipelines.md
@@ -6,7 +6,7 @@ Pipelines define complete automation workflows consisting of jobs that run nodes
 
 [`PipelineJob`](https://openvmm.dev/rustdoc/linux/flowey_core/pipeline/struct.PipelineJob.html) instances are configured using a builder pattern:
 
-```rust
+```rust,ignore
 let job = pipeline
     .new_job(platform, arch, "my-job")
     .with_timeout_in_minutes(60)
@@ -26,7 +26,7 @@ Parameters allow runtime configuration of pipelines. In Azure DevOps, parameters
 
 ![Azure DevOps parameter UI](images/Parameters.png)
 
-```rust
+```rust,ignore
 // Define a boolean parameter
 let verbose = pipeline.new_parameter_bool(
     "verbose",

--- a/Guide/src/dev_guide/dev_tools/flowey/steps.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/steps.md
@@ -126,7 +126,7 @@ If a step reads a secret value, **all subsequent writes from that step are autom
 
 For example:
 
-```rust
+```rust,ignore
 ctx.emit_rust_step("process token", |ctx| {
     let secret_token = secret_token.claim(ctx);
     let output_var = output_var.claim(ctx);
@@ -144,7 +144,7 @@ ctx.emit_rust_step("process token", |ctx| {
 
 If you need to write non-secret data after reading a secret, use `write_not_secret()`:
 
-```rust
+```rust,ignore
 rt.write_not_secret(output_var, &"done".to_string());
 ```
 

--- a/Guide/src/dev_guide/dev_tools/flowey/variables.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/variables.md
@@ -14,7 +14,7 @@ Variables can only be claimed inside step closures using the `claim()` method.
 
 **Nested closure pattern and related contexts:**
 
-```rust
+```rust,ignore
 // Inside a SimpleFlowNode's process_request() method
 fn process_request(&self, request: Self::Request, ctx: &mut NodeCtx<'_>) {
     // Assume a single Request provided an input ReadVar and output WriteVar
@@ -79,7 +79,7 @@ The type system ensures that `claim()` is the only way to convert from `VarNotCl
 
 Sometimes you know a value at build-time:
 
-```rust
+```rust,ignore
 // Create a ReadVar with a static value
 let version = ReadVar::from_static("1.2.3".to_string());
 

--- a/flowey/flowey_lib_hvlite/src/build_guide.rs
+++ b/flowey/flowey_lib_hvlite/src/build_guide.rs
@@ -63,13 +63,19 @@ impl FlowNode for Node {
                     let guide_source: PathBuf = rt.read(guide_source);
 
                     rt.sh.change_dir(&guide_source);
+
+                    // intercepted by the `mdbook-openvmm-shim`
+                    rt.sh.set_var("SHIM_MDBOOK_ADMONISH", &mdbook_admonish_bin);
+                    rt.sh.set_var("SHIM_MDBOOK_MERMAID", &mdbook_mermaid_bin);
+
+                    // Test code examples in the guide
+                    flowey::shell_cmd!(rt, "{mdbook_bin} test {guide_source}").run()?;
+
+                    // Build the guide
                     flowey::shell_cmd!(
                         rt,
                         "{mdbook_bin} build {guide_source} --dest-dir {out_path}"
                     )
-                    // intercepted by the `mdbook-openvmm-shim`
-                    .env("SHIM_MDBOOK_ADMONISH", mdbook_admonish_bin)
-                    .env("SHIM_MDBOOK_MERMAID", mdbook_mermaid_bin)
                     .run()?;
 
                     rt.write(built_guide, &GuideOutput { guide: out_path });


### PR DESCRIPTION
This change ensures that code samples in the rust code samples compile and fixes any current issues preventing `mdbook test` from currently passing.