### PR TITLE
nvme_driver: Fix rust-analyzer false positive

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1105,11 +1105,10 @@ impl IoIssuers {
             .await
             .map_err(RequestError::Gone)?;
 
-        Ok(self.per_cpu[cpu as usize]
+        Ok(&self.per_cpu[cpu as usize]
             .get()
             .expect("issuer was set by rpc")
-            .issuer
-            .as_ref())
+            .issuer)
     }
 }
 


### PR DESCRIPTION
Even though the file compiled successfully, rust-analyzer marked the `as_ref` part with red. Resolve by using `&` instead of `as_ref`.