### PR TITLE
Ask mode: Update mirror pipeline to update staging branch

### DIFF
--- a/.github/scripts/refresh_mirror/refresh-mirror.py
+++ b/.github/scripts/refresh_mirror/refresh-mirror.py
@@ -19,7 +19,7 @@ def main(pipeline_id: str, token: str, organization: str, project: str, debug: b
 
         build = {
                     'definition': {'id': pipeline_id},
-                    'templateParameters': {'branchToMirror': 'release/1.7.2511', 'branchToUpdateSubmodule': 'release/1.7.2511', 'updateSubmodule': 'true'},
+                    'templateParameters': {'branchToMirror': 'release/1.7.2511', 'branchToUpdateSubmodule': 'staging/1.7.2511', 'updateSubmodule': 'true'},
                 }
         build = client.queue_build(build, project=project)
         print(f'Scheduled build: {build.id}. Url: {organization}/{project}/_build/results?buildId={build.id}&view=results', file=sys.stderr)


### PR DESCRIPTION
OpenHCL 1.7 is now in Ask Mode. Please see https://openvmm.dev/guide/dev_guide/contrib/release.html?highlight=ask%20mode#marking-approval-process-code-flow for more details.