### PR TITLE
flowey: vmm-tests must download alpine linux image

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -375,6 +375,9 @@ impl SimpleFlowNode for Node {
                         if windows || ubuntu {
                             artifacts.push(KnownTestArtifacts::VmgsWithBootEntry);
                         }
+                        if linux {
+                            artifacts.push(KnownTestArtifacts::Alpine323X64Vhd);
+                        }
 
                         artifacts
                     }
@@ -389,6 +392,9 @@ impl SimpleFlowNode for Node {
                         }
                         if windows || ubuntu {
                             artifacts.push(KnownTestArtifacts::VmgsWithBootEntry);
+                        }
+                        if linux {
+                            artifacts.push(KnownTestArtifacts::Alpine323Aarch64Vhd);
                         }
 
                         artifacts


### PR DESCRIPTION
We now have tests that run against alpine. The `vmm-tests` xflowey command wasn't downloading that image for the user. Add it.