### PR TITLE
opentmk: Remove use of lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5114,7 +5114,6 @@ dependencies = [
  "bitfield-struct 0.11.0",
  "cfg-if",
  "hvdef",
- "lazy_static",
  "linked_list_allocator",
  "log",
  "memory_range",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -490,7 +490,6 @@ jiff = "0.2.14"
 kvm-bindings = "0.14.0"
 # Use of these specific REPO will go away when changes are taken upstream.
 landlock = "0.4.1"
-lazy_static = "1.4.0"
 libc = "0.2"
 libfuzzer-sys = "0.4"
 libtest-mimic = "0.8"

--- a/opentmk/Cargo.toml
+++ b/opentmk/Cargo.toml
@@ -10,7 +10,6 @@ rust-version.workspace = true
 bitfield-struct.workspace = true
 cfg-if.workspace  = true
 hvdef.workspace = true
-lazy_static = { workspace = true, features = ["spin_no_std"] }
 linked_list_allocator.workspace = true
 log.workspace = true
 memory_range.workspace = true

--- a/opentmk/src/arch/x86_64/interrupt.rs
+++ b/opentmk/src/arch/x86_64/interrupt.rs
@@ -2,11 +2,10 @@
 // Licensed under the MIT License.
 
 //! x86_64-specific interrupt handling implementation.
-//!
 
 use alloc::boxed::Box;
 
-use lazy_static::lazy_static;
+use spin::Lazy;
 use spin::Mutex;
 use x86_64::structures::idt::InterruptDescriptorTable;
 use x86_64::structures::idt::InterruptStackFrame;
@@ -14,14 +13,12 @@ use x86_64::structures::idt::InterruptStackFrame;
 use super::interrupt_handler_register::register_interrupt_handler;
 use super::interrupt_handler_register::set_common_handler;
 
-lazy_static! {
-    static ref IDT: InterruptDescriptorTable = {
-        let mut idt = InterruptDescriptorTable::new();
-        register_interrupt_handler(&mut idt);
-        idt.double_fault.set_handler_fn(handler_double_fault);
-        idt
-    };
-}
+static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
+    let mut idt = InterruptDescriptorTable::new();
+    register_interrupt_handler(&mut idt);
+    idt.double_fault.set_handler_fn(handler_double_fault);
+    idt
+});
 
 static mut HANDLERS: [Option<Box<dyn Fn() + 'static>>; 256] = [const { None }; 256];
 static MUTEX: Mutex<()> = Mutex::new(());


### PR DESCRIPTION
Spin provides its own primitive, just use that.