### PR TITLE
flowey: fix --with-perf-tools command line parameter

### DIFF
--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -66,6 +66,9 @@ in stdenv.mkDerivation {
     fi
     cp -r modules/* $out/modules/
     cp kernel_build_metadata.json $out/
+    if [ -d tools ]; then
+      cp -r tools $out/
+    fi
     runHook postInstall
   '';
 }

--- a/openhcl/perftoolsfs.config
+++ b/openhcl/perftoolsfs.config
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-file /usr/bin/perf    ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/tools/perf/bin/perf  0755 0 0
-file /usr/bin/trace    ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/tools/perf/bin/trace  0755 0 0
+file /usr/bin/perf    ${OPENHCL_KERNEL_PATH}/tools/perf/bin/perf  0755 0 0
+file /usr/bin/trace    ${OPENHCL_KERNEL_PATH}/tools/perf/bin/trace  0755 0 0


### PR DESCRIPTION
Some of the changes I've made have ended up regressing the `--with-perf-tools` option in the `build-igvm` CLI. In the past we used to reconstruct the NuGet kernel's directory layout from the open source kernel but this no longer happens, which means the path in `openhcl/perftoolsfs.config` is wrong. 

Verified fix by running `cargo xflowey build-igvm x64 --with-perf-tools --release` both with and without a nix shell.