### PR TITLE
nvme_driver: Drain all queues after restore

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -898,12 +898,17 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             .iter()
             .filter(|q| !q.queue_data.handler_data.pending_cmds.commands.is_empty())
             .count();
-        tracing::info!(nonempty_queues, "drain-after-restore initialization");
+        tracing::info!(
+            nonempty_queues,
+            ?pci_id,
+            "drain-after-restore initialization"
+        );
         // This DrainAfterRestore template tracks which IO queues need to be
         // drained after restore. We initialize it with the number of non-empty queues
         // we are restoring eagerly here, but all queues (eagerly restored and
         // lazily restored) will wait for all (non-empty) queues to drain.
-        let drain_after_restore_template = DrainAfterRestoreBuilder::new(nonempty_queues);
+        let drain_after_restore_template =
+            DrainAfterRestoreBuilder::new(nonempty_queues, pci_id.clone());
 
         let proto_queues_count = saved_state
             .worker_data


### PR DESCRIPTION
```
w1 | w1' c1' w2 c2 c1
```

Guest sends a write request w1. Then we do servicing. Then storvsp duplicates the request into w1', which completes at c1'. If we allow the queue to run freely (aka accept new guest requests), then at this point the guest can issue another write w2 which completes at c2 and only then the original pre-save write completes at c1 overwriting the "latest" write w2, as far as the guest is concerned.

That's the reason we stop the queue before all pre-save requests complete.

But with multiple queues if we drain one queue and start accepting new guest requests on it, while there are other still-draining queues, we can have the same race.

Therefore, with this PR, all queues are drained before new guest requests are accepted to avoid races.