### PR TITLE
ovmm_entry: Remove use of macaddr crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,12 +3933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macaddr"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
-
-[[package]]
 name = "make_imc_hive"
 version = "0.0.0"
 dependencies = [
@@ -5285,7 +5279,6 @@ dependencies = [
  "input_core",
  "inspect",
  "inspect_proto",
- "macaddr",
  "mcr_resources",
  "mesh",
  "mesh_process",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -497,7 +497,6 @@ linked_list_allocator = "0.10.5"
 linkme = "0.3.9"
 log = "0.4"
 loom = "0.7.2"
-macaddr = "1.0"
 mimalloc = { version = "0.1.39", default-features = false }
 ms-tpm-20-ref = { version = "0.1", git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", branch = "main" }
 mshv-bindings = "0.6.0"

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -94,7 +94,6 @@ futures.workspace = true
 futures-concurrency.workspace = true
 getrandom.workspace = true
 openssl = { optional = true, workspace = true }
-macaddr.workspace = true
 parking_lot.workspace = true
 prost.workspace = true
 rustyline = { workspace = true, features = ["derive"] }

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -729,10 +729,8 @@ fn parse_nic_config(
         instance_id: nic.nic_id.parse().context("invalid instance ID")?,
         mac_address: nic
             .mac_address
-            .parse::<macaddr::MacAddr6>()
-            .context("invalid mac address")?
-            .into_array()
-            .into(),
+            .parse::<net_backend_resources::mac_address::MacAddress>()
+            .context("invalid mac address")?,
         endpoint,
         max_queues: None,
     };


### PR DESCRIPTION
We have our own mac address type already, we should just use that.