### PR TITLE
guide: make WSL cross-compile UEFI example fully copy-pasteable

### DIFF
--- a/Guide/src/dev_guide/getting_started/cross_compile.md
+++ b/Guide/src/dev_guide/getting_started/cross_compile.md
@@ -325,7 +325,7 @@ Here is a full working example that launches OpenVMM with a VHDX disk:
 cargo run --target x86_64-pc-windows-msvc -- \
   --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx)" \
   --uefi \
-  --uefi-firmware "$(wslpath -w oss/.packages/hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV/MSVM.fd)" \
+  --uefi-firmware "$(wslpath -w .packages/hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV/MSVM.fd)" \
   --gfx -p 6 -m 8GB
 ```
 
@@ -336,7 +336,7 @@ env var (set in `.cargo/config.toml`) is automatically translated to a
 Windows path:
 
 ```bash
-export WSLENV=$WSLENV:X86_64_OPENVMM_UEFI_FIRMWARE
+export WSLENV=$WSLENV:X86_64_OPENVMM_UEFI_FIRMWARE/p
 cargo run --target x86_64-pc-windows-msvc -- \
   --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx)" \
   --uefi --gfx -p 6 -m 8GB


### PR DESCRIPTION
The cross-compile working example uses `--uefi` without specifying the firmware path, which fails when WSLENV isn't configured — the Windows binary receives a Linux-format path and can't find the firmware.

Make the default example fully copy-pasteable by adding explicit `--uefi-firmware` with `wslpath -w` translation. Move the shorter WSLENV-based command into a tip admonish as an alternative.

Addresses feedback from @jakeatmicrosoft on #2901.