### PR TITLE
nvme_test: added delay functionality for io queue (#2717)

### DIFF
--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -43,6 +43,9 @@ pub enum IoQueueFaultBehavior {
     CustomPayload(Vec<u8>),
     /// Panic
     Panic(String),
+    /// Delay. Note: This delay is not asynchronously applied. i.e. Subsequent
+    /// commands will be processed until the delay is over.
+    Delay(Duration),
 }
 
 /// Supported fault behaviour for PCI faults

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -232,6 +232,7 @@ impl AdminState {
 
                 IoSq {
                     task: TaskControl::new(IoHandler::new(
+                        handler.driver.clone(),
                         handler.config.mem.clone(),
                         i as u16 + 1,
                         self.sq_delete_response.sender(),
@@ -535,6 +536,11 @@ impl AdminHandler {
                             return Ok(());
                         }
                         AdminQueueFaultBehavior::Delay(duration) => {
+                            tracing::info!(
+                                "configured fault: admin command delay of {:?} for command: {:?}",
+                                &duration,
+                                &command
+                            );
                             self.timer.sleep(*duration).await;
                         }
                         AdminQueueFaultBehavior::Panic(message) => {


### PR DESCRIPTION
Clean cherry pick of PR #2717

Working on a vmm test that requires delays on io queues. This mimics the same pattern that we have in the AdminQueueFault case. Putting this chunk through to keep the vmm PR clean
