### PR TITLE
deps: Update mu_msvm to v25.1.10 release 

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -23,7 +23,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "25.1.9";
+pub const MU_MSVM: &str = "25.1.10";
 pub const NEXTEST: &str = "0.9.101";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly


### PR DESCRIPTION
mu_msvm release notes: https://github.com/microsoft/mu_msvm/releases/tag/v25.1.10

Fast forwards UEFI with the following changes:

- Adds HttpLib to ARM64 flavors
- Delay secure boot status code errors until a real secure boot failure is hit
- Fix for Volatile variable store on RemainingVariableStorageSize initialization
- Add ACPI device for hv sint discovery for ARM64 linux