### PR TITLE
virtio: validate descriptor index from avail ring

### DIFF
--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -242,6 +242,10 @@ impl SplitQueueGetWork {
         mem: GuestMemory,
         params: QueueParams,
     ) -> Result<Self, QueueError> {
+        if params.size == 0 {
+            return Err(QueueError::InvalidQueueSize(params.size));
+        }
+
         let queue_avail = mem
             .subrange(
                 params.avail_addr,


### PR DESCRIPTION
The descriptor index read from the guest's available ring was used directly without checking it against queue_size. A malicious or buggy guest could supply an out-of-range index. Add an explicit bounds check with a clear error message.