### PR TITLE
openhcl: Add HvSintEnabled flag to UEFI config for aarch64 (#2715)

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -659,6 +659,7 @@ pub fn write_uefi_config(
 
         flags.set_cxl_memory_enabled(platform_config.general.cxl_memory_enabled);
         flags.set_default_boot_always_attempt(platform_config.general.default_boot_always_attempt);
+        flags.set_hv_sint_enabled(platform_config.general.hv_sint_enabled);
 
         // Some settings do not depend on host config
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3618,6 +3618,7 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         guest_state_encryption_policy: _,
         guest_state_lifetime: _,
         management_vtl_features: _,
+        hv_sint_enabled: _,
     } = &dps.general;
 
     if *hibernation_enabled {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1062,6 +1062,7 @@ fn vm_config_from_command_line(
                             EfiDiagnosticsLogLevelCli::Full => get_resources::ged::EfiDiagnosticsLogLevelType::Full,
                         }
                     },
+                    hv_sint_enabled: false,
                 }
                 .into_resource(),
             ),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -853,6 +853,7 @@ impl PetriVmConfigSetupCore<'_> {
             igvm_attest_test_config: None,
             test_gsp_by_id,
             efi_diagnostics_log_level: Default::default(), // TODO: make configurable
+            hv_sint_enabled: false,
         };
 
         Ok((ged, guest_request_send))

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -218,6 +218,8 @@ pub struct HclDevicePlatformSettingsV2Static {
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
     #[serde(default)]
     pub management_vtl_features: ManagementVtlFeatures,
+    #[serde(default)]
+    pub hv_sint_enabled: bool,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -93,6 +93,8 @@ pub mod ged {
         pub test_gsp_by_id: bool,
         /// EFI diagnostics log level
         pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
+        /// Enable PPI-based SINT ACPI device for ARM64 Linux L1VH
+        pub hv_sint_enabled: bool,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -168,6 +168,8 @@ pub struct GuestConfig {
     /// EFI diagnostics log level
     #[inspect(debug)]
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
+    /// Enable PPI-based SINT ACPI device for ARM64 Linux L1VH
+    pub hv_sint_enabled: bool,
 }
 
 #[derive(Debug, Clone, Inspect)]
@@ -1407,6 +1409,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     guest_state_encryption_policy: state.config.guest_state_encryption_policy,
                     management_vtl_features: state.config.management_vtl_features,
                     efi_diagnostics_log_level: state.config.efi_diagnostics_log_level,
+                    hv_sint_enabled: state.config.hv_sint_enabled,
                 },
                 dynamic: get_protocol::dps_json::HclDevicePlatformSettingsV2Dynamic {
                     is_servicing_scenario: state.save_restore_buf.is_some(),

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -205,6 +205,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                         get_protocol::dps_json::EfiDiagnosticsLogLevelType::FULL
                     }
                 },
+                hv_sint_enabled: resource.hv_sint_enabled,
             },
             halt,
             resource.firmware_event_send,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -261,6 +261,7 @@ pub fn create_host_channel(
         guest_state_encryption_policy: Default::default(),
         management_vtl_features: Default::default(),
         efi_diagnostics_log_level: Default::default(),
+        hv_sint_enabled: false,
     };
 
     let halt_reason = Arc::new(Mutex::new(None));

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -131,6 +131,7 @@ pub mod platform_settings {
         pub guest_state_encryption_policy: GuestStateEncryptionPolicy,
         #[inspect(debug)]
         pub management_vtl_features: ManagementVtlFeatures,
+        pub hv_sint_enabled: bool,
     }
 
     #[derive(Copy, Clone, Debug, Inspect)]

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -342,6 +342,7 @@ impl GuestEmulationTransportClient {
                 guest_state_lifetime: json.v2.r#static.guest_state_lifetime,
                 guest_state_encryption_policy: json.v2.r#static.guest_state_encryption_policy,
                 management_vtl_features: json.v2.r#static.management_vtl_features,
+                hv_sint_enabled: json.v2.r#static.hv_sint_enabled,
             },
             acpi_tables: json.v2.dynamic.acpi_tables,
         })

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -322,8 +322,9 @@ pub struct Flags {
     pub dhcp6_link_layer_address: bool,
     pub cxl_memory_enabled: bool,
     pub mtrrs_initialized_at_load: bool,
+    pub hv_sint_enabled: bool,
 
-    #[bits(35)]
+    #[bits(34)]
     _reserved: u64,
 }
 


### PR DESCRIPTION
Cherry-pick of #2715.

This flag enables an ACPI device whose purpose is to reserve an interrupt for a VMM to use for hypervisor SINTs on aarch64.

(cherry picked from commit 46b2e02acd5b5e42abfe05fe29cfc58b5bda67d5)