### PR TITLE
deps: Update mu_msvm to v25.1.11 release

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -22,7 +22,7 @@ pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const RUSTUP_TOOLCHAIN: &str = "1.90.0";
-pub const MU_MSVM: &str = "25.1.9";
+pub const MU_MSVM: &str = "25.1.11";
 pub const NEXTEST: &str = "0.9.101";
 pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly


### PR DESCRIPTION
mu_msvm release notes (note, this change bumps UEFI by two versions): 
- https://github.com/microsoft/mu_msvm/releases/tag/v25.1.11
- https://github.com/microsoft/mu_msvm/releases/tag/v25.1.10

This contains a critical change to prevent the AziHsm UEFI driver from loading unless a PCD is set to enable it.