### PR TITLE
netvsp: adding test for subchannel request max

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1524,14 +1524,6 @@ impl Nic {
                 saved_state::Primary::Version => vec![true],
                 saved_state::Primary::Init(_) => vec![true],
                 saved_state::Primary::Ready(ready) => {
-                    if ready.channels.len() as u16 > self.adapter.max_queues {
-                        // Should not happen since UMED capacity should not change.
-                        tracing::error!(
-                            saved_num_channels = ready.channels.len(),
-                            adapter_max_queues = self.adapter.max_queues,
-                            "saved state has more channels than the adapter supports",
-                        );
-                    }
                     ready.channels.iter().map(|x| x.is_some()).collect()
                 }
             };


### PR DESCRIPTION
There are crash dumps from netvsp restore_queues()
 `driver: Box::new(drivers[queue_index as usize].clone()),`
 
 Should be fixed by https://github.com/microsoft/openvmm/pull/2430

* Adding unit test to validate.