### PR TITLE
petri: Expose the Update command of the Inspect protocol

### DIFF
--- a/petri/src/openhcl_diag.rs
+++ b/petri/src/openhcl_diag.rs
@@ -115,6 +115,14 @@ impl OpenHclDiagHandler {
             .await
     }
 
+    pub async fn inspect_update(
+        &self,
+        path: impl Into<String>,
+        value: impl Into<String>,
+    ) -> anyhow::Result<inspect::Value> {
+        self.diag_client().await?.update(path, value).await
+    }
+
     pub async fn kmsg(&self) -> anyhow::Result<KmsgStream> {
         self.diag_client().await?.kmsg(false).await
     }

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1283,6 +1283,25 @@ impl<T: PetriVmmBackend> PetriVm<T> {
             .await
     }
 
+    /// Invoke Update (Inspect protocol) on the running OpenHCL instance.
+    ///
+    /// IMPORTANT: As mentioned in the Guide, inspect output is *not* guaranteed
+    /// to be stable. Use this to test that components in OpenHCL are working as
+    /// you would expect. But, if you are adding a test simply to verify that
+    /// the inspect output as some other tool depends on it, then that is
+    /// incorrect.
+    ///
+    /// - `path` and `value` are passed to the [`inspect::Inspect`] machinery.
+    pub async fn inspect_update_openhcl(
+        &self,
+        path: impl Into<String>,
+        value: impl Into<String>,
+    ) -> anyhow::Result<inspect::Value> {
+        self.openhcl_diag()?
+            .inspect_update(path.into(), value.into())
+            .await
+    }
+
     /// Test that we are able to inspect OpenHCL.
     pub async fn test_inspect_openhcl(&mut self) -> anyhow::Result<()> {
         self.inspect_openhcl("", None, None).await.map(|_| ())


### PR DESCRIPTION
This is going to be used in a future test as the counterpart to `ohcldiag-dev.exe uhdiag.sock inspect <path> --update <value>`