### PR TITLE
petri: fix screenshots for generation 1 hyper-v vms

### DIFF
--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -670,7 +670,7 @@ function Get-VmScreenshot
     $vmcs = Get-MsvmComputerSystem $Vm
 
     # Get the resolution of the screen at the moment
-    $videoHead = $vmcs | Get-CimAssociatedInstance -ResultClassName "Msvm_VideoHead"
+    $videoHead = @($vmcs | Get-CimAssociatedInstance -ResultClassName "Msvm_VideoHead")[0]
     $x = $videoHead.CurrentHorizontalResolution
     $y = $videoHead.CurrentVerticalResolution
 

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -714,9 +714,7 @@ impl PetriVmRuntime for HyperVPetriRuntime {
     }
 
     fn take_framebuffer_access(&mut self) -> Option<vm::HyperVFramebufferAccess> {
-        // TODO: fix gen 1 screenshots
-        (!self.properties.is_isolated && !self.properties.is_pcat)
-            .then(|| self.vm.get_framebuffer_access())
+        (!self.properties.is_isolated).then(|| self.vm.get_framebuffer_access())
     }
 
     async fn reset(&mut self) -> anyhow::Result<()> {


### PR DESCRIPTION
Fixes and re-enabled hyper-v screenshots for generation 1 VMs. This should help debug some timeouts we have been seeing occasionally.