### PR TITLE
nix: update overlay version since we updated rust version

### DIFF
--- a/Guide/src/dev_guide/dev_tools/flowey/nix.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/nix.md
@@ -29,3 +29,19 @@ error: Cannot build '/nix/store/spg5vbm6mzmsxpg5v2ibg97qrz8khc70-openhcl-kernel-
 ```
 
 Given this error, you would update the corresponding hash to `sha256-An1N76i1MPb+rrQ1nBpoiuxnNeD0E+VuwqXdkPzaZn0=` in the `openhcl_kernel.nix` file.
+
+## Updating the Rust Version
+
+The Nix shell derives its Rust toolchain version from `rust-version` in the root `Cargo.toml` and resolves it against a pinned [rust-overlay](https://github.com/oxalica/rust-overlay) commit in `shell.nix`. When `rust-version` is bumped in `Cargo.toml`, the pinned rust-overlay may not yet include the new version, causing an error like:
+
+```bash
+error: No rust version matching 1.XX.* found in rust-overlay
+```
+
+To fix this, update the rust-overlay pin in `shell.nix` to a commit that includes the new Rust version:
+
+1. Go to the [rust-overlay stable branch commits](https://github.com/oxalica/rust-overlay/commits/stable) and copy the latest commit SHA
+2. In `shell.nix`, find the `rust_overlay` `fetchTarball` block and replace the commit SHA in the `url` with the new one (the long hex string in the URL path, e.g., `https://github.com/oxalica/rust-overlay/archive/<commit-sha>.tar.gz`)
+3. Clear the `sha256` field to an empty string — this is a _content_ hash of the tarball (not the commit SHA), and Nix will compute the correct value for you
+4. Run `nix-shell --pure` and use the printed error to get the new `sha256`
+5. Update the `sha256` with the correct hash from the error

--- a/shell.nix
+++ b/shell.nix
@@ -4,10 +4,10 @@ let
     url = "https://github.com/NixOS/nixpkgs/archive/50ab793786d9de88ee30ec4e4c24fb4236fc2674.tar.gz";
     sha256 = "1s2gr5rcyqvpr58vxdcb095mdhblij9bfzaximrva2243aal3dgx";
   };
-  # Pinned rust-overlay from stable branch
+  # Pinned rust-overlay from stable branch which has our current rust version (1.93)
   rust_overlay = import (builtins.fetchTarball {
-    url = "https://github.com/oxalica/rust-overlay/archive/2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2.tar.gz";
-    sha256 = "138a0p83qzflw8wj4a7cainqanjmvjlincx8imr3yq1b924lg9cz";
+    url = "https://github.com/oxalica/rust-overlay/archive/ec6a3d5cdf14bb5a1dd03652bd3f6351004d2188.tar.gz";
+    sha256 = "0pik603mmxsgs2gndk681j9rkxjlrx3lxbpwd9linn2rn8vacg0a";
   });
   pkgs = import nixpkgs { overlays = [ rust_overlay ]; };
 


### PR DESCRIPTION
When we updated Rust to 1.93, the oxalica rust overlay that Nix uses wasn't updated, which means the overlay doesn't have the right version of rust to use. This updates the commit for the overlay and also adds some instructions to figure out how to do so.