### PR TITLE
clippy: lint for xshell::Shell::new and xshell::cmd!

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -13,6 +13,7 @@ disallowed-macros = [
     { path = "futures::pin_mut", reason = "use std::pin::pin" },
     { path = "futures::ready", reason = "use std::task::ready" },
     { path = "tracing::enabled", reason = "https://github.com/tokio-rs/tracing/issues/2519" },
+    { path = "xshell::cmd", reason = "use `flowey::shell_cmd!` and `rt.sh` instead unless outside of a flowey node" },
 ]
 
 disallowed-methods = [
@@ -30,6 +31,7 @@ disallowed-methods = [
 
     { path = "std::fs::canonicalize", reason = "you likely want std::path::absolute" },
     { path = "std::path::Path::canonicalize", reason = "you likely want std::path::absolute" },
+    { path = "xshell::Shell::new", reason = "use `rt.sh` instead unless outside of a flowey node" },
 ]
 
 avoid-breaking-exported-api = false

--- a/flowey/flowey_cli/src/cli/regen.rs
+++ b/flowey/flowey_cli/src/cli/regen.rs
@@ -51,8 +51,13 @@ impl Regen {
                     // build the requested flowey
                     {
                         let quiet = self.quiet.then_some("-q");
+                        #[expect(
+                            clippy::disallowed_methods,
+                            reason = "not in a flowey runtime context"
+                        )]
                         let sh = xshell::Shell::new()?;
                         sh.change_dir(&working_dir);
+                        #[expect(clippy::disallowed_macros)]
                         xshell::cmd!(sh, "cargo build -p {bin_name} {quiet...}").run()?;
                     }
 
@@ -84,8 +89,13 @@ impl Regen {
                             vec![]
                         };
 
+                        #[expect(
+                            clippy::disallowed_methods,
+                            reason = "not in a flowey runtime context"
+                        )]
                         let sh = xshell::Shell::new()?;
                         sh.change_dir(&working_dir);
+                        #[expect(clippy::disallowed_macros)]
                         let res = xshell::cmd!(
                             sh,
                             "{bin} pipeline {backend} --out {file} {check...} {cmd...}"
@@ -185,11 +195,14 @@ fn install_flowey_merge_driver() -> anyhow::Result<()> {
     const DRIVER_NAME: &str = "flowey-theirs merge driver";
     const DRIVER_COMMAND: &str = "cp %B %A";
 
+    #[expect(clippy::disallowed_methods, reason = "not in a flowey runtime context")]
     let sh = xshell::Shell::new()?;
+    #[expect(clippy::disallowed_macros, reason = "not in a flowey runtime context")]
     xshell::cmd!(sh, "git config merge.flowey-theirs.name {DRIVER_NAME}")
         .quiet()
         .ignore_status()
         .run()?;
+    #[expect(clippy::disallowed_macros, reason = "not in a flowey runtime context")]
     xshell::cmd!(sh, "git config merge.flowey-theirs.driver {DRIVER_COMMAND}")
         .quiet()
         .ignore_status()

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -2162,6 +2162,8 @@ pub mod steps {
                 platform,
                 arch,
                 has_read_secret: false,
+                // This is an extension point so that we can swap out the shell implementation to wrap commands using `nix-shell --pure --run <cmd>` in the future
+                #[expect(clippy::disallowed_methods)]
                 sh: xshell::Shell::new()?,
             })
         }
@@ -3042,7 +3044,10 @@ macro_rules! flowey_request {
 /// ```
 #[macro_export]
 macro_rules! shell_cmd {
-    ($rt:expr, $cmd:literal) => {
-        $crate::reexports::xshell::cmd!($rt.sh, $cmd)
-    };
+    ($rt:expr, $cmd:literal) => {{
+        // This is an extension point so that we can swap out the shell implementation to wrap commands using `nix-shell --pure --run <cmd>` in the future
+        #[expect(clippy::disallowed_macros)]
+        let __cmd = $crate::reexports::xshell::cmd!($rt.sh, $cmd);
+        __cmd
+    }};
 }

--- a/flowey/flowey_lib_common/src/_util/wslpath.rs
+++ b/flowey/flowey_lib_common/src/_util/wslpath.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use flowey::node::prelude::RustRuntimeServices;
 use std::path::Path;
 use std::path::PathBuf;
 
-pub fn win_to_linux(path: impl AsRef<Path>) -> PathBuf {
-    let sh = xshell::Shell::new().unwrap();
+pub fn win_to_linux(rt: &RustRuntimeServices<'_>, path: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
-    xshell::cmd!(sh, "wslpath {path}")
+    flowey::shell_cmd!(rt, "wslpath {path}")
         .quiet()
         .ignore_status()
         .read()
@@ -15,10 +15,9 @@ pub fn win_to_linux(path: impl AsRef<Path>) -> PathBuf {
         .into()
 }
 
-pub fn linux_to_win(path: impl AsRef<Path>) -> PathBuf {
-    let sh = xshell::Shell::new().unwrap();
+pub fn linux_to_win(rt: &RustRuntimeServices<'_>, path: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
-    xshell::cmd!(sh, "wslpath -aw {path}")
+    flowey::shell_cmd!(rt, "wslpath -aw {path}")
         .quiet()
         .ignore_status()
         .read()

--- a/flowey/flowey_lib_common/src/download_nuget_exe.rs
+++ b/flowey/flowey_lib_common/src/download_nuget_exe.rs
@@ -194,7 +194,7 @@ impl Node {
                                 flowey::shell_cmd!(rt, "cmd.exe /c echo %UserProfile%").read()?;
 
                             let windows_dot_nuget_path =
-                                crate::_util::wslpath::win_to_linux(windows_userprofile)
+                                crate::_util::wslpath::win_to_linux(rt, windows_userprofile)
                                     .join(".nuget");
 
                             let linux_dot_nuget_path =
@@ -222,6 +222,7 @@ impl Node {
                             // nuget.exe will only work correctly when launched
                             // from a windows filesystem.
                             let windows_tempdir = crate::_util::wslpath::win_to_linux(
+                                rt,
                                 flowey::shell_cmd!(rt, "cmd.exe /c echo %Temp%").read()?,
                             );
                             let flowey_nuget = windows_tempdir.join("flowey_nuget.exe");

--- a/flowey/flowey_lib_common/src/install_nuget_azure_credential_provider.rs
+++ b/flowey/flowey_lib_common/src/install_nuget_azure_credential_provider.rs
@@ -142,7 +142,7 @@ fn check_if_aacp_installed(
             .read()?;
 
         if crate::_util::running_in_wsl(rt) {
-            crate::_util::wslpath::win_to_linux(path)
+            crate::_util::wslpath::win_to_linux(rt, path)
         } else {
             path.into()
         }

--- a/flowey/flowey_lib_common/src/nuget_install_package.rs
+++ b/flowey/flowey_lib_common/src/nuget_install_package.rs
@@ -170,8 +170,8 @@ impl FlowNode for Node {
                             && matches!(nuget_config_platform, NugetInstallPlatform::Windows)
                         {
                             (
-                                crate::_util::wslpath::linux_to_win(&packages_config_filepath),
-                                crate::_util::wslpath::linux_to_win(&nuget_config_file),
+                                crate::_util::wslpath::linux_to_win(rt, &packages_config_filepath),
+                                crate::_util::wslpath::linux_to_win(rt, &nuget_config_file),
                             )
                         } else {
                             (packages_config_filepath, nuget_config_file)

--- a/flowey/flowey_lib_common/src/run_cargo_doc.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_doc.rs
@@ -19,8 +19,8 @@ pub struct CargoDocCommands {
 impl CargoDocCommands {
     /// Execute the doc command(s), returning a path to the built docs
     /// directory.
-    pub fn run(self, sh: &xshell::Shell) -> anyhow::Result<PathBuf> {
-        self.run_with(sh, |x| x)
+    pub fn run(self, rt: &RustRuntimeServices<'_>) -> anyhow::Result<PathBuf> {
+        self.run_with(rt, |x| x)
     }
 
     /// Execute the doc command(s), returning path(s) to the built artifact.
@@ -30,7 +30,7 @@ impl CargoDocCommands {
     /// artifacts will be placed, etc...).
     pub fn run_with(
         self,
-        sh: &xshell::Shell,
+        rt: &RustRuntimeServices<'_>,
         f: impl Fn(xshell::Cmd<'_>) -> xshell::Cmd<'_>,
     ) -> anyhow::Result<PathBuf> {
         let Self {
@@ -38,13 +38,13 @@ impl CargoDocCommands {
             cargo_work_dir,
         } = self;
 
-        let out_dir = sh.current_dir();
-        sh.change_dir(cargo_work_dir);
+        let out_dir = rt.sh.current_dir();
+        rt.sh.change_dir(cargo_work_dir);
 
         let mut json = String::new();
         for mut cmd in cmds {
             let argv0 = cmd.remove(0);
-            let cmd = xshell::cmd!(sh, "{argv0} {cmd...}");
+            let cmd = flowey::shell_cmd!(rt, "{argv0} {cmd...}");
             let cmd = f(cmd);
             json.push_str(&cmd.read()?);
         }

--- a/flowey/flowey_lib_hvlite/src/build_rustdoc.rs
+++ b/flowey/flowey_lib_hvlite/src/build_rustdoc.rs
@@ -93,7 +93,7 @@ impl FlowNode for Node {
                 let cargo_cmd = cargo_cmd.claim(ctx);
                 move |rt| {
                     let cargo_cmd = rt.read(cargo_cmd);
-                    let out_path = cargo_cmd.run(&rt.sh)?;
+                    let out_path = cargo_cmd.run(rt)?;
 
                     rt.write(output, &RustdocOutput { docs: out_path });
                     Ok(())

--- a/flowey/flowey_lib_hvlite/src/install_git_credential_manager.rs
+++ b/flowey/flowey_lib_hvlite/src/install_git_credential_manager.rs
@@ -102,11 +102,11 @@ impl FlowNode for Node {
 
                 if flowey_lib_common::_util::running_in_wsl(rt) && !use_native_linux_on_wsl2 {
                     let windows_user_profile_path_windows = flowey::shell_cmd!(rt, "cmd.exe /c echo %UserProfile%").read().map_err(|_| anyhow::anyhow!("Unable to run cmd.exe, please restart WSL by running `wsl --shutdown` in powershell and try again."))?;
-                    let windows_user_profile_path = wslpath::win_to_linux(windows_user_profile_path_windows);
+                    let windows_user_profile_path = wslpath::win_to_linux(rt, windows_user_profile_path_windows);
                     let gcm_path_opt_1 = windows_user_profile_path.join("AppData/Local/Programs/Git Credential Manager/git-credential-manager.exe");
-                    let gcm_path_opt_2 = wslpath::win_to_linux(r#"C:\Program Files\Git\mingw64\bin\git-credential-manager.exe"#);
-                    let gcm_path_opt_3 = wslpath::win_to_linux(r#"C:\Program Files\Git\mingw64\libexec\git-core\git-credential-manager.exe"#);
-                    let gcm_path_opt_4 = wslpath::win_to_linux(r#"C:\Program Files (x86)\Git Credential Manager\git-credential-manager.exe"#);
+                    let gcm_path_opt_2 = wslpath::win_to_linux(rt, r#"C:\Program Files\Git\mingw64\bin\git-credential-manager.exe"#);
+                    let gcm_path_opt_3 = wslpath::win_to_linux(rt, r#"C:\Program Files\Git\mingw64\libexec\git-core\git-credential-manager.exe"#);
+                    let gcm_path_opt_4 = wslpath::win_to_linux(rt, r#"C:\Program Files (x86)\Git Credential Manager\git-credential-manager.exe"#);
 
                     let gcm_path = if rt.sh.path_exists(&gcm_path_opt_1) {
                         &gcm_path_opt_1

--- a/xtask/src/fs_helpers.rs
+++ b/xtask/src/fs_helpers.rs
@@ -7,15 +7,21 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
+use crate::shell::XtaskShell;
+
 /// Return a list of all files that are currently git diffed, including
 /// those which have been staged, but not yet been committed.
 pub fn git_diffed(in_git_hook: bool) -> anyhow::Result<Vec<PathBuf>> {
-    let sh = xshell::Shell::new()?;
+    let sh = XtaskShell::new()?;
 
-    let files = xshell::cmd!(sh, "git diff --diff-filter MAR --name-only")
+    let files = sh
+        .cmd("git")
+        .args(["diff", "--diff-filter", "MAR", "--name-only"])
         .output()?
         .stdout;
-    let files_cached = xshell::cmd!(sh, "git diff --diff-filter MAR --name-only --cached")
+    let files_cached = sh
+        .cmd("git")
+        .args(["diff", "--diff-filter", "MAR", "--name-only", "--cached"])
         .output()?
         .stdout;
 
@@ -39,11 +45,11 @@ pub fn git_diffed(in_git_hook: bool) -> anyhow::Result<Vec<PathBuf>> {
 /// Return files tracked by git (excluding those from .gitignore), including
 /// those which have not yet been staged / committed.
 pub fn git_ls_files() -> anyhow::Result<Vec<PathBuf>> {
-    let sh = xshell::Shell::new()?;
+    let sh = XtaskShell::new()?;
 
     macro_rules! as_set {
-        ($cmd:literal) => {{
-            let output = xshell::cmd!(sh, $cmd).output()?.stdout;
+        ($($arg:literal),+) => {{
+            let output = sh.cmd("git").args([$($arg),+]).output()?.stdout;
             let output = String::from_utf8_lossy(&output).to_string();
             output
                 .split('\n')
@@ -53,9 +59,9 @@ pub fn git_ls_files() -> anyhow::Result<Vec<PathBuf>> {
     }
 
     // "extra" corresponds to files not-yet committed to git
-    let all = as_set!("git ls-files");
-    let extra = as_set!("git ls-files --others --exclude-standard");
-    let deleted = as_set!("git ls-files --deleted");
+    let all = as_set!("ls-files");
+    let extra = as_set!("ls-files", "--others", "--exclude-standard");
+    let deleted = as_set!("ls-files", "--deleted");
 
     let mut allow_list = all;
     allow_list.extend(extra);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 
 mod completions;
 pub mod fs_helpers;
+pub mod shell;
 pub mod tasks;
 
 /// Default location to maintain a `xtask-path` file

--- a/xtask/src/shell.rs
+++ b/xtask/src/shell.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Wrapper around [`xshell::Shell`] that centralizes the `clippy::disallowed_methods`
+//! allow to a single place, since xtask is not a flowey node and legitimately
+//! needs to spawn subprocesses.
+
+/// Thin wrapper around [`xshell::Shell`] for use in xtask code.
+pub struct XtaskShell(xshell::Shell);
+
+impl XtaskShell {
+    /// Create a new shell for spawning subprocesses.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "xtask runs outside of a flowey runtime context and needs to spawn subprocesses"
+    )]
+    pub fn new() -> anyhow::Result<Self> {
+        Ok(Self(xshell::Shell::new()?))
+    }
+
+    /// Build a command with `program` as the executable.
+    ///
+    /// Returns an [`xshell::Cmd`] builder; chain `.arg()`/`.args()`/`.run()`/
+    /// `.output()` etc. on the result.
+    pub fn cmd(&self, program: impl AsRef<std::path::Path>) -> xshell::Cmd<'_> {
+        self.0.cmd(program)
+    }
+
+    /// Read the value of an environment variable.
+    pub fn var(&self, key: &str) -> Result<String, xshell::Error> {
+        self.0.var(key)
+    }
+
+    /// Set an environment variable for commands spawned from this shell.
+    pub fn set_var(&self, key: impl AsRef<std::ffi::OsStr>, val: impl AsRef<std::ffi::OsStr>) {
+        self.0.set_var(key, val)
+    }
+}

--- a/xtask/src/tasks/clean.rs
+++ b/xtask/src/tasks/clean.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::Xtask;
+use crate::shell::XtaskShell;
 
 /// Clean build artifacts beyond what `cargo clean` removes.
 ///
@@ -57,8 +58,8 @@ impl Xtask for Clean {
                 println!("would run `cargo clean`");
             } else {
                 println!("running `cargo clean`");
-                let sh = xshell::Shell::new()?;
-                xshell::cmd!(sh, "cargo clean").run()?;
+                let sh = XtaskShell::new()?;
+                sh.cmd("cargo").arg("clean").run()?;
             }
             removed_anything = true;
         }

--- a/xtask/src/tasks/fmt/verify_flowey.rs
+++ b/xtask/src/tasks/fmt/verify_flowey.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::Xtask;
+use crate::shell::XtaskShell;
 use anyhow::Context;
 use clap::Parser;
 
@@ -42,8 +43,12 @@ impl Xtask for VerifyFlowey {
 
         let check = (!self.fix).then_some("--check");
 
-        let sh = xshell::Shell::new()?;
-        xshell::cmd!(sh, "cargo --quiet {cmd...} regen --quiet {check...}")
+        let sh = XtaskShell::new()?;
+        sh.cmd("cargo")
+            .arg("--quiet")
+            .args(&cmd)
+            .args(["regen", "--quiet"])
+            .args(check)
             .quiet()
             .run()?;
 

--- a/xtask/src/tasks/fmt/workspace.rs
+++ b/xtask/src/tasks/fmt/workspace.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::Xtask;
+use crate::shell::XtaskShell;
 use anyhow::Context;
 use clap::Parser;
 use rayon::prelude::*;
@@ -118,7 +119,7 @@ struct Package {
 }
 
 fn workspace_manifests() -> anyhow::Result<HashSet<PathBuf>> {
-    let json = xshell::Shell::new()?
+    let json = XtaskShell::new()?
         .cmd("cargo")
         .arg("metadata")
         .arg("--no-deps")

--- a/xtask/src/tasks/fuzz/cargo_fuzz.rs
+++ b/xtask/src/tasks/fuzz/cargo_fuzz.rs
@@ -3,6 +3,7 @@
 
 //! Glue to invoke external `cargo-fuzz` commands
 
+use crate::shell::XtaskShell;
 use anyhow::Context;
 use std::path::Path;
 use std::path::PathBuf;
@@ -56,12 +57,12 @@ impl CargoFuzzCommand {
             anyhow::bail!("could not find cargo-fuzz! did you run `cargo install cargo-fuzz`?");
         }
 
-        let sh = xshell::Shell::new()?;
+        let sh = XtaskShell::new()?;
         if matches!(&self, CargoFuzzCommand::Run { artifact: Some(_) }) {
             sh.set_var("XTASK_FUZZ_REPRO", "1");
         }
 
-        let mut toolchain_check_cmd = xshell::cmd!(sh, "rustc");
+        let mut toolchain_check_cmd = sh.cmd("rustc");
         if let Some(toolchain_override) = toolchain {
             toolchain_check_cmd = toolchain_check_cmd.arg(format!("+{}", toolchain_override));
         }
@@ -72,7 +73,7 @@ impl CargoFuzzCommand {
         let output = std::str::from_utf8(&result.stdout)?.to_ascii_lowercase();
         let is_nightly = output.contains("-nightly") || output.contains("-dev");
 
-        let mut cmd = xshell::cmd!(sh, "cargo");
+        let mut cmd = sh.cmd("cargo");
         if let Some(toolchain_override) = toolchain {
             cmd = cmd.arg(format!("+{}", toolchain_override));
         }

--- a/xtask/src/tasks/guest_test/uefi/mod.rs
+++ b/xtask/src/tasks/guest_test/uefi/mod.rs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 use crate::Xtask;
+use crate::shell::XtaskShell;
 use clap::Parser;
 use std::path::Path;
 use std::path::PathBuf;
-use xshell::cmd;
 
 mod gpt_efi_disk;
 
@@ -47,12 +47,16 @@ impl Xtask for Uefi {
             if let Some(bootx64) = bootx64 {
                 files.push((Path::new("efi/boot/bootx64.efi"), bootx64.as_path()));
             } else {
-                let sh = xshell::Shell::new()?;
-                cmd!(
-                    sh,
-                    "cargo build -p guest_test_uefi --target x86_64-unknown-uefi"
-                )
-                .run()?;
+                let sh = XtaskShell::new()?;
+                sh.cmd("cargo")
+                    .args([
+                        "build",
+                        "-p",
+                        "guest_test_uefi",
+                        "--target",
+                        "x86_64-unknown-uefi",
+                    ])
+                    .run()?;
 
                 files.push((
                     Path::new("efi/boot/bootx64.efi"),
@@ -65,12 +69,16 @@ impl Xtask for Uefi {
             if let Some(bootaa64) = bootaa64 {
                 files.push((Path::new("efi/boot/bootaa64.efi"), bootaa64.as_path()))
             } else {
-                let sh = xshell::Shell::new()?;
-                cmd!(
-                    sh,
-                    "cargo build -p guest_test_uefi --target aarch64-unknown-uefi"
-                )
-                .run()?;
+                let sh = XtaskShell::new()?;
+                sh.cmd("cargo")
+                    .args([
+                        "build",
+                        "-p",
+                        "guest_test_uefi",
+                        "--target",
+                        "aarch64-unknown-uefi",
+                    ])
+                    .run()?;
 
                 files.push((
                     Path::new("efi/boot/bootaa64.efi"),


### PR DESCRIPTION
#2743 added a macro to use an integrated `xshell::Shell` as part of rust flowey steps, but no way to enforce usage. This is problematic because future nodes could use `xshell::cmd!` and escape the `nix-shell --pure` wrapping that's coming.  

This disallows `xshell::Shell::new()` and `xshell::cmd!` in our clippy.toml.