### PR TITLE
pal_async: fix use-after-free in AfdSocketReady::io_complete

### DIFF
--- a/support/pal/pal_async/src/windows/socket.rs
+++ b/support/pal/pal_async/src/windows/socket.rs
@@ -230,6 +230,10 @@ impl AfdSocketReady {
         // the reference.
         let op = unsafe { Arc::from_raw(op_ptr) };
         op.io_complete(&mut inner, afd_handle, status, wakers);
+        // Drop the lock before `op`, since dropping `op` may free the
+        // `AfdSocketReadyOp` (and the mutex it contains) if this is the last
+        // reference.
+        drop(inner);
     }
 }
 


### PR DESCRIPTION
Drop the MutexGuard before the Arc so that unlocking the mutex doesn't touch freed memory when this is the last Arc reference.

This should fix this virtio_net crash:
```
 # Call Site
00 ntdll!ZwWaitForMultipleObjects
01 KERNELBASE!WaitForMultipleObjectsEx
02 KERNELBASE!WaitForMultipleObjects
03 kernel32!WerpReportFaultInternal
04 kernel32!WerpReportFault
05 KERNELBASE!UnhandledExceptionFilter
06 ntdll!RtlpThreadExceptionFilter
07 ntdll!RtlUserThreadStart$filt$0
08 ntdll!__C_specific_handler
09 ntdll!RtlpExecuteHandlerForException
0a ntdll!RtlDispatchException
0b ntdll!KiUserExceptionDispatch
0c wsldevicehost!core::sync::atomic::atomic_compare_exchange
0d wsldevicehost!core::sync::atomic::AtomicU8::compare_exchange
0e wsldevicehost!parking_lot::raw_mutex::impl$0::unlock
0f wsldevicehost!lock_api::mutex::impl$15::drop
10 wsldevicehost!core::ptr::drop_in_place
11 wsldevicehost!pal_async::sys::socket::AfdSocketReady::io_complete<pal_async::sys::iocp::IocpBackend>
12 wsldevicehost!pal_async::sys::iocp::impl$2::run<enum2$<pal_async::task::impl$6::run::async_fn_env$0> >
13 wsldevicehost!pal_async::io_pool::IoPool<pal_async::sys::iocp::IocpBackend>::run<pal_async::sys::iocp::IocpBackend>
14 wsldevicehost!hdv::api::impl$10::new_device::closure$0
15 wsldevicehost!std::sys::backtrace::__rust_begin_short_backtrace<hdv::api::impl$10::new_device::closure_env$0<hdv::virtio_plugin::HdvVirtioPluginDeviceFactory<wsldevicehost::virtio_plugin::VirtioPlugin> >,tuple$<> >
16 wsldevicehost!core::ops::function::FnOnce::call_once<std::thread::impl$0::spawn_unchecked_::closure_env$1<hdv::api::impl$10::new_device::closure_env$0<hdv::virtio_net::HdvVirtioNetDeviceFactory>,tuple$<> >,tuple$<> >
17 wsldevicehost!alloc::boxed::impl$29::call_once
18 wsldevicehost!alloc::boxed::impl$29::call_once
19 wsldevicehost!std::sys::thread::windows::impl$0::new::thread_start
1a kernel32!BaseThreadInitThunk
1b ntdll!RtlUserThreadStart
```