### PR TITLE
virtio_net: fix register read truncation at offset 16

### DIFF
--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -252,7 +252,7 @@ impl VirtioDevice for Device {
             16 => {
                 (self.registers.duplex as u32)
                     | ((self.registers.rss_max_key_size as u32) << 8)
-                    | ((self.registers.rss_max_indirection_table_length as u32) << 24)
+                    | ((self.registers.rss_max_indirection_table_length as u32) << 16)
             }
             20 => self.registers.supported_hash_types,
             _ => 0,


### PR DESCRIPTION
The rss_max_indirection_table_length field was shifted left by 24 instead of 16, causing its upper bits to be truncated. This field occupies bits [23:16] of the register at offset 16, not bits [31:24].