### PR TITLE
flowey: resolve local uefi path like other deps

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -463,7 +463,6 @@ impl SimpleFlowNode for Node {
                             openhcl_initrd_extra_params: None,
                             custom_openvmm_hcl: None,
                             custom_openhcl_boot: None,
-                            custom_uefi: None,
                             custom_kernel: custom_kernel_abs.clone(),
                             custom_sidecar: None,
                             custom_extra_rootfs: vec![],

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
@@ -30,7 +30,6 @@ pub struct Customizations {
     pub custom_openhcl_boot: Option<PathBuf>,
     pub custom_openvmm_hcl: Option<PathBuf>,
     pub custom_sidecar: Option<PathBuf>,
-    pub custom_uefi: Option<PathBuf>,
     pub custom_vtl0_kernel: Option<PathBuf>,
     pub custom_extra_rootfs: Vec<PathBuf>,
     pub override_arch: Option<CommonArch>,
@@ -88,7 +87,6 @@ impl SimpleFlowNode for Node {
             custom_openhcl_boot,
             custom_openvmm_hcl,
             custom_sidecar,
-            custom_uefi,
             custom_vtl0_kernel,
             override_arch,
             override_kernel_pkg,
@@ -156,7 +154,6 @@ impl SimpleFlowNode for Node {
                 }),
                 custom_openvmm_hcl: custom_openvmm_hcl.map(|p| p.absolute()).transpose()?,
                 custom_openhcl_boot: custom_openhcl_boot.map(|p| p.absolute()).transpose()?,
-                custom_uefi: custom_uefi.map(|p| p.absolute()).transpose()?,
                 custom_kernel: custom_kernel.map(|p| p.absolute()).transpose()?,
                 custom_sidecar: custom_sidecar.map(|p| p.absolute()).transpose()?,
                 custom_extra_rootfs: custom_extra_rootfs

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -74,7 +74,6 @@ pub struct OpenhclIgvmRecipeDetailsLocalOnly {
     pub openhcl_initrd_extra_params: Option<OpenhclInitrdExtraParams>,
     pub custom_openvmm_hcl: Option<PathBuf>,
     pub custom_openhcl_boot: Option<PathBuf>,
-    pub custom_uefi: Option<PathBuf>,
     pub custom_kernel: Option<PathBuf>,
     pub custom_sidecar: Option<PathBuf>,
     pub custom_extra_rootfs: Vec<PathBuf>,
@@ -310,7 +309,6 @@ impl SimpleFlowNode for Node {
             openhcl_initrd_extra_params,
             custom_openvmm_hcl,
             custom_openhcl_boot,
-            custom_uefi,
             custom_kernel,
             custom_sidecar,
             custom_extra_rootfs,
@@ -319,7 +317,6 @@ impl SimpleFlowNode for Node {
             openhcl_initrd_extra_params: None,
             custom_openvmm_hcl: None,
             custom_openhcl_boot: None,
-            custom_uefi: None,
             custom_kernel: None,
             custom_sidecar: None,
             custom_extra_rootfs: Vec::new(),
@@ -374,17 +371,13 @@ impl SimpleFlowNode for Node {
             );
 
         let uefi_resource = with_uefi.then(|| UefiResource {
-            msvm_fd: if let Some(path) = custom_uefi {
-                ReadVar::from_static(path)
-            } else {
-                ctx.reqv(|v| crate::download_uefi_mu_msvm::Request::GetMsvmFd {
-                    arch: match arch {
-                        CommonArch::X86_64 => MuMsvmArch::X86_64,
-                        CommonArch::Aarch64 => MuMsvmArch::Aarch64,
-                    },
-                    msvm_fd: v,
-                })
-            },
+            msvm_fd: ctx.reqv(|v| crate::download_uefi_mu_msvm::Request::GetMsvmFd {
+                arch: match arch {
+                    CommonArch::X86_64 => MuMsvmArch::X86_64,
+                    CommonArch::Aarch64 => MuMsvmArch::Aarch64,
+                },
+                msvm_fd: v,
+            }),
         });
 
         let vtl0_kernel_resource = vtl0_kernel_type.map(|typ| {


### PR DESCRIPTION
Using a local uefi had its own special path in the `build-igvm` pipeline. I was going to leave this alone, but consolidating makes it easier down the line. Not renaming the download_uefi_mu_msvm.rs node to avoid an internal break (should likely be renamed to resolve_uefi_mu_msvm.rs). This aligns the dependency resolution to be the same as the other dependencies we use for the build.