### PR TITLE
petri/hyperv: use `TotalSeconds` for WMI call timeout

### DIFF
--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -947,7 +947,7 @@ filter Trace-CimMethodExecution {
         }
 
         while ($job.JobState -eq 4) {
-            if (($timer -ne $null) -and ($timer.Elapsed.Seconds -gt $TimeoutSeconds)) {
+            if (($timer -ne $null) -and ($timer.Elapsed.TotalSeconds -gt $TimeoutSeconds)) {
                 throw "Job did not complete within $TimeoutSeconds seconds!"
             }
             Write-Progress -Activity $caption -Status ("{0} - {1}%" -f $jobStatus, $percentComplete) -PercentComplete $percentComplete


### PR DESCRIPTION
`.Seconds` is always in the range `[0, 59]`, so this check does not work for times greater than `59` seconds. Use the correct var.
