### PR TITLE
virt_mshv_vtl: Report all crash_ctl bits as supported (#2822)

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1047,11 +1047,13 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     #[cfg(guest_arch = "x86_64")]
     fn read_crash_msr(&self, msr: u32, _vtl: GuestVtl) -> Result<u64, MsrError> {
         let v = match msr {
-            // Reads of CRASH_CTL report our supported capabilities, not the
-            // current value.
+            // Reads of CRASH_CTL report our supported capabilities, not any
+            // previously written value.
             hvdef::HV_X64_MSR_GUEST_CRASH_CTL => hvdef::GuestCrashCtl::new()
                 .with_crash_notify(true)
                 .with_crash_message(true)
+                .with_no_crash_dump(true)
+                .with_pre_os_id(0b111)
                 .into(),
             hvdef::HV_X64_MSR_GUEST_CRASH_P0 => self.crash_reg[0],
             hvdef::HV_X64_MSR_GUEST_CRASH_P1 => self.crash_reg[1],


### PR DESCRIPTION
This allows guests to report more information to us during a crash. We don't have to do anything based on the values of these bits, we were already logging them, they were just always 0.

Clean cherry-pick