### PR TITLE
virtio_net: don't deliver corrupt packets on guest memory write failure

### DIFF
--- a/vm/devices/virtio/virtio_net/src/buffers.rs
+++ b/vm/devices/virtio/virtio_net/src/buffers.rs
@@ -18,6 +18,7 @@ struct RxPacket {
     work: VirtioQueueCallbackWork,
     len: u32,
     cap: u32,
+    data_write_failed: bool,
 }
 
 /// Holds virtio buffers available for a network backend to send data to the client.
@@ -91,7 +92,12 @@ impl VirtioWorkPool {
             );
             return Err(work);
         };
-        *packet = Some(RxPacket { len: 0, cap, work });
+        *packet = Some(RxPacket {
+            len: 0,
+            cap,
+            work,
+            data_write_failed: false,
+        });
         Ok(RxId(idx.into()))
     }
 
@@ -132,6 +138,8 @@ impl BufferAccess for VirtioWorkPool {
                 error = &err as &dyn std::error::Error,
                 "rx memory write failure"
             );
+            packet.data_write_failed = true;
+            packet.len = 0;
         }
     }
 
@@ -178,6 +186,11 @@ impl BufferAccess for VirtioWorkPool {
         let packet = self.rx_packets[id.0 as usize]
             .as_mut()
             .expect("invalid buffer index");
+        if packet.data_write_failed {
+            // write_data failed; skip header so complete_packet delivers a
+            // zero-length packet instead of corrupt data.
+            return;
+        }
         if let Err(err) = packet
             .work
             .write(&self.mem, &virtio_net_header.as_bytes()[..header_size()])


### PR DESCRIPTION
write_data logs an error when write_at_offset fails but does not prevent the packet from being delivered. write_header, called afterwards, unconditionally sets packet.len = metadata.len, so complete_packet sees a non-zero length and delivers the packet — including any partial or corrupt data written before the failure.

Add a data_write_failed flag to RxPacket. Set it when write_data's write_at_offset call fails. Check it at the top of write_header and return early, leaving packet.len at zero. complete_packet then treats the packet as empty and completes it with zero length.