### PR TITLE
openhcl: handle HvRestorePartitionTime hvcall intercept (#2754)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -28,8 +28,8 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.4";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.4";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.5";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.5";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -167,6 +167,8 @@ pub enum Error {
     AllocVp(#[source] anyhow::Error),
     #[error("failed to map or unmap redirected device interrupt")]
     MapRedirectedDeviceInterrupt(#[source] nix::Error),
+    #[error("failed to restore partition time")]
+    RestorePartitionTime(#[source] nix::Error),
 }
 
 /// Error for IOCTL errors specifically.
@@ -382,6 +384,7 @@ mod ioctls {
     const MSHV_VTL_RETURN_TO_LOWER_VTL: u16 = 0x27;
     const MSHV_SET_VP_REGISTERS: u16 = 0x6;
     const MSHV_GET_VP_REGISTERS: u16 = 0x5;
+    const MSHV_RESTORE_PARTITION_TIME: u16 = 0x13;
     const MSHV_HVCALL_SETUP: u16 = 0x1E;
     const MSHV_HVCALL: u16 = 0x1F;
     const MSHV_VTL_ADD_VTL0_MEMORY: u16 = 0x21;
@@ -472,6 +475,15 @@ mod ioctls {
         pub apic_id: u32,
         pub create_mapping: u8,
         pub padding: [u8; 7],
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct mshv_restore_partition_time {
+        pub tsc_sequence: u32,
+        pub reserved: u32,
+        pub reference_time_in_100_ns: u64,
+        pub tsc: u64,
     }
 
     ioctl_none!(
@@ -637,6 +649,14 @@ mod ioctls {
         MSHV_IOCTL,
         MSHV_MAP_REDIRECTED_DEVICE_INTERRUPT,
         mshv_map_device_int
+    );
+
+    ioctl_write_ptr!(
+        /// Restore partition time.
+        hcl_restore_partition_time,
+        MSHV_IOCTL,
+        MSHV_RESTORE_PARTITION_TIME,
+        mshv_restore_partition_time
     );
 }
 
@@ -3413,5 +3433,29 @@ impl Hcl {
         }
 
         Ok(param.vector)
+    }
+
+    /// Restore partition time. This is typically called after resume from
+    /// hibernate to synchronize the TSC with the value at hibernate time.
+    pub fn restore_partition_time(
+        &self,
+        tsc_sequence: u32,
+        reference_time_in_100_ns: u64,
+        tsc: u64,
+    ) -> Result<(), Error> {
+        let partition_time = mshv_restore_partition_time {
+            tsc_sequence,
+            reserved: 0,
+            reference_time_in_100_ns,
+            tsc,
+        };
+
+        // SAFETY: ioctl has no prerequisites.
+        unsafe {
+            hcl_restore_partition_time(self.mshv_vtl.file.as_raw_fd(), &partition_time)
+                .map_err(Error::RestorePartitionTime)?;
+        }
+
+        Ok(())
     }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1342,6 +1342,26 @@ impl IoApicRouting for UhPartitionInner {
     }
 }
 
+// xtask-fmt allow-target-arch cpu-intrinsic
+#[cfg(target_arch = "x86_64")]
+fn is_restore_partition_time_available() -> bool {
+    let result =
+        safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION, 0);
+    let enlightenment_info = hvdef::HvEnlightenmentInformation::from(
+        result.eax as u128
+            | (result.ebx as u128) << 32
+            | (result.ecx as u128) << 64
+            | (result.edx as u128) << 96,
+    );
+    enlightenment_info.restore_time_on_resume()
+}
+// xtask-fmt allow-target-arch cpu-intrinsic
+#[cfg(not(target_arch = "x86_64"))]
+fn is_restore_partition_time_available() -> bool {
+    // Only available on x86_64 Hyper-V hypervisor.
+    false
+}
+
 /// Configure the [`hvdef::HvRegisterVsmPartitionConfig`] register with the
 /// values used by underhill.
 fn set_vtl2_vsm_partition_config(hcl: &Hcl) -> Result<(), Error> {
@@ -1349,7 +1369,6 @@ fn set_vtl2_vsm_partition_config(hcl: &Hcl) -> Result<(), Error> {
     let caps = hcl.get_vsm_capabilities().map_err(Error::Hcl)?;
     let hardware_isolated = hcl.isolation().is_hardware_isolated();
     let isolated = hcl.isolation().is_isolated();
-
     let config = HvRegisterVsmPartitionConfig::new()
         .with_default_vtl_protection_mask(0xF)
         .with_enable_vtl_protection(!hardware_isolated)
@@ -1360,7 +1379,8 @@ fn set_vtl2_vsm_partition_config(hcl: &Hcl) -> Result<(), Error> {
         .with_intercept_not_present(caps.intercept_not_present_available() && !isolated)
         .with_intercept_acceptance(isolated)
         .with_intercept_enable_vtl_protection(isolated && !hardware_isolated)
-        .with_intercept_system_reset(caps.intercept_system_reset_available());
+        .with_intercept_system_reset(caps.intercept_system_reset_available())
+        .with_intercept_restore_partition_time(is_restore_partition_time_available());
 
     hcl.set_vtl2_vsm_partition_config(config)
         .map_err(Error::VsmPartitionConfig)

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1388,7 +1388,8 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, HypervisorBackedX86> {
             hv1_hypercall::HvRetargetDeviceInterrupt,
             hv1_hypercall::HvGetVpIndexFromApicId,
             hv1_hypercall::HvSetVpRegisters,
-            hv1_hypercall::HvModifyVtlProtectionMask
+            hv1_hypercall::HvModifyVtlProtectionMask,
+            hv1_hypercall::HvRestorePartitionTime,
         ]
     );
 }

--- a/vm/hv1/hv1_hypercall/src/imp.rs
+++ b/vm/hv1/hv1_hypercall/src/imp.rs
@@ -1034,3 +1034,39 @@ impl<T: VbsVmCallReport> HypercallDispatch<HvVbsVmCallReport> for T {
         })
     }
 }
+
+/// Defines the `HvRestorePartitionTime` hypercall.
+pub type HvRestorePartitionTime = SimpleHypercall<
+    defs::RestorePartitionTime,
+    (),
+    { HypercallCode::HvCallRestorePartitionTime.0 },
+>;
+
+/// Implements the `HvRestorePartitionTime` hypercall.
+pub trait RestorePartitionTime {
+    /// Restores the partition time.
+    fn restore_partition_time(
+        &mut self,
+        partition_id: u64,
+        tsc_sequence: u32,
+        reference_time_in_100_ns: u64,
+        tsc: u64,
+    ) -> HvResult<()>;
+}
+
+impl<T: RestorePartitionTime> HypercallDispatch<HvRestorePartitionTime> for T {
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        HvRestorePartitionTime::run(params, |input| {
+            if input.reserved != 0 {
+                return Err(HvError::InvalidParameter);
+            }
+
+            self.restore_partition_time(
+                input.partition_id,
+                input.tsc_sequence,
+                input.reference_time_in_100_ns,
+                input.tsc,
+            )
+        })
+    }
+}

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -318,6 +318,7 @@ open_enum! {
         HvCallCheckSparseGpaPageVtlAccess = 0x00D4,
         HvCallAcceptGpaPages = 0x00D9,
         HvCallModifySparseGpaPageHostVisibility = 0x00DB,
+        HvCallRestorePartitionTime = 0x0103,
         HvCallMemoryMappedIoRead = 0x0106,
         HvCallMemoryMappedIoWrite = 0x0107,
         HvCallPinGpaPageRanges = 0x0112,
@@ -2009,6 +2010,16 @@ pub mod hypercall {
         pub access_width: u32,
         pub reserved_z0: u32,
         pub data: [u8; HV_HYPERCALL_MMIO_MAX_DATA_LENGTH],
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub struct RestorePartitionTime {
+        pub partition_id: u64,
+        pub tsc_sequence: u32,
+        pub reserved: u32,
+        pub reference_time_in_100_ns: u64,
+        pub tsc: u64,
     }
 }
 


### PR DESCRIPTION
When the guest makes a hypercall to restore partition time, send the request to the Linux kernel. The kernel will forward the request to the hypervisor but needs to update its own clocks to account for the time shift. This guest hypercall is typically made from Windows guests on restore from hibernation.

Requires kernel commit
https://github.com/microsoft/OHCL-Linux-Kernel/commit/09712b0ca93066d516a6064ef30a6ed6513dcc1f

CP of #2754 
---------