### PR TITLE
nvme_driver: split the mesh channel to the queue handler between commands and requests (#2708)

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -67,7 +67,7 @@ const SQ_ENTRIES_PER_PAGE: usize = PAGE_SIZE / SQ_ENTRY_SIZE;
 pub(crate) struct QueuePair<A: AerHandler, D: DeviceBacking> {
     #[inspect(skip)]
     task: TaskControl<QueueHandlerLoop<A, D>, ()>,
-    #[inspect(flatten, with = "|x| inspect::send(&x.send, Req::Inspect)")]
+    #[inspect(flatten, with = "|x| inspect::send(&x.send_req, Req::Inspect)")]
     issuer: Arc<Issuer>,
     #[inspect(skip)]
     mem: MemoryBlock,
@@ -183,7 +183,8 @@ impl PendingCommands {
 struct QueueHandlerLoop<A: AerHandler, D: DeviceBacking> {
     queue_handler: QueueHandler<A>,
     registers: Arc<DeviceRegisters<D>>,
-    recv: Option<mesh::Receiver<Req>>,
+    recv_req: Option<mesh::Receiver<Req>>,
+    recv_cmd: Option<mesh::Receiver<Cmd>>,
     interrupt: DeviceInterrupt,
 }
 
@@ -197,7 +198,8 @@ impl<A: AerHandler, D: DeviceBacking> AsyncRun<()> for QueueHandlerLoop<A, D> {
             self.queue_handler
                 .run(
                     &self.registers,
-                    self.recv.take().unwrap(),
+                    self.recv_req.take().unwrap(),
+                    self.recv_cmd.take().unwrap(),
                     &mut self.interrupt,
                 )
                 .await;
@@ -337,11 +339,13 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
             }
         };
 
-        let (send, recv) = mesh::channel();
+        let (send_req, recv_req) = mesh::channel();
+        let (send_cmd, recv_cmd) = mesh::channel();
         let mut task = TaskControl::new(QueueHandlerLoop {
             queue_handler,
             registers,
-            recv: Some(recv),
+            recv_req: Some(recv_req),
+            recv_cmd: Some(recv_cmd),
             interrupt,
         });
         task.insert(spawner, "nvme-queue", ());
@@ -374,7 +378,11 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
 
         Ok(Self {
             task,
-            issuer: Arc::new(Issuer { send, alloc }),
+            issuer: Arc::new(Issuer {
+                send_req,
+                send_cmd,
+                alloc,
+            }),
             mem,
             qid,
             sq_entries,
@@ -419,7 +427,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
         }
         // Send an RPC request to QueueHandler thread to save its data.
         // QueueHandler stops any other processing after completing Save request.
-        let handler_data = self.issuer.send.call(Req::Save, ()).await??;
+        let handler_data = self.issuer.send_req.call(Req::Save, ()).await??;
 
         Ok(QueuePairSavedState {
             mem_len: self.mem.len(),
@@ -542,7 +550,9 @@ impl std::fmt::Display for NvmeError {
 #[derive(Debug, Inspect)]
 pub struct Issuer {
     #[inspect(skip)]
-    send: mesh::Sender<Req>,
+    send_cmd: mesh::Sender<Cmd>,
+    #[inspect(skip)]
+    send_req: mesh::Sender<Req>,
     alloc: PageAllocator,
 }
 
@@ -551,7 +561,7 @@ impl Issuer {
         &self,
         command: spec::Command,
     ) -> Result<spec::Completion, RequestError> {
-        match self.send.call(Req::Command, command).await {
+        match self.send_cmd.call(Cmd::Command, command).await {
             Ok(completion) if completion.status.status() == 0 => Ok(completion),
             Ok(completion) => Err(RequestError::Nvme(NvmeError(spec::Status(
                 completion.status.status(),
@@ -561,7 +571,7 @@ impl Issuer {
     }
 
     pub async fn issue_get_aen(&self) -> Result<AsynchronousEventRequestDw0, RequestError> {
-        match self.send.call_failable(Req::NextAen, ()).await {
+        match self.send_req.call_failable(Req::NextAen, ()).await {
             Ok(aen_completion) => Ok(aen_completion),
             Err(RpcError::Call(e)) => Err(e),
             Err(RpcError::Channel(e)) => Err(RequestError::Gone(RpcError::Channel(e))),
@@ -750,12 +760,20 @@ struct PendingCommand {
     respond: Rpc<(), spec::Completion>,
 }
 
+// "ControlPlane" requests sent to the QueueHandler. These can be processed at
+// any time; regardless of whether submission queue is full or not and will be
+// prioritized over IO completions to keep the save path responsive.
 enum Req {
-    Command(Rpc<spec::Command, spec::Completion>),
-    Inspect(inspect::Deferred),
     Save(Rpc<(), Result<QueueHandlerSavedState, anyhow::Error>>),
-    SendAer(),
+    Inspect(inspect::Deferred),
     NextAen(Rpc<(), Result<AsynchronousEventRequestDw0, RequestError>>),
+}
+
+// "DataPlane" commands sent to the QueueHandler. Actual NVMe commands that
+// require space in the submission queue.
+enum Cmd {
+    Command(Rpc<spec::Command, spec::Completion>),
+    SendAer(),
 }
 
 /// Functionality for an AER handler. The default implementation
@@ -922,27 +940,35 @@ impl<A: AerHandler> QueueHandler<A> {
     async fn run(
         &mut self,
         registers: &DeviceRegisters<impl DeviceBacking>,
-        mut recv: mesh::Receiver<Req>,
+        mut recv_req: mesh::Receiver<Req>,
+        mut recv_cmd: mesh::Receiver<Cmd>,
         interrupt: &mut DeviceInterrupt,
     ) {
         loop {
             enum Event {
                 Request(Req),
+                Command(Cmd),
                 Completion(spec::Completion),
             }
 
             let event = if !self.drain_after_restore {
                 // Normal processing of the requests and completions.
                 poll_fn(|cx| {
+                    // Look for NVME commands
                     if !self.sq.is_full() && !self.commands.is_full() {
                         // Prioritize sending AERs to keep the cycle going
                         if self.aer_handler.poll_send_aer() {
-                            return Poll::Ready(Event::Request(Req::SendAer()));
+                            return Event::Command(Cmd::SendAer()).into();
                         }
-                        if let Poll::Ready(Some(req)) = recv.poll_next_unpin(cx) {
-                            return Event::Request(req).into();
+                        if let Poll::Ready(Some(cmd)) = recv_cmd.poll_next_unpin(cx) {
+                            return Event::Command(cmd).into();
                         }
                     }
+                    // Look for control plane requests like Save/Inspect
+                    if let Poll::Ready(Some(req)) = recv_req.poll_next_unpin(cx) {
+                        return Event::Request(req).into();
+                    }
+                    // Look for completions
                     while !self.commands.is_empty() {
                         if let Some(completion) = self.cq.read() {
                             return Event::Completion(completion).into();
@@ -977,22 +1003,24 @@ impl<A: AerHandler> QueueHandler<A> {
 
             match event {
                 Event::Request(req) => match req {
-                    Req::Command(rpc) => {
-                        let (mut command, respond) = rpc.split();
-                        self.commands.insert(&mut command, respond);
-                        self.sq.write(command).unwrap();
-                        self.stats.issued.increment();
-                    }
-                    Req::Inspect(deferred) => deferred.inspect(&self),
                     Req::Save(queue_state) => {
                         queue_state.complete(self.save().await);
                         // Do not allow any more processing after save completed.
                         break;
                     }
+                    Req::Inspect(deferred) => deferred.inspect(&self),
                     Req::NextAen(rpc) => {
                         self.aer_handler.handle_aen_request(rpc);
                     }
-                    Req::SendAer() => {
+                },
+                Event::Command(cmd) => match cmd {
+                    Cmd::Command(rpc) => {
+                        let (mut command, respond) = rpc.split();
+                        self.commands.insert(&mut command, respond);
+                        self.sq.write(command).unwrap();
+                        self.stats.issued.increment();
+                    }
+                    Cmd::SendAer() => {
                         let mut command = admin_cmd(spec::AdminOpcode::ASYNCHRONOUS_EVENT_REQUEST);
                         self.commands.insert(&mut command, Rpc::detached(()));
                         self.aer_handler.update_awaiting_cid(command.cdw0.cid());


### PR DESCRIPTION
Clean cherry pick of PR #2708

Currently, in QueueHandler::poll_fn, we register a waker with the receiving channel only when there is space available in the submission queue (SQ). This channel multiplexes two kinds of traffic: requests that write to the submission queue, and control‑plane requests for the handler.
When the submission queue is full, poll_fn does not register a waker with recv. Instead, it relies entirely on incoming completions and interrupts to wake the task. As a result, if completions are slow, not only is command submission affected, but control‑plane operations such as Save, Inspect, and NextAen are also delayed—even though they are unrelated to SQ writes.
With this change, the run loop now listens on three separate channels:

1. A command channel for requests that write to the submission queue
2. A control‑plane channel for operations like Save and Inspect
3. A completion channel

This separation ensures that control‑plane operations can continue to make progress even when the submission queue is full and completions are slow. In particular, Save() should no longer be blocked by SQ backpressure.
Note: I am still working on a VMM test to validate behavior when the submission queue is full.
