### PR TITLE
Update bytes to 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache_topology"


### PR DESCRIPTION
Previous versions are affected by CVE-2026-25541.