### PR TITLE
virtio_p9: modernize to VirtioDevice trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8994,12 +8994,16 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "event-listener",
  "guestmem",
+ "pal_async",
  "plan9",
+ "task_control",
  "tracing",
  "virtio",
  "virtio_resources",
  "vm_resource",
+ "vmcore",
 ]
 
 [[package]]

--- a/vm/devices/virtio/virtio_p9/Cargo.toml
+++ b/vm/devices/virtio/virtio_p9/Cargo.toml
@@ -13,9 +13,13 @@ virtio.workspace = true
 virtio_resources.workspace = true
 guestmem.workspace = true
 vm_resource.workspace = true
+vmcore.workspace = true
+task_control.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
+event-listener.workspace = true
+pal_async.workspace = true
 tracing.workspace = true
 
 [lints]

--- a/vm/devices/virtio/virtio_p9/src/resolver.rs
+++ b/vm/devices/virtio/virtio_p9/src/resolver.rs
@@ -5,7 +5,6 @@
 
 use crate::VirtioPlan9Device;
 use plan9::Plan9FileSystem;
-use virtio::LegacyWrapper;
 use virtio::resolve::ResolvedVirtioDevice;
 use virtio::resolve::VirtioResolveInput;
 use virtio_resources::p9::VirtioPlan9Handle;
@@ -30,14 +29,11 @@ impl ResolveResource<VirtioDeviceHandle, VirtioPlan9Handle> for VirtioPlan9Resol
         resource: VirtioPlan9Handle,
         input: VirtioResolveInput<'_>,
     ) -> Result<Self::Output, Self::Error> {
-        let device = LegacyWrapper::new(
+        let device = VirtioPlan9Device::new(
             input.driver_source,
-            VirtioPlan9Device::new(
-                &resource.tag,
-                Plan9FileSystem::new(&resource.root_path, resource.debug)?,
-                input.guest_memory.clone(),
-            ),
-            input.guest_memory,
+            &resource.tag,
+            Plan9FileSystem::new(&resource.root_path, resource.debug)?,
+            input.guest_memory.clone(),
         );
         Ok(device.into())
     }


### PR DESCRIPTION
Replace LegacyVirtioDevice impl with direct VirtioDevice impl:
- Add driver, worker, exit_event fields for direct queue management
- Implement enable()/disable() following virtiofs pattern
- Constructor now takes VmTaskDriverSource parameter
- Remove LegacyWrapper from resolver, construct device directly
- Use Option<TaskControl> instead of Vec since there is only one queue
- Add deps: vmcore, task_control, event-listener, pal_async

The VirtioPlan9Worker and process_work() logic is unchanged. This is one step toward removing LegacyVirtioDevice entirely.