### PR TITLE
nvme_driver: allow control plane commands when in drain_after_restore (#2736)

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -986,6 +986,11 @@ impl<A: AerHandler> QueueHandler<A> {
             } else {
                 // Only process in-flight completions.
                 poll_fn(|cx| {
+                    // Look for control plane requests like Save/Inspect
+                    if let Poll::Ready(Some(req)) = recv_req.poll_next_unpin(cx) {
+                        return Event::Request(req).into();
+                    }
+
                     while !self.commands.is_empty() {
                         if let Some(completion) = self.cq.read() {
                             return Event::Completion(completion).into();


### PR DESCRIPTION
Clean cherry pick of PR #2736

After doing a restore, the `nvme_driver` goes into a `drain_after_restore` mode. The point of this is
to prevent new IOs from racing with IOs that are pending out to the driver (this is a data correctness
guarantee).

However, that drain path doesn't listen for new `save` requests. So, it is possible that a second save
will hang if there are IOs from a previous save that has not yet completed.

Tested manaully using a preview of tests from @gurasinghMS.
