### PR TITLE
ci: upload memory validation logs to separate container

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -86,13 +86,6 @@ jobs:
             --source results \
             --auth-mode login
 
-          az storage blob upload-batch \
-            --destination "$BASE_URL/memoryvalidation" \
-            --destination-path "$run_id" \
-            --source results \
-            --filter */*memory_validation*/petri.jsonl \
-            --auth-mode login
-
           # Store a metadata blob in a separate portion of the hierarchy so that
           # it can be cheaply queried.
           az storage blob upload \
@@ -103,6 +96,18 @@ jobs:
               "petripassed=$PASS_COUNT" \
               "ghbranch=$SOURCE_BRANCH" \
               "ghpr=$SOURCE_PR" \
+            --auth-mode login
+        env:
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Upload to memory validation results to Azure Blob Storage
+        if: ${{ github.event.workflow_run.event == 'push' }}
+        run: |
+          az storage blob upload-batch \
+            --destination "$BASE_URL/memoryvalidation" \
+            --destination-path "$run_id" \
+            --source results \
+            --pattern '*/*memory_validation*/petri.jsonl' \
             --auth-mode login
         env:
           run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
upload the memory validation logs to a separate azure storage container that won't delete them (test results usually get deleted after 2 weeks)