### PR TITLE
keepalive: Add inspect command to disable keepalives

### DIFF
--- a/openhcl/ohcldiag-dev/src/main.rs
+++ b/openhcl/ohcldiag-dev/src/main.rs
@@ -108,7 +108,7 @@ enum Command {
         /// Update the path with a new value.
         #[clap(short, long, conflicts_with("recursive"))]
         update: Option<String>,
-        /// Timeout to wait for the inspection. 0 means no timeout.
+        /// Timeout in seconds to wait for the inspection. 0 means no timeout.
         #[clap(short, default_value = "1", conflicts_with("update"))]
         timeout: u64,
     },


### PR DESCRIPTION
The new `vm/nvme/save_restore_enabled` inspect node shows the current status, defauling to `vm/nvme/save_restore_supported` , but can be updated through `ohcldiag-dev`.

```
C:\openvmm>ohcldiag-dev.exe uhdiag.sock inspect vm/nvme
{
    devices: _,
    force_load_pci_id: "",
    save_restore_enabled: true,
    save_restore_supported: true,
    shutdown: false,
    tasks: 2,
    vp_count: 4,
}

C:\openvmm>ohcldiag-dev.exe uhdiag.sock inspect vm/nvme/save_restore_enabled --update blah
Error: update error: invalid value for save_restore_enabled: blah, expecting true/false or 1/0.

C:\openvmm>ohcldiag-dev.exe uhdiag.sock inspect vm/nvme/save_restore_enabled --update false
false

C:\openvmm>ohcldiag-dev.exe uhdiag.sock inspect vm/nvme/save_restore_enabled --update true
Error: update error: cannot enable save/restore support after it has been disabled

C:\openvmm>ohcldiag-dev.exe uhdiag.sock inspect vm/nvme
{
    devices: _,
    force_load_pci_id: "",
    save_restore_enabled: false,
    save_restore_supported: true,
    shutdown: false,
    tasks: 2,
    vp_count: 4,
}
```

And OpenHCL log shows:
```
<30>[  129.688916] underhill_core::nvme_manager::manager:  INFO  setting save_restore_supported save_restore_supported=false
```