### PR TITLE
ci: associate vmgstool github release with current commit

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3949,6 +3949,10 @@ jobs:
         EOF
         flowey e 23 flowey_lib_common::git_checkout 3
         flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: get current commit
+      run: |-
+        flowey e 23 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
         flowey e 23 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
       shell: bash
     - name: get cargo crate version

--- a/flowey/flowey_lib_common/src/publish_gh_release.rs
+++ b/flowey/flowey_lib_common/src/publish_gh_release.rs
@@ -19,6 +19,8 @@ pub struct GhReleaseParams<C = VarNotClaimed> {
     ///
     /// e.g: the "bar" in "github.com/foo/bar"
     pub repo_name: String,
+    /// Commit hash to target
+    pub target: ReadVar<String, C>,
     /// Tag associated with the release artifact.
     pub tag: ReadVar<String, C>,
     /// Title associated with the release artifact.
@@ -36,6 +38,7 @@ impl GhReleaseParams {
         let GhReleaseParams {
             repo_owner,
             repo_name,
+            target,
             tag,
             title,
             files,
@@ -46,6 +49,7 @@ impl GhReleaseParams {
         GhReleaseParams {
             repo_owner,
             repo_name,
+            target: target.claim(ctx),
             tag: tag.claim(ctx),
             title: title.claim(ctx),
             files: files.claim(ctx),
@@ -86,6 +90,7 @@ impl FlowNode for Node {
                     let GhReleaseParams {
                         repo_owner,
                         repo_name,
+                        target,
                         tag,
                         title,
                         files,
@@ -94,6 +99,7 @@ impl FlowNode for Node {
                     } = req;
 
                     let repo = format!("{repo_owner}/{repo_name}");
+                    let target = rt.read(target);
                     let tag = rt.read(tag);
 
                     // check if the release already exists
@@ -128,11 +134,7 @@ impl FlowNode for Node {
                         .collect::<Vec<_>>();
                     let draft = draft.then_some("--draft");
 
-                    // create the tag to make sure the release is associated with the right commit
-                    flowey::shell_cmd!(rt, "git tag -a {tag} -m {title}").run()?;
-                    flowey::shell_cmd!(rt, "git push origin {tag}").run()?;
-
-                    flowey::shell_cmd!(rt, "{gh_cli} release create --repo {repo} {tag} --title {title} --notes TODO {draft...} {files...}").run()?;
+                    flowey::shell_cmd!(rt, "{gh_cli} release create --repo {repo} --target {target} {tag} --title {title} --notes TODO {draft...} {files...}").run()?;
                 }
 
                 Ok(())

--- a/flowey/flowey_lib_hvlite/src/_jobs/publish_vmgstool_gh_release.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/publish_vmgstool_gh_release.rs
@@ -73,10 +73,22 @@ impl SimpleFlowNode for Node {
         let tag = version.map(ctx, |v| format!("vmgstool-v{v}"));
         let title = version.map(ctx, |v| format!("VmgsTool v{v}"));
 
+        let target = ctx.emit_rust_stepv("get current commit", |ctx| {
+            let openvmm_repo_path = openvmm_repo_path.claim(ctx);
+            move |rt| {
+                let path = rt.read(openvmm_repo_path);
+                rt.sh.change_dir(path);
+                let target = flowey::shell_cmd!(rt, "git rev-parse HEAD").read()?;
+                log::info!("current commit is {target}");
+                Ok(target)
+            }
+        });
+
         ctx.req(flowey_lib_common::publish_gh_release::Request(
             flowey_lib_common::publish_gh_release::GhReleaseParams {
                 repo_owner: "microsoft".into(),
                 repo_name: "openvmm".into(),
+                target,
                 tag,
                 title,
                 files,


### PR DESCRIPTION
Associate the (draft) GitHub release for VmgsTool with the current commit using the `--target` argument.