### PR TITLE
xtask: implement clean command

### DIFF
--- a/Guide/src/dev_guide/dev_tools/xtask.md
+++ b/Guide/src/dev_guide/dev_tools/xtask.md
@@ -8,6 +8,7 @@ For more info on how `xtask` is different from `xflowey`, see [`xflowey` vs
 
 Some examples of tools that you can find under `xtask`:
 
+- `cargo xtask clean` cleans build system artifacts (flowey, packages, test results)
 - `cargo xtask fmt` implements various OpenVMM-specific style / linting rules
 - `cargo xtask fuzz` implements various OpenVMM-specific `cargo fuzz` extensions
 - `cargo xtask install-git-hooks` sets up git hooks for developers

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -84,6 +84,7 @@ enum Commands {
     Complete(clap_dyn_complete::Complete),
     Completions(completions::Completions),
 
+    Clean(tasks::Clean),
     Fmt(tasks::Fmt),
     Fuzz(tasks::Fuzz),
     GuestTest(tasks::GuestTest),
@@ -148,6 +149,7 @@ fn try_main() -> anyhow::Result<()> {
             Ok(())
         }
 
+        Commands::Clean(task) => task.run(ctx),
         Commands::Fmt(task) => task.run(ctx),
         Commands::Fuzz(task) => task.run(ctx),
         Commands::GuestTest(task) => task.run(ctx),

--- a/xtask/src/tasks/clean.rs
+++ b/xtask/src/tasks/clean.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::Xtask;
+
+/// Clean build artifacts beyond what `cargo clean` removes.
+///
+/// By default, removes: flowey-out, flowey-persist, .packages, and
+/// vmm_test_results. Use `--cargo` to also clean the cargo build output.
+#[derive(Debug, clap::Parser)]
+#[clap(about = "Clean build system artifacts (flowey, packages, test results)")]
+pub struct Clean {
+    /// Clean everything (equivalent to --cargo)
+    #[clap(long)]
+    all: bool,
+
+    /// Also run `cargo clean` to remove the target/ directory
+    #[clap(long)]
+    cargo: bool,
+
+    /// Print what would be removed without actually deleting anything
+    #[clap(long)]
+    dry_run: bool,
+}
+
+/// Directories that are always cleaned.
+const DEFAULT_DIRS: &[&str] = &[
+    "flowey-out",
+    "flowey-persist",
+    ".packages",
+    "vmm_test_results",
+];
+
+impl Xtask for Clean {
+    fn run(self, ctx: crate::XtaskCtx) -> anyhow::Result<()> {
+        let do_cargo = self.all || self.cargo;
+
+        let mut removed_anything = false;
+
+        // Remove default directories
+        for dir_name in DEFAULT_DIRS {
+            let path = ctx.root.join(dir_name);
+            if path.exists() {
+                if self.dry_run {
+                    println!("would remove {}", path.display());
+                } else {
+                    println!("removing {}", path.display());
+                    fs_err::remove_dir_all(&path)?;
+                }
+                removed_anything = true;
+            }
+        }
+
+        // Optionally run cargo clean
+        if do_cargo {
+            if self.dry_run {
+                println!("would run `cargo clean`");
+            } else {
+                println!("running `cargo clean`");
+                let sh = xshell::Shell::new()?;
+                xshell::cmd!(sh, "cargo clean").run()?;
+            }
+            removed_anything = true;
+        }
+
+        if !removed_anything {
+            println!("nothing to clean");
+        }
+
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -3,6 +3,7 @@
 
 //! Implementations of various Xtasks
 
+mod clean;
 mod fmt;
 mod fuzz;
 mod git_hooks;
@@ -11,6 +12,7 @@ mod verify_size;
 
 pub use git_hooks::update_hooks;
 
+pub use self::clean::Clean;
 pub use self::fmt::Fmt;
 pub use self::fuzz::Fuzz;
 pub use self::git_hooks::InstallGitHooks;


### PR DESCRIPTION
Flowey has some persistent directories that don't get cleaned up by `cargo clean`. When testing nix changes locally I've been bit in the past by the local cache being hit (which means something would've been downloaded) and not realizing that using local deps hadn't been properly implemented. 

This task cleans up flowey-out, flowey-persist, .packages, and can run `cargo clean` if specified.

Example usage with all available parameters:
```
justuscamp@DESKTOP-J6M7TP0:~/openvmm$ cargo xtask clean --dry-run --cargo
    Finished `light` profile [optimized + debuginfo] target(s) in 1.01s
     Running `target/light/xtask clean --dry-run --cargo`
would remove /home/justuscamp/openvmm/flowey-out
would remove /home/justuscamp/openvmm/flowey-persist
would remove /home/justuscamp/openvmm/.packages
would remove /home/justuscamp/openvmm/vmm_test_results
would run `cargo clean`
```