### PR TITLE
ovmm_entry: Replace awaitgroup with just a Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,12 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "awaitgroup"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a872ceb3db05a391fbe7cf8eba07a1239b2d946eee66f9e942be9bff06206302"
-
-[[package]]
 name = "azure_profiler_proto"
 version = "0.0.0"
 dependencies = [
@@ -5256,7 +5250,6 @@ name = "openvmm_entry"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "awaitgroup",
  "build_rs_guest_arch",
  "chipset_device_worker_defs",
  "chipset_resources",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,7 +424,6 @@ arrayvec = { version = "0.7", default-features = false }
 async-channel = "2.3"
 async-task = "4.4"
 async-trait = "0.1"
-awaitgroup = "0.7"
 base64 = "0.22.1"
 base64-serde = "0.8"
 bitfield-struct = "0.11.0"

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -86,7 +86,6 @@ tracelimit.workspace = true
 tracing_helpers.workspace = true
 
 anyhow.workspace = true
-awaitgroup.workspace = true
 clap = { workspace = true, features = ["derive", "string"] }
 dirs.workspace = true
 fs-err.workspace = true

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -10,7 +10,6 @@ use crate::serial_io::bind_serial;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
-use awaitgroup::WaitGroup;
 use futures::FutureExt;
 use futures::StreamExt;
 use guid::Guid;
@@ -49,6 +48,7 @@ use openvmm_ttrpc_vmservice as vmservice;
 use pal_async::DefaultDriver;
 use pal_async::DefaultPool;
 use pal_async::task::Spawn;
+use pal_async::task::Task;
 use parking_lot::Mutex;
 use scsidisk_resources::SimpleScsiDiskHandle;
 use std::fs::File;
@@ -131,7 +131,7 @@ impl Worker for TtrpcWorker {
                 driver,
                 vm: None,
                 worker_handle: None,
-                rpc_wait_group: WaitGroup::new(),
+                rpc_tasks: Vec::new(),
                 transport: self.transport,
             };
             service.run(self.listener, recv).await?;
@@ -225,7 +225,7 @@ impl VmService {
         }
 
         // Drain any remaining RPCs.
-        self.rpc_wait_group.wait().await;
+        futures::future::join_all(self.rpc_tasks.drain(..)).await;
         if let Some(vm) = self.vm.take() {
             let _ = Arc::try_unwrap(vm).ok().expect("no more VM references");
         }
@@ -237,7 +237,7 @@ impl VmService {
     }
 
     fn start_rpc<F, R>(
-        &self,
+        &mut self,
         response: mesh::OneshotSender<Result<R, Status>>,
         r: anyhow::Result<F>,
     ) where
@@ -246,13 +246,10 @@ impl VmService {
     {
         match r {
             Ok(fut) => {
-                let worker = self.rpc_wait_group.worker();
-                self.driver
-                    .spawn("ttrpc-rpc", async move {
-                        response.send(map_grpc(fut.await));
-                        worker.done();
-                    })
-                    .detach();
+                let task = self.driver.spawn("ttrpc-rpc", async move {
+                    response.send(map_grpc(fut.await));
+                });
+                self.rpc_tasks.push(task);
             }
             Err(err) => response.send(Err(grpc_error(err))),
         }
@@ -269,7 +266,7 @@ struct VmService {
     driver: DefaultDriver,
     vm: Option<Arc<Vm>>,
     worker_handle: Option<mesh_worker::WorkerHandle>,
-    rpc_wait_group: WaitGroup,
+    rpc_tasks: Vec<Task<()>>,
     transport: ResolvedTransport,
 }
 


### PR DESCRIPTION
There's no need to pull in a dep (even if it's small) for something that can be done with just a Vec