### PR TITLE
petri: hyperv: increase default servicing timeout to 60s

### DIFF
--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -628,7 +628,7 @@ function Restart-OpenHCL
         [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
         [System.Object] $Vm,
 
-        [int] $TimeoutHintSeconds = 30, # Ends up as the deadline in GuestSaveRequest (see the handling of
+        [int] $TimeoutHintSeconds = 60, # Ends up as the deadline in GuestSaveRequest (see the handling of
                                         # SaveGuestVtl2StateNotification in guest_emulation_transport).
                                         #
                                         # Also used as the hint for how long to wait (in this cmdlet) for the


### PR DESCRIPTION
In recent tests(*), I noticed that the servicing operations are proceeding, but are just slow. Increase the default timeout to 60 seconds, up from 30.

(*) e.g. https://openvmm.dev/test-results/#/runs/21687574748/x64-windows-amd-snp-vmm-tests-logs/multiarch__openhcl_servicing__hyperv_openhcl_pcat_x64_ubuntu_2504_server_x64_servicing_downgrade?log=6787
    In this case, `UnderhillWorker/New` took *9* seconds :( `[20.779028] underhill_core::worker: INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/restore{ correlation_id=31db0c76-3dc6-423c-9055-9d63754d388f}: "close" time.busy=9.20s time.idle=56.6ms`

