### PR TITLE
storage: Fix duplicate namespace removal (#2721)

### DIFF
--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -276,12 +276,6 @@ impl AdminState {
 
         // Notify the guest driver of the change.
         self.add_changed_namespace(nsid);
-
-        self.poll_namespace_change
-            .remove(&nsid)
-            .unwrap()
-            .cancel()
-            .await;
     }
 }
 


### PR DESCRIPTION
Clean cherry pick of PR #2721

The namespace to-be-removed was removed from `poll_namespace_change` a few lines above, and is removed again causing a panic. Seems this code path is not excercised in any test, which I'm planning on fixing in a future PR.
