### PR TITLE
Prevent battery from being added for isolated VMs instead of failing

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3198,23 +3198,6 @@ async fn new_underhill_vm(
                     sub_system_id: None,
                 });
 
-                // Allow Manticore devices.
-                let mcr_vendor_id = 0x1414;
-                let mcr_device_id = 0xC003;
-                let mcr_prog_if = None;
-                let mcr_sub_class = None;
-                let mcr_base_class = None;
-                relay.add_allowed_device(AllowedDevice {
-                    vendor_id: Some(mcr_vendor_id),
-                    device_id: Some(mcr_device_id),
-                    revision_id: None,
-                    prog_if: mcr_prog_if,
-                    sub_class: mcr_sub_class,
-                    base_class: mcr_base_class,
-                    sub_vendor_id: None,
-                    sub_system_id: None,
-                });
-
                 vpci_relay = Some(relay);
             }
 


### PR DESCRIPTION
Work Item: MSFT#59988631

OpenHCL VBS vmm_tests fail on client SKUs because the host sends battery_enabled = true for isolated VMs. 

The previous code would reject this configuration with a hard error in `validate_isolated_configuration`, causing the VM to fail to start.

Instead of failing when battery is requested for isolated VMs, simply skip adding the battery device. The condition for adding battery was changed from:
```
if dps.general.battery_enabled {
```

```
if dps.general.battery_enabled && !isolation.is_isolated() {
```

This allows isolated VMs to boot successfully even when the host incorrectly requests a battery, while non-isolated VMs continue to get battery support when requested.