### PR TITLE
openvmm: add hint about file paths on failure to open disks when running cross compiled

### DIFF
--- a/openvmm/openvmm_helpers/src/disk.rs
+++ b/openvmm/openvmm_helpers/src/disk.rs
@@ -3,9 +3,24 @@
 
 //! Guest disk helpers.
 
+use anyhow::Context;
 use std::path::Path;
 use vm_resource::Resource;
 use vm_resource::kind::DiskHandleKind;
+
+fn disk_open_error(path: &Path, verb: &str) -> String {
+    let mut msg = format!("{verb} '{}'", path.display());
+
+    // On windows, attempt to detect we ran under wsl by reading the WSLENV and
+    // bail out with a helpful hint that it needs to be a windows path.
+    if cfg!(windows) && std::env::var_os("WSLENV").is_some() {
+        msg += ". Linux paths are not supported when running Windows executables \
+                under WSL, make sure the path is a valid Windows path \
+                (use `wslpath -w` to convert)";
+    }
+
+    msg
+}
 
 /// Opens the resources needed for using a disk from a file at `path`.
 ///
@@ -18,7 +33,8 @@ pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<D
             let file = std::fs::OpenOptions::new()
                 .read(true)
                 .write(!read_only)
-                .open(path)?;
+                .open(path)
+                .with_context(|| disk_open_error(path, "failed to open"))?;
 
             match disk_vhd1::Vhd1Disk::open_fixed(file, read_only) {
                 Ok(vhd) => Resource::new(disk_backend_resources::FixedVhd1DiskHandle(
@@ -28,7 +44,8 @@ pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<D
                     #[cfg(windows)]
                     {
                         Resource::new(disk_vhdmp::OpenVhdmpDiskConfig(
-                            disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)?,
+                            disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)
+                                .with_context(|| disk_open_error(path, "failed to open"))?,
                         ))
                     }
                     #[cfg(not(windows))]
@@ -41,7 +58,8 @@ pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<D
             #[cfg(windows)]
             {
                 Resource::new(disk_vhdmp::OpenVhdmpDiskConfig(
-                    disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)?,
+                    disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)
+                        .with_context(|| disk_open_error(path, "failed to open"))?,
                 ))
             }
             #[cfg(not(windows))]
@@ -56,7 +74,8 @@ pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<D
             let file = std::fs::OpenOptions::new()
                 .read(true)
                 .write(!read_only)
-                .open(path)?;
+                .open(path)
+                .with_context(|| disk_open_error(path, "failed to open"))?;
 
             Resource::new(disk_backend_resources::FixedVhd1DiskHandle(file))
         }
@@ -64,7 +83,8 @@ pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<D
             let file = std::fs::OpenOptions::new()
                 .read(true)
                 .write(!read_only)
-                .open(path)?;
+                .open(path)
+                .with_context(|| disk_open_error(path, "failed to open"))?;
 
             Resource::new(disk_backend_resources::FileDiskHandle(file))
         }
@@ -80,7 +100,8 @@ pub fn create_disk_type(path: &Path, size: u64) -> anyhow::Result<Resource<DiskH
                 .truncate(true)
                 .read(true)
                 .write(true)
-                .open(path)?;
+                .open(path)
+                .with_context(|| disk_open_error(path, "failed to create"))?;
 
             file.set_len(size)?;
             disk_vhd1::Vhd1Disk::make_fixed(&file)?;
@@ -98,7 +119,8 @@ pub fn create_disk_type(path: &Path, size: u64) -> anyhow::Result<Resource<DiskH
                 .truncate(true)
                 .read(true)
                 .write(true)
-                .open(path)?;
+                .open(path)
+                .with_context(|| disk_open_error(path, "failed to create"))?;
 
             file.set_len(size)?;
             Resource::new(disk_backend_resources::FileDiskHandle(file))


### PR DESCRIPTION
It's a common mistake to use a Linux path when running cross compiled under WSL, which won't work and sometimes is hard to figure out why. Add a note to clarify that it needs to be a Windows path. 

The env var is best effort since we don't want to print the message if we don't think we're running under WSL to confuse users.