### PR TITLE
flowey: backport fix for gh release download node

### DIFF
--- a/flowey/flowey_lib_common/src/download_gh_release.rs
+++ b/flowey/flowey_lib_common/src/download_gh_release.rs
@@ -247,7 +247,16 @@ fn download_all_reqs(
         } else {
             // FUTURE: parallelize curl invocations across all download_reqs
             for file in files.keys() {
-                xshell::cmd!(sh, "curl --fail -L https://github.com/{repo_owner}/{repo_name}/releases/download/{tag}/{file} -o {file}").run()?;
+                let mut cmd = xshell::cmd!(
+                    sh,
+                    "curl --fail -L https://github.com/{repo_owner}/{repo_name}/releases/download/{tag}/{file} -o {file}"
+                );
+
+                if matches!(rt.platform(), FlowPlatform::Windows) {
+                    cmd = cmd.arg("--ssl-revoke-best-effort");
+                }
+
+                cmd.run()?;
             }
         }
     }


### PR DESCRIPTION
Cherry-pick of #2883 - not a clean cherry-pick because of the `flowey::shell_cmd!` macro