### PR TITLE
flowey: fix gh release download on windows

### DIFF
--- a/flowey/flowey_lib_common/src/download_gh_release.rs
+++ b/flowey/flowey_lib_common/src/download_gh_release.rs
@@ -251,7 +251,7 @@ fn download_all_reqs(
                 );
 
                 if matches!(rt.platform(), FlowPlatform::Windows) {
-                    cmd = cmd.arg("--ssl-no-revoke");
+                    cmd = cmd.arg("--ssl-revoke-best-effort");
                 }
 
                 cmd.run()?;


### PR DESCRIPTION
This node is failing for our internal build - add `--ssl-revoke-best-effort` to the curl command. Validated fix by running a build internally.