### PR TITLE
flowey: add an `xshell::Shell` to `RustRuntimeServices` and update callsites within rust steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "xshell",
 ]
 
 [[package]]
@@ -2034,7 +2035,6 @@ dependencies = [
  "target-lexicon",
  "vmm_test_images",
  "which 8.0.0",
- "xshell",
 ]
 
 [[package]]

--- a/flowey/flowey/src/lib.rs
+++ b/flowey/flowey/src/lib.rs
@@ -10,6 +10,8 @@
 //! that level are only supposed to be used by flowey _infrastructure_ (e.g: in
 //! `flowey_cli`).
 
+pub use flowey_core::shell_cmd;
+
 /// Types and traits for implementing flowey nodes.
 pub mod node {
     pub mod prelude {

--- a/flowey/flowey_cli/src/cli/exec_snippet.rs
+++ b/flowey/flowey_cli/src/cli/exec_snippet.rs
@@ -135,7 +135,7 @@ impl ExecSnippet {
                     flow_backend.into(),
                     flow_platform,
                     flow_arch,
-                );
+                )?;
 
             let mut ctx_backend = ExecSnippetCtx::new(
                 flow_backend.into(),

--- a/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
@@ -342,7 +342,7 @@ fn direct_run_do_work(
             FlowBackend::Local,
             platform,
             flow_arch,
-        );
+        )?;
 
         for ResolvedRunnableStep {
             node_handle,
@@ -360,7 +360,9 @@ fn direct_run_do_work(
             if !node_working_dir.exists() {
                 fs_err::create_dir(&node_working_dir)?;
             }
-            std::env::set_current_dir(node_working_dir)?;
+
+            std::env::set_current_dir(node_working_dir.clone())?;
+            runtime_services.sh.change_dir(node_working_dir);
 
             if can_merge {
                 log::debug!("minor step: {} ({})", label, node_handle.modpath(),);

--- a/flowey/flowey_core/Cargo.toml
+++ b/flowey/flowey_core/Cargo.toml
@@ -13,6 +13,7 @@ linkme.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 serde_yaml.workspace = true
+xshell.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/flowey/flowey_core/src/reexports.rs
+++ b/flowey/flowey_core/src/reexports.rs
@@ -7,3 +7,4 @@
 
 pub use serde::Deserialize;
 pub use serde::Serialize;
+pub use xshell;

--- a/flowey/flowey_lib_common/src/_util/extract.rs
+++ b/flowey/flowey_lib_common/src/_util/extract.rs
@@ -69,11 +69,9 @@ pub fn extract_zip_if_new(
         bsdtar_installed: _,
     } = deps;
 
-    let sh = xshell::Shell::new()?;
-
     let root_dir = match persistent_dir {
         Some(dir) => rt.read(dir),
-        None => sh.current_dir(),
+        None => rt.sh.current_dir(),
     };
 
     let filename = file.file_name().expect("zip file was not a file");
@@ -100,10 +98,10 @@ pub fn extract_zip_if_new(
         fs_err::remove_dir_all(&extract_dir)?;
         fs_err::create_dir(&extract_dir)?;
 
-        sh.change_dir(&extract_dir);
+        rt.sh.change_dir(&extract_dir);
 
         let bsdtar = crate::_util::bsdtar_name(rt);
-        xshell::cmd!(sh, "{bsdtar} -xf {file}").run()?;
+        flowey::shell_cmd!(rt, "{bsdtar} -xf {file}").run()?;
         fs_err::write(pkg_info_file, file_version)?;
     } else {
         log::info!("already extracted!");
@@ -163,11 +161,9 @@ pub fn extract_tar_bz2_if_new(
         bzip2_installed: _,
     } = deps;
 
-    let sh = xshell::Shell::new()?;
-
     let root_dir = match persistent_dir {
         Some(dir) => rt.read(dir),
-        None => sh.current_dir(),
+        None => rt.sh.current_dir(),
     };
 
     let filename = file.file_name().expect("tar.bz2 file was not a file");
@@ -186,7 +182,7 @@ pub fn extract_tar_bz2_if_new(
     }
 
     if !already_extracted {
-        sh.change_dir(&extract_dir);
+        rt.sh.change_dir(&extract_dir);
 
         // clear out any old version that was present
         //
@@ -197,7 +193,7 @@ pub fn extract_tar_bz2_if_new(
         fs_err::create_dir(&extract_dir)?;
 
         // windows builds past Windows 10 build 17063 come with tar installed
-        xshell::cmd!(sh, "tar -xf {file}").run()?;
+        flowey::shell_cmd!(rt, "tar -xf {file}").run()?;
 
         fs_err::write(pkg_info_file, file_version)?;
     } else {

--- a/flowey/flowey_lib_common/src/check_needs_relaunch.rs
+++ b/flowey/flowey_lib_common/src/check_needs_relaunch.rs
@@ -52,9 +52,8 @@ impl SimpleFlowNode for Node {
         };
 
         let check_env = {
-            move |_: &mut RustRuntimeServices<'_>, env: &String, expected: &String| {
-                let sh = xshell::Shell::new()?;
-                let env = sh.var(env)?;
+            move |rt: &mut RustRuntimeServices<'_>, env: &String, expected: &String| {
+                let env = rt.sh.var(env)?;
 
                 if !env.contains(expected) {
                     anyhow::bail!(format!("did not find '{}' in {}", expected, env));

--- a/flowey/flowey_lib_common/src/download_azcopy.rs
+++ b/flowey/flowey_lib_common/src/download_azcopy.rs
@@ -96,14 +96,15 @@ impl FlowNode for Node {
             move |rt| {
                 let azcopy_archive = rt.read(azcopy_archive);
 
-                let sh = xshell::Shell::new()?;
-                sh.change_dir(azcopy_archive.parent().unwrap());
+                rt.sh.change_dir(azcopy_archive.parent().unwrap());
 
                 if is_tar {
-                    xshell::cmd!(sh, "tar -xf {azcopy_archive} --strip-components=1").run()?;
+                    flowey::shell_cmd!(rt, "tar -xf {azcopy_archive} --strip-components=1")
+                        .run()?;
                 } else {
                     let bsdtar = crate::_util::bsdtar_name(rt);
-                    xshell::cmd!(sh, "{bsdtar} -xf {azcopy_archive} --strip-components=1").run()?;
+                    flowey::shell_cmd!(rt, "{bsdtar} -xf {azcopy_archive} --strip-components=1")
+                        .run()?;
                 }
 
                 let path_to_azcopy = azcopy_archive

--- a/flowey/flowey_lib_common/src/download_cargo_fuzz.rs
+++ b/flowey/flowey_lib_common/src/download_cargo_fuzz.rs
@@ -93,13 +93,12 @@ impl FlowNode for Node {
                 } else {
                     let root = rt.read(cargo_install_persistent_dir).unwrap_or("./".into());
 
-                    let sh = xshell::Shell::new()?;
                     let rust_toolchain = rt.read(rust_toolchain);
                     let run = |offline| {
                         let rust_toolchain = rust_toolchain.as_ref().map(|s| format!("+{s}"));
 
-                        xshell::cmd!(
-                            sh,
+                        flowey::shell_cmd!(
+                            rt,
                             "cargo {rust_toolchain...}
                                 install
                                 --locked

--- a/flowey/flowey_lib_common/src/download_cargo_nextest.rs
+++ b/flowey/flowey_lib_common/src/download_cargo_nextest.rs
@@ -92,11 +92,9 @@ impl FlowNode for Node {
                     let target = target.to_string();
 
                     if !matches!(rt.read(hitvar), CacheHit::Hit) {
-                        let sh = xshell::Shell::new()?;
-
                         let nextest_archive = "nextest.tar.gz";
-                        xshell::cmd!(sh, "curl --fail -L https://get.nexte.st/{version}/{target}.tar.gz -o {nextest_archive}").run()?;
-                        xshell::cmd!(sh, "tar -xf {nextest_archive}").run()?;
+                        flowey::shell_cmd!(rt, "curl --fail -L https://get.nexte.st/{version}/{target}.tar.gz -o {nextest_archive}").run()?;
+                        flowey::shell_cmd!(rt, "tar -xf {nextest_archive}").run()?;
 
                         // move the downloaded bin into the cache dir
                         fs_err::create_dir_all(&cache_dir)?;

--- a/flowey/flowey_lib_common/src/download_gh_artifact.rs
+++ b/flowey/flowey_lib_common/src/download_gh_artifact.rs
@@ -50,16 +50,15 @@ impl SimpleFlowNode for Node {
             let run_id = run_id.claim(ctx);
             let path = path.claim(ctx);
             move |rt| {
-                let sh = xshell::Shell::new()?;
                 let gh_cli = rt.read(gh_cli);
                 let run_id = rt.read(run_id);
 
                 let path_end = format!("{repo_owner}/{repo_name}/{run_id}");
                 let out_dir = std::env::current_dir()?.absolute()?.join(path_end);
                 fs_err::create_dir_all(&out_dir)?;
-                sh.change_dir(&out_dir);
+                rt.sh.change_dir(&out_dir);
 
-                xshell::cmd!(sh, "{gh_cli} run download {run_id} -R {repo_owner}/{repo_name} --pattern {file_name}").run()?;
+                flowey::shell_cmd!(rt, "{gh_cli} run download {run_id} -R {repo_owner}/{repo_name} --pattern {file_name}").run()?;
 
                 if !out_dir.join(file_name).exists() {
                     anyhow::bail!("Failed to download artifact");

--- a/flowey/flowey_lib_common/src/download_gh_cli.rs
+++ b/flowey/flowey_lib_common/src/download_gh_cli.rs
@@ -87,19 +87,18 @@ impl FlowNode for Node {
                 let path_to_gh = if let Some(cached) = cached {
                     cached
                 } else {
-                    let sh = xshell::Shell::new()?;
                     match rt.platform() {
                         FlowPlatform::Windows => {
-                            xshell::cmd!(sh, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_windows_{gh_arch}.zip -o gh.zip").run()?;
-                            xshell::cmd!(sh, "tar -xf gh.zip").run()?;
+                            flowey::shell_cmd!(rt, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_windows_{gh_arch}.zip -o gh.zip").run()?;
+                            flowey::shell_cmd!(rt, "tar -xf gh.zip").run()?;
                         },
                         FlowPlatform::Linux(_) => {
-                            xshell::cmd!(sh, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_{gh_arch}.tar.gz -o gh.tar.gz").run()?;
-                            xshell::cmd!(sh, "tar -xf gh.tar.gz --strip-components=1").run()?;
+                            flowey::shell_cmd!(rt, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_{gh_arch}.tar.gz -o gh.tar.gz").run()?;
+                            flowey::shell_cmd!(rt, "tar -xf gh.tar.gz --strip-components=1").run()?;
                         },
                         FlowPlatform::MacOs => {
-                            xshell::cmd!(sh, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_macOS_{gh_arch}.zip -o gh.zip").run()?;
-                            xshell::cmd!(sh, "tar -xf gh.zip --strip-components=1").run()?;
+                            flowey::shell_cmd!(rt, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_macOS_{gh_arch}.zip -o gh.zip").run()?;
+                            flowey::shell_cmd!(rt, "tar -xf gh.zip --strip-components=1").run()?;
                         }
                         platform => anyhow::bail!("unsupported platform {platform}"),
                     };

--- a/flowey/flowey_lib_common/src/gen_cargo_nextest_run_cmd.rs
+++ b/flowey/flowey_lib_common/src/gen_cargo_nextest_run_cmd.rs
@@ -220,10 +220,10 @@ impl FlowNode for Node {
                                 .absolute()?
                                 .join("cargo_metadata.json");
 
-                            let sh = xshell::Shell::new()?;
-                            sh.change_dir(&working_dir);
+                            rt.sh.change_dir(&working_dir);
                             let output =
-                                xshell::cmd!(sh, "cargo metadata --format-version 1").output()?;
+                                flowey::shell_cmd!(rt, "cargo metadata --format-version 1")
+                                    .output()?;
                             let cargo_metadata = String::from_utf8(output.stdout)?;
                             fs_err::write(&cargo_metadata_path, cargo_metadata)?;
 

--- a/flowey/flowey_lib_common/src/gh_download_azure_key_vault_secret.rs
+++ b/flowey/flowey_lib_common/src/gh_download_azure_key_vault_secret.rs
@@ -61,9 +61,8 @@ impl FlowNode for Node {
                     |rt| {
                         let az_cli_bin = rt.read(az_cli_bin);
                         let key_vault_name = key_vault_name;
-                        let sh = xshell::Shell::new()?;
                         for (secret, vars) in secrets_and_vars {
-                            let secret_value = xshell::cmd!(sh, "{az_cli_bin} keyvault secret show --name {secret} --vault-name {key_vault_name} --query value --output tsv").read()?;
+                            let secret_value = flowey::shell_cmd!(rt, "{az_cli_bin} keyvault secret show --name {secret} --vault-name {key_vault_name} --query value --output tsv").read()?;
                             for var in vars {
                                 rt.write_secret(var, &secret_value);
                             }

--- a/flowey/flowey_lib_common/src/gh_latest_completed_workflow_id.rs
+++ b/flowey/flowey_lib_common/src/gh_latest_completed_workflow_id.rs
@@ -40,12 +40,11 @@ impl SimpleFlowNode for Node {
             let branch = branch.claim(ctx);
 
             move |rt| {
-                let sh = xshell::Shell::new()?;
                 let gh_cli = rt.read(gh_cli);
                 let branch = rt.read(branch);
 
-                let id = xshell::cmd!(
-                    sh,
+                let id = flowey::shell_cmd!(
+                    rt,
                     "{gh_cli} run list -R {repo} -b {branch} -w {pipeline_name} -s success --limit 1 --json databaseId -q .[0].databaseId"
                 )
                 .read()?;

--- a/flowey/flowey_lib_common/src/git_checkout.rs
+++ b/flowey/flowey_lib_common/src/git_checkout.rs
@@ -627,10 +627,9 @@ impl Node {
                                 anyhow::bail!("`LocalOnlyRequireExistingClones` is active, all repos must be registered using `RepoKind::ExistingClone`");
                             }
                             RepoSource::LocalOnlyNewClone { url, path, ignore_existing_clone } => {
-                                let sh = xshell::Shell::new()?;
-                                if sh.path_exists(path) {
-                                    sh.change_dir(path);
-                                    if xshell::cmd!(sh, "git status").run().is_ok()
+                                if rt.sh.path_exists(path) {
+                                    rt.sh.change_dir(path);
+                                    if flowey::shell_cmd!(rt, "git status").run().is_ok()
                                         && *ignore_existing_clone
                                     {
                                         rt.write(repo_path, path);
@@ -639,9 +638,9 @@ impl Node {
                                 }
                                 if let Some(depth_arg) = depth {
                                     let depth_arg_string = depth_arg.to_string();
-                                    xshell::cmd!(sh, "git clone --depth {depth_arg_string} {url} {path}").run()?;
+                                    flowey::shell_cmd!(rt, "git clone --depth {depth_arg_string} {url} {path}").run()?;
                                 } else {
-                                    xshell::cmd!(sh, "git clone {url} {path}").run()?;
+                                    flowey::shell_cmd!(rt, "git clone {url} {path}").run()?;
                                 }
                                 found_path = Some(path.clone());
                                 break;

--- a/flowey/flowey_lib_common/src/git_merge_commit.rs
+++ b/flowey/flowey_lib_common/src/git_merge_commit.rs
@@ -34,15 +34,15 @@ impl SimpleFlowNode for Node {
             let repo_path = repo_path.claim(ctx);
 
             move |rt| {
-                let sh = xshell::Shell::new()?;
                 let repo_path = rt.read(repo_path);
 
-                sh.change_dir(repo_path);
+                rt.sh.change_dir(repo_path);
 
-                xshell::cmd!(sh, "git fetch --unshallow").run()?;
+                flowey::shell_cmd!(rt, "git fetch --unshallow").run()?;
 
-                xshell::cmd!(sh, "git fetch origin {base_branch}").run()?;
-                let commit = xshell::cmd!(sh, "git merge-base HEAD origin/{base_branch}").read()?;
+                flowey::shell_cmd!(rt, "git fetch origin {base_branch}").run()?;
+                let commit =
+                    flowey::shell_cmd!(rt, "git merge-base HEAD origin/{base_branch}").read()?;
                 rt.write(merge_commit, &commit);
 
                 Ok(())

--- a/flowey/flowey_lib_common/src/install_azure_cli.rs
+++ b/flowey/flowey_lib_common/src/install_azure_cli.rs
@@ -120,32 +120,31 @@ impl FlowNode for Node {
                 ctx.emit_rust_step("installing azure-cli", |ctx| {
                     let get_az_cli = get_az_cli.claim(ctx);
                     move |rt| {
-                        let sh = xshell::Shell::new()?;
                         if let Ok(path) = check_az_install(rt) {
                             rt.write_all(get_az_cli, &path);
                             return Ok(());
                         }
                         match rt.platform() {
                             FlowPlatform::Windows => {
-                                let az_dir = sh.current_dir().join("az");
-                                sh.create_dir(&az_dir)?;
-                                sh.change_dir(&az_dir);
-                                xshell::cmd!(
-                                    sh,
+                                let az_dir = rt.sh.current_dir().join("az");
+                                rt.sh.create_dir(&az_dir)?;
+                                rt.sh.change_dir(&az_dir);
+                                flowey::shell_cmd!(
+                                    rt,
                                     "curl --fail -L https://aka.ms/installazurecliwindowszipx64 -o az.zip"
                                 )
                                 .run()?;
-                                xshell::cmd!(sh, "tar -xf az.zip").run()?;
+                                flowey::shell_cmd!(rt, "tar -xf az.zip").run()?;
                                 rt.write_all(get_az_cli, &az_dir.join("bin\\az.cmd"));
                             }
                             FlowPlatform::Linux(_) => {
-                                xshell::cmd!(
-                                    sh,
+                                flowey::shell_cmd!(
+                                    rt,
                                     "curl --fail -sL https://aka.ms/InstallAzureCLIDeb -o InstallAzureCLIDeb.sh"
                                 )
                                 .run()?;
-                                xshell::cmd!(sh, "chmod +x ./InstallAzureCLIDeb.sh").run()?;
-                                xshell::cmd!(sh, "sudo ./InstallAzureCLIDeb.sh").run()?;
+                                flowey::shell_cmd!(rt, "chmod +x ./InstallAzureCLIDeb.sh").run()?;
+                                flowey::shell_cmd!(rt, "sudo ./InstallAzureCLIDeb.sh").run()?;
                                 let path = check_az_install(rt)?;
                                 rt.write_all(get_az_cli, &path);
                             }

--- a/flowey/flowey_lib_common/src/install_git.rs
+++ b/flowey/flowey_lib_common/src/install_git.rs
@@ -73,8 +73,7 @@ impl FlowNode for Node {
                         },
                         FlowPlatform::Windows => {
                             if which::which("git.exe").is_err() {
-                                let sh = xshell::Shell::new()?;
-                                xshell::cmd!(sh, "powershell.exe winget install --id Microsoft.Git --accept-source-agreements").run()?;
+                                flowey::shell_cmd!(rt, "powershell.exe winget install --id Microsoft.Git --accept-source-agreements").run()?;
                             }
 
                             rt.write(write_bin, &Some(crate::check_needs_relaunch::BinOrEnv::Bin("git".to_string())));

--- a/flowey/flowey_lib_common/src/install_nuget_azure_credential_provider.rs
+++ b/flowey/flowey_lib_common/src/install_nuget_azure_credential_provider.rs
@@ -86,11 +86,9 @@ impl FlowNode for Node {
                                 return Ok(())
                             }
 
-                            let sh = xshell::Shell::new()?;
-
                             if matches!(nuget_config_platform, NugetInstallPlatform::Windows) {
                                 let install_aacp_cmd = r#""& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx""#;
-                                xshell::cmd!(sh, "powershell.exe iex {install_aacp_cmd}").run()?;
+                                flowey::shell_cmd!(rt, "powershell.exe iex {install_aacp_cmd}").run()?;
                             } else {
                                 log::warn!("automatic Azure Artifacts Credential Provider installation is not supported yet for this platform!");
                                 log::warn!("follow the guide, and press <enter> to continue");
@@ -138,10 +136,8 @@ fn check_if_aacp_installed(
     rt: &mut RustRuntimeServices<'_>,
     nuget_config_platform: &NugetInstallPlatform,
 ) -> anyhow::Result<()> {
-    let sh = xshell::Shell::new()?;
-
     let profile: PathBuf = if matches!(nuget_config_platform, NugetInstallPlatform::Windows) {
-        let path = xshell::cmd!(sh, "cmd.exe /c echo %UserProfile%")
+        let path = flowey::shell_cmd!(rt, "cmd.exe /c echo %UserProfile%")
             .ignore_status()
             .read()?;
 

--- a/flowey/flowey_lib_common/src/nuget_install_package.rs
+++ b/flowey/flowey_lib_common/src/nuget_install_package.rs
@@ -183,9 +183,8 @@ impl FlowNode for Node {
                     // FUTURE: add checks to avoid having to invoke
                     // nuget at all (a-la the "expected_hashes" in the
                     // old ci/restore.sh)
-                    let sh = xshell::Shell::new()?;
-                    xshell::cmd!(
-                        sh,
+                    flowey::shell_cmd!(
+                        rt,
                         "{nuget_bin}
                                     install
                                     {non_interactive...}

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -261,12 +261,10 @@ impl FlowNode for Node {
                         crate_type,
                     } = cmd;
 
-                    let sh = xshell::Shell::new()?;
+                    let out_dir = rt.sh.current_dir();
 
-                    let out_dir = sh.current_dir();
-
-                    sh.change_dir(cargo_work_dir);
-                    let mut cmd = xshell::cmd!(sh, "{argv0} {params...}");
+                    rt.sh.change_dir(cargo_work_dir);
+                    let mut cmd = flowey::shell_cmd!(rt, "{argv0} {params...}");
                     if !matches!(rt.backend(), FlowBackend::Local) {
                         // if running in CI, no need to waste time with incremental
                         // build artifacts
@@ -296,7 +294,7 @@ impl FlowNode for Node {
                             .collect::<Result<_, _>>()
                             .context("failed to deserialize cargo output")?;
 
-                    sh.change_dir(out_dir.clone());
+                    rt.sh.change_dir(out_dir.clone());
 
                     let build_output =
                         rename_output(&messages, &crate_name, &out_name, crate_type, &out_dir)?;

--- a/flowey/flowey_lib_common/src/run_cargo_clippy.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_clippy.rs
@@ -123,14 +123,12 @@ impl FlowNode for Node {
                         }
                     }
 
-                    let sh = xshell::Shell::new()?;
-
-                    sh.change_dir(in_folder);
+                    rt.sh.change_dir(in_folder);
 
                     let mut cmd = if let Some(rust_toolchain) = &rust_toolchain {
-                        xshell::cmd!(sh, "rustup run {rust_toolchain} cargo")
+                        flowey::shell_cmd!(rt, "rustup run {rust_toolchain} cargo")
                     } else {
-                        xshell::cmd!(sh, "cargo")
+                        flowey::shell_cmd!(rt, "cargo")
                     };
 
                     // if running in CI, no need to waste time with incremental

--- a/flowey/flowey_lib_common/src/run_cargo_nextest_archive.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_archive.rs
@@ -93,13 +93,12 @@ impl FlowNode for Node {
                                 extra_env,
                             );
 
-                        let sh = xshell::Shell::new()?;
+                        let out_archive_file =
+                            rt.sh.current_dir().absolute()?.join("archive.tar.zst");
 
-                        let out_archive_file = sh.current_dir().absolute()?.join("archive.tar.zst");
-
-                        sh.change_dir(working_dir);
-                        let mut cmd = xshell::cmd!(
-                            sh,
+                        rt.sh.change_dir(working_dir);
+                        let mut cmd = flowey::shell_cmd!(
+                            rt,
                             "cargo {rust_toolchain...} nextest archive
                                 {build_args...}
                                 --archive-file {out_archive_file}

--- a/flowey/flowey_lib_common/src/use_gh_cli.rs
+++ b/flowey/flowey_lib_common/src/use_gh_cli.rs
@@ -97,8 +97,6 @@ impl FlowNode for Node {
             let get_reqs = get_reqs.claim(ctx);
             let gh_bin_path = gh_bin_path.claim(ctx);
             |rt| {
-                let sh = xshell::Shell::new()?;
-
                 let gh_bin_path = rt.read(gh_bin_path).display().to_string();
                 let gh_token = match auth {
                     GhCliAuth::LocalOnlyInteractive => String::new(),
@@ -135,14 +133,14 @@ impl FlowNode for Node {
                     file.write_all(shim_txt.as_bytes())?;
                     dst.absolute()?
                 };
-                if !xshell::cmd!(sh, "{path} auth status")
+                if !flowey::shell_cmd!(rt, "{path} auth status")
                     .ignore_status()
                     .output()?
                     .status
                     .success()
                 {
                     if matches!(rt.backend(), FlowBackend::Local) {
-                        xshell::cmd!(sh, "{path} auth login").run()?;
+                        flowey::shell_cmd!(rt, "{path} auth login").run()?;
                     } else {
                         anyhow::bail!("unable to authenticate with github - is GhCliAuth valid?")
                     }

--- a/flowey/flowey_lib_hvlite/Cargo.toml
+++ b/flowey/flowey_lib_hvlite/Cargo.toml
@@ -21,7 +21,6 @@ serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 target-lexicon = { workspace = true, features = ["serde_support"] }
 which.workspace = true
-xshell.workspace = true
 
 [lints]
 workspace = true

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs
@@ -44,16 +44,15 @@ impl SimpleFlowNode for Node {
             rust_installed.claim(ctx);
             let openvmm_repo_path = openvmm_repo_path.claim(ctx);
             move |rt| {
-                let sh = xshell::Shell::new()?;
-
                 let target = target.to_string();
                 let profile = match profile {
                     CommonProfile::Release => "release",
                     CommonProfile::Debug => "dev",
                 };
 
-                sh.change_dir(rt.read(openvmm_repo_path));
-                xshell::cmd!(sh, "cargo test --locked --doc --workspace --no-fail-fast --target {target} --profile {profile}").run()?;
+                let path = rt.read(openvmm_repo_path);
+                rt.sh.change_dir(path);
+                flowey::shell_cmd!(rt, "cargo test --locked --doc --workspace --no-fail-fast --target {target} --profile {profile}").run()?;
 
                 Ok(())
             }

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_test_results_website.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_test_results_website.rs
@@ -34,7 +34,6 @@ impl SimpleFlowNode for Node {
             let openvmm_repo_path = openvmm_repo_path.claim(ctx);
 
             move |rt| {
-                let sh = xshell::Shell::new()?;
                 let mut dist_path = rt.read(openvmm_repo_path);
 
                 // Navigate to the petri/logview_new directory within the
@@ -42,12 +41,12 @@ impl SimpleFlowNode for Node {
                 dist_path.push("petri");
                 dist_path.push("logview_new");
 
-                sh.change_dir(&dist_path);
+                rt.sh.change_dir(&dist_path);
 
                 // Because the project is using vite, the output will go
                 // directly to the 'dist-ci' folder
-                xshell::cmd!(sh, "npm install").run()?;
-                xshell::cmd!(sh, "npm run build:ci").run()?;
+                flowey::shell_cmd!(rt, "npm install").run()?;
+                flowey::shell_cmd!(rt, "npm run build:ci").run()?;
 
                 dist_path.push("dist-ci");
                 if !dist_path.exists() {

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -161,9 +161,9 @@ impl SimpleFlowNode for Node {
                         crate::build_xtask::XtaskOutput::WindowsBin { exe, pdb: _ } => exe,
                     };
 
-                    let sh = xshell::Shell::new()?;
-                    sh.change_dir(repo_path);
-                    let output = xshell::cmd!(sh, "{xtask_bin} fuzz list --crates").output()?;
+                    rt.sh.change_dir(repo_path);
+                    let output =
+                        flowey::shell_cmd!(rt, "{xtask_bin} fuzz list --crates").output()?;
                     let output = String::from_utf8(output.stdout)?;
 
                     let fuzz_crates = output.trim().split('\n').map(|s| s.to_owned());

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -188,10 +188,10 @@ impl SimpleFlowNode for Node {
                     merge_run.commit, merge_run.id
                 );
 
-                let sh = xshell::Shell::new()?;
-                sh.change_dir(rt.read(openvmm_repo_path));
-                xshell::cmd!(
-                    sh,
+                let path = rt.read(openvmm_repo_path);
+                rt.sh.change_dir(path);
+                flowey::shell_cmd!(
+                    rt,
                     "{xtask} verify-size --original {old_path} --new {new_path}"
                 )
                 .run()?;

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs
@@ -40,9 +40,9 @@ impl SimpleFlowNode for Node {
                     crate::build_xtask::XtaskOutput::WindowsBin { exe, .. } => exe,
                 };
 
-                let sh = xshell::Shell::new()?;
-                sh.change_dir(rt.read(openvmm_repo_path));
-                xshell::cmd!(sh, "{xtask} fmt --no-parallel")
+                let path = rt.read(openvmm_repo_path);
+                rt.sh.change_dir(path);
+                flowey::shell_cmd!(rt, "{xtask} fmt --no-parallel")
                     // CI runs with trace logging, but that results in a lot of
                     // spam when running the xtask flowey check
                     .env("FLOWEY_LOG", "info")

--- a/flowey/flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs
@@ -42,10 +42,9 @@ impl SimpleFlowNode for Node {
                     let hvlite_repo = rt.read(hvlite_repo);
                     let gh_token = rt.read(gh_token);
                     let base_recipe = non_production_build_igvm_tool_out_name(&base_recipe);
-                    let sh = xshell::Shell::new()?;
-                    sh.change_dir(hvlite_repo);
-                    let mut cmd = xshell::cmd!(
-                        sh,
+                    rt.sh.change_dir(hvlite_repo);
+                    let mut cmd = flowey::shell_cmd!(
+                        rt,
                         "cargo xflowey build-igvm {base_recipe} --install-missing-deps"
                     )
                     .env("I_HAVE_A_GOOD_REASON_TO_RUN_BUILD_IGVM_IN_CI", "true");

--- a/flowey/flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs
+++ b/flowey/flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs
@@ -130,13 +130,12 @@ impl SimpleFlowNode for Node {
                             openvmm_repo_path.join("vm/vmgs/vmgs_lib/examples/vmgs_testlib.c");
 
                         if which::which("clang").is_ok() {
-                            let sh = xshell::Shell::new()?;
-                            xshell::cmd!(
-                                sh,
+                            flowey::shell_cmd!(
+                                rt,
                                 "clang {vmgs_testlib_c} {so} -rpath {so_dir} -o ./vmgs_lib_test"
                             )
                             .run()?;
-                            xshell::cmd!(sh, "./vmgs_lib_test").run()?;
+                            flowey::shell_cmd!(rt, "./vmgs_lib_test").run()?;
                         } else {
                             log::warn!("skipping vmgs_lib test (could not find clang)");
                         }
@@ -190,13 +189,12 @@ impl SimpleFlowNode for Node {
                         fs_err::copy(dll_lib, "vmgs_lib.dll.lib")?;
                         fs_err::copy(dll, "vmgs_lib.dll")?;
 
-                        let sh = xshell::Shell::new()?;
-                        xshell::cmd!(
-                            sh,
+                        flowey::shell_cmd!(
+                            rt,
                             "clang {vmgs_testlib_c} -o vmgs_lib_test.exe -l vmgs_lib.dll"
                         )
                         .run()?;
-                        xshell::cmd!(sh, "./vmgs_lib_test.exe").run()?;
+                        flowey::shell_cmd!(rt, "./vmgs_lib_test.exe").run()?;
 
                         Ok(())
                     }

--- a/flowey/flowey_lib_hvlite/src/build_guest_test_uefi.rs
+++ b/flowey/flowey_lib_hvlite/src/build_guest_test_uefi.rs
@@ -92,15 +92,15 @@ impl FlowNode for Node {
                     };
 
                     // package it up into an img using the xtask
-                    let sh = xshell::Shell::new()?;
-                    let img_path = sh.current_dir().join("guest_test_uefi.img");
+                    let img_path = rt.sh.current_dir().join("guest_test_uefi.img");
                     let arch_arg = match arch {
                         CommonArch::X86_64 => "bootx64",
                         CommonArch::Aarch64 => "bootaa64",
                     };
-                    sh.change_dir(rt.read(openvmm_repo_path));
-                    xshell::cmd!(
-                        sh,
+                    let path = rt.read(openvmm_repo_path);
+                    rt.sh.change_dir(path);
+                    flowey::shell_cmd!(
+                        rt,
                         "cargo xtask guest-test uefi --output {img_path} --{arch_arg} {efi}"
                     )
                     .run()?;

--- a/flowey/flowey_lib_hvlite/src/build_guide.rs
+++ b/flowey/flowey_lib_hvlite/src/build_guide.rs
@@ -59,14 +59,12 @@ impl FlowNode for Node {
                     let mdbook_admonish_bin = rt.read(mdbook_admonish_bin);
                     let mdbook_mermaid_bin = rt.read(mdbook_mermaid_bin);
 
-                    let sh = xshell::Shell::new()?;
-
-                    let out_path: PathBuf = sh.current_dir().absolute()?.join("book");
+                    let out_path: PathBuf = rt.sh.current_dir().absolute()?.join("book");
                     let guide_source: PathBuf = rt.read(guide_source);
 
-                    sh.change_dir(&guide_source);
-                    xshell::cmd!(
-                        sh,
+                    rt.sh.change_dir(&guide_source);
+                    flowey::shell_cmd!(
+                        rt,
                         "{mdbook_bin} build {guide_source} --dest-dir {out_path}"
                     )
                     // intercepted by the `mdbook-openvmm-shim`

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -135,9 +135,9 @@ impl FlowNode for Node {
                         crate::build_xtask::XtaskOutput::WindowsBin { exe, pdb: _ } => exe,
                     };
 
-                    let sh = xshell::Shell::new()?;
-                    sh.change_dir(openvmm_repo_path);
-                    let output = xshell::cmd!(sh, "{xtask_bin} fuzz list --crates").output()?;
+                    rt.sh.change_dir(openvmm_repo_path);
+                    let output =
+                        flowey::shell_cmd!(rt, "{xtask_bin} fuzz list --crates").output()?;
                     let output = String::from_utf8(output.stdout)?;
 
                     let fuzz_crates = output.trim().split('\n').map(|s| s.to_owned());

--- a/flowey/flowey_lib_hvlite/src/build_rustdoc.rs
+++ b/flowey/flowey_lib_hvlite/src/build_rustdoc.rs
@@ -93,8 +93,7 @@ impl FlowNode for Node {
                 let cargo_cmd = cargo_cmd.claim(ctx);
                 move |rt| {
                     let cargo_cmd = rt.read(cargo_cmd);
-                    let sh = xshell::Shell::new()?;
-                    let out_path = cargo_cmd.run(&sh)?;
+                    let out_path = cargo_cmd.run(&rt.sh)?;
 
                     rt.write(output, &RustdocOutput { docs: out_path });
                     Ok(())

--- a/flowey/flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs
+++ b/flowey/flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs
@@ -79,9 +79,8 @@ impl FlowNode for Node {
                             });
                     fs_err::create_dir_all(&extracted_sysroot_path)?;
 
-                    let sh = xshell::Shell::new()?;
-                    xshell::cmd!(
-                        sh,
+                    flowey::shell_cmd!(
+                        rt,
                         "tar
                                 -xf {openhcl_sysroot_tar_gz}
                                 -C {extracted_sysroot_path}

--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -74,7 +74,6 @@ impl FlowNode for Node {
                     let write_commands = write_commands.claim(ctx);
 
                     move |rt| {
-                        let sh = xshell::Shell::new()?;
                         let mut commands = Vec::new();
 
                         if !matches!(rt.platform(), FlowPlatform::Windows)
@@ -96,7 +95,7 @@ impl FlowNode for Node {
 
                         // Check if features are already enabled
                         if installing && !features_to_enable.is_empty() {
-                            let features = xshell::cmd!(sh, "DISM.exe /Online /Get-Features").output()?;
+                            let features = flowey::shell_cmd!(rt, "DISM.exe /Online /Get-Features").output()?;
                             assert!(features.status.success());
                             let features = String::from_utf8_lossy(&features.stdout).to_string();
                             let mut feature = None;
@@ -147,7 +146,7 @@ Otherwise, press `ctrl-c` to cancel the run.
                         // Install the features
                         for feature in features_to_enable {
                             if installing {
-                                xshell::cmd!(sh, "DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}").run()?;
+                                flowey::shell_cmd!(rt, "DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}").run()?;
                             }
                             commands.push(format!("DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}"));
                         }
@@ -167,7 +166,7 @@ Otherwise, press `ctrl-c` to cancel the run.
 
                         // Check if reg keys are set
                         if installing && !reg_keys_to_set.is_empty() {
-                            let output = xshell::cmd!(sh, "reg.exe query {VIRT_REG_PATH}").output()?;
+                            let output = flowey::shell_cmd!(rt, "reg.exe query {VIRT_REG_PATH}").output()?;
                             if output.status.success() {
                                 let output = String::from_utf8_lossy(&output.stdout).to_string();
                                 for line in output.lines() {
@@ -210,7 +209,7 @@ Otherwise, press `ctrl-c` to cancel the run.
                             // TODO: figure out why reg.exe is not found if I
                             // render the command as a string first and share
                             if installing {
-                                xshell::cmd!(sh, "reg.exe add {VIRT_REG_PATH} /v {v} /t REG_DWORD /d 1 /f").run()?;
+                                flowey::shell_cmd!(rt, "reg.exe add {VIRT_REG_PATH} /v {v} /t REG_DWORD /d 1 /f").run()?;
                             }
                             commands.push(format!("reg.exe add \"{VIRT_REG_PATH}\" /v {v} /t REG_DWORD /d 1 /f"));
                         }

--- a/flowey/flowey_lib_hvlite/src/run_igvmfilegen.rs
+++ b/flowey/flowey_lib_hvlite/src/run_igvmfilegen.rs
@@ -55,19 +55,17 @@ impl SimpleFlowNode for Node {
                 let manifest = rt.read(manifest);
                 let resources = rt.read(resources);
 
-                let sh = xshell::Shell::new()?;
-
                 let igvm_file_stem = "igvm";
-                let igvm_path = sh.current_dir().join(format!("{igvm_file_stem}.bin"));
-                let resources_path = sh.current_dir().join("igvm.json");
+                let igvm_path = rt.sh.current_dir().join(format!("{igvm_file_stem}.bin"));
+                let resources_path = rt.sh.current_dir().join("igvm.json");
 
                 let resources = igvmfilegen_config::Resources::new(resources.into_iter().collect())
                     .context("creating igvm resources")?;
                 std::fs::write(&resources_path, serde_json::to_string_pretty(&resources)?)
                     .context("writing resources")?;
 
-                xshell::cmd!(
-                    sh,
+                flowey::shell_cmd!(
+                    rt,
                     "{igvmfilegen} manifest
                             -m {manifest}
                             -r {resources_path}

--- a/flowey/flowey_lib_hvlite/src/run_prep_steps.rs
+++ b/flowey/flowey_lib_hvlite/src/run_prep_steps.rs
@@ -73,12 +73,11 @@ impl SimpleFlowNode for Node {
                         .output()?;
                 }
 
-                let sh = xshell::Shell::new()?;
                 let binary_path = match prep_steps {
                     PrepStepsOutput::WindowsBin { exe, .. } => exe,
                     PrepStepsOutput::LinuxBin { bin, .. } => bin,
                 };
-                xshell::cmd!(sh, "{binary_path}").envs(env).run()?;
+                flowey::shell_cmd!(rt, "{binary_path}").envs(env).run()?;
 
                 Ok(())
             }

--- a/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
+++ b/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
@@ -95,11 +95,10 @@ impl SimpleFlowNode for Node {
             move |rt| {
                 let in_bin = rt.read(in_bin);
 
-                let sh = xshell::Shell::new()?;
-                let output = sh.current_dir().join(in_bin.file_name().unwrap());
-                xshell::cmd!(sh, "{objcopy_bin} --only-keep-debug {in_bin} {output}.dbg").run()?;
-                xshell::cmd!(
-                    sh,
+                let output = rt.sh.current_dir().join(in_bin.file_name().unwrap());
+                flowey::shell_cmd!(rt, "{objcopy_bin} --only-keep-debug {in_bin} {output}.dbg").run()?;
+                flowey::shell_cmd!(
+                    rt,
                     "{objcopy_bin} --strip-all --keep-section=.build_info --add-gnu-debuglink={output}.dbg {in_bin} {output}"
                 )
                 .run()?;

--- a/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
@@ -68,9 +68,8 @@ impl SimpleFlowNode for Node {
         {
             pre_run_deps.push({
                 ctx.emit_rust_step("ensure /dev/kvm is accessible", |_| {
-                    |_| {
-                        let sh = xshell::Shell::new()?;
-                        xshell::cmd!(sh, "sudo chmod a+rw /dev/kvm").run()?;
+                    |rt| {
+                        flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/kvm").run()?;
                         Ok(())
                     }
                 })


### PR DESCRIPTION
Integrates a shell into RustRuntimeServices, which becomes useful later when we eventually will want to start wrapping shell commands in `nix-shell --pure --run` for builds running in the Nix environment. 

This lays the groundwork to do so by having flowey provide the shell. A follow-up change will introduce a shim when running in Nix mode to wrap commands in `nix-shell --pure --run`. The remaining instances of `xshell::Shell::new()` are callsites outside of rust steps in flowey nodes.