### PR TITLE
vmm_tests: servicing with io to verify `save()` responsiveness when draining io after restore

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -959,7 +959,9 @@ impl<A: AerHandler> QueueHandler<A> {
         mut recv_cmd: mesh::Receiver<Cmd>,
         interrupt: &mut DeviceInterrupt,
     ) {
-        tracing::info!(pci_id = ?self.device_id, qid = self.qid, "Have {} outstanding IOs from before save, draining them before allowing new IO...", self.commands.len());
+        if self.drain_after_restore {
+            tracing::info!(pci_id = ?self.device_id, qid = self.qid, "Have {} outstanding IOs from before save, draining them before allowing new IO...", self.commands.len());
+        }
 
         loop {
             enum Event {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -705,8 +705,7 @@ async fn servicing_keepalive_with_unresponsive_io(
     let _io_child = large_read_from_disk(&agent, disk_path).await?;
 
     // 60 seconds should be plenty of time for the save to complete. Save should
-    // NEVER get stuck on the first attempt. Keeping a timeout to avoid long
-    // running tests.
+    // NEVER get stuck. Keeping a timeout to avoid long running tests.
     CancelContext::new()
         .with_timeout(Duration::from_secs(60))
         .until_cancelled(vm.save_openhcl(igvm_file.clone(), flags))


### PR DESCRIPTION
When there is slow/stuck IO in the nvme driver, the second servicing event would get stuck in the `draining_after_restore` case where we don't poll for "Control Plane" commands like `Save`. @mattkur added a fix for this in #2736. This test validates the pathway and fix efficacy by performing two servicing events back-to-back with stuck io. 