### PR TITLE
ci: stop failing upload petri results when tests haven't actually run

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -17,6 +17,13 @@ permissions:
 
 jobs:
   upload-logs:
+    # Only attempt upload if the workflow run could have actually produced some artifacts
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' ||
+        github.event.workflow_run.conclusion == 'failure' ||
+        github.event.workflow_run.conclusion == 'timed_out'
+      }}
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://openvmmghtestresults.blob.core.windows.net/results


### PR DESCRIPTION
Right now every opened PR or push to an open PR sends an email with a failed "Upload Petri Test Results." This occurs because the action is triggered by the release variants of pipelines, which are immediately skipped unless the PR is tagged. Those still send a workflow completion to the "Upload Petri Results" workflow, which then fails to download logs because there are none. 

This checks the workflow completion status to upload on success or failure, but not on skipped or cancelled.