### PR TITLE
Remove stale SNP TODO comment

### DIFF
--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -623,8 +623,6 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             tlb_access.flush_entire();
         }
 
-        // TODO SNP: check list of locks, roll back bitmap changes if there was one.
-
         if shared {
             // Unaccept the pages so that the hypervisor can reclaim them.
             for &range in &ranges {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1570,7 +1570,7 @@ impl UhProcessor<'_, SnpBacked> {
                 // for injection but injection cannot complete due to the intercept. Rewind the pending
                 // virtual interrupt so it is reinjected as a fixed interrupt.
 
-                // TODO SNP: Rewind the interrupt.
+                // TODO SNP ALTERNATE INJECTION: Rewind the interrupt.
                 unimplemented!("SevExitCode::VINTR");
             }
 


### PR DESCRIPTION
Remove stale comment in change_host_visibility around the need to check for locked pages and rollback bitmap changes. The locked pages list is checked on lines 531-533. The bitmap changes are rolled back on failure on lines 679-691.
