### PR TITLE
snp: remove TODO comment around unexpected intercepts

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1667,9 +1667,8 @@ impl UhProcessor<'_, SnpBacked> {
                 }
                 HvMessageType::HvMessageTypeX64Halt
                 | HvMessageType::HvMessageTypeExceptionIntercept => {
-                    // Ignore.
-                    //
-                    // TODO SNP: Figure out why we are getting these.
+                    // Ignore. Note: it is possible to get the ExceptionIntercept
+                    // message for reflect #VC.
                 }
                 message_type => {
                     tracelimit::error_ratelimited!(


### PR DESCRIPTION
The hypervisor will send halt messages when the guest exits because of a HLT, and it will also send the ExceptionIntercept type message e.g. as part of reflect #VC, so these are all expected messages. Dispatch and handling should be based on the state in the VMSA as the hypervisor message can't be trusted.