### PR TITLE
openvmm_entry: fix scsi controller always added to vtl2settings

### DIFF
--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1166,7 +1166,7 @@ async fn vm_config_from_command_line(
             version: vtl2_settings_proto::vtl2_settings_base::Version::V1.into(),
             fixed: Some(Default::default()),
             dynamic: Some(vtl2_settings_proto::Vtl2SettingsDynamic {
-                storage_controllers: storage.build_underhill(),
+                storage_controllers: storage.build_underhill(opt.vmbus_redirect),
                 nic_devices: underhill_nics,
             }),
             namespace_settings: Vec::default(),


### PR DESCRIPTION
93403cd regressed openvmm when you boot VTL2 without --vmbus-redirect. Fix it to only add the scsi controller if there are scsi controllers already, or if --vmbus-redirect was specified. 