### PR TITLE
vmbus_serial_guest: add tx only option (#2404)

### DIFF
--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -429,6 +429,8 @@ pub mod runtime_claims {
         pub root_cert_thumbprint: String,
         /// Whether the serial console is enabled
         pub console_enabled: bool,
+        /// Whether the serial console, if enabled, is interactive
+        pub interactive_console_enabled: bool,
         /// Whether secure boot is enabled
         pub secure_boot: bool,
         /// Whether the TPM is enabled

--- a/openhcl/underhill_attestation/src/hardware_key_sealing.rs
+++ b/openhcl/underhill_attestation/src/hardware_key_sealing.rs
@@ -196,6 +196,7 @@ mod tests {
             current_time: None,
             root_cert_thumbprint: "".to_string(),
             console_enabled: false,
+            interactive_console_enabled: false,
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -487,12 +487,13 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_no_time() {
-        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"filtered-vpci-devices-allowed":true,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"interactive-console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"filtered-vpci-devices-allowed":true,"vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
             root_cert_thumbprint: String::new(),
             console_enabled: false,
+            interactive_console_enabled: false,
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,
@@ -508,12 +509,13 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_with_time() {
-        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"filtered-vpci-devices-allowed":true,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"interactive-console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"filtered-vpci-devices-allowed":true,"vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
             root_cert_thumbprint: String::new(),
             console_enabled: false,
+            interactive_console_enabled: false,
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1606,6 +1606,7 @@ mod tests {
             current_time: None,
             root_cert_thumbprint: String::new(),
             console_enabled: false,
+            interactive_console_enabled: false,
             secure_boot: false,
             tpm_enabled: true,
             tpm_persisted: true,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1898,14 +1898,18 @@ async fn new_underhill_vm(
     // Create the `AttestationVmConfig` from `dps`, which will be used in
     // - stateful mode (the attestation is not suppressed)
     // - stateless mode (isolated VM with attestation suppressed)
+    let console_enabled = dps.general.com1_enabled
+        || dps.general.com2_enabled
+        || dps.general.com1_vmbus_redirector
+        || dps.general.com2_vmbus_redirector;
+    let interactive_console =
+        console_enabled && !dps.general.management_vtl_features.tx_only_serial_port();
     let attestation_vm_config = AttestationVmConfig {
         current_time: None,
         // TODO CVM: Support vmgs provisioning config
         root_cert_thumbprint: String::new(),
-        console_enabled: dps.general.com1_enabled
-            || dps.general.com2_enabled
-            || dps.general.com1_vmbus_redirector
-            || dps.general.com2_vmbus_redirector,
+        console_enabled,
+        interactive_console_enabled: interactive_console,
         secure_boot: dps.general.secure_boot_enabled,
         tpm_enabled: dps.general.tpm_enabled,
         tpm_persisted: !dps.general.suppress_attestation.unwrap_or(false),
@@ -2475,6 +2479,7 @@ async fn new_underhill_vm(
         serial_inputs[0] = Some(Resource::new(
             vmbus_serial_guest::OpenVmbusSerialGuestConfig::open(
                 &vmbus_serial_guest::UART_INTERFACE_INSTANCE_COM1,
+                dps.general.management_vtl_features.tx_only_serial_port(),
             )
             .context("failed to open com1")?,
         ));
@@ -2484,6 +2489,7 @@ async fn new_underhill_vm(
         serial_inputs[1] = Some(Resource::new(
             vmbus_serial_guest::OpenVmbusSerialGuestConfig::open(
                 &vmbus_serial_guest::UART_INTERFACE_INSTANCE_COM2,
+                dps.general.management_vtl_features.tx_only_serial_port(),
             )
             .context("failed to open com2")?,
         ));

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -266,6 +266,10 @@ options:
     #[structopt(long, value_name = "SERIAL")]
     pub vmbus_com2_serial: Option<SerialConfigCli>,
 
+    /// Only allow guest to host serial traffic
+    #[clap(long)]
+    pub serial_tx_only: bool,
+
     /// debugcon binding (port:serial, where port is a u16, and serial is (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none))
     #[clap(long, value_name = "SERIAL")]
     pub debugcon: Option<DebugconSerialConfigCli>,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1030,6 +1030,7 @@ fn vm_config_from_command_line(
                     },
                     com1: with_vmbus_com1_serial,
                     com2: with_vmbus_com2_serial,
+                    serial_tx_only: opt.serial_tx_only,
                     vtl2_settings: Some(prost::Message::encode_to_vec(&vtl2_settings)),
                     vmbus_redirection: opt.vmbus_redirect,
                     vmgs,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -831,6 +831,7 @@ impl PetriVmConfigSetupCore<'_> {
             },
             com1: true,
             com2: true,
+            serial_tx_only: false,
             vmbus_redirection: *vmbus_redirect,
             vtl2_settings: None, // Will be added at startup to allow tests to modify
             vmgs: memdiff_vmgs(self.vmgs)?,

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -158,7 +158,8 @@ pub struct ManagementVtlFeatures {
     pub _reserved1: bool,
     pub control_ak_cert_provisioning: bool,
     pub attempt_ak_cert_callback: bool,
-    #[bits(60)]
+    pub tx_only_serial_port: bool,
+    #[bits(59)]
     pub _reserved2: u64,
 }
 

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -65,6 +65,8 @@ pub mod ged {
         pub com1: bool,
         /// Enable COM2 for VTL0 and the VMBUS redirector in VTL2.
         pub com2: bool,
+        /// Only allow guest to host serial traffic
+        pub serial_tx_only: bool,
         /// Enable vmbus redirection.
         pub vmbus_redirection: bool,
         /// Enable the TPM.

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -140,6 +140,8 @@ pub struct GuestConfig {
     pub com1: bool,
     /// Enable COM2 for VTL0 and the VMBUS redirector in VTL2.
     pub com2: bool,
+    /// Only allow guest to host serial traffic
+    pub serial_tx_only: bool,
     /// Enable vmbus redirection.
     pub vmbus_redirection: bool,
     /// Enable the TPM.

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -99,7 +99,8 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
         };
 
         let management_vtl_features = get_protocol::dps_json::ManagementVtlFeatures::new()
-            .with_strict_encryption_policy(guest_state_encryption_policy.is_strict());
+            .with_strict_encryption_policy(guest_state_encryption_policy.is_strict())
+            .with_tx_only_serial_port(resource.serial_tx_only);
 
         let guest_state_encryption_policy = match guest_state_encryption_policy {
             GuestStateEncryptionPolicy::Auto => {
@@ -174,6 +175,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                 },
                 com1: resource.com1,
                 com2: resource.com2,
+                serial_tx_only: resource.serial_tx_only,
                 vmbus_redirection: resource.vmbus_redirection,
                 enable_tpm: resource.enable_tpm,
                 vtl2_settings: resource.vtl2_settings,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -250,6 +250,7 @@ pub fn create_host_channel(
         },
         com1: true,
         com2: true,
+        serial_tx_only: false,
         vmbus_redirection: false,
         enable_tpm: false,
         vtl2_settings: None,

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -84,12 +84,14 @@ pub mod platform_settings {
         pub battery_enabled: bool,
         pub processor_idle_enabled: bool,
         pub tpm_enabled: bool,
+
         pub com1_enabled: bool,
         pub com1_debugger_mode: bool,
         pub com1_vmbus_redirector: bool,
         pub com2_enabled: bool,
         pub com2_debugger_mode: bool,
         pub com2_vmbus_redirector: bool,
+
         pub firmware_debugging_enabled: bool,
         pub hibernation_enabled: bool,
 


### PR DESCRIPTION
Add an option to the VMBUS serial relay that runs in OpenHCL to ignore all rx traffic from the host and only allow tx traffic from the guest. This can be attested to, offering a more secure way to debug a VM using the serial console, since only allowing one-way serial traffic would greatly reduce the possible attack surface. This is useful primarily for CVMs that don't have a framebuffer and are usually configured with serial disabled completely.