### PR TITLE
Initialize vTPM with correct NVRAM size (#2819)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "ms-tpm-20-ref"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?branch=main#c7433fb1a74e47cea5daf13d3aac24cd0ccac1f4"
+source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?branch=main#5b8ca3b5b423859da441f51ec8b1610708ed53c2"
 dependencies = [
  "cc",
  "once_cell",
@@ -7527,6 +7527,7 @@ dependencies = [
  "pal_async",
  "parking_lot",
  "sha2",
+ "static_assertions",
  "thiserror 2.0.16",
  "tpm_lib",
  "tpm_protocol",

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1050,6 +1050,7 @@ impl IntoPipeline for CheckinGatesCli {
             KnownTestArtifacts::Ubuntu2404ServerX64Vhd,
             KnownTestArtifacts::Ubuntu2504ServerX64Vhd,
             KnownTestArtifacts::VmgsWithBootEntry,
+            KnownTestArtifacts::VmgsWith16kTpm,
         ];
 
         let cvm_filter = |arch| {
@@ -1079,6 +1080,7 @@ impl IntoPipeline for CheckinGatesCli {
             KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd,
             KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd,
             KnownTestArtifacts::Ubuntu2504ServerX64Vhd,
+            KnownTestArtifacts::VmgsWith16kTpm,
         ];
 
         for VmmTestJobParams {
@@ -1161,6 +1163,7 @@ impl IntoPipeline for CheckinGatesCli {
                     KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
                     KnownTestArtifacts::Windows11EnterpriseAarch64Vhdx,
                     KnownTestArtifacts::VmgsWithBootEntry,
+                    KnownTestArtifacts::VmgsWith16kTpm,
                 ],
                 needs_prep_run: false,
             },

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -354,6 +354,7 @@ impl SimpleFlowNode for Node {
                         if ubuntu {
                             artifacts.push(KnownTestArtifacts::Ubuntu2404ServerX64Vhd);
                             artifacts.push(KnownTestArtifacts::Ubuntu2504ServerX64Vhd);
+                            artifacts.push(KnownTestArtifacts::VmgsWith16kTpm);
                         }
                         if windows && uefi {
                             artifacts.push(KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd);
@@ -378,6 +379,7 @@ impl SimpleFlowNode for Node {
 
                         if ubuntu {
                             artifacts.push(KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd);
+                            artifacts.push(KnownTestArtifacts::VmgsWith16kTpm);
                         }
                         if windows {
                             artifacts.push(KnownTestArtifacts::Windows11EnterpriseAarch64Vhdx);

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1747,6 +1747,15 @@ async fn new_underhill_vm(
         }
     };
 
+    // Get TPM data size from VMGS. This is used by the TPM device later to
+    // initialize it with the correct size. VMGS file control blocks are saved
+    // and restored during servicing, so this is cached and doesn't directly
+    // access the VMGS file.
+    let tpm_size = vmgs
+        .as_ref()
+        .and_then(|(_, vmgs)| vmgs.get_file_info(vmgs::FileId::TPM_NVRAM).ok())
+        .map(|info| info.valid_bytes as usize);
+
     // Determine if the VTL0 alias map is in use.
     let vtl0_alias_map_bit =
         runtime_params
@@ -2887,6 +2896,7 @@ async fn new_underhill_vm(
                 logger: Some(GetTpmLoggerHandle.into_resource()),
                 is_confidential_vm: isolation.is_isolated(),
                 bios_guid: dps.general.bios_guid,
+                nvram_size: tpm_size,
             }
             .into_resource(),
         });

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1102,6 +1102,7 @@ fn vm_config_from_command_line(
                 logger: None,
                 is_confidential_vm: false,
                 bios_guid,
+                nvram_size: None,
             }
             .into_resource(),
         });

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -940,6 +940,7 @@ impl PetriVmConfigSetupCore<'_> {
                     is_confidential_vm: self.firmware.isolation().is_some(),
                     // TODO: generate an actual BIOS GUID and put it here
                     bios_guid: Guid::ZERO,
+                    nvram_size: None,
                 }
                 .into_resource(),
             })

--- a/vm/devices/tpm/tpm_device/Cargo.toml
+++ b/vm/devices/tpm/tpm_device/Cargo.toml
@@ -33,6 +33,7 @@ pal_async.workspace = true
 async-trait.workspace = true
 getrandom.workspace = true
 parking_lot.workspace = true
+static_assertions.workspace = true
 thiserror.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true

--- a/vm/devices/tpm/tpm_device/src/resolver.rs
+++ b/vm/devices/tpm/tpm_device/src/resolver.rs
@@ -119,6 +119,7 @@ impl AsyncResolveResource<ChipsetDeviceHandleKind, TpmDeviceHandle> for TpmDevic
             input.encrypted_guest_memory.clone(),
             ppi_store.0,
             nvram_store.0,
+            resource.nvram_size,
             monotonic_timer,
             resource.refresh_tpm_seeds,
             input.is_restoring,

--- a/vm/devices/tpm_resources/src/lib.rs
+++ b/vm/devices/tpm_resources/src/lib.rs
@@ -35,6 +35,8 @@ pub struct TpmDeviceHandle {
     pub is_confidential_vm: bool,
     /// BIOS GUID (for logging purposes)
     pub bios_guid: Guid,
+    /// NVRAM size (default size if None)
+    pub nvram_size: Option<usize>,
 }
 
 impl ResourceId<ChipsetDeviceHandleKind> for TpmDeviceHandle {

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -81,6 +81,7 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == test_iso::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Iso),
 
             _ if id == test_vmgs::VMGS_WITH_BOOT_ENTRY => get_test_artifact_path(KnownTestArtifacts::VmgsWithBootEntry),
+            _ if id == test_vmgs::VMGS_WITH_16K_TPM => get_test_artifact_path(KnownTestArtifacts::VmgsWith16kTpm),
 
             _ if id == tmks::TMK_VMM_NATIVE => tmk_vmm_native_executable_path(),
             _ if id == tmks::TMK_VMM_LINUX_X64_MUSL => tmk_vmm_paravisor_path(MachineArch::X86_64),

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -537,6 +537,11 @@ pub mod artifacts {
             /// with a persistent VMGS file enabled. This is useful for testing
             /// whether default_boot_always_attempt works to boot other VHDs.
             VMGS_WITH_BOOT_ENTRY,
+            /// VMGS file containing a 16k vTPM blob
+            ///
+            /// This file was created by creating a 16k vTPM blob and loading
+            /// it into file index 3 of a blank VMGS file.
+            VMGS_WITH_16K_TPM,
         }
 
         impl IsHostedOnHvliteAzureBlobStore for VMGS_WITH_BOOT_ENTRY {
@@ -545,6 +550,13 @@ pub mod artifacts {
         }
 
         impl IsTestVmgs for VMGS_WITH_BOOT_ENTRY {}
+
+        impl IsHostedOnHvliteAzureBlobStore for VMGS_WITH_16K_TPM {
+            const FILENAME: &'static str = "tpm-16k-vmgs.vhd";
+            const SIZE: u64 = 4194816;
+        }
+
+        impl IsTestVmgs for VMGS_WITH_16K_TPM {}
     }
 
     /// TMK-related artifacts

--- a/vmm_tests/vmm_test_images/src/lib.rs
+++ b/vmm_tests/vmm_test_images/src/lib.rs
@@ -36,6 +36,7 @@ pub enum KnownTestArtifacts {
     Ubuntu2404ServerAarch64Vhd,
     Windows11EnterpriseAarch64Vhdx,
     VmgsWithBootEntry,
+    VmgsWith16kTpm,
 }
 
 struct KnownTestArtifactMeta {
@@ -115,6 +116,11 @@ const KNOWN_TEST_ARTIFACT_METADATA: &[KnownTestArtifactMeta] = &[
         KnownTestArtifacts::VmgsWithBootEntry,
         petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY::SIZE,
+    ),
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::VmgsWith16kTpm,
+        petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_16K_TPM::FILENAME,
+        petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_16K_TPM::SIZE,
     ),
 ];
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
@@ -13,6 +13,11 @@ use petri::pipette::cmd;
 use petri_artifacts_common::tags::OsFlavor;
 use petri_artifacts_vmm_test::artifacts::guest_tools::TPM_GUEST_TESTS_LINUX_X64;
 use petri_artifacts_vmm_test::artifacts::guest_tools::TPM_GUEST_TESTS_WINDOWS_X64;
+#[allow(unused_imports)]
+use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_AARCH64;
+#[allow(unused_imports)]
+use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64;
+use petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_16K_TPM;
 use pipette_client::PipetteClient;
 use std::path::Path;
 use vmm_test_macros::openvmm_test;
@@ -501,5 +506,48 @@ async fn cvm_tpm_guest_tests<T, U: PetriVmmBackend>(
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;
 
+    Ok(())
+}
+
+/// Test that TPM NVRAM size persists across servicing.
+#[vmm_test(
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))[LATEST_STANDARD_X64, VMGS_WITH_16K_TPM],
+    hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))[LATEST_STANDARD_X64, VMGS_WITH_16K_TPM],
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[LATEST_STANDARD_AARCH64, VMGS_WITH_16K_TPM]
+)]
+async fn tpm_servicing<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+    (igvm_file, vmgs_file): (
+        ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
+        ResolvedArtifact<VMGS_WITH_16K_TPM>,
+    ),
+) -> anyhow::Result<()> {
+    let mut flags = config.default_servicing_flags();
+    flags.override_version_checks = true;
+
+    let config = config
+        .with_tpm(true)
+        .with_tpm_state_persistence(true)
+        .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
+        .with_initial_vmgs(vmgs_file);
+
+    let (mut vm, agent) = config.run().await?;
+
+    agent.ping().await?;
+
+    let inspect_before = vm
+        .inspect_openhcl("vm/tpm/worker/nvram_size", None, None)
+        .await?;
+
+    vm.restart_openhcl(igvm_file.clone(), flags).await?;
+    agent.ping().await?;
+
+    let inspect_after = vm
+        .inspect_openhcl("vm/tpm/worker/nvram_size", None, None)
+        .await?;
+    assert_eq!(inspect_before, inspect_after);
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
     Ok(())
 }


### PR DESCRIPTION
OpenHCL has a bug where the vTPM can try to write past the end of its NVRAM after OpenHCL servicing (the old TpmFail bug). The TPM's serialized state does not contain the NVRAM size, so after servicing, the TPM core thinks it has 32kB available regardless of the actual size.

OpenHCL creates the TPM device by creating a new TPM engine with a blank state, then reinitializing it with the saved state from the VMGS. This reinit makes it see the correct NVRAM size. In servicing, though, we skip that reinitialization and instead restore the serialized state. The TPM will have the size it was first initialized with, which is 32kB by default.

This change fixes TPM init:
- When creating the TPM device, get the correct NVRAM size from the cached/saved/restored VMGS file control blocks.
- Create the initial empty TPM with the correct size, instead of the default 32kB.

The _best_ solution would be to fix this in the TPM core code by adding the NVRAM size to its serialized state. However, that would change the format of its save state, which would break UH's ability to live-service the TPM core. Doing this fix optimally would probably require adding versioning to the TPM core save-state, and also figuring out how to handle a serialized TPM state that doesn't have the NVRAM size in the TPM core.