### PR TITLE
nvme_driver: Don't swallow errors during save()

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1398,14 +1398,50 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
         worker_state: &mut WorkerState,
     ) -> anyhow::Result<NvmeDriverWorkerSavedState> {
         let admin = match self.admin.as_ref() {
-            Some(a) => Some(a.save().await?),
-            None => None,
+            Some(a) => match a.save().await {
+                Ok(admin_state) => {
+                    tracing::info!(
+                        pci_id = ?self.device.id(),
+                        id = admin_state.qid,
+                        pending_commands_count = admin_state.handler_data.pending_cmds.commands.len(),
+                        "saved admin queue",
+                    );
+                    Some(admin_state)
+                }
+                Err(e) => {
+                    tracing::error!(
+                            pci_id = ?self.device.id(),
+                            error = e.as_ref() as &dyn std::error::Error,
+                            "failed to save admin queue",
+                    );
+                    return Err(e);
+                }
+            },
+            None => {
+                tracing::warn!(pci_id = ?self.device.id(), "no admin queue saved");
+                None
+            }
         };
 
-        let io: Vec<IoQueueSavedState> = join_all(self.io.drain(..).map(async |q| q.save().await))
-            .await
+        let (ok, errs): (Vec<_>, Vec<_>) =
+            join_all(self.io.drain(..).map(async |q| q.save().await))
+                .await
+                .into_iter()
+                .partition(Result::is_ok);
+        if !errs.is_empty() {
+            for e in errs.into_iter().map(Result::unwrap_err) {
+                tracing::error!(
+                    pci_id = ?self.device.id(),
+                    error = e.as_ref() as &dyn std::error::Error,
+                    "failed to save io queue",
+                );
+            }
+            return Err(anyhow::anyhow!("failed to save one or more io queues"));
+        }
+
+        let io: Vec<IoQueueSavedState> = ok
             .into_iter()
-            .flatten()
+            .map(Result::unwrap)
             // Don't forget to include any queues that were saved from a _previous_ save, but were never restored
             // because they didn't see any IO.
             .chain(
@@ -1414,16 +1450,6 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
                     .map(|(_cpu, proto_queue)| proto_queue.save_state),
             )
             .collect();
-
-        match admin {
-            None => tracing::warn!(pci_id = ?self.device.id(), "no admin queue saved"),
-            Some(ref admin_state) => tracing::info!(
-                pci_id = ?self.device.id(),
-                id = admin_state.qid,
-                pending_commands_count = admin_state.handler_data.pending_cmds.commands.len(),
-                "saved admin queue",
-            ),
-        }
 
         match io.is_empty() {
             true => tracing::warn!(pci_id = ?self.device.id(), "no io queues saved"),


### PR DESCRIPTION
Errors during IO queue save were swallowed (due to `flatten`) and never logged or reported. This PR makes sure all save errors for admin and IO queues are logged, and an error is reported if so (no more swallowing).

Fixes Microsoft ADO 60941937