### PR TITLE
virtio: validate indirect descriptor table size

### DIFF
--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -41,9 +41,7 @@ pub enum QueueError {
     TooLong,
     #[error("Invalid queue size {0}. Must be a power of 2.")]
     InvalidQueueSize(u16),
-    #[error(
-        "indirect descriptor table has invalid byte length {0}; expected a non-zero multiple of 16 (descriptor size)"
-    )]
+    #[error("indirect descriptor table has invalid byte length {0}")]
     InvalidIndirectSize(u32),
 }
 
@@ -516,7 +514,9 @@ impl<'a> DescriptorChain<'a> {
                 return Err(QueueError::DoubleIndirect);
             }
             let indirect_len = descriptor.length;
-            if indirect_len == 0 || !(indirect_len as usize).is_multiple_of(size_of::<SplitDescriptor>()) {
+            if indirect_len == 0
+                || !(indirect_len as usize).is_multiple_of(size_of::<SplitDescriptor>())
+            {
                 return Err(QueueError::InvalidIndirectSize(indirect_len));
             }
             let indirect_queue = self.indirect_queue.insert(

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -1920,9 +1920,8 @@ fn indirect_descriptor_zero_length_rejected() {
     }
 
     let mem = GuestMemory::new("test", test_mem);
-    let features = VirtioDeviceFeatures::new().with_bank0(
-        VirtioDeviceFeaturesBank0::new().with_ring_indirect_desc(true),
-    );
+    let features = VirtioDeviceFeatures::new()
+        .with_bank0(VirtioDeviceFeaturesBank0::new().with_ring_indirect_desc(true));
     let params = QueueParams {
         size: queue_size,
         enable: true,
@@ -1933,7 +1932,10 @@ fn indirect_descriptor_zero_length_rejected() {
     let mut queue = crate::queue::QueueCoreGetWork::new(features, mem, params).unwrap();
     let result = queue.try_next_work();
     assert!(
-        matches!(result, Err(crate::queue::QueueError::InvalidIndirectSize(0))),
+        matches!(
+            result,
+            Err(crate::queue::QueueError::InvalidIndirectSize(0))
+        ),
         "expected InvalidIndirectSize(0)"
     );
 }
@@ -1982,9 +1984,8 @@ fn indirect_descriptor_misaligned_length_rejected() {
     }
 
     let mem = GuestMemory::new("test", test_mem);
-    let features = VirtioDeviceFeatures::new().with_bank0(
-        VirtioDeviceFeaturesBank0::new().with_ring_indirect_desc(true),
-    );
+    let features = VirtioDeviceFeatures::new()
+        .with_bank0(VirtioDeviceFeaturesBank0::new().with_ring_indirect_desc(true));
     let params = QueueParams {
         size: queue_size,
         enable: true,
@@ -1995,7 +1996,10 @@ fn indirect_descriptor_misaligned_length_rejected() {
     let mut queue = crate::queue::QueueCoreGetWork::new(features, mem, params).unwrap();
     let result = queue.try_next_work();
     assert!(
-        matches!(result, Err(crate::queue::QueueError::InvalidIndirectSize(17))),
+        matches!(
+            result,
+            Err(crate::queue::QueueError::InvalidIndirectSize(17))
+        ),
         "expected InvalidIndirectSize(17)"
     );
 }


### PR DESCRIPTION
The indirect descriptor table length from the guest was not validated to be a non-zero multiple of the descriptor size (16 bytes). A misaligned length could cause the last partial descriptor to be read from adjacent memory. Add an explicit check.