### PR TITLE
consomme: fix tcp checksum calculation

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -467,13 +467,13 @@ impl<T: Client> Sender<'_, T> {
                 let ipv4_packet = Ipv4Packet::new_unchecked(&*ip_packet_buf);
                 let total_len = ipv4_packet.total_len() as usize;
                 let payload_offset = ipv4_packet.header_len() as usize;
-                (&mut ip_packet_buf[payload_offset..], total_len)
+                (&mut ip_packet_buf[payload_offset..total_len], total_len)
             }
             SocketAddr::V6(_) => {
                 let ipv6_packet = Ipv6Packet::new_unchecked(&*ip_packet_buf);
                 let total_len = ipv6_packet.total_len();
                 let payload_offset = IPV6_HEADER_LEN;
-                (&mut ip_packet_buf[payload_offset..], total_len)
+                (&mut ip_packet_buf[payload_offset..total_len], total_len)
             }
         };
 


### PR DESCRIPTION
There was an connectivity issue that surfaced when testing WSL with virtio-net. The issue was caused by an incorrect checksum in tcp packets which caused the guest to ignore them. 

It's unclear why this issue did not affect connectivity within openvmm vms (with both linux and windows guests).