### PR TITLE
mesh_protobuf: don't print the bytes of a ProtobufAny by default

### DIFF
--- a/support/mesh/mesh_protobuf/src/message.rs
+++ b/support/mesh/mesh_protobuf/src/message.rs
@@ -81,12 +81,30 @@ impl<R> MessageDecode<'_, ProtobufMessage, R> for ProtobufMessageEncoding {
 /// A protobuf message and the associated protobuf type URL.
 ///
 /// This has the encoding of `google.protobuf.Any`.
-#[derive(Debug, Protobuf)]
+#[derive(Protobuf)]
 pub struct ProtobufAny {
     #[mesh(1)]
     type_url: String, // FUTURE: avoid allocation here
     #[mesh(2)]
     value: ProtobufMessage,
+}
+
+impl core::fmt::Debug for ProtobufAny {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if f.alternate() {
+            // Full debug output like derive would produce
+            f.debug_struct("ProtobufAny")
+                .field("type_url", &self.type_url)
+                .field("value", &self.value)
+                .finish()
+        } else {
+            // Compact output with just type_url and data length
+            f.debug_struct("ProtobufAny")
+                .field("type_url", &self.type_url)
+                .field("value_len", &self.value.0.len())
+                .finish()
+        }
+    }
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Make the default `Debug` output of a `ProtobufAny` the `type_url` and the length of the encoded data.

In looking at some trace logs for a test failure, I noticed that some vmbus-related messages seemed to slow things down (in the context of our known slowness running VTL2 emulation inside VMs). This is one of two changes to reduce some of that output.

Related to #2744.
