### PR TITLE
virtiofs: increment lookup count in link()

### DIFF
--- a/vm/devices/virtio/virtiofs/src/inode.rs
+++ b/vm/devices/virtio/virtiofs/src/inode.rs
@@ -55,6 +55,11 @@ impl VirtioFsInode {
         *path = new_path;
     }
 
+    /// Increments the lookup count without changing the stored path.
+    pub fn add_ref(&self) {
+        self.lookup_count.fetch_add(1, Ordering::AcqRel);
+    }
+
     /// Decrements the lookup count, and returns the new count.
     pub fn forget(&self, node_id: u64, lookup_count: u64) -> u64 {
         let mut old_count = self.lookup_count.load(Ordering::Acquire);

--- a/vm/devices/virtio/virtiofs/src/lib.rs
+++ b/vm/devices/virtio/virtiofs/src/lib.rs
@@ -221,6 +221,10 @@ impl Fuse for VirtioFs {
         let target_inode = self.get_inode(target)?;
         let attr = inode.link(name, &target_inode)?;
 
+        // Increment the lookup count since returning fuse_entry_out creates a
+        // new kernel reference that will be released via forget().
+        target_inode.add_ref();
+
         // Use the target inode as the reply, with refreshed attributes.
         Ok(fuse_entry_out::new(
             target,


### PR DESCRIPTION
link() returns a fuse_entry_out for the target inode, which creates a kernel dentry reference that will later be released via forget(). Without incrementing the lookup count, the subsequent forget would undercount and potentially free the inode prematurely.