### PR TITLE
test_igvm_agent_rpc_server: migrate from winapi to windows-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7400,7 +7400,6 @@ dependencies = [
  "test_igvm_agent_lib",
  "tracing",
  "tracing-subscriber",
- "winapi",
  "windows-sys 0.61.0",
 ]
 

--- a/vm/devices/get/test_igvm_agent_rpc_server/Cargo.toml
+++ b/vm/devices/get/test_igvm_agent_rpc_server/Cargo.toml
@@ -19,7 +19,6 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(windows)'.dependencies]
-winapi.workspace = true
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_System_Memory",

--- a/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/handlers.rs
+++ b/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/handlers.rs
@@ -7,14 +7,14 @@ use std::ffi::c_void;
 use std::mem::size_of;
 use std::ptr;
 use std::slice;
-use winapi::shared::winerror::E_FAIL;
-use winapi::shared::winerror::E_INVALIDARG;
-use winapi::shared::winerror::E_OUTOFMEMORY;
-use winapi::shared::winerror::E_POINTER;
-use winapi::shared::winerror::HRESULT;
-use winapi::shared::winerror::S_OK;
+use windows_sys::Win32::Foundation::E_FAIL;
+use windows_sys::Win32::Foundation::E_INVALIDARG;
+use windows_sys::Win32::Foundation::E_OUTOFMEMORY;
+use windows_sys::Win32::Foundation::E_POINTER;
+use windows_sys::Win32::Foundation::S_OK;
 use windows_sys::Win32::System::Rpc::RPC_S_SERVER_UNAVAILABLE;
 use windows_sys::Win32::System::Rpc::RpcRaiseException;
+use windows_sys::core::HRESULT;
 
 #[unsafe(no_mangle)]
 /// Allocator shim invoked by the generated MIDL stubs.

--- a/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/server.rs
+++ b/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/server.rs
@@ -7,7 +7,6 @@ use std::os::windows::ffi::OsStrExt;
 use std::ptr;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use winapi::shared::minwindef::BOOL;
 use windows_sys::Win32::Foundation::FALSE;
 use windows_sys::Win32::Foundation::TRUE;
 use windows_sys::Win32::System::Console::CTRL_BREAK_EVENT;
@@ -25,6 +24,7 @@ use windows_sys::Win32::System::Rpc::RpcServerListen;
 use windows_sys::Win32::System::Rpc::RpcServerRegisterIf3;
 use windows_sys::Win32::System::Rpc::RpcServerUnregisterIf;
 use windows_sys::Win32::System::Rpc::RpcServerUseProtseqEpW;
+use windows_sys::core::BOOL;
 
 pub const PROTOCOL_SEQUENCE: &str = "ncalrpc";
 pub const ENDPOINT: &str = "IGVM_AGENT_RPC_SERVER";


### PR DESCRIPTION
Part of #1061, removes winapi deps from test_igvm_agent_rpc_server