### PR TITLE
openvmm_entry: migrate from winapi to windows-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5303,7 +5303,7 @@ dependencies = [
  "vtl2_settings_proto",
  "whp",
  "win_etw_tracing",
- "winapi",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -113,22 +113,11 @@ whp.workspace = true
 
 win_etw_tracing.workspace = true
 
-[target.'cfg(windows)'.dependencies.winapi]
-features = [
-  "consoleapi",
-  "handleapi",
-  "memoryapi",
-  "namedpipeapi",
-  "processenv",
-  "realtimeapiset",
-  "synchapi",
-  "winbase",
-  "wincon",
-  "winnls",
-  "winnt",
-  "winsock2",
-]
+[target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true
+features = [
+  "Win32_Foundation",
+]
 
 [build-dependencies]
 build_rs_guest_arch.workspace = true

--- a/openvmm/openvmm_entry/src/serial_io.rs
+++ b/openvmm/openvmm_entry/src/serial_io.rs
@@ -239,7 +239,8 @@ pub fn bind_serial(path: &Path) -> io::Result<Resource<SerialBackendHandle>> {
         if path.starts_with("//./pipe") {
             let pipe = pal::windows::pipe::new_named_pipe(
                 path,
-                winapi::um::winnt::GENERIC_READ | winapi::um::winnt::GENERIC_WRITE,
+                windows_sys::Win32::Foundation::GENERIC_READ
+                    | windows_sys::Win32::Foundation::GENERIC_WRITE,
                 pal::windows::pipe::Disposition::Create,
                 pal::windows::pipe::PipeMode::Byte,
             )?;


### PR DESCRIPTION
Part of #1061, migrate openvmm_entry off of winapi