### PR TITLE
consomme/tcp: use memcpy for ring buffer payload copy

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -497,13 +497,6 @@ impl<T: Client> Sender<'_, T> {
         let mut eth_packet = EthernetFrame::new_unchecked(&mut buffer[..]);
         eth_packet.set_dst_addr(self.state.params.client_mac);
         eth_packet.set_src_addr(self.state.params.gateway_mac);
-        let copy_payload_into_buffer = |buf: &mut [u8], payload: Option<ring::View<'_>>| {
-            if let Some(payload) = payload {
-                for (b, c) in buf.iter_mut().zip(payload.iter()) {
-                    *b = *c;
-                }
-            }
-        };
         let ip = IpRepr::new(
             self.ft.dst.ip().into(),
             self.ft.src.ip().into(),
@@ -547,7 +540,9 @@ impl<T: Client> Sender<'_, T> {
         );
 
         // Copy payload into TCP packet
-        copy_payload_into_buffer(tcp_packet.payload_mut(), payload);
+        if let Some(payload) = &payload {
+            payload.copy_to_slice(tcp_packet.payload_mut());
+        }
         tcp_packet.fill_checksum(&self.ft.dst.ip().into(), &self.ft.src.ip().into());
         let n = ETHERNET_HEADER_LEN + ip_total_len;
         let checksum_state = match self.ft.dst {

--- a/vm/devices/net/net_consomme/consomme/src/tcp/ring.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/ring.rs
@@ -100,9 +100,14 @@ impl<'a> View<'a> {
         }
     }
 
-    pub fn iter(&self) -> impl '_ + Iterator<Item = &u8> {
+    /// Copies the view contents into `buf`.
+    ///
+    /// # Panics
+    /// Panics if `buf` is smaller than the view length.
+    pub fn copy_to_slice(&self, buf: &mut [u8]) {
         let (a, b) = self.as_slices();
-        a.iter().chain(b)
+        buf[..a.len()].copy_from_slice(a);
+        buf[a.len()..a.len() + b.len()].copy_from_slice(b);
     }
 }
 


### PR DESCRIPTION
Replace byte-by-byte iterator copy with copy_from_slice on the ring buffer's contiguous slices. This compiles to memcpy and avoids per-byte iterator overhead when constructing outbound TCP packets.

Add View::copy_to_slice() to encapsulate the two-slice copy pattern and remove the now-unused View::iter() method.