### PR TITLE
flowey: vmm-tests must download alpine linux image (#2784)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -371,6 +371,9 @@ impl SimpleFlowNode for Node {
                         if windows || ubuntu {
                             artifacts.push(KnownTestArtifacts::VmgsWithBootEntry);
                         }
+                        if linux {
+                            artifacts.push(KnownTestArtifacts::Alpine323X64Vhd);
+                        }
 
                         artifacts
                     }
@@ -386,6 +389,9 @@ impl SimpleFlowNode for Node {
                         }
                         if windows || ubuntu {
                             artifacts.push(KnownTestArtifacts::VmgsWithBootEntry);
+                        }
+                        if linux {
+                            artifacts.push(KnownTestArtifacts::Alpine323Aarch64Vhd);
                         }
 
                         artifacts


### PR DESCRIPTION
Clean cherry pick of PR #2784

We now have tests that run against alpine. The `vmm-tests` xflowey command wasn't downloading that image for the user. Add it.
