### PR TITLE
ci: no unstable test helpers in vmgstool releases

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -2786,6 +2786,7 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
@@ -2796,7 +2797,6 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3038,6 +3038,8 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool-release"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool-release" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgstool-release' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 2 flowey_lib_common::install_rust 0
@@ -3106,7 +3108,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build hypestv
       run: |-
@@ -3123,7 +3125,7 @@ jobs:
         flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -3131,7 +3133,7 @@ jobs:
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 2 flowey_lib_hvlite::build_igvmfilegen 0
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -3139,6 +3141,14 @@ jobs:
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 2 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 2 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 2 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 2 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 2 flowey_lib_common::cache 3
@@ -3166,6 +3176,12 @@ jobs:
       with:
         name: aarch64-windows-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmgstool-release
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-windows-vmgstool-release
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool-release/
         include-hidden-files: true
   job20:
     name: run vmm-tests [x64-linux]
@@ -3214,12 +3230,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
+        flowey e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey e 20 flowey_core::pipeline::artifact::resolve 6
         flowey e 20 flowey_core::pipeline::artifact::resolve 1
         flowey e 20 flowey_core::pipeline::artifact::resolve 0
         flowey e 20 flowey_core::pipeline::artifact::resolve 2
         flowey e 20 flowey_core::pipeline::artifact::resolve 5
-        flowey e 20 flowey_core::pipeline::artifact::resolve 3
-        flowey e 20 flowey_core::pipeline::artifact::resolve 6
         flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
@@ -3867,7 +3883,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-8,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-8,aarch64-linux-vmgstool-release,aarch64-windows-vmgstool-release,x64-linux-vmgstool-release,x64-windows-vmgstool-release}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-8" >> $GITHUB_PATH
       shell: bash
@@ -3886,10 +3902,10 @@ jobs:
         cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 23 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 23 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 23 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool-release" | flowey v 23 'artifact_use_from_aarch64-linux-vmgstool-release' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool-release" | flowey v 23 'artifact_use_from_aarch64-windows-vmgstool-release' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool-release" | flowey v 23 'artifact_use_from_x64-linux-vmgstool-release' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool-release" | flowey v 23 'artifact_use_from_x64-windows-vmgstool-release' --is-raw-string update
       shell: bash
     - name: create gh cache dir
       run: flowey e 23 flowey_lib_common::download_gh_cli 0
@@ -4129,6 +4145,14 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 3 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 3 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 5
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build prep_steps
@@ -4136,7 +4160,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 2
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 3 flowey_lib_hvlite::build_prep_steps 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 6
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
@@ -4144,7 +4168,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 6
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 10
         flowey.exe e 3 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 6
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 7
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 3
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 7
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 8
@@ -4154,7 +4178,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 5
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 9
         flowey.exe e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 7
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 1
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 3
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 4
@@ -4164,7 +4188,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 3
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 5
         flowey.exe e 3 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4205,7 +4229,7 @@ jobs:
       run: |-
         flowey.exe e 3 flowey_lib_common::run_cargo_nextest_archive 0
         flowey.exe e 3 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 2
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build openvmm
@@ -4213,7 +4237,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 0
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 3 flowey_lib_hvlite::build_openvmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 3
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build pipette
@@ -4221,14 +4245,6 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 1
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 3 flowey_lib_hvlite::build_tmk_vmm 0
         flowey.exe e 3 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
@@ -4370,6 +4386,8 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool-release"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool-release" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgstool-release' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -4438,7 +4456,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build hypestv
       run: |-
@@ -4459,7 +4477,7 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -4467,7 +4485,7 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 4 flowey_lib_hvlite::build_igvmfilegen 0
         flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -4475,6 +4493,14 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 4 flowey_lib_common::cache 3
@@ -4502,6 +4528,12 @@ jobs:
       with:
         name: x64-windows-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-vmgstool-release
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-vmgstool-release
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgstool-release/
         include-hidden-files: true
   job5:
     name: build artifacts (for VMM tests) [x64-windows]
@@ -4919,6 +4951,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool-release"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool-release" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool-release' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
@@ -5019,7 +5053,7 @@ jobs:
       run: |-
         flowey e 6 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 6 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 6 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 6 flowey_lib_hvlite::build_vmgstool 1
         flowey e 6 flowey_core::pipeline::artifact::publish 1
         flowey e 6 flowey_lib_hvlite::init_cross_build 4
       shell: bash
@@ -5030,7 +5064,7 @@ jobs:
         flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 6 flowey_core::pipeline::artifact::publish 2
-        flowey e 6 flowey_lib_hvlite::init_cross_build 6
+        flowey e 6 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -5039,7 +5073,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 6 flowey_lib_hvlite::run_cargo_build 2
         flowey e 6 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 6 flowey_core::pipeline::artifact::publish 3
@@ -5056,7 +5090,7 @@ jobs:
         flowey e 6 flowey_lib_hvlite::run_cargo_build 4
         flowey e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 6 flowey_core::pipeline::artifact::publish 4
-        flowey e 6 flowey_lib_hvlite::init_cross_build 7
+        flowey e 6 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -5095,6 +5129,19 @@ jobs:
         flowey e 6 flowey_lib_hvlite::run_cargo_build 12
         flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 6 flowey_core::pipeline::artifact::publish 7
+        flowey e 6 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 8
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 16
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 17
+        flowey e 6 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 6 flowey_lib_common::cache 3
@@ -5140,6 +5187,12 @@ jobs:
       with:
         name: aarch64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-vmgstool-release
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-linux-vmgstool-release
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool-release/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v4
@@ -5238,6 +5291,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool-release"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool-release" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool-release' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
@@ -5340,7 +5395,7 @@ jobs:
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 7 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 7 flowey_lib_hvlite::build_vmgstool 1
         flowey e 7 flowey_core::pipeline::artifact::publish 1
         flowey e 7 flowey_lib_hvlite::init_cross_build 5
       shell: bash
@@ -5355,7 +5410,7 @@ jobs:
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 7 flowey_core::pipeline::artifact::publish 2
-        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+        flowey e 7 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -5364,7 +5419,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 7 flowey_lib_hvlite::run_cargo_build 2
         flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 7 flowey_core::pipeline::artifact::publish 3
@@ -5381,7 +5436,7 @@ jobs:
         flowey e 7 flowey_lib_hvlite::run_cargo_build 4
         flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 7 flowey_core::pipeline::artifact::publish 4
-        flowey e 7 flowey_lib_hvlite::init_cross_build 8
+        flowey e 7 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -5420,6 +5475,19 @@ jobs:
         flowey e 7 flowey_lib_hvlite::run_cargo_build 12
         flowey e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 7 flowey_core::pipeline::artifact::publish 7
+        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 8
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 16
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 17
+        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -5460,7 +5528,7 @@ jobs:
       run: |-
         flowey e 7 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 8
+        flowey e 7 flowey_core::pipeline::artifact::publish 9
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 7 flowey_lib_common::cache 3
@@ -5509,6 +5577,12 @@ jobs:
       with:
         name: x64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool-release
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-linux-vmgstool-release
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool-release/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmm-tests-archive
       uses: actions/upload-artifact@v4

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -2733,6 +2733,7 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
@@ -2743,7 +2744,6 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -2987,6 +2987,8 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool-release"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool-release" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgstool-release' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 2 flowey_lib_common::install_rust 0
@@ -3055,7 +3057,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build hypestv
       run: |-
@@ -3072,7 +3074,7 @@ jobs:
         flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -3080,7 +3082,7 @@ jobs:
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 2 flowey_lib_hvlite::build_igvmfilegen 0
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -3088,6 +3090,14 @@ jobs:
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 2 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 2 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 2 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 2 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 2 flowey_lib_common::cache 3
@@ -3115,6 +3125,12 @@ jobs:
       with:
         name: aarch64-windows-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmgstool-release
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-windows-vmgstool-release
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool-release/
         include-hidden-files: true
   job20:
     name: run vmm-tests [x64-linux]
@@ -3164,12 +3180,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
+        flowey e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey e 20 flowey_core::pipeline::artifact::resolve 6
         flowey e 20 flowey_core::pipeline::artifact::resolve 1
         flowey e 20 flowey_core::pipeline::artifact::resolve 0
         flowey e 20 flowey_core::pipeline::artifact::resolve 2
         flowey e 20 flowey_core::pipeline::artifact::resolve 5
-        flowey e 20 flowey_core::pipeline::artifact::resolve 3
-        flowey e 20 flowey_core::pipeline::artifact::resolve 6
         flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
@@ -3904,6 +3920,14 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey.exe e 3 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 4
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build tmk_vmm
@@ -3911,7 +3935,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 4
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 6
         flowey.exe e 3 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 4
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 5
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build prep_steps
@@ -3919,7 +3943,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 2
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 3 flowey_lib_hvlite::build_prep_steps 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 6
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
@@ -3927,7 +3951,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 6
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 10
         flowey.exe e 3 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 6
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 7
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 3
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 7
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 8
@@ -3937,7 +3961,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 5
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 9
         flowey.exe e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 7
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 1
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 3
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 4
@@ -3947,7 +3971,7 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 3
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 5
         flowey.exe e 3 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3988,7 +4012,7 @@ jobs:
       run: |-
         flowey.exe e 3 flowey_lib_common::run_cargo_nextest_archive 0
         flowey.exe e 3 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 2
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build openvmm
@@ -3996,14 +4020,6 @@ jobs:
         flowey.exe e 3 flowey_lib_common::run_cargo_build 0
         flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 3 flowey_lib_hvlite::build_openvmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
         flowey.exe e 3 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
@@ -4147,6 +4163,8 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool-release"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool-release" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgstool-release' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -4215,7 +4233,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build hypestv
       run: |-
@@ -4236,7 +4254,7 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -4244,7 +4262,7 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 4 flowey_lib_hvlite::build_igvmfilegen 0
         flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -4252,6 +4270,14 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 4 flowey_lib_common::cache 3
@@ -4279,6 +4305,12 @@ jobs:
       with:
         name: x64-windows-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-vmgstool-release
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-vmgstool-release
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgstool-release/
         include-hidden-files: true
   job5:
     name: build artifacts (for VMM tests) [x64-windows]
@@ -4656,6 +4688,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool-release"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool-release" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool-release' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
@@ -4756,7 +4790,7 @@ jobs:
       run: |-
         flowey e 6 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 6 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 6 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 6 flowey_lib_hvlite::build_vmgstool 1
         flowey e 6 flowey_core::pipeline::artifact::publish 1
         flowey e 6 flowey_lib_hvlite::init_cross_build 4
       shell: bash
@@ -4767,7 +4801,7 @@ jobs:
         flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 6 flowey_core::pipeline::artifact::publish 2
-        flowey e 6 flowey_lib_hvlite::init_cross_build 6
+        flowey e 6 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -4776,7 +4810,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 6 flowey_lib_hvlite::run_cargo_build 2
         flowey e 6 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 6 flowey_core::pipeline::artifact::publish 3
@@ -4793,7 +4827,7 @@ jobs:
         flowey e 6 flowey_lib_hvlite::run_cargo_build 4
         flowey e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 6 flowey_core::pipeline::artifact::publish 4
-        flowey e 6 flowey_lib_hvlite::init_cross_build 7
+        flowey e 6 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -4832,6 +4866,19 @@ jobs:
         flowey e 6 flowey_lib_hvlite::run_cargo_build 12
         flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 6 flowey_core::pipeline::artifact::publish 7
+        flowey e 6 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 8
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 16
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 17
+        flowey e 6 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 6 flowey_lib_common::cache 3
@@ -4877,6 +4924,12 @@ jobs:
       with:
         name: aarch64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-vmgstool-release
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-linux-vmgstool-release
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool-release/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v4
@@ -4933,6 +4986,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool-release"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool-release" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool-release' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
@@ -5035,7 +5090,7 @@ jobs:
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 7 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 7 flowey_lib_hvlite::build_vmgstool 1
         flowey e 7 flowey_core::pipeline::artifact::publish 1
         flowey e 7 flowey_lib_hvlite::init_cross_build 5
       shell: bash
@@ -5050,7 +5105,7 @@ jobs:
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 7 flowey_core::pipeline::artifact::publish 2
-        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+        flowey e 7 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -5059,7 +5114,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 7 flowey_lib_hvlite::run_cargo_build 2
         flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 7 flowey_core::pipeline::artifact::publish 3
@@ -5076,7 +5131,7 @@ jobs:
         flowey e 7 flowey_lib_hvlite::run_cargo_build 4
         flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 7 flowey_core::pipeline::artifact::publish 4
-        flowey e 7 flowey_lib_hvlite::init_cross_build 8
+        flowey e 7 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -5115,6 +5170,19 @@ jobs:
         flowey e 7 flowey_lib_hvlite::run_cargo_build 12
         flowey e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 7 flowey_core::pipeline::artifact::publish 7
+        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 8
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 16
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 17
+        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -5155,7 +5223,7 @@ jobs:
       run: |-
         flowey e 7 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 8
+        flowey e 7 flowey_core::pipeline::artifact::publish 9
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 7 flowey_lib_common::cache 3
@@ -5204,6 +5272,12 @@ jobs:
       with:
         name: x64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool-release
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-linux-vmgstool-release
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool-release/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmm-tests-archive
       uses: actions/upload-artifact@v4

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -352,21 +352,17 @@ impl IntoPipeline for CheckinGatesCli {
                 pipeline.new_typed_artifact(format!("{arch_tag}-windows-hypestv"));
             let (pub_ohcldiag_dev, _use_ohcldiag_dev) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-windows-ohcldiag-dev"));
-            let (pub_vmgstool_release, use_vmgstool_release) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-windows-vmgstool-release"));
+
+            let vmgstool_release = release.then(|| {
+                pipeline.new_typed_artifact(format!("{arch_tag}-windows-vmgstool-release"))
+            });
 
             let vmgstool_target = CommonTriple::Common {
                 arch,
                 platform: CommonPlatform::WindowsMsvc,
             };
-            if vmgstools
-                .insert(vmgstool_target.to_string(), use_vmgstool_release)
-                .is_some()
-            {
-                anyhow::bail!("multiple vmgstools for the same target");
-            }
 
-            let job = pipeline
+            let mut job = pipeline
                 .new_job(
                     FlowPlatform::Windows,
                     FlowArch::X86_64,
@@ -409,14 +405,24 @@ impl IntoPipeline for CheckinGatesCli {
                     },
                     profile: CommonProfile::from_release(release),
                     ohcldiag_dev: ctx.publish_typed_artifact(pub_ohcldiag_dev),
-                })
-                .dep_on(|ctx| flowey_lib_hvlite::build_vmgstool::Request {
+                });
+
+            if let Some((pub_vmgstool_release, use_vmgstool_release)) = vmgstool_release {
+                job = job.dep_on(|ctx| flowey_lib_hvlite::build_vmgstool::Request {
                     target: vmgstool_target.clone(),
                     profile: CommonProfile::Release,
                     with_crypto: true,
                     with_test_helpers: false,
                     vmgstool: ctx.publish_typed_artifact(pub_vmgstool_release),
                 });
+
+                if vmgstools
+                    .insert(vmgstool_target.to_string(), use_vmgstool_release.clone())
+                    .is_some()
+                {
+                    anyhow::bail!("multiple vmgstools for the same target");
+                }
+            }
 
             all_jobs.push(job.finish());
 
@@ -546,8 +552,9 @@ impl IntoPipeline for CheckinGatesCli {
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-igvmfilegen"));
             let (pub_vmgs_lib, _) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgs_lib"));
-            let (pub_vmgstool_release, use_vmgstool_release) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgstool-release"));
+
+            let vmgstool_release = release
+                .then(|| pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgstool-release")));
             let (pub_vmgstool, _) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgstool"));
             let (pub_ohcldiag_dev, _) =
@@ -589,12 +596,6 @@ impl IntoPipeline for CheckinGatesCli {
                 arch,
                 platform: CommonPlatform::LinuxGnu,
             };
-            if vmgstools
-                .insert(vmgstool_target.to_string(), use_vmgstool_release.clone())
-                .is_some()
-            {
-                anyhow::bail!("multiple vmgstools for the same target");
-            }
 
             let mut job = pipeline
                 .new_job(
@@ -623,13 +624,6 @@ impl IntoPipeline for CheckinGatesCli {
                 })
                 .dep_on(|ctx| flowey_lib_hvlite::build_vmgstool::Request {
                     target: vmgstool_target.clone(),
-                    profile: CommonProfile::Release,
-                    with_crypto: true,
-                    with_test_helpers: false,
-                    vmgstool: ctx.publish_typed_artifact(pub_vmgstool_release),
-                })
-                .dep_on(|ctx| flowey_lib_hvlite::build_vmgstool::Request {
-                    target: vmgstool_target,
                     profile: CommonProfile::from_release(release),
                     with_crypto: true,
                     with_test_helpers: true,
@@ -679,6 +673,23 @@ impl IntoPipeline for CheckinGatesCli {
                     profile: CommonProfile::from_release(release),
                     tpm_guest_tests: ctx.publish_typed_artifact(pub_tpm_guest_tests),
                 });
+
+            if let Some((pub_vmgstool_release, use_vmgstool_release)) = vmgstool_release {
+                job = job.dep_on(|ctx| flowey_lib_hvlite::build_vmgstool::Request {
+                    target: vmgstool_target.clone(),
+                    profile: CommonProfile::Release,
+                    with_crypto: true,
+                    with_test_helpers: false,
+                    vmgstool: ctx.publish_typed_artifact(pub_vmgstool_release),
+                });
+
+                if vmgstools
+                    .insert(vmgstool_target.to_string(), use_vmgstool_release.clone())
+                    .is_some()
+                {
+                    anyhow::bail!("multiple vmgstools for the same target");
+                }
+            }
 
             // Hang building the linux VMM tests off this big linux job.
             //

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -352,6 +352,19 @@ impl IntoPipeline for CheckinGatesCli {
                 pipeline.new_typed_artifact(format!("{arch_tag}-windows-hypestv"));
             let (pub_ohcldiag_dev, _use_ohcldiag_dev) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-windows-ohcldiag-dev"));
+            let (pub_vmgstool_release, use_vmgstool_release) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-windows-vmgstool-release"));
+
+            let vmgstool_target = CommonTriple::Common {
+                arch,
+                platform: CommonPlatform::WindowsMsvc,
+            };
+            if vmgstools
+                .insert(vmgstool_target.to_string(), use_vmgstool_release)
+                .is_some()
+            {
+                anyhow::bail!("multiple vmgstools for the same target");
+            }
 
             let job = pipeline
                 .new_job(
@@ -396,20 +409,16 @@ impl IntoPipeline for CheckinGatesCli {
                     },
                     profile: CommonProfile::from_release(release),
                     ohcldiag_dev: ctx.publish_typed_artifact(pub_ohcldiag_dev),
+                })
+                .dep_on(|ctx| flowey_lib_hvlite::build_vmgstool::Request {
+                    target: vmgstool_target.clone(),
+                    profile: CommonProfile::Release,
+                    with_crypto: true,
+                    with_test_helpers: false,
+                    vmgstool: ctx.publish_typed_artifact(pub_vmgstool_release),
                 });
 
             all_jobs.push(job.finish());
-
-            let vmgstool_target = CommonTriple::Common {
-                arch,
-                platform: CommonPlatform::WindowsMsvc,
-            };
-            if vmgstools
-                .insert(vmgstool_target.to_string(), use_vmgstool.clone())
-                .is_some()
-            {
-                anyhow::bail!("multiple vmgstools for the same target");
-            }
 
             // emit a job for artifacts which _are_ in the VMM tests "hot path"
             let mut job = pipeline
@@ -471,7 +480,7 @@ impl IntoPipeline for CheckinGatesCli {
                     target: vmgstool_target,
                     profile: CommonProfile::from_release(release),
                     with_crypto: true,
-                    with_test_helpers: !release,
+                    with_test_helpers: true,
                     vmgstool: ctx.publish_typed_artifact(pub_vmgstool),
                 })
                 .dep_on(|ctx| flowey_lib_hvlite::build_tpm_guest_tests::Request {
@@ -537,7 +546,9 @@ impl IntoPipeline for CheckinGatesCli {
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-igvmfilegen"));
             let (pub_vmgs_lib, _) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgs_lib"));
-            let (pub_vmgstool, use_vmgstool) =
+            let (pub_vmgstool_release, use_vmgstool_release) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgstool-release"));
+            let (pub_vmgstool, _) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgstool"));
             let (pub_ohcldiag_dev, _) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-ohcldiag-dev"));
@@ -579,7 +590,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: CommonPlatform::LinuxGnu,
             };
             if vmgstools
-                .insert(vmgstool_target.to_string(), use_vmgstool.clone())
+                .insert(vmgstool_target.to_string(), use_vmgstool_release.clone())
                 .is_some()
             {
                 anyhow::bail!("multiple vmgstools for the same target");
@@ -611,10 +622,17 @@ impl IntoPipeline for CheckinGatesCli {
                     }
                 })
                 .dep_on(|ctx| flowey_lib_hvlite::build_vmgstool::Request {
+                    target: vmgstool_target.clone(),
+                    profile: CommonProfile::Release,
+                    with_crypto: true,
+                    with_test_helpers: false,
+                    vmgstool: ctx.publish_typed_artifact(pub_vmgstool_release),
+                })
+                .dep_on(|ctx| flowey_lib_hvlite::build_vmgstool::Request {
                     target: vmgstool_target,
                     profile: CommonProfile::from_release(release),
                     with_crypto: true,
-                    with_test_helpers: !release,
+                    with_test_helpers: true,
                     vmgstool: ctx.publish_typed_artifact(pub_vmgstool),
                 })
                 .dep_on(|ctx| flowey_lib_hvlite::build_and_test_vmgs_lib::Request {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -471,7 +471,7 @@ impl IntoPipeline for CheckinGatesCli {
                     target: vmgstool_target,
                     profile: CommonProfile::from_release(release),
                     with_crypto: true,
-                    with_test_helpers: true,
+                    with_test_helpers: !release,
                     vmgstool: ctx.publish_typed_artifact(pub_vmgstool),
                 })
                 .dep_on(|ctx| flowey_lib_hvlite::build_tpm_guest_tests::Request {
@@ -614,7 +614,7 @@ impl IntoPipeline for CheckinGatesCli {
                     target: vmgstool_target,
                     profile: CommonProfile::from_release(release),
                     with_crypto: true,
-                    with_test_helpers: true,
+                    with_test_helpers: !release,
                     vmgstool: ctx.publish_typed_artifact(pub_vmgstool),
                 })
                 .dep_on(|ctx| flowey_lib_hvlite::build_and_test_vmgs_lib::Request {


### PR DESCRIPTION
Release versions of vmgstool shouldn't include the unstable test helpers. Build a version without the feature to publish, while still building with the feature for VMM tests.