### PR TITLE
openhcl/snp: handle IDLE_HLT exits correctly

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1500,7 +1500,7 @@ impl UhProcessor<'_, SnpBacked> {
 
             SevExitCode::NPF => &mut self.backing.exit_stats[entered_from_vtl].npf_no_intercept,
 
-            SevExitCode::HLT => {
+            SevExitCode::HLT | SevExitCode::IDLE_HLT => {
                 self.backing.cvm.lapics[entered_from_vtl].activity = MpState::Halted;
                 // RIP has already advanced. Clear interrupt shadow.
                 vmsa.v_intr_cntrl_mut().set_intr_shadow(false);
@@ -1559,8 +1559,7 @@ impl UhProcessor<'_, SnpBacked> {
             | SevExitCode::PAUSE
             | SevExitCode::SMI
             | SevExitCode::VMGEXIT
-            | SevExitCode::BUSLOCK
-            | SevExitCode::IDLE_HLT => {
+            | SevExitCode::BUSLOCK => {
                 // Ignore intercept processing if the guest exited due to an automatic exit.
                 &mut self.backing.exit_stats[entered_from_vtl].automatic_exit
             }


### PR DESCRIPTION
When this feature is advertised via CPUID and exposed to the guest, we need to correctly handle the IDLE_HLT exit as the same as a HLT. This is a new feature added in AMD's Turin architecture. Without it, we see a bunch of extra CPU usage as instead of halting we immediately return to the guest, where it tries to just halt again. 

Tested via booting a UEFI VM with no guest OS and seeing no extra exits. Tested that Windows and Linux VMs still work on Turin. 