### PR TITLE
netvsp: adding uevent logging to vf manager

### DIFF
--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -698,7 +698,7 @@ impl HclNetworkVFManagerWorker {
                         (Vtl2DeviceState::Missing, true) => NextWorkItem::ManaDeviceArrived,
                         (state, false) => {
                             // Tracing to diagnose add that is not acted on due to missing device.
-                            if notification.action == UeventAction::Add {
+                            if action == UeventAction::Add {
                                  tracelimit::warn_ratelimited!(?state, ?action, exists, %device_path, "uevent received");
                             }
                             NextWorkItem::Continue


### PR DESCRIPTION
The Network VF Manager has a listener for uevents. These are Linux kernel notifications that tell UH in userspace that a device (MANA) has been added or removed. The UeventHandler squashes together `add`, `remove`, and `rescan` events and sends over a string representing the device path. VF Manager then uses the existence of the device path to determine whether to schedule a ManaDeviceArrived work item.

In a recent investigation into a customer issue, it was difficult to work out why ManaDeviceArrived was not scheduled. There are several possibilities and nothing is logged when it is not scheduled.

* Modifying UeventHandler to pass back a new `UeventNotification` which specifies which uevent arrived along with the device path.
* Added tracing to VF Manager to log the uevent received to help in future investigations where we want to answer "Why was ManaDeviceArrived not scheduled?".
* I have preserved the existing logic that treats `add`, `remove`, and `rescan` interchangeably in VF Manager. I have no way of knowing what (if anything) would break if prevented remove uevents from scheduling ManaDeviceArrived.