### PR TITLE
netvsp: Log VF IDs for tracking

### DIFF
--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -77,17 +77,22 @@ enum VfManagerSaveResult {
 async fn create_mana_device(
     driver_source: &VmTaskDriverSource,
     pci_id: &str,
+    vtl2_vf_instance_id: &Guid,
     vp_count: u32,
     max_sub_channels: u16,
     keepalive_mode: KeepAliveConfig,
     dma_clients: VfioDmaClients,
     mut mana_state: Option<&ManaSavedState>,
 ) -> anyhow::Result<ManaDevice<VfioDevice>> {
+    let vtl2_vfid = vfid_from_guid(vtl2_vf_instance_id);
     // This guards from situations where we have saved state from keepalive
     // but the host does not support restoring it. In this case we log a warning,
     // free the memory, and continue with a fresh device.
     if mana_state.is_some() && !keepalive_mode.is_enabled() {
-        tracing::warn!("have saved state from keepalive but restoring on an unsupported host");
+        tracing::warn!(
+            vtl2_vfid,
+            "have saved state from keepalive but restoring on an unsupported host"
+        );
 
         // Re-attach pending buffers, but discard them so that they get freed.
         let dma_client = match &dma_clients {
@@ -106,6 +111,7 @@ async fn create_mana_device(
         try_create_mana_device(
             driver_source,
             pci_id,
+            vtl2_vf_instance_id,
             vp_count,
             max_sub_channels,
             dma_clients.clone(),
@@ -121,6 +127,7 @@ async fn create_mana_device(
         let update_reset = |method: PciDeviceResetMethod| {
             if let Err(err) = vfio_set_device_reset_method(pci_id, method) {
                 tracing::warn!(
+                    vtl2_vfid,
                     ?method,
                     err = &err as &dyn std::error::Error,
                     "Failed to update reset_method"
@@ -135,6 +142,7 @@ async fn create_mana_device(
             match try_create_mana_device(
                 driver_source,
                 pci_id,
+                vtl2_vf_instance_id,
                 vp_count,
                 max_sub_channels,
                 dma_clients.clone(),
@@ -152,6 +160,7 @@ async fn create_mana_device(
                 }
                 Err(err) => {
                     tracing::error!(
+                        vtl2_vfid,
                         pci_id,
                         ?reset_method,
                         err = err.as_ref() as &dyn std::error::Error,
@@ -172,25 +181,36 @@ async fn create_mana_device(
 async fn try_create_mana_device(
     driver_source: &VmTaskDriverSource,
     pci_id: &str,
+    vtl2_vf_instance_id: &Guid,
     vp_count: u32,
     max_sub_channels: u16,
     dma_clients: VfioDmaClients,
     mana_state: Option<&ManaSavedState>,
 ) -> anyhow::Result<ManaDevice<VfioDevice>> {
+    let vtl2_vfid = vfid_from_guid(vtl2_vf_instance_id);
     // Restore the device if we have saved state from servicing, otherwise create a new one.
     let device = if mana_state.is_some() {
-        tracing::debug!("Restoring VFIO device from saved state");
+        tracing::debug!(vtl2_vfid, "Restoring VFIO device from saved state");
         VfioDevice::restore(driver_source, pci_id, true, dma_clients)
-            .instrument(tracing::info_span!("restore_mana_vfio_device"))
+            .instrument(tracing::info_span!(
+                "restore_mana_vfio_device",
+                vtl2_vfid,
+                pci_id
+            ))
             .await
             .with_context(|| format!("failed to restore vfio device for {}", pci_id))?
     } else {
         VfioDevice::new(driver_source, pci_id, dma_clients)
-            .instrument(tracing::info_span!("new_mana_vfio_device"))
+            .instrument(tracing::info_span!(
+                "new_mana_vfio_device",
+                vtl2_vfid,
+                pci_id
+            ))
             .await
             .with_context(|| format!("failed to open vfio device for {}", pci_id))?
     };
 
+    tracing::info!(vtl2_vfid, pci_id, "Creating MANA device");
     ManaDevice::new(
         &driver_source.simple(),
         device,
@@ -198,16 +218,24 @@ async fn try_create_mana_device(
         max_sub_channels + 1,
         mana_state.map(|state| &state.mana_device),
     )
-    .instrument(tracing::info_span!("new_mana_device"))
+    .instrument(tracing::info_span!("new_mana_device", vtl2_vfid, pci_id))
     .await
     .context("failed to initialize mana device")
 }
 
 fn vtl0_vfid_from_bus_control(vtl0_bus_control: &Vtl0Bus) -> Option<u32> {
     match vtl0_bus_control {
-        Vtl0Bus::Present(bus_control) => Some(bus_control.instance_id().data1),
+        Vtl0Bus::Present(bus_control) => Some(vfid_from_guid(&bus_control.instance_id())),
         _ => None,
     }
+}
+
+fn vtl2_vfid_from_bus_control(vtl2_bus_control: &HclVpciBusControl) -> u32 {
+    vfid_from_guid(&vtl2_bus_control.instance_id())
+}
+
+fn vfid_from_guid(id: &Guid) -> u32 {
+    id.data1
 }
 
 #[derive(Clone, Debug)]
@@ -346,6 +374,7 @@ impl HclNetworkVFManagerWorker {
     pub async fn connect_endpoints(&mut self) -> anyhow::Result<Vec<MacAddress>> {
         let device = self.mana_device.as_ref().expect("valid endpoint");
         let indices = (0..device.num_vports()).collect::<Vec<u32>>();
+        let vtl2_vfid = vtl2_vfid_from_bus_control(&self.vtl2_bus_control);
         let result = futures::future::try_join_all(
             indices.iter().zip(self.endpoint_controls.iter_mut()).map(
                 |(index, endpoint_control)| {
@@ -358,10 +387,10 @@ impl HclNetworkVFManagerWorker {
                     async {
                         let vport = pending_device
                             .await
-                            .context("failed to create mana vport")?;
+                            .with_context(|| format!("failed to create mana vport {vtl2_vfid}"))?;
                         let mac_address = vport.mac_address();
                         vport.set_serial_no(*index).await.with_context(|| {
-                            format!("failed to set vport serial number {mac_address}")
+                            format!("failed to set vport serial number {mac_address} {vtl2_vfid}")
                         })?;
                         let mana_ep = Box::new(
                             net_mana::ManaEndpoint::new(
@@ -376,9 +405,9 @@ impl HclNetworkVFManagerWorker {
                         endpoint_control
                             .connect(Box::new(pkt_capture_ep))
                             .with_context(|| {
-                                format!("failed to connect new endpoint {mac_address}")
+                                format!("failed to connect new endpoint {mac_address} {vtl2_vfid}")
                             })?;
-                        tracing::info!(%mac_address, "Network endpoint connected",);
+                        tracing::info!(vtl2_vfid, %mac_address, "Network endpoint connected",);
                         anyhow::Ok((mac_address, control))
                     }
                 },
@@ -386,6 +415,7 @@ impl HclNetworkVFManagerWorker {
         )
         .instrument(tracing::info_span!(
             "connecting endpoints",
+            vtl2_vfid,
             num_endpoints = indices.len()
         ))
         .await?;
@@ -416,12 +446,15 @@ impl HclNetworkVFManagerWorker {
             return;
         }
 
+        let vtl2_vfid = vtl2_vfid_from_bus_control(&self.vtl2_bus_control);
+
         // Make removal request a no-op by setting offered to false. The actual removal will be done at the end of this
         // method.
         *self.guest_state.offered_to_guest.lock().await = false;
         // Give the network stack a chance to prepare for the removal.
         if let Err(err) = self.send_vf_state_change_notifications().await {
             tracing::error!(
+                vtl2_vfid,
                 err = err.as_ref() as &dyn std::error::Error,
                 "Notify VTL0 VF removal"
             );
@@ -436,6 +469,7 @@ impl HclNetworkVFManagerWorker {
                     if let Some(endpoint) = endpoint {
                         if let Err(err) = endpoint.set_data_path_to_guest_vf(false).await {
                             tracing::error!(
+                                vtl2_vfid,
                                 err = err.as_ref() as &dyn std::error::Error,
                                 "Failed to force data path to synthetic"
                             );
@@ -446,12 +480,16 @@ impl HclNetworkVFManagerWorker {
                     }
                     Ok::<(), anyhow::Error>(())
                 }))
-                .instrument(tracing::info_span!("forcing datapath to synthetic"))
+                .instrument(tracing::info_span!(
+                    "forcing datapath to synthetic",
+                    vtl2_vfid
+                ))
                 .await
                 .into_iter()
                 .collect::<anyhow::Result<Vec<_>, _>>()
             {
                 tracing::error!(
+                    vtl2_vfid,
                     err = err.as_ref() as &dyn std::error::Error,
                     "Failed forcing endpoint to switch data path"
                 );
@@ -472,10 +510,13 @@ impl HclNetworkVFManagerWorker {
             };
             vpci_bus_control
                 .revoke_device()
-                .instrument(tracing::info_span!("revoking vtl0 vf", vtl0_bus = %bus_control))
+                .instrument(
+                    tracing::info_span!("revoking vtl0 vf", vtl2_vfid, vtl0_bus = %bus_control),
+                )
                 .await
         } {
             tracing::error!(
+                vtl2_vfid,
                 err = err.as_ref() as &dyn std::error::Error,
                 "Failed to revoke VTL0 VF"
             );
@@ -491,10 +532,15 @@ impl HclNetworkVFManagerWorker {
 
     pub async fn shutdown_vtl2_device(&mut self, keep_vf_alive: bool) {
         self.disconnect_all_endpoints().await;
+        let vtl2_vfid = vtl2_vfid_from_bus_control(&self.vtl2_bus_control);
         if let Some(device) = self.mana_device.take() {
             let (result, device) = device
                 .shutdown()
-                .instrument(tracing::info_span!("shutdown vtl2 device", keep_vf_alive))
+                .instrument(tracing::info_span!(
+                    "shutdown vtl2 device",
+                    vtl2_vfid,
+                    keep_vf_alive
+                ))
                 .await;
             // Closing the VFIO device handle can take a long time. Leak the handle by
             // stashing it away.
@@ -503,6 +549,7 @@ impl HclNetworkVFManagerWorker {
             } else {
                 if let Err(err) = result {
                     tracing::warn!(
+                        vtl2_vfid,
                         error = err.as_ref() as &dyn std::error::Error,
                         "Destroying MANA device"
                     );
@@ -510,10 +557,14 @@ impl HclNetworkVFManagerWorker {
                     match vfio_set_device_reset_method(&self.vtl2_pci_id, PciDeviceResetMethod::Flr)
                     {
                         Ok(_) => {
-                            tracing::info!("Attempt to reset device via FLR on next teardown.");
+                            tracing::info!(
+                                vtl2_vfid,
+                                "Attempt to reset device via FLR on next teardown."
+                            );
                         }
                         Err(err) => {
                             tracing::warn!(
+                                vtl2_vfid,
                                 err = &err as &dyn std::error::Error,
                                 "Failed to re-enable FLR"
                             );
@@ -526,6 +577,8 @@ impl HclNetworkVFManagerWorker {
     }
 
     async fn remove_vtl0_vf(&mut self) {
+        let vtl0_vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control);
+        let vtl2_vfid = vtl2_vfid_from_bus_control(&self.vtl2_bus_control);
         if self.guest_state.is_offered_to_guest().await {
             *self.guest_state.offered_to_guest.lock().await = false;
             if let Vtl0Bus::Present(vtl0_bus_control) = &self.vtl0_bus_control {
@@ -533,13 +586,16 @@ impl HclNetworkVFManagerWorker {
                     .revoke_device()
                     .instrument(tracing::info_span!(
                         "Removing VF from VTL0",
-                        vtl0_bus = %self.vtl0_bus_control
+                        vtl2_vfid,
+                        vtl0_vfid,
                     ))
                     .await
                 {
                     Ok(_) => (),
                     Err(err) => {
                         tracing::error!(
+                            vtl2_vfid,
+                            vtl0_vfid,
                             err = err.as_ref() as &dyn std::error::Error,
                             "Failed to remove VTL0 VF"
                         );
@@ -551,15 +607,17 @@ impl HclNetworkVFManagerWorker {
 
     async fn disconnect_all_endpoints(&mut self) {
         let num_endpoints = self.endpoint_controls.len();
+        let vtl2_vfid = vtl2_vfid_from_bus_control(&self.vtl2_bus_control);
         futures::future::join_all(self.endpoint_controls.iter_mut().map(async |control| {
             match control.disconnect().await {
                 Ok(Some(mut endpoint)) => {
-                    tracing::info!("Network endpoint disconnected");
+                    tracing::info!(vtl2_vfid, "Network endpoint disconnected");
                     endpoint.stop().await;
                 }
                 Ok(None) => (),
                 Err(err) => {
                     tracing::error!(
+                        vtl2_vfid,
                         err = err.as_ref() as &dyn std::error::Error,
                         "Failed to disconnect endpoint"
                     );
@@ -568,6 +626,7 @@ impl HclNetworkVFManagerWorker {
         }))
         .instrument(tracing::info_span!(
             "disconnecting all endpoints",
+            vtl2_vfid,
             num_endpoints
         ))
         .await;
@@ -578,7 +637,8 @@ impl HclNetworkVFManagerWorker {
             .update_vtl2_device_bind_state(is_bound)
             .instrument(tracing::info_span!(
                 "update vtl2 device bind state",
-                is_bound
+                vtl2_vfid = vtl2_vfid_from_bus_control(&self.vtl2_bus_control),
+                is_bound,
             ))
             .await
     }
@@ -586,9 +646,12 @@ impl HclNetworkVFManagerWorker {
     async fn startup_vtl2_device(&mut self, update_vtl2_device_bind_state: bool) -> bool {
         // Each async call within this function handles its own tracing.
         let mut vtl2_device_present = false;
+        let vtl2_vfid = vtl2_vfid_from_bus_control(&self.vtl2_bus_control);
+        let vtl2_instance_id = self.vtl2_bus_control.instance_id();
         let device_bound = match create_mana_device(
             &self.driver_source,
             &self.vtl2_pci_id,
+            &vtl2_instance_id,
             self.vp_count,
             self.max_sub_channels,
             KeepAliveConfig::Disabled,
@@ -608,6 +671,7 @@ impl HclNetworkVFManagerWorker {
             }
             Err(err) => {
                 tracing::error!(
+                    vtl2_vfid,
                     err = err.as_ref() as &dyn std::error::Error,
                     "Failed to create MANA device"
                 );
@@ -618,6 +682,7 @@ impl HclNetworkVFManagerWorker {
         if update_vtl2_device_bind_state {
             if let Err(err) = self.update_vtl2_device_bind_state(device_bound).await {
                 tracing::error!(
+                    vtl2_vfid,
                     err = err.as_ref() as &dyn std::error::Error,
                     "Failed to report new binding state to host"
                 );
@@ -668,6 +733,7 @@ impl HclNetworkVFManagerWorker {
 
         let mut vtl2_device_state = Vtl2DeviceState::Present;
         let mut vf_reconfig_backoff: Option<VfReconfigBackoff> = None;
+        let vtl2_vfid = vtl2_vfid_from_bus_control(&self.vtl2_bus_control);
         loop {
             let next_work_item = {
                 let next_message = self
@@ -678,7 +744,7 @@ impl HclNetworkVFManagerWorker {
                     .chain(iter([NextWorkItem::ExitWorker]));
                 let device_change = self.vtl2_bus_control.notifier().map(|device| match device {
                     VpciBusEvent::DeviceEnumerated => {
-                        tracing::info!("MANA device enumerated, waiting for uevent.");
+                        tracing::info!(vtl2_vfid, "MANA device enumerated, waiting for uevent.");
                         NextWorkItem::Continue
                     }
                     VpciBusEvent::PrepareForRemoval => NextWorkItem::ManaDeviceRemoved,
@@ -749,7 +815,8 @@ impl HclNetworkVFManagerWorker {
                         && self.guest_state.vtl0_vfid().await.is_some()
                     {
                         tracing::info!(
-                            vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
+                            vtl2_vfid,
+                            vtl0_vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
                             "Adding VF to VTL0"
                         );
                         if let Vtl0Bus::Present(vtl0_bus_control) = &self.vtl0_bus_control {
@@ -759,6 +826,9 @@ impl HclNetworkVFManagerWorker {
                                 }
                                 Err(err) => {
                                     tracing::error!(
+                                        vtl2_vfid,
+                                        vtl0_vfid =
+                                            vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
                                         err = err.as_ref() as &dyn std::error::Error,
                                         "Failed to add VTL0 VF"
                                     );
@@ -784,7 +854,12 @@ impl HclNetworkVFManagerWorker {
                             Vtl0Bus::Present(_) | Vtl0Bus::HiddenPresent(_)
                         );
                         assert!(is_present != bus_control.is_some());
-                        tracing::info!(present = bus_control.is_some(), "VTL0 VF device change");
+                        tracing::info!(
+                            vtl2_vfid,
+                            vtl0_vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
+                            present = bus_control.is_some(),
+                            "VTL0 VF device change"
+                        );
                         if matches!(&self.vtl0_bus_control, Vtl0Bus::HiddenNotPresent) {
                             self.vtl0_bus_control = Vtl0Bus::HiddenPresent(bus_control.unwrap())
                         } else if matches!(&self.vtl0_bus_control, Vtl0Bus::HiddenPresent(_)) {
@@ -822,7 +897,12 @@ impl HclNetworkVFManagerWorker {
                         continue;
                     }
                     rpc.handle(async |hide_vtl0| {
-                        tracing::info!(hide_vtl0, "VTL0 VF device is hidden");
+                        tracing::info!(
+                            vtl2_vfid,
+                            vtl0_vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
+                            hide_vtl0,
+                            "VTL0 VF device is hidden"
+                        );
                         if hide_vtl0 {
                             *self.save_state.hidden_vtl0.lock() = Some(true);
                             if !matches!(self.vtl0_bus_control, Vtl0Bus::HiddenPresent(_)) {
@@ -874,7 +954,11 @@ impl HclNetworkVFManagerWorker {
                         if let Some(device) = self.mana_device.take() {
                             let (saved_state, device) = device
                                 .save()
-                                .instrument(tracing::info_span!("saving mana device state"))
+                                .instrument(tracing::info_span!(
+                                    "saving mana device state",
+                                    vtl2_vfid,
+                                    vtl0_vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
+                                ))
                                 .await;
 
                             match saved_state {
@@ -889,6 +973,9 @@ impl HclNetworkVFManagerWorker {
                                 }
                                 Err(err) => {
                                     tracing::error!(
+                                        vtl2_vfid,
+                                        vtl0_vfid =
+                                            vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
                                         error = err.as_ref() as &dyn std::error::Error,
                                         "Failed while saving MANA device state"
                                     );
@@ -899,11 +986,13 @@ impl HclNetworkVFManagerWorker {
                                     ) {
                                         Ok(_) => {
                                             tracing::info!(
+                                                vtl2_vfid,
                                                 "Attempt to reset device via FLR on next teardown."
                                             );
                                         }
                                         Err(err) => {
                                             tracing::warn!(
+                                                vtl2_vfid,
                                                 err = &err as &dyn std::error::Error,
                                                 "Failed to re-enable FLR"
                                             );
@@ -914,7 +1003,7 @@ impl HclNetworkVFManagerWorker {
                                 }
                             }
                         } else {
-                            tracing::warn!("no MANA device present when saving state");
+                            tracing::warn!(vtl2_vfid, "no MANA device present when saving state");
                             VfManagerSaveResult::DeviceMissing
                         }
                     })
@@ -931,7 +1020,7 @@ impl HclNetworkVFManagerWorker {
                     self.is_shutdown_active = true;
                 }
                 NextWorkItem::ManagerMessage(HclNetworkVfManagerMessage::ShutdownComplete(rpc)) => {
-                    tracing::info!("shutting down VTL2 device");
+                    tracing::info!(vtl2_vfid, "shutting down VTL2 device");
                     assert!(self.is_shutdown_active);
                     drop(self.messages.take().unwrap());
                     rpc.handle(async |keep_vf_alive| {
@@ -946,6 +1035,7 @@ impl HclNetworkVFManagerWorker {
                         || matches!(vtl2_device_state, Vtl2DeviceState::Missing)
                     {
                         tracing::debug!(
+                            vtl2_vfid,
                             is_shutdown_active = self.is_shutdown_active,
                             vtl2_device_state_missing =
                                 matches!(vtl2_device_state, Vtl2DeviceState::Missing),
@@ -954,11 +1044,15 @@ impl HclNetworkVFManagerWorker {
                         continue;
                     }
 
-                    tracing::info!("VTL2 VF reconfiguration requested");
+                    tracing::info!(vtl2_vfid, "VTL2 VF reconfiguration requested");
                     // Remove VTL0 VF if present
                     *self.guest_state.vtl0_vfid.lock().await = None;
                     if self.guest_state.is_offered_to_guest().await {
-                        tracing::warn!("VTL0 VF being removed as a result of VF Reconfiguration.");
+                        tracing::warn!(
+                            vtl2_vfid,
+                            vtl0_vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
+                            "VTL0 VF being removed as a result of VF Reconfiguration."
+                        );
                         self.try_notify_guest_and_revoke_vtl0_vf(&Vtl0Bus::NotPresent)
                             .await;
                     }
@@ -979,7 +1073,10 @@ impl HclNetworkVFManagerWorker {
                 }
                 NextWorkItem::VfReconfigRestart => {
                     let Some(mut backoff) = vf_reconfig_backoff else {
-                        tracing::debug!("VF reconfiguration restart without backoff state");
+                        tracing::debug!(
+                            vtl2_vfid,
+                            "VF reconfiguration restart without backoff state"
+                        );
                         continue;
                     };
 
@@ -995,6 +1092,7 @@ impl HclNetworkVFManagerWorker {
                         .await;
                     if restarted {
                         tracing::info!(
+                            vtl2_vfid,
                             attempts = backoff.attempts,
                             "VTL2 device restarted after VF reconfiguration"
                         );
@@ -1003,6 +1101,7 @@ impl HclNetworkVFManagerWorker {
                     } else {
                         if backoff.attempts >= RECONFIG_MAX_ATTEMPTS {
                             tracing::error!(
+                                vtl2_vfid,
                                 attempts = backoff.attempts,
                                 "VTL2 device restart not ready after VF reconfiguration"
                             );
@@ -1014,6 +1113,7 @@ impl HclNetworkVFManagerWorker {
 
                         if backoff.attempts == 1 || backoff.attempts.is_multiple_of(10) {
                             tracing::warn!(
+                                vtl2_vfid,
                                 attempts = backoff.attempts,
                                 sleep_ms = backoff.sleep.as_millis(),
                                 "VTL2 device restart not ready after VF reconfiguration; retrying"
@@ -1032,7 +1132,7 @@ impl HclNetworkVFManagerWorker {
                         vf_reconfig_backoff.is_none(),
                         "device arrival should only occur after device removal and not vf reconfiguration"
                     );
-                    tracing::info!("VTL2 VF arrived");
+                    tracing::info!(vtl2_vfid, "VTL2 VF arrived");
                     let mut ctx =
                         mesh::CancelContext::new().with_timeout(std::time::Duration::from_secs(1));
                     // Ignore error here for waiting for the PCI path and continue to create the MANA device.
@@ -1042,7 +1142,11 @@ impl HclNetworkVFManagerWorker {
                         .is_err()
                     {
                         let pci_path = Path::new("/sys/bus/pci/devices").join(&self.vtl2_pci_id);
-                        tracing::error!(?pci_path, "Timed out waiting for MANA PCI path");
+                        tracing::error!(
+                            vtl2_vfid,
+                            ?pci_path,
+                            "Timed out waiting for MANA PCI path"
+                        );
                     }
 
                     let update_vtl2_device_bind_state = true;
@@ -1055,10 +1159,14 @@ impl HclNetworkVFManagerWorker {
                 }
                 NextWorkItem::ManaDeviceRemoved => {
                     assert!(!self.is_shutdown_active);
-                    tracing::info!("VTL2 VF being removed");
+                    tracing::info!(vtl2_vfid, "VTL2 VF being removed");
                     *self.guest_state.vtl0_vfid.lock().await = None;
                     if self.guest_state.is_offered_to_guest().await {
-                        tracing::warn!("VTL0 VF being removed as a result of VTL2 VF revoke.");
+                        tracing::warn!(
+                            vtl2_vfid,
+                            vtl0_vfid = vtl0_vfid_from_bus_control(&self.vtl0_bus_control),
+                            "VTL0 VF being removed as a result of VTL2 VF revoke."
+                        );
                         self.try_notify_guest_and_revoke_vtl0_vf(&Vtl0Bus::NotPresent)
                             .await;
                     }
@@ -1070,6 +1178,7 @@ impl HclNetworkVFManagerWorker {
 
                     if let Err(err) = self.update_vtl2_device_bind_state(false).await {
                         tracing::error!(
+                            vtl2_vfid,
                             err = err.as_ref() as &dyn std::error::Error,
                             "Failed to report new binding state to host"
                         );
@@ -1077,7 +1186,7 @@ impl HclNetworkVFManagerWorker {
                 }
                 NextWorkItem::ExitWorker => {
                     drop(self.messages.take().unwrap());
-                    tracing::info!(pci_id = &self.vtl2_pci_id, "Worker exiting");
+                    tracing::info!(vtl2_vfid, "Worker exiting");
                     return;
                 }
             }
@@ -1200,6 +1309,7 @@ impl HclNetworkVFManager {
         let device = create_mana_device(
             driver_source,
             &vtl2_pci_id,
+            &vtl2_vf_instance_id,
             vp_count,
             max_sub_channels,
             keepalive_mode.clone(),


### PR DESCRIPTION
Logging changes only.
With multi VF setup, without the log identifying the VTL2/VTL0 VF ID, it will become difficult to identify the VF for troubleshooting purposes. Log the VF IDs