### PR TITLE
virtio: remove LegacyVirtioDevice trait and LegacyWrapper

### DIFF
--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -19,7 +19,6 @@ use guestmem::GuestMemoryError;
 use guestmem::MappedMemoryRegion;
 use pal_async::DefaultPool;
 use pal_async::driver::Driver;
-use pal_async::task::Spawn;
 use pal_async::wait::PolledWait;
 use pal_event::Event;
 use parking_lot::Mutex;
@@ -34,8 +33,6 @@ use task_control::StopTask;
 use task_control::TaskControl;
 use thiserror::Error;
 use vmcore::interrupt::Interrupt;
-use vmcore::vm_task::VmTaskDriver;
-use vmcore::vm_task::VmTaskDriverSource;
 
 #[async_trait]
 pub trait VirtioQueueWorkerContext {
@@ -61,15 +58,6 @@ impl VirtioQueueUsedHandler {
     pub fn add_outstanding_descriptor(&self) {
         let (count, _) = &mut *self.outstanding_desc_count.lock();
         *count += 1;
-    }
-
-    pub fn await_outstanding_descriptors(&self) -> event_listener::EventListener {
-        let (count, event) = &*self.outstanding_desc_count.lock();
-        let listener = event.listen();
-        if *count == 0 {
-            event.notify(usize::MAX);
-        }
-        listener
     }
 
     pub fn complete_descriptor(&mut self, work: &QueueWork, bytes_written: u32) {
@@ -249,11 +237,6 @@ impl VirtioQueue {
         })
     }
 
-    async fn wait_for_outstanding_descriptors(&self) {
-        let wait_for_descriptors = self.used_handler.lock().await_outstanding_descriptors();
-        wait_for_descriptors.await;
-    }
-
     fn poll_next_buffer(
         &mut self,
         cx: &mut Context<'_>,
@@ -412,17 +395,6 @@ impl AsyncRun<VirtioQueueState> for VirtioQueueWorker {
     }
 }
 
-pub struct VirtioRunningState {
-    pub features: VirtioDeviceFeatures,
-    pub enabled_queues: Vec<bool>,
-}
-
-pub enum VirtioState {
-    Unknown,
-    Running(VirtioRunningState),
-    Stopped,
-}
-
 pub(crate) struct VirtioDoorbells {
     registration: Option<Arc<dyn DoorbellRegistration>>,
     doorbells: Vec<Box<dyn Send + Sync>>,
@@ -465,14 +437,6 @@ pub struct DeviceTraits {
     pub shared_memory: DeviceTraitsSharedMemory,
 }
 
-pub trait LegacyVirtioDevice: Send {
-    fn traits(&self) -> DeviceTraits;
-    fn read_registers_u32(&self, offset: u16) -> u32;
-    fn write_registers_u32(&mut self, offset: u16, val: u32);
-    fn get_work_callback(&mut self, index: u16) -> Box<dyn VirtioQueueWorkerContext + Send>;
-    fn state_change(&mut self, state: &VirtioState);
-}
-
 pub trait VirtioDevice: Send {
     fn traits(&self) -> DeviceTraits;
     fn read_registers_u32(&self, offset: u16) -> u32;
@@ -492,102 +456,4 @@ pub struct Resources {
     pub queues: Vec<QueueResources>,
     pub shared_memory_region: Option<Arc<dyn MappedMemoryRegion>>,
     pub shared_memory_size: u64,
-}
-
-/// Wraps an object implementing [`LegacyVirtioDevice`] and implements [`VirtioDevice`].
-pub struct LegacyWrapper<T: LegacyVirtioDevice> {
-    device: T,
-    driver: VmTaskDriver,
-    mem: GuestMemory,
-    workers: Vec<TaskControl<VirtioQueueWorker, VirtioQueueState>>,
-    exit_event: event_listener::Event,
-}
-
-impl<T: LegacyVirtioDevice> LegacyWrapper<T> {
-    pub fn new(driver_source: &VmTaskDriverSource, device: T, mem: &GuestMemory) -> Self {
-        Self {
-            device,
-            driver: driver_source.simple(),
-            mem: mem.clone(),
-            workers: Vec::new(),
-            exit_event: event_listener::Event::new(),
-        }
-    }
-}
-
-impl<T: LegacyVirtioDevice> VirtioDevice for LegacyWrapper<T> {
-    fn traits(&self) -> DeviceTraits {
-        self.device.traits()
-    }
-
-    fn read_registers_u32(&self, offset: u16) -> u32 {
-        self.device.read_registers_u32(offset)
-    }
-
-    fn write_registers_u32(&mut self, offset: u16, val: u32) {
-        self.device.write_registers_u32(offset, val)
-    }
-
-    fn enable(&mut self, resources: Resources) {
-        let running_state = VirtioRunningState {
-            features: resources.features.clone(),
-            enabled_queues: resources
-                .queues
-                .iter()
-                .map(|QueueResources { params, .. }| params.enable)
-                .collect(),
-        };
-
-        self.device
-            .state_change(&VirtioState::Running(running_state));
-        self.workers = resources
-            .queues
-            .into_iter()
-            .enumerate()
-            .filter_map(|(i, queue_resources)| {
-                if !queue_resources.params.enable {
-                    return None;
-                }
-                let worker = VirtioQueueWorker::new(
-                    self.driver.clone(),
-                    self.device.get_work_callback(i as u16),
-                );
-                Some(worker.into_running_task(
-                    "virtio-queue".to_string(),
-                    self.mem.clone(),
-                    resources.features.clone(),
-                    queue_resources,
-                    self.exit_event.listen(),
-                ))
-            })
-            .collect();
-    }
-
-    fn disable(&mut self) {
-        if self.workers.is_empty() {
-            return;
-        }
-        self.exit_event.notify(usize::MAX);
-        self.device.state_change(&VirtioState::Stopped);
-        let mut workers = self.workers.drain(..).collect::<Vec<_>>();
-        self.driver
-            .spawn("shutdown-legacy-virtio-queues".to_owned(), async move {
-                futures::future::join_all(workers.iter_mut().map(async |worker| {
-                    worker.stop().await;
-                    if let Some(VirtioQueueStateInner::Running { queue, .. }) =
-                        worker.state_mut().map(|s| &s.inner)
-                    {
-                        queue.wait_for_outstanding_descriptors().await;
-                    }
-                }))
-                .await;
-            })
-            .detach();
-    }
-}
-
-impl<T: LegacyVirtioDevice> Drop for LegacyWrapper<T> {
-    fn drop(&mut self) {
-        self.disable();
-    }
 }


### PR DESCRIPTION
With virtio_p9 modernized (Phase 1) and virtio_serial deleted (Phase 2), the only remaining LegacyVirtioDevice user was TestDevice in tests.rs.

Convert TestDevice to implement VirtioDevice directly with enable/disable, following the same pattern used by real devices (driver-owned workers, exit_event for shutdown). This removes all LegacyVirtioDevice usage.

Remove from common.rs:
- LegacyVirtioDevice trait
- LegacyWrapper struct and all impls (VirtioDevice, Drop)
- VirtioState and VirtioRunningState enums (only used by LegacyWrapper)
- wait_for_outstanding_descriptors (dead after LegacyWrapper removal)
- await_outstanding_descriptors on VirtioQueueUsedHandler (dead)
- Unused imports (Spawn, VmTaskDriver, VmTaskDriverSource)

Also fix pre-existing unused tracing_helpers dep in openvmm_core.

All 14 virtio tests pass. This is Phase 3 of the legacy virtio removal.