### PR TITLE
netvsp: adding libfuzz tests to validate packet processing and event handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,6 +2399,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzz_netvsp"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "async-trait",
+ "futures",
+ "guestmem",
+ "guid",
+ "hvdef",
+ "inspect",
+ "libfuzzer-sys",
+ "mesh",
+ "net_backend",
+ "netvsp",
+ "pal_async",
+ "parking_lot",
+ "vmbus_async",
+ "vmbus_channel",
+ "vmbus_core",
+ "vmbus_ring",
+ "vmcore",
+ "xtask_fuzz",
+ "zerocopy 0.8.27",
+]
+
+[[package]]
 name = "fuzz_nvme_driver"
 version = "0.0.0"
 dependencies = [
@@ -4593,6 +4620,7 @@ name = "netvsp"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "arrayvec",
  "async-trait",
  "bitfield-struct 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "vm/devices/chipset/fuzz",
   "vm/devices/pci/pcie/fuzz",
   "vm/devices/firmware/firmware_uefi/fuzz",
+  "vm/devices/net/netvsp/fuzz",
   "vm/devices/storage/disk_nvme/nvme_driver/fuzz",
   "vm/devices/storage/ide/fuzz",
   "vm/devices/storage/scsi_buffers/fuzz",

--- a/Guide/src/SUMMARY.md
+++ b/Guide/src/SUMMARY.md
@@ -39,6 +39,7 @@
   - [Fuzzing](./dev_guide/tests/fuzzing.md)
     - [Running Fuzzers](./dev_guide/tests/fuzzing/running.md)
     - [Writing Fuzzers](./dev_guide/tests/fuzzing/writing.md)
+    - [NetVSP Fuzzing](./dev_guide/tests/fuzzing/netvsp.md)
 - [Developer Tools / Utilities](./dev_guide/dev_tools.md)
   - [`flowey`](./dev_guide/dev_tools/flowey.md)
     - [`Flowey Fundamentals`](./dev_guide/dev_tools/flowey/flowey_fundamentals.md)

--- a/Guide/src/dev_guide/tests/fuzzing/netvsp.md
+++ b/Guide/src/dev_guide/tests/fuzzing/netvsp.md
@@ -1,0 +1,115 @@
+# NetVSP Fuzzing
+
+## NetVSP fuzzing design
+
+- Attempt to catch bugs that appear after a sequence of state transitions.
+  - A test consumes one byte stream and interprets it as a sequence of actions, not just one packet.
+  - The harness panics on timeout (`500ms`) to turn hangs into detectable failures.
+- Add support for `Arbitrary` to NVSP/RNDIS protocol types.
+  - Enables control, OID, and data fields to be mutated directly.
+  - Example: `#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]`
+- Provide a robust fuzzing dictionary `netvsp_rndis.dict`.
+  - Includes NVSP versions, message IDs, transaction IDs, RNDIS message types, OIDs, status codes, and handshake payload fragments.
+- Provide infrastructure mocks to remove external environment setup.
+  - Fuzzing tests are focused on parser and state-machine behavior.
+- Split fuzzing into separate fuzz targets.
+  - Faster triage as crashes are scoped to a domain.
+  - Each corpus can specialize.
+
+### What each `fuzz_netvsp_*` target fuzzes
+
+Legend: **✓ primary focus**, **~ partial/indirect coverage**
+
+| Target | NVSP control | RNDIS OID | TX packet path | RX packet path | Link events | VF/SR-IOV | Subchannels | Save/Restore |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `fuzz_netvsp_control` | ✓ | ~ | ~ | ~ |  |  | ~ |  |
+| `fuzz_netvsp_oid` | ~ | ✓ |  |  |  |  |  |  |
+| `fuzz_netvsp_tx_path` | ~ | ~ | ✓ | ~ |  |  |  |  |
+| `fuzz_netvsp_rx_path` | ~ | ~ | ~ | ✓ |  |  |  |  |
+| `fuzz_netvsp_interop` | ✓ | ✓ | ✓ | ✓ | ~ | ~ | ~ |  |
+| `fuzz_netvsp_link_status` | ~ |  | ~ | ~ | ✓ |  |  |  |
+| `fuzz_netvsp_vf_state` | ~ |  | ~ |   |  | ✓ |  |  |
+| `fuzz_netvsp_subchannel` | ✓ |  | ✓ | ~ |  |  | ✓ |  |
+| `fuzz_netvsp_save_restore` | ~ | ~ | ~ | ~ | ~ | ✓ | ~ | ✓ |
+
+### Execution model of `fuzz_netvsp_interop`
+
+1. Negotiates NetVSP to ready state.
+2. Mostly initializes RNDIS (90% of runs), but sometimes deliberately skips it (10%) to test pre-init interactions.
+3. Runs arbitrary interleavings until input is exhausted.
+4. Periodically drains queue to preserve pressure while preventing backlog stalls.
+
+## Mocks in NetVSP fuzz tests
+
+- **`FuzzEndpoint` (loopback-based endpoint wrapper)**
+  - Controllable RX packet injection and endpoint
+    action injection (example: link notifications).
+  - Source pointers: `fuzz_helpers/endpoint.rs`
+
+- **`FuzzMockVmbus` + `MultiChannelMockVmbus`**
+  - In-process VMBus, with offer/open lifecycle, GPADL
+    registration, ring plumbing, and server request handling hooks.
+  - Source pointers: `fuzz_helpers/vmbus.rs`
+
+- **`FuzzVirtualFunction` (mock VF provider)**
+  - VF ID updates and state-change signaling hooks.
+  - Source pointers: `fuzz_helpers/vf.rs`
+
+- **`FuzzNicConfig` + NIC setup/teardown**
+  - NIC on a mock VMBus channel, with reproducible memory layout,
+    send and receive buffers, and customizability for different tests.
+  - Source pointers: `fuzz_helpers/nic_setup.rs`
+
+- **`SubchannelOpener` and multi-channel mock state**
+  - Synthetic opening of pending subchannel offers, including GPADL + ring handshake
+    for each opened subchannel.
+  - Source pointers: `fuzz_helpers/nic_setup.rs`
+
+- **Reusable fuzz loop/runtime controls in `fuzz_helpers`**
+  - Common `run_fuzz_loop*`, timeout guardrails, queue drain helpers,
+    and canonical negotiation helpers.
+  - Source pointers: `fuzz_helpers/mod.rs`
+
+## Helper xtask commands
+
+Run all netvsp fuzz tests for 1 minute (default is 5).
+Note: To run with sanitizers, supply a toolchain that supports unstable compiler features.
+
+`cargo xtask fuzz netvsp 1 --toolchain nightly`
+
+```
+==============================================
+ Campaign Complete
+==============================================
+  fuzz_netvsp_control: clean
+  fuzz_netvsp_tx_path: clean
+  fuzz_netvsp_oid: clean
+  fuzz_netvsp_interop: clean
+  fuzz_netvsp_rx_path: clean
+  fuzz_netvsp_link_status: clean
+  fuzz_netvsp_vf_state: clean
+  fuzz_netvsp_subchannel: clean
+  fuzz_netvsp_save_restore: clean
+
+ Total (new): 0 crashes, 0 timeouts, 0 slow-units, 0 OOM
+ Targets failed: 0 / 9
+```
+
+Collect coverage data from all netvsp fuzz tests.
+Note: To run with sanitizers, supply a toolchain that supports unstable compiler features.
+
+`cargo xtask fuzz netvsp-coverage --toolchain nightly`
+
+```
+----------------------------------------------
+ Per-File Coverage
+----------------------------------------------
+
+  buffers.rs                                116 /  153 lines ( 75.8%)  8/11 fn (72.7%)
+  lib.rs                                   3088 / 3529 lines ( 87.5%)  205/218 fn (94.0%)
+  protocol.rs                                 0 /    9 lines (  0.0%)  0/3 fn (0.0%)
+  resolver.rs                                 0 /    2 lines (  0.0%)  0/1 fn (0.0%)
+  rndisprot.rs                               85 /  147 lines ( 57.8%)  20/36 fn (55.6%)
+  rx_bufs.rs                                 74 /   78 lines ( 94.9%)  11/11 fn (100.0%)
+  saved_state.rs                             11 /   11 lines (100.0%)  3/3 fn (100.0%)
+```

--- a/Guide/src/dev_guide/tests/fuzzing/netvsp.md
+++ b/Guide/src/dev_guide/tests/fuzzing/netvsp.md
@@ -77,7 +77,7 @@ Note: To run with sanitizers, supply a toolchain that supports unstable compiler
 
 `cargo xtask fuzz netvsp 1 --toolchain nightly`
 
-```
+```text
 ==============================================
  Campaign Complete
 ==============================================
@@ -100,7 +100,7 @@ Note: To run with sanitizers, supply a toolchain that supports unstable compiler
 
 `cargo xtask fuzz netvsp-coverage --toolchain nightly`
 
-```
+```text
 ----------------------------------------------
  Per-File Coverage
 ----------------------------------------------

--- a/vm/devices/net/netvsp/Cargo.toml
+++ b/vm/devices/net/netvsp/Cargo.toml
@@ -6,6 +6,11 @@ name = "netvsp"
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+# Expose some implementation details publicly, used for fuzzing.
+test = []
+arbitrary = ["dep:arbitrary"]
+
 [dependencies]
 net_backend.workspace = true
 net_backend_resources.workspace = true
@@ -41,6 +46,7 @@ tracelimit.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
 hvdef.workspace = true
+arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 event-listener.workspace = true

--- a/vm/devices/net/netvsp/fuzz/.gitignore
+++ b/vm/devices/net/netvsp/fuzz/.gitignore
@@ -1,0 +1,2 @@
+# Local fuzzing artifacts
+*.log

--- a/vm/devices/net/netvsp/fuzz/.gitignore
+++ b/vm/devices/net/netvsp/fuzz/.gitignore
@@ -1,2 +1,3 @@
 # Local fuzzing artifacts
 *.log
+fuzz_logs/

--- a/vm/devices/net/netvsp/fuzz/Cargo.toml
+++ b/vm/devices/net/netvsp/fuzz/Cargo.toml
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "fuzz_netvsp"
+publish = false
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+netvsp = { workspace = true, features = ["test", "arbitrary"] }
+net_backend.workspace = true
+guid.workspace = true
+pal_async.workspace = true
+vmbus_async.workspace = true
+vmbus_channel.workspace = true
+vmbus_core.workspace = true
+vmbus_ring.workspace = true
+vmcore.workspace = true
+guestmem.workspace = true
+hvdef.workspace = true
+mesh.workspace = true
+parking_lot.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+inspect = { workspace = true, features = ["initiate"] }
+zerocopy.workspace = true
+xtask_fuzz.workspace = true
+
+arbitrary = { workspace = true, features = ["derive"] }
+
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
+libfuzzer-sys.workspace = true
+
+[package.metadata.xtask.unused-deps]
+# required for the xtask_fuzz macro, but unused_deps doesn't know that
+ignored = ["libfuzzer-sys"]
+
+[package.metadata]
+cargo-fuzz = true
+
+[package.metadata.xtask.fuzz.onefuzz-allowlist]
+fuzz_netvsp_control = ["fuzz_netvsp_control.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "netvsp_rndis.dict", "../src/**/*.rs"]
+fuzz_netvsp_tx_path = ["fuzz_netvsp_tx_path.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "netvsp_rndis.dict", "../src/**/*.rs"]
+fuzz_netvsp_oid = ["fuzz_netvsp_oid.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "netvsp_rndis.dict", "../src/**/*.rs"]
+fuzz_netvsp_interop = ["fuzz_netvsp_interop.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "netvsp_rndis.dict", "../src/**/*.rs"]
+fuzz_netvsp_rx_path = ["fuzz_netvsp_rx_path.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "netvsp_rndis.dict", "../src/**/*.rs"]
+fuzz_netvsp_link_status = ["fuzz_netvsp_link_status.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "netvsp_rndis.dict", "../src/**/*.rs"]
+fuzz_netvsp_vf_state = ["fuzz_netvsp_vf_state.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "netvsp_rndis.dict", "../src/**/*.rs"]
+fuzz_netvsp_subchannel = ["fuzz_netvsp_subchannel.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "netvsp_rndis.dict", "../src/**/*.rs"]
+fuzz_netvsp_save_restore = ["fuzz_netvsp_save_restore.rs", "fuzz_helpers.rs", "fuzz_helpers/**/*.rs", "../src/**/*.rs"]
+
+[[bin]]
+name = "fuzz_netvsp_control"
+path = "fuzz_netvsp_control.rs"
+test = false
+doc = false
+doctest = false
+
+[[bin]]
+name = "fuzz_netvsp_tx_path"
+path = "fuzz_netvsp_tx_path.rs"
+test = false
+doc = false
+doctest = false
+
+[[bin]]
+name = "fuzz_netvsp_oid"
+path = "fuzz_netvsp_oid.rs"
+test = false
+doc = false
+doctest = false
+
+[[bin]]
+name = "fuzz_netvsp_interop"
+path = "fuzz_netvsp_interop.rs"
+test = false
+doc = false
+doctest = false
+
+[[bin]]
+name = "fuzz_netvsp_rx_path"
+path = "fuzz_netvsp_rx_path.rs"
+test = false
+doc = false
+doctest = false
+
+[[bin]]
+name = "fuzz_netvsp_link_status"
+path = "fuzz_netvsp_link_status.rs"
+test = false
+doc = false
+doctest = false
+
+[[bin]]
+name = "fuzz_netvsp_vf_state"
+path = "fuzz_netvsp_vf_state.rs"
+test = false
+doc = false
+doctest = false
+
+[[bin]]
+name = "fuzz_netvsp_subchannel"
+path = "fuzz_netvsp_subchannel.rs"
+test = false
+doc = false
+doctest = false
+
+[[bin]]
+name = "fuzz_netvsp_save_restore"
+path = "fuzz_netvsp_save_restore.rs"
+test = false
+doc = false
+doctest = false
+
+[lints]
+workspace = true

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/endpoint.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/endpoint.rs
@@ -1,0 +1,439 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzable network endpoint and queue implementations.
+//!
+//! [`FuzzEndpoint`] wraps a [`LoopbackEndpoint`] with additional
+//! fuzzer-controlled capabilities: RX packet injection, endpoint action
+//! injection (link status changes), and TX error injection.
+
+use arbitrary::Arbitrary;
+use async_trait::async_trait;
+use inspect::InspectMut;
+use net_backend::Endpoint;
+use net_backend::EndpointAction;
+use net_backend::L4Protocol;
+use net_backend::MultiQueueSupport;
+use net_backend::Queue as BackendQueue;
+use net_backend::QueueConfig;
+use net_backend::RssConfig;
+use net_backend::RxChecksumState;
+use net_backend::RxId;
+use net_backend::RxMetadata;
+use net_backend::TxError;
+use net_backend::TxId;
+use net_backend::TxOffloadSupport;
+use net_backend::TxSegment;
+use net_backend::TxSegmentType;
+use net_backend::linearize;
+use net_backend::loopback::LoopbackEndpoint;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+
+/// Fuzzer-controllable receive metadata. Allows the fuzzer to exercise all
+/// checksum-reporting branches in `write_header()` (48 combinations of IP
+/// checksum state × L4 protocol × L4 checksum state).
+#[derive(Clone, Copy, Debug, Arbitrary)]
+pub enum FuzzRxChecksumState {
+    Unknown,
+    Good,
+    Bad,
+    ValidatedButWrong,
+}
+
+impl From<FuzzRxChecksumState> for RxChecksumState {
+    fn from(v: FuzzRxChecksumState) -> Self {
+        match v {
+            FuzzRxChecksumState::Unknown => RxChecksumState::Unknown,
+            FuzzRxChecksumState::Good => RxChecksumState::Good,
+            FuzzRxChecksumState::Bad => RxChecksumState::Bad,
+            FuzzRxChecksumState::ValidatedButWrong => RxChecksumState::ValidatedButWrong,
+        }
+    }
+}
+
+/// Fuzzer-controllable L4 protocol selection.
+#[derive(Clone, Copy, Debug, Arbitrary)]
+pub enum FuzzL4Protocol {
+    Unknown,
+    Tcp,
+    Udp,
+}
+
+impl From<FuzzL4Protocol> for L4Protocol {
+    fn from(v: FuzzL4Protocol) -> Self {
+        match v {
+            FuzzL4Protocol::Unknown => L4Protocol::Unknown,
+            FuzzL4Protocol::Tcp => L4Protocol::Tcp,
+            FuzzL4Protocol::Udp => L4Protocol::Udp,
+        }
+    }
+}
+
+/// Fuzzer-driven RX metadata. Use this in fuzz actions that inject RX packets
+/// to exercise all checksum-flag branches in the NIC's `write_header()`.
+#[derive(Clone, Copy, Debug, Arbitrary)]
+pub struct FuzzRxMetadata {
+    pub ip_checksum: FuzzRxChecksumState,
+    pub l4_checksum: FuzzRxChecksumState,
+    pub l4_protocol: FuzzL4Protocol,
+}
+
+impl FuzzRxMetadata {
+    /// Convert to `RxMetadata` using the given packet length.
+    pub fn to_rx_metadata(self, packet_len: usize) -> RxMetadata {
+        RxMetadata {
+            offset: 0,
+            len: packet_len,
+            ip_checksum: self.ip_checksum.into(),
+            l4_checksum: self.l4_checksum.into(),
+            l4_protocol: self.l4_protocol.into(),
+        }
+    }
+}
+
+impl Default for FuzzRxMetadata {
+    fn default() -> Self {
+        Self {
+            ip_checksum: FuzzRxChecksumState::Unknown,
+            l4_checksum: FuzzRxChecksumState::Unknown,
+            l4_protocol: FuzzL4Protocol::Unknown,
+        }
+    }
+}
+
+/// Configuration for creating a [`FuzzEndpoint`].
+#[derive(Default)]
+pub struct FuzzEndpointConfig {
+    /// Whether to enable RX packet injection via a channel.
+    pub enable_rx_injection: bool,
+    /// Whether to enable endpoint action injection (link status, restart).
+    pub enable_action_injection: bool,
+    /// When true, `set_data_path_to_guest_vf()` returns `Err`, exercising
+    /// the `DataPathSynthetic` fallback state.  When false, it succeeds,
+    /// exercising the `DataPathSwitched` state.  Default: false (succeeds).
+    pub fail_vf_switch: bool,
+    /// When true, creates a shared `Arc<AtomicU8>` for TX error injection.
+    /// The fuzz loop can set the atomic to 1 (`TxError::TryRestart`) or
+    /// 2 (`TxError::Fatal`) to exercise error handling in
+    /// `process_endpoint_tx`.  Default: false.
+    pub enable_tx_error_injection: bool,
+    /// When true, `tx_avail` returns `(false, sent)` (asynchronous TX),
+    /// and completed `TxId`s are returned via `tx_poll`. This exercises
+    /// the `process_endpoint_tx` → `complete_tx_packet` path and
+    /// `reset_tx_after_endpoint_stop` cleanup, which are unreachable
+    /// when TX is always synchronous.  Default: false (synchronous TX).
+    pub enable_async_tx: bool,
+}
+
+/// Handles returned to the fuzz loop for injecting events into the endpoint.
+pub struct FuzzEndpointHandles {
+    /// Send RX packets (with metadata) to be delivered by the endpoint.
+    /// Only present if `enable_rx_injection` was set.
+    pub rx_send: Option<mesh::Sender<(Vec<u8>, FuzzRxMetadata)>>,
+    /// Send endpoint actions (link status, restart) to be delivered.
+    /// Only present if `enable_action_injection` was set.
+    pub action_send: Option<mesh::Sender<EndpointAction>>,
+    /// Shared atomic controlling TX error injection in `FuzzableQueue::tx_poll`.
+    /// Set to 0 (normal), 1 (`TxError::TryRestart`), or 2 (`TxError::Fatal`).
+    /// Only present if `enable_tx_error_injection` was set.
+    pub tx_error_mode: Option<Arc<AtomicU8>>,
+}
+
+/// A network endpoint wrapping [`LoopbackEndpoint`] with additional
+/// fuzzer-controlled capabilities:
+/// - RX packet injection via a channel
+/// - EndpointAction injection (link status changes, restart signals)
+#[derive(InspectMut)]
+#[inspect(skip)]
+pub struct FuzzEndpoint {
+    inner: LoopbackEndpoint,
+    rx_recv: Option<mesh::Receiver<(Vec<u8>, FuzzRxMetadata)>>,
+    action_recv: Option<mesh::Receiver<EndpointAction>>,
+    /// Metadata template applied to loopback (TX→RX) packets.
+    /// Configurable per-endpoint so that all loopback traffic also exercises
+    /// varied checksum branches in `write_header()`.
+    pub loopback_metadata: FuzzRxMetadata,
+    /// When true, `set_data_path_to_guest_vf()` returns an error.
+    fail_vf_switch: bool,
+    /// Shared atomic for TX error injection.  Cloned into each
+    /// `FuzzableQueue` during `get_queues()`.
+    tx_error_mode: Option<Arc<AtomicU8>>,
+    /// When true, `FuzzableQueue` uses asynchronous TX completions.
+    async_tx: bool,
+}
+
+#[derive(InspectMut)]
+#[inspect(skip)]
+struct FuzzableQueue {
+    pool: Box<dyn net_backend::BufferAccess>,
+    rx_avail: VecDeque<RxId>,
+    rx_done: VecDeque<RxId>,
+    rx_recv: Option<mesh::Receiver<(Vec<u8>, FuzzRxMetadata)>>,
+    pending_injected: VecDeque<(Vec<u8>, FuzzRxMetadata)>,
+    /// Metadata template for loopback (TX→RX) packets.
+    loopback_metadata: FuzzRxMetadata,
+    /// Shared atomic for TX error injection.  When non-zero,
+    /// `tx_poll` returns the corresponding `TxError` variant.
+    tx_error_mode: Option<Arc<AtomicU8>>,
+    /// When false, `tx_avail` returns `(false, sent)` and completed
+    /// `TxId`s are stored for retrieval via `tx_poll`.
+    sync_tx: bool,
+    /// Completed TX packet IDs pending retrieval via `tx_poll`.
+    /// Only populated when `sync_tx` is false.
+    pending_tx_completions: VecDeque<TxId>,
+}
+
+impl FuzzableQueue {
+    fn ingest_injected_packets(&mut self) {
+        if let Some(rx_recv) = &mut self.rx_recv {
+            while let Ok(entry) = rx_recv.try_recv() {
+                self.pending_injected.push_back(entry);
+            }
+        }
+    }
+
+    fn materialize_injected_packets(&mut self) {
+        self.ingest_injected_packets();
+        while !self.pending_injected.is_empty() && !self.rx_avail.is_empty() {
+            let Some((packet, fuzz_meta)) = self.pending_injected.pop_front() else {
+                break;
+            };
+            let rx_id = self
+                .rx_avail
+                .pop_front()
+                .expect("checked non-empty rx_avail");
+            // Use the fuzzer-provided metadata so that the NIC's RX path
+            // exercises all checksum-flag branches in `write_header()`.
+            let metadata = fuzz_meta.to_rx_metadata(packet.len());
+            self.pool.write_packet(rx_id, &metadata, &packet);
+            self.rx_done.push_back(rx_id);
+        }
+    }
+}
+
+impl BackendQueue for FuzzableQueue {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        self.materialize_injected_packets();
+        if !self.rx_done.is_empty() || !self.pending_tx_completions.is_empty() {
+            return Poll::Ready(());
+        }
+        if let Some(rx_recv) = &mut self.rx_recv {
+            // Poll the receiver to register the waker for new injected
+            // RX messages.  When a new packet arrives, the executor
+            // re-polls this queue.
+            match rx_recv.poll_recv(cx) {
+                Poll::Ready(Ok(entry)) => {
+                    self.pending_injected.push_back(entry);
+                    self.materialize_injected_packets();
+                    if !self.rx_done.is_empty() {
+                        return Poll::Ready(());
+                    }
+                }
+                Poll::Ready(Err(_)) => {} // channel closed
+                Poll::Pending => {}       // waker registered
+            }
+        }
+        // When `rx_recv` is None, no external waker needed:
+        // Worker drives `tx_avail` → `rx_avail` → `poll_ready`
+        Poll::Pending
+    }
+
+    fn rx_avail(&mut self, done: &[RxId]) {
+        self.rx_avail.extend(done.iter().copied());
+        self.materialize_injected_packets();
+    }
+
+    fn rx_poll(&mut self, packets: &mut [RxId]) -> anyhow::Result<usize> {
+        self.materialize_injected_packets();
+        let n = packets.len().min(self.rx_done.len());
+        for (d, s) in packets.iter_mut().zip(self.rx_done.drain(..n)) {
+            *d = s;
+        }
+        Ok(n)
+    }
+
+    fn tx_avail(&mut self, mut segments: &[TxSegment]) -> anyhow::Result<(bool, usize)> {
+        let mut sent = 0;
+        let original_segments = segments;
+        // Consume all segments to prevent the NIC worker retry the same segments.
+        while !segments.is_empty() {
+            let before = segments.len();
+            let packet = linearize(self.pool.as_ref(), &mut segments)?;
+            sent += before - segments.len();
+            if let Some(rx_id) = self.rx_avail.pop_front() {
+                // Use the loopback metadata template so that TX→RX loopback
+                // packets exercise varied checksum branches in `write_header()`.
+                let metadata = self.loopback_metadata.to_rx_metadata(packet.len());
+                self.pool.write_packet(rx_id, &metadata, &packet);
+                self.rx_done.push_back(rx_id);
+            }
+            // else: RX pool exhausted — packet is discarded.
+        }
+
+        if !self.sync_tx {
+            // Extract TxIds from consumed segments for async completion.
+            for seg in &original_segments[..sent] {
+                if let TxSegmentType::Head(metadata) = &seg.ty {
+                    self.pending_tx_completions.push_back(metadata.id);
+                }
+            }
+        }
+
+        self.materialize_injected_packets();
+        Ok((self.sync_tx, sent))
+    }
+
+    fn tx_poll(&mut self, done: &mut [TxId]) -> Result<usize, TxError> {
+        if let Some(mode) = &self.tx_error_mode {
+            match mode.swap(0, Ordering::Relaxed) {
+                1 => {
+                    return Err(TxError::TryRestart(anyhow::anyhow!(
+                        "fuzz: injected TxError::TryRestart"
+                    )));
+                }
+                2 => {
+                    return Err(TxError::Fatal(anyhow::anyhow!(
+                        "fuzz: injected TxError::Fatal"
+                    )));
+                }
+                _ => {}
+            }
+        }
+        // Drain pending async TX completions.
+        let n = done.len().min(self.pending_tx_completions.len());
+        for (d, s) in done.iter_mut().zip(self.pending_tx_completions.drain(..n)) {
+            *d = s;
+        }
+        Ok(n)
+    }
+
+    fn buffer_access(&mut self) -> Option<&mut dyn net_backend::BufferAccess> {
+        Some(self.pool.as_mut())
+    }
+}
+
+impl FuzzEndpoint {
+    /// Create a new fuzzable endpoint and its control handles.
+    pub fn new(config: FuzzEndpointConfig) -> (Self, FuzzEndpointHandles) {
+        let (rx_send, rx_recv) = if config.enable_rx_injection {
+            let (s, r) = mesh::channel();
+            (Some(s), Some(r))
+        } else {
+            (None, None)
+        };
+
+        let (action_send, action_recv) = if config.enable_action_injection {
+            let (s, r) = mesh::channel();
+            (Some(s), Some(r))
+        } else {
+            (None, None)
+        };
+
+        let tx_error_mode = if config.enable_tx_error_injection {
+            Some(Arc::new(AtomicU8::new(0)))
+        } else {
+            None
+        };
+
+        (
+            Self {
+                inner: LoopbackEndpoint::new(),
+                rx_recv,
+                action_recv,
+                loopback_metadata: FuzzRxMetadata::default(),
+                fail_vf_switch: config.fail_vf_switch,
+                tx_error_mode: tx_error_mode.clone(),
+                async_tx: config.enable_async_tx,
+            },
+            FuzzEndpointHandles {
+                rx_send,
+                action_send,
+                tx_error_mode,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl Endpoint for FuzzEndpoint {
+    fn endpoint_type(&self) -> &'static str {
+        "fuzzable"
+    }
+
+    fn tx_offload_support(&self) -> TxOffloadSupport {
+        TxOffloadSupport {
+            ipv4_header: true,
+            tcp: true,
+            udp: true,
+            tso: true,
+        }
+    }
+
+    async fn get_queues(
+        &mut self,
+        config: Vec<QueueConfig<'_>>,
+        rss: Option<&RssConfig<'_>>,
+        queues: &mut Vec<Box<dyn BackendQueue>>,
+    ) -> anyhow::Result<()> {
+        if self.rx_recv.is_none() && self.tx_error_mode.is_none() && !self.async_tx {
+            return self.inner.get_queues(config, rss, queues).await;
+        }
+
+        // RSS is intentionally not applied to FuzzableQueue.
+        let _ = rss;
+        let loopback_metadata = self.loopback_metadata;
+        let tx_error_mode = self.tx_error_mode.clone();
+        let sync_tx = !self.async_tx;
+        queues.extend(config.into_iter().enumerate().map(|(idx, config)| {
+            let rx_recv = if idx == 0 { self.rx_recv.take() } else { None };
+            Box::new(FuzzableQueue {
+                pool: config.pool,
+                rx_avail: config.initial_rx.to_vec().into(),
+                rx_done: VecDeque::new(),
+                rx_recv,
+                pending_injected: VecDeque::new(),
+                loopback_metadata,
+                tx_error_mode: tx_error_mode.clone(),
+                sync_tx,
+                pending_tx_completions: VecDeque::new(),
+            }) as Box<dyn BackendQueue>
+        }));
+        Ok(())
+    }
+
+    async fn stop(&mut self) {
+        self.inner.stop().await
+    }
+
+    fn is_ordered(&self) -> bool {
+        self.inner.is_ordered()
+    }
+
+    fn multiqueue_support(&self) -> MultiQueueSupport {
+        self.inner.multiqueue_support()
+    }
+
+    async fn set_data_path_to_guest_vf(&self, _use_vf: bool) -> anyhow::Result<()> {
+        if self.fail_vf_switch {
+            Err(anyhow::anyhow!("fuzz: simulated VF switch failure"))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn wait_for_endpoint_action(&mut self) -> EndpointAction {
+        if let Some(recv) = &mut self.action_recv {
+            match recv.recv().await {
+                Ok(action) => action,
+                Err(_) => std::future::pending().await,
+            }
+        } else {
+            std::future::pending().await
+        }
+    }
+}

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/mod.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/mod.rs
@@ -1,0 +1,1425 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Not every fuzz binary uses every helper, so suppress dead-code warnings
+// for the entire module.
+#![allow(dead_code)]
+
+//! Shared helpers for netvsp fuzz targets.
+//!
+//! ## Error types
+//! [`RingFullError`]
+//! ## Constants & page layout
+//! [`PageLayout`], [`DATA_PAGES`]
+//! ## Low-level VMBus I/O
+//! [`write_packet`]
+//! ## NVSP helpers
+//! [`nvsp_payload`], [`send_inband_nvsp`],
+//! [`send_completion_packet`], [`send_tx_rndis_completion`],
+//! [`VF_ASSOCIATION_TRANSACTION_ID`],
+//! [`SWITCH_DATA_PATH_TRANSACTION_ID`]
+//! ## RNDIS helpers
+//! [`build_rndis_message`], [`build_rndis_oid_query`],
+//! [`build_rndis_oid_set`], [`build_rss_oid_set`],
+//! [`build_rndis_config_parameter`],
+//! [`KNOWN_CONFIG_PARAM_NAMES`],
+//! [`send_rndis_gpadirect`],
+//! [`send_rndis_control`], [`send_rndis_via_direct_path`],
+//! [`send_rndis_via_send_buffer`],
+//! [`rndis_set_packet_filter`]
+//! ## NVSP protocol negotiation
+//! [`negotiate_to_ready`],
+//! [`negotiate_to_ready_with_capabilities`],
+//! [`negotiate_to_ready_full`], [`pick_version_pair`],
+//! [`rndis_initialize`]
+//! ## Structured fuzz types
+//! [`StructuredRndisMessage`],
+//! [`StructuredRndisPacketMessage`],
+//! [`serialize_structured_rndis_packet_message`],
+//! [`build_concatenated_rndis_messages`]
+//! ## Structured PPI types
+//! [`StructuredPpiEntry`],
+//! [`serialize_ppi_chain`], [`build_lso_ppi_entry`],
+//! [`build_checksum_ppi_entry`]
+//! ## Send path helpers
+//! [`build_structured_rndis_packet`],
+//! [`page_boundary_frame_size`]
+//! ## Arbitrary generators
+//! [`arbitrary_outgoing_packet_type`],
+//! [`arbitrary_send_receive_buffer_message`],
+//! [`arbitrary_send_send_buffer_message`],
+//! [`arbitrary_valid_ethernet_frame`]
+//! ## Guest OS identity
+//! [`FuzzGuestOsId`]
+//! ## Fuzz loop boilerplate
+//! [`FuzzNicSetup`], [`yield_to_executor`],
+//! [`try_read_one_completion`], [`drain_queue`],
+//! [`drain_queue_async`], [`run_fuzz_loop`],
+//! [`run_fuzz_loop_with_config`]
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use guestmem::GuestMemory;
+use guestmem::MemoryRead;
+use guestmem::ranges::PagedRange;
+use hvdef::hypercall::HvGuestOsId;
+use netvsp::protocol;
+use netvsp::rndisprot;
+use std::future::poll_fn;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+use vmbus_async::queue::IncomingPacket;
+use vmbus_async::queue::OutgoingPacket;
+use vmbus_async::queue::Queue;
+use vmbus_async::queue::TryWriteError;
+use vmbus_channel::gpadl::GpadlId;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use vmbus_ring::OutgoingPacketType;
+use vmbus_ring::PAGE_SIZE;
+use xtask_fuzz::fuzz_eprintln;
+use zerocopy::IntoBytes;
+
+// ---------------------------------------------------------------------------
+// Child modules
+// ---------------------------------------------------------------------------
+pub mod endpoint;
+pub mod nic_setup;
+pub mod vf;
+mod vmbus;
+
+// ===========================================================================
+// Error types
+// ===========================================================================
+
+/// The outgoing (fuzz→worker) ring buffer is full.
+///
+/// This is a non-fatal condition: the NIC worker is alive but applying
+/// backpressure because it cannot send completions back to the guest
+/// (the guest hasn't drained the host→guest ring). Treated as a clean
+/// stop signal in the fuzz loop, identical to exhausted `Unstructured`
+/// data.
+#[derive(Debug)]
+pub struct RingFullError;
+
+impl std::fmt::Display for RingFullError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("outgoing ring full (backpressure)")
+    }
+}
+
+impl std::error::Error for RingFullError {}
+
+// ===========================================================================
+// Constants & page layout
+// ===========================================================================
+
+/// Number of pages used for the VMBus ring buffer.
+const RING_PAGES: usize = 4;
+/// Number of pages used for the receive buffer GPADL.
+const RECV_BUF_PAGES: usize = 9;
+/// Number of extra pages for writing fuzzed RNDIS data via GpaDirect.
+pub const DATA_PAGES: usize = 4;
+/// Section size used when writing RNDIS data into the send buffer GPADL.
+const SEND_BUFFER_SECTION_SIZE_BYTES: usize = 6144;
+
+/// Describes the guest memory page layout for a fuzz target.
+///
+/// The layout is: ring pages | receive buffer | send buffer | data pages.
+/// `data_pages` may be zero for fuzz targets that don't send GpaDirect data.
+pub struct PageLayout {
+    /// Number of pages for the send buffer GPADL.
+    pub send_buf_pages: usize,
+    /// Number of extra pages for fuzzed RNDIS data (0 if unused).
+    pub data_pages: usize,
+}
+
+impl PageLayout {
+    /// Total guest memory pages needed.
+    pub const fn total_pages(&self) -> usize {
+        RING_PAGES + RECV_BUF_PAGES + self.send_buf_pages + self.data_pages
+    }
+
+    /// Page offset where fuzzed RNDIS data starts (after ring + recv + send).
+    pub const fn data_page_start(&self) -> usize {
+        RING_PAGES + RECV_BUF_PAGES + self.send_buf_pages
+    }
+}
+
+// ===========================================================================
+// Low-level VMBus I/O
+// ===========================================================================
+
+/// Write one outgoing packet and increment transaction ID.
+///
+/// Uses [`try_write`] to avoid blocking when the ring is full (which
+/// happens when the NIC worker has terminated).  With deterministic
+/// draining the ring should always have space when the worker is alive.
+pub async fn write_packet(
+    queue: &mut Queue<GpadlRingMem>,
+    tid: &mut u64,
+    packet_type: OutgoingPacketType<'_>,
+    payload: &[&[u8]],
+) -> anyhow::Result<()> {
+    let (_, mut writer) = queue.split();
+    match writer.try_write(&OutgoingPacket {
+        transaction_id: *tid,
+        packet_type,
+        payload,
+    }) {
+        Ok(()) => {
+            *tid += 1;
+            Ok(())
+        }
+        Err(TryWriteError::Full(_)) => {
+            anyhow::bail!(RingFullError);
+        }
+        Err(TryWriteError::Queue(err)) => Err(err.into()),
+    }
+}
+
+// ===========================================================================
+// NVSP helpers
+// ===========================================================================
+
+/// Build an NVSP message payload (header + data), padded to 8-byte alignment.
+pub fn nvsp_payload(message_type: u32, data: &[u8]) -> Vec<u8> {
+    let header = protocol::MessageHeader { message_type };
+    let mut buf = Vec::with_capacity(4 + data.len());
+    buf.extend_from_slice(header.as_bytes());
+    buf.extend_from_slice(data);
+    while buf.len() % 8 != 0 {
+        buf.push(0);
+    }
+    buf
+}
+
+/// Build an NVSP `Message1SendRndisPacket` payload with header.
+///
+/// Internal helper — callers outside this module should use
+/// [`send_rndis_gpadirect`] or [`send_rndis_via_send_buffer`] instead.
+fn nvsp_rndis_payload(channel_type: u32, section_index: u32, section_size: u32) -> Vec<u8> {
+    nvsp_payload(
+        protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET,
+        protocol::Message1SendRndisPacket {
+            channel_type,
+            send_buffer_section_index: section_index,
+            send_buffer_section_size: section_size,
+        }
+        .as_bytes(),
+    )
+}
+
+/// Send one NVSP in-band message with configurable completion behavior.
+pub async fn send_inband_nvsp(
+    queue: &mut Queue<GpadlRingMem>,
+    tid: &mut u64,
+    message_type: u32,
+    data: &[u8],
+    with_completion: bool,
+) -> anyhow::Result<()> {
+    let payload = nvsp_payload(message_type, data);
+    let packet_type = if with_completion {
+        OutgoingPacketType::InBandWithCompletion
+    } else {
+        OutgoingPacketType::InBandNoCompletion
+    };
+    write_packet(queue, tid, packet_type, &[&payload]).await
+}
+
+/// Send a completion packet with a caller-supplied transaction id and payload.
+pub async fn send_completion_packet(
+    queue: &mut Queue<GpadlRingMem>,
+    transaction_id: u64,
+    payload: &[&[u8]],
+) -> anyhow::Result<()> {
+    let (_, mut writer) = queue.split();
+    match writer.try_write(&OutgoingPacket {
+        transaction_id,
+        packet_type: OutgoingPacketType::Completion,
+        payload,
+    }) {
+        Ok(()) => Ok(()),
+        Err(TryWriteError::Full(_)) => {
+            anyhow::bail!(RingFullError);
+        }
+        Err(TryWriteError::Queue(err)) => Err(err.into()),
+    }
+}
+
+/// Transaction ID for VF association completion packets.
+pub const VF_ASSOCIATION_TRANSACTION_ID: u64 = 0x8000000000000000;
+/// Transaction ID for switch data-path completion packets.
+pub const SWITCH_DATA_PATH_TRANSACTION_ID: u64 = 0x8000000000000001;
+
+/// Send a TX RNDIS completion packet with the given transaction ID.
+///
+/// This wraps a `Completion` packet containing an
+/// NVSP `MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE` payload.
+pub async fn send_tx_rndis_completion(
+    queue: &mut Queue<GpadlRingMem>,
+    transaction_id: u64,
+    completion: &protocol::Message1SendRndisPacketComplete,
+) -> anyhow::Result<()> {
+    let payload = nvsp_payload(
+        protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE,
+        completion.as_bytes(),
+    );
+    let (_, mut writer) = queue.split();
+    match writer.try_write(&OutgoingPacket {
+        transaction_id,
+        packet_type: OutgoingPacketType::Completion,
+        payload: &[&payload],
+    }) {
+        Ok(()) => Ok(()),
+        Err(TryWriteError::Full(_)) => {
+            anyhow::bail!(RingFullError);
+        }
+        Err(TryWriteError::Queue(err)) => Err(err.into()),
+    }
+}
+
+// ===========================================================================
+// RNDIS helpers
+// ===========================================================================
+
+/// Build a complete RNDIS message with header + body.
+pub fn build_rndis_message(message_type: u32, body: &[u8]) -> Vec<u8> {
+    let header = rndisprot::MessageHeader {
+        message_type,
+        message_length: (size_of::<rndisprot::MessageHeader>() + body.len()) as u32,
+    };
+    let mut buf = Vec::with_capacity(header.message_length as usize);
+    buf.extend_from_slice(header.as_bytes());
+    buf.extend_from_slice(body);
+    buf
+}
+
+/// Build an RNDIS OID query message (MESSAGE_TYPE_QUERY_MSG).
+pub fn build_rndis_oid_query(oid: rndisprot::Oid, extra_data: &[u8]) -> Vec<u8> {
+    let request = rndisprot::QueryRequest {
+        request_id: 1,
+        oid,
+        information_buffer_length: extra_data.len() as u32,
+        information_buffer_offset: if extra_data.is_empty() {
+            0
+        } else {
+            size_of::<rndisprot::QueryRequest>() as u32
+        },
+        device_vc_handle: 0,
+    };
+    let mut body = Vec::new();
+    body.extend_from_slice(request.as_bytes());
+    body.extend_from_slice(extra_data);
+    build_rndis_message(rndisprot::MESSAGE_TYPE_QUERY_MSG, &body)
+}
+
+/// Build an RNDIS OID set message (MESSAGE_TYPE_SET_MSG).
+pub fn build_rndis_oid_set(oid: rndisprot::Oid, payload: &[u8]) -> Vec<u8> {
+    let request = rndisprot::SetRequest {
+        request_id: 1,
+        oid,
+        information_buffer_length: payload.len() as u32,
+        information_buffer_offset: size_of::<rndisprot::SetRequest>() as u32,
+        device_vc_handle: 0,
+    };
+    let mut body = Vec::new();
+    body.extend_from_slice(request.as_bytes());
+    body.extend_from_slice(payload);
+    build_rndis_message(rndisprot::MESSAGE_TYPE_SET_MSG, &body)
+}
+
+/// Build a well-formed RSS OID SET message (`OID_GEN_RECEIVE_SCALE_PARAMETERS`)
+/// with a valid hash key and indirection table. Use `max_queues` to bound the
+/// indirection table entries so they pass the `entry < max_queues` check.
+pub fn build_rss_oid_set(
+    hash_information: u32,
+    indirection_entries: &[u32],
+    max_queues: u32,
+    flags: u16,
+) -> Vec<u8> {
+    let key = [0xDAu8; 40]; // 40-byte Toeplitz hash key
+    let itable_len = indirection_entries.len();
+    let itable_byte_len = itable_len * 4;
+
+    // Build NdisReceiveScaleParameters with correct offsets.
+    let params_size = size_of::<rndisprot::NdisReceiveScaleParameters>();
+    let itable_offset = params_size as u32;
+    let key_offset = (params_size + itable_byte_len) as u32;
+
+    let header = rndisprot::NdisObjectHeader {
+        object_type: rndisprot::NdisObjectType::RSS_PARAMETERS,
+        revision: 2,
+        size: rndisprot::NDIS_SIZEOF_RECEIVE_SCALE_PARAMETERS_REVISION_2 as u16,
+    };
+
+    let params = rndisprot::NdisReceiveScaleParameters {
+        header,
+        flags,
+        base_cpu_number: 0,
+        hash_information,
+        indirection_table_size: itable_byte_len as u16,
+        pad0: 0,
+        indirection_table_offset: itable_offset,
+        hash_secret_key_size: 40,
+        pad1: 0,
+        hash_secret_key_offset: key_offset,
+        processor_masks_offset: 0,
+        number_of_processor_masks: 0,
+        processor_masks_entry_size: 0,
+        default_processor_number: 0,
+    };
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(params.as_bytes());
+    for &entry in indirection_entries {
+        // Clamp entries to valid range.
+        payload.extend_from_slice((entry % max_queues.max(1)).as_bytes());
+    }
+    payload.extend_from_slice(&key);
+
+    build_rndis_oid_set(rndisprot::Oid::OID_GEN_RECEIVE_SCALE_PARAMETERS, &payload)
+}
+
+/// Known RNDIS config parameter names that exercise the named match arms in
+/// `oid_set_rndis_config_parameter`.
+pub const KNOWN_CONFIG_PARAM_NAMES: &[&str] = &[
+    "*IPChecksumOffloadIPv4",
+    "*LsoV2IPv4",
+    "*LsoV2IPv6",
+    "*TCPChecksumOffloadIPv4",
+    "*TCPChecksumOffloadIPv6",
+    "*UDPChecksumOffloadIPv4",
+    "*UDPChecksumOffloadIPv6",
+];
+
+/// Build a well-formed `OID_GEN_RNDIS_CONFIG_PARAMETER` SET message with a
+/// properly UTF-16LE–encoded parameter name and value.
+///
+/// `param_name` is the ASCII parameter name (e.g. `"*IPChecksumOffloadIPv4"`).
+/// `param_type` is the NDIS parameter type (STRING, INTEGER, etc.).
+/// `value_bytes` is the raw value payload — for STRING, the caller should
+/// provide UTF-16LE encoded bytes; for INTEGER, 4 bytes of a u32.
+pub fn build_rndis_config_parameter(
+    param_name: &str,
+    param_type: rndisprot::NdisParameterType,
+    value_bytes: &[u8],
+) -> Vec<u8> {
+    // Encode the name as UTF-16LE.
+    let name_u16: Vec<u16> = param_name.encode_utf16().collect();
+    let name_bytes_len = name_u16.len() * 2;
+
+    let info_size = size_of::<rndisprot::RndisConfigParameterInfo>();
+    let name_offset = info_size as u32;
+    let value_offset = (info_size + name_bytes_len) as u32;
+
+    let info = rndisprot::RndisConfigParameterInfo {
+        name_offset,
+        name_length: name_bytes_len as u32,
+        parameter_type: param_type,
+        value_offset,
+        value_length: value_bytes.len() as u32,
+    };
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(info.as_bytes());
+    // Name as UTF-16LE bytes.
+    for &code_unit in &name_u16 {
+        payload.extend_from_slice(&code_unit.to_le_bytes());
+    }
+    // Value bytes.
+    payload.extend_from_slice(value_bytes);
+
+    build_rndis_oid_set(rndisprot::Oid::OID_GEN_RNDIS_CONFIG_PARAMETER, &payload)
+}
+
+/// Write raw bytes into guest memory at a given page-aligned offset.
+/// Returns the number of bytes written, or None when no bytes can be written.
+fn write_to_guest(
+    mem: &GuestMemory,
+    data: &[u8],
+    page_start: usize,
+    max_pages: usize,
+) -> Option<usize> {
+    let max_bytes = max_pages * PAGE_SIZE;
+    let len = data.len().min(max_bytes);
+    if len == 0 {
+        return None;
+    }
+    let base_addr = (page_start * PAGE_SIZE) as u64;
+    mem.write_at(base_addr, &data[..len]).ok()?;
+    Some(len)
+}
+
+/// Send a GpaDirect packet referencing data previously written to guest
+/// memory at `page_start`.
+async fn send_gpadirect(
+    queue: &mut Queue<GpadlRingMem>,
+    page_start: usize,
+    byte_len: usize,
+    payload: &[u8],
+    tid: &mut u64,
+) -> Result<(), anyhow::Error> {
+    let page_count = byte_len.div_ceil(PAGE_SIZE);
+    let pages: Vec<u64> = (page_start..page_start + page_count)
+        .map(|p| p as u64)
+        .collect();
+    let gpa_range = PagedRange::new(0, byte_len, pages.as_slice()).unwrap();
+    write_packet(
+        queue,
+        tid,
+        OutgoingPacketType::GpaDirect(&[gpa_range]),
+        &[payload],
+    )
+    .await
+}
+
+/// Write RNDIS data to guest memory and send it via GpaDirect with an
+/// NVSP `Message1SendRndisPacket` wrapper.
+pub async fn send_rndis_gpadirect(
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    rndis_bytes: &[u8],
+    channel_type: u32,
+    data_page_start: usize,
+    data_page_count: usize,
+    tid: &mut u64,
+) -> Result<(), anyhow::Error> {
+    if let Some(byte_len) = write_to_guest(mem, rndis_bytes, data_page_start, data_page_count) {
+        let nvsp = nvsp_rndis_payload(channel_type, 0xffffffff, 0);
+        send_gpadirect(queue, data_page_start, byte_len, &nvsp, tid).await?;
+    }
+    Ok(())
+}
+
+/// Send an RNDIS control message via GpaDirect using the control channel.
+pub async fn send_rndis_control(
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    rndis_bytes: &[u8],
+    layout: &PageLayout,
+    tid: &mut u64,
+) -> Result<(), anyhow::Error> {
+    send_rndis_gpadirect(
+        queue,
+        mem,
+        rndis_bytes,
+        protocol::CONTROL_CHANNEL_TYPE,
+        layout.data_page_start(),
+        layout.data_pages,
+        tid,
+    )
+    .await
+}
+
+/// Send RNDIS data via GpaDirect using a given layout's data page region.
+///
+/// This is a convenience wrapper around [`send_rndis_gpadirect`] that
+/// unpacks `layout.data_page_start()` and `layout.data_pages`.  Use this
+/// when you have a [`PageLayout`] and an arbitrary channel type.  For the
+/// common case of sending on the control channel, prefer
+/// [`send_rndis_control`].
+pub async fn send_rndis_via_direct_path(
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    rndis_bytes: &[u8],
+    channel_type: u32,
+    layout: &PageLayout,
+    tid: &mut u64,
+) -> Result<(), anyhow::Error> {
+    send_rndis_gpadirect(
+        queue,
+        mem,
+        rndis_bytes,
+        channel_type,
+        layout.data_page_start(),
+        layout.data_pages,
+        tid,
+    )
+    .await
+}
+
+/// Write RNDIS data into the send buffer GPADL and send it via the send buffer
+/// path. This consolidates the duplicated send-buffer logic from the synthetic
+/// datapath and interop fuzz targets.
+pub async fn send_rndis_via_send_buffer(
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    rndis_bytes: &[u8],
+    nvsp_msg: &protocol::Message1SendRndisPacket,
+    layout: &PageLayout,
+    tid: &mut u64,
+) -> Result<(), anyhow::Error> {
+    let send_buf_page_start = RING_PAGES + RECV_BUF_PAGES;
+    let send_buf_max = layout.send_buf_pages * PAGE_SIZE;
+    let write_len = rndis_bytes.len().min(send_buf_max);
+    if write_len > 0 {
+        let base_addr = (send_buf_page_start * PAGE_SIZE) as u64;
+        let offset = (nvsp_msg.send_buffer_section_index as usize)
+            .wrapping_mul(SEND_BUFFER_SECTION_SIZE_BYTES)
+            % send_buf_max;
+        let _ = mem.write_at(base_addr + offset as u64, &rndis_bytes[..write_len]);
+    }
+
+    send_inband_nvsp(
+        queue,
+        tid,
+        protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET,
+        nvsp_msg.as_bytes(),
+        true,
+    )
+    .await
+}
+
+/// Set `OID_GEN_CURRENT_PACKET_FILTER` to `NPROTO_PACKET_FILTER` via RNDIS
+/// OID set so that RX packets are actually delivered instead of being
+/// silently dropped in `process_endpoint_rx`.
+pub async fn rndis_set_packet_filter(
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    layout: &PageLayout,
+    tid: &mut u64,
+) -> Result<(), anyhow::Error> {
+    let filter_bytes = build_rndis_oid_set(
+        rndisprot::Oid::OID_GEN_CURRENT_PACKET_FILTER,
+        &rndisprot::NPROTO_PACKET_FILTER.to_le_bytes(),
+    );
+    send_rndis_gpadirect(
+        queue,
+        mem,
+        &filter_bytes,
+        protocol::CONTROL_CHANNEL_TYPE,
+        layout.data_page_start(),
+        layout.data_pages,
+        tid,
+    )
+    .await?;
+    drain_queue_async(queue).await;
+    Ok(())
+}
+
+/// Compute a frame size that targets page-boundary edge cases in the RX
+/// buffer `write_at()` / `write_header()` code paths.
+///
+/// The `variant` byte selects one of eight interesting sizes:
+/// - 0–2: sizes around one `PAGE_SIZE` boundary
+/// - 3–4: sizes around one page minus the 256-byte RX header
+/// - 5–6: sizes around two pages minus the RX header
+/// - 7+: pseudorandom spread across the full data-page range
+pub fn page_boundary_frame_size(variant: u8) -> usize {
+    const RX_HDR: usize = 256; // RX_HEADER_LEN from buffers.rs
+    let size = match variant % 8 {
+        0 => PAGE_SIZE - 1,
+        1 => PAGE_SIZE,
+        2 => PAGE_SIZE + 1,
+        3 => PAGE_SIZE - RX_HDR,     // header fits perfectly in first page
+        4 => PAGE_SIZE - RX_HDR + 1, // header + 1 byte crosses page
+        5 => 2 * PAGE_SIZE - RX_HDR, // two full pages of data
+        6 => 2 * PAGE_SIZE - RX_HDR + 1, // crosses into third page by 1 byte
+        _ => (variant as usize * 127) % (DATA_PAGES * PAGE_SIZE), // spread across range
+    };
+    size.min(DATA_PAGES * PAGE_SIZE)
+}
+
+// ===========================================================================
+// NVSP protocol negotiation
+// ===========================================================================
+
+/// Send an NVSP InBandWithCompletion message and read the completion,
+/// validating that it is well-formed and successful.
+async fn send_and_read_completion(
+    queue: &mut Queue<GpadlRingMem>,
+    tid: &mut u64,
+    message_type: u32,
+    data: &[u8],
+) -> anyhow::Result<()> {
+    send_inband_nvsp(queue, tid, message_type, data, true).await?;
+    let (mut reader, _) = queue.split();
+    let packet = reader.read().await?;
+    match &*packet {
+        IncomingPacket::Completion(completion) => {
+            match message_type {
+                protocol::MESSAGE_TYPE_INIT => {
+                    let mut r = completion.reader();
+                    let header: protocol::MessageHeader = r.read_plain()?;
+                    anyhow::ensure!(
+                        header.message_type == protocol::MESSAGE_TYPE_INIT_COMPLETE,
+                        "unexpected init completion message type: {}",
+                        header.message_type
+                    );
+                    let c: protocol::MessageInitComplete = r.read_plain()?;
+                    anyhow::ensure!(
+                        c.status == protocol::Status::SUCCESS,
+                        "init completion status not SUCCESS: {:?}",
+                        c.status
+                    );
+                }
+                protocol::MESSAGE1_TYPE_SEND_RECEIVE_BUFFER => {
+                    let mut r = completion.reader();
+                    let header: protocol::MessageHeader = r.read_plain()?;
+                    anyhow::ensure!(
+                        header.message_type == protocol::MESSAGE1_TYPE_SEND_RECEIVE_BUFFER_COMPLETE,
+                        "unexpected receive buffer completion message type: {}",
+                        header.message_type
+                    );
+                    let c: protocol::Message1SendReceiveBufferComplete = r.read_plain()?;
+                    anyhow::ensure!(
+                        c.status == protocol::Status::SUCCESS,
+                        "receive buffer completion status not SUCCESS: {:?}",
+                        c.status
+                    );
+                }
+                protocol::MESSAGE1_TYPE_SEND_SEND_BUFFER => {
+                    let mut r = completion.reader();
+                    let header: protocol::MessageHeader = r.read_plain()?;
+                    anyhow::ensure!(
+                        header.message_type == protocol::MESSAGE1_TYPE_SEND_SEND_BUFFER_COMPLETE,
+                        "unexpected send buffer completion message type: {}",
+                        header.message_type
+                    );
+                    let c: protocol::Message1SendSendBufferComplete = r.read_plain()?;
+                    anyhow::ensure!(
+                        c.status == protocol::Status::SUCCESS,
+                        "send buffer completion status not SUCCESS: {:?}",
+                        c.status
+                    );
+                }
+                _ => {
+                    // NDIS config and NDIS version completions have empty
+                    // payloads — just verify we got a completion packet.
+                }
+            }
+        }
+        IncomingPacket::Data(_) => {
+            anyhow::bail!("expected completion packet, got data packet");
+        }
+    }
+    Ok(())
+}
+
+/// The set of NVSP protocol versions used by fuzz targets.
+///
+/// V1 is excluded because the post-init messages (NDIS config, receive/send
+/// buffer, RNDIS, etc.) use V2+ message types.  Negotiating V1 causes the
+/// device to reject those messages with `PacketError::UnknownType`, which
+/// crashes the NIC worker and leaves the guest hanging.
+const SUPPORTED_VERSIONS: &[protocol::Version] = &[
+    protocol::Version::V2,
+    protocol::Version::V4,
+    protocol::Version::V5,
+    protocol::Version::V6,
+    protocol::Version::V61,
+];
+
+/// Pick a fuzzer-driven protocol version pair from the supported set.
+///
+/// Returns `(protocol_version, protocol_version2)` for `MessageInit`,
+/// where `protocol_version` <= `protocol_version2`.
+pub fn pick_version_pair(u: &mut Unstructured<'_>) -> arbitrary::Result<protocol::MessageInit> {
+    let v1 = *u.choose(SUPPORTED_VERSIONS)?;
+    let v2 = *u.choose(SUPPORTED_VERSIONS)?;
+    let (lo, hi) = if (v1 as u32) <= (v2 as u32) {
+        (v1, v2)
+    } else {
+        (v2, v1)
+    };
+    Ok(protocol::MessageInit {
+        protocol_version: lo as u32,
+        protocol_version2: hi as u32,
+    })
+}
+
+/// Negotiate NVSP up to the Ready state with custom capabilities and
+/// a caller-supplied version init message.
+///
+/// This is the most flexible negotiation helper. Use [`negotiate_to_ready`]
+/// or [`negotiate_to_ready_with_capabilities`] for common cases.
+pub async fn negotiate_to_ready_full(
+    queue: &mut Queue<GpadlRingMem>,
+    tid: &mut u64,
+    recv_buf_gpadl: GpadlId,
+    send_buf_gpadl: GpadlId,
+    capabilities: protocol::NdisConfigCapabilities,
+    version_init: protocol::MessageInit,
+) -> anyhow::Result<()> {
+    // Version init — use the caller-supplied version pair.
+    send_and_read_completion(
+        queue,
+        tid,
+        protocol::MESSAGE_TYPE_INIT,
+        version_init.as_bytes(),
+    )
+    .await?;
+
+    // NDIS config.
+    let config = protocol::Message2SendNdisConfig {
+        mtu: 1500,
+        reserved: 0,
+        capabilities,
+    };
+    send_and_read_completion(
+        queue,
+        tid,
+        protocol::MESSAGE2_TYPE_SEND_NDIS_CONFIG,
+        config.as_bytes(),
+    )
+    .await?;
+
+    // NDIS version.
+    let version = protocol::Message1SendNdisVersion {
+        ndis_major_version: 6,
+        ndis_minor_version: 30,
+    };
+    send_and_read_completion(
+        queue,
+        tid,
+        protocol::MESSAGE1_TYPE_SEND_NDIS_VERSION,
+        version.as_bytes(),
+    )
+    .await?;
+
+    // Receive buffer.
+    let msg = protocol::Message1SendReceiveBuffer {
+        gpadl_handle: recv_buf_gpadl,
+        id: 0,
+        reserved: 0,
+    };
+    send_and_read_completion(
+        queue,
+        tid,
+        protocol::MESSAGE1_TYPE_SEND_RECEIVE_BUFFER,
+        msg.as_bytes(),
+    )
+    .await?;
+
+    // Send buffer.
+    let msg = protocol::Message1SendSendBuffer {
+        gpadl_handle: send_buf_gpadl,
+        id: 0,
+        reserved: 0,
+    };
+    send_and_read_completion(
+        queue,
+        tid,
+        protocol::MESSAGE1_TYPE_SEND_SEND_BUFFER,
+        msg.as_bytes(),
+    )
+    .await?;
+
+    // Yield to the executor so the coordinator task can process the
+    // CoordinatorMessage::Restart sent by the Worker after initialization.
+    // The coordinator needs multiple poll rounds to: receive the Restart,
+    // stop the worker, transition it to Ready, call restart_queues (which
+    // sets up QueueState with endpoint queues), and re-start the worker.
+    // Without this yield, the single-threaded executor never polls the
+    // coordinator, so the worker stays in WaitingForCoordinator and
+    // main_loop is never entered.
+    yield_to_executor(20).await;
+
+    Ok(())
+}
+
+/// Negotiate NVSP up to the Ready state with custom NDIS capabilities.
+///
+/// Use this when the fuzz target needs specific NDIS capabilities (e.g.
+/// `.with_sriov(true)` for VF testing).
+pub async fn negotiate_to_ready_with_capabilities(
+    queue: &mut Queue<GpadlRingMem>,
+    tid: &mut u64,
+    recv_buf_gpadl: GpadlId,
+    send_buf_gpadl: GpadlId,
+    capabilities: protocol::NdisConfigCapabilities,
+) -> anyhow::Result<()> {
+    negotiate_to_ready_full(
+        queue,
+        tid,
+        recv_buf_gpadl,
+        send_buf_gpadl,
+        capabilities,
+        protocol::MessageInit {
+            protocol_version: protocol::Version::V5 as u32,
+            protocol_version2: protocol::Version::V6 as u32,
+        },
+    )
+    .await
+}
+
+/// Perform full protocol negotiation (version init, NDIS config, NDIS version,
+/// receive buffer, send buffer) to reach the ready state.
+pub async fn negotiate_to_ready(
+    queue: &mut Queue<GpadlRingMem>,
+    tid: &mut u64,
+    recv_buf_gpadl: GpadlId,
+    send_buf_gpadl: GpadlId,
+) -> anyhow::Result<()> {
+    negotiate_to_ready_full(
+        queue,
+        tid,
+        recv_buf_gpadl,
+        send_buf_gpadl,
+        protocol::NdisConfigCapabilities::new(),
+        protocol::MessageInit {
+            protocol_version: protocol::Version::V5 as u32,
+            protocol_version2: protocol::Version::V6 as u32,
+        },
+    )
+    .await
+}
+
+/// Send RNDIS initialize to transition to RndisState::Operational.
+pub async fn rndis_initialize(
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    data_page_start: usize,
+    data_page_count: usize,
+    tid: &mut u64,
+) -> Result<(), anyhow::Error> {
+    let init_request = rndisprot::InitializeRequest {
+        request_id: 0,
+        major_version: rndisprot::MAJOR_VERSION,
+        minor_version: rndisprot::MINOR_VERSION,
+        max_transfer_size: 0,
+    };
+    let rndis_bytes = build_rndis_message(
+        rndisprot::MESSAGE_TYPE_INITIALIZE_MSG,
+        init_request.as_bytes(),
+    );
+    send_rndis_gpadirect(
+        queue,
+        mem,
+        &rndis_bytes,
+        protocol::CONTROL_CHANNEL_TYPE,
+        data_page_start,
+        data_page_count,
+        tid,
+    )
+    .await?;
+
+    // Yield so the worker (now in main_loop after the coordinator restart
+    // sequence) can process the RNDIS initialize from the ring buffer.
+    yield_to_executor(10).await;
+
+    // Read and discard the RNDIS initialize completion (and any other
+    // interleaved messages) so the ring doesn't fill up.
+    drain_queue_async(queue).await;
+    Ok(())
+}
+
+// ===========================================================================
+// Structured fuzz types
+// ===========================================================================
+
+/// Fuzzed RNDIS message with arbitrary header and payload.
+#[derive(Arbitrary, Debug)]
+pub struct StructuredRndisMessage {
+    pub header: rndisprot::MessageHeader,
+    pub payload: Vec<u8>,
+}
+
+/// Build one byte buffer containing multiple concatenated RNDIS messages.
+pub fn build_concatenated_rndis_messages(messages: &[StructuredRndisMessage]) -> Vec<u8> {
+    let mut rndis_buf = Vec::new();
+    for message in messages {
+        let mut header = message.header;
+        header.message_length =
+            (size_of::<rndisprot::MessageHeader>() + message.payload.len()) as u32;
+        rndis_buf.extend_from_slice(header.as_bytes());
+        rndis_buf.extend_from_slice(&message.payload);
+    }
+    rndis_buf
+}
+
+/// Fuzzed RNDIS packet message with structured header, packet, and tail.
+#[derive(Arbitrary, Debug)]
+pub struct StructuredRndisPacketMessage {
+    pub header: rndisprot::MessageHeader,
+    pub packet: rndisprot::Packet,
+    pub tail_bytes: Vec<u8>,
+}
+
+/// Serialize a [`StructuredRndisPacketMessage`] into a byte vector,
+/// fixing up `message_length` to match the actual serialized size.
+pub fn serialize_structured_rndis_packet_message(
+    rndis: &mut StructuredRndisPacketMessage,
+) -> Vec<u8> {
+    rndis.header.message_length = (size_of::<rndisprot::MessageHeader>()
+        + size_of::<rndisprot::Packet>()
+        + rndis.tail_bytes.len()) as u32;
+    let mut rndis_bytes = Vec::with_capacity(rndis.header.message_length as usize);
+    rndis_bytes.extend_from_slice(rndis.header.as_bytes());
+    rndis_bytes.extend_from_slice(rndis.packet.as_bytes());
+    rndis_bytes.extend_from_slice(&rndis.tail_bytes);
+    rndis_bytes
+}
+
+// ===========================================================================
+// Structured PPI (Per-Packet Info) types for offload fuzzing
+// ===========================================================================
+
+/// A single PPI entry with structured content. This enables the fuzzer to
+/// produce well-formed PPI chains that actually exercise the checksum and LSO
+/// parsing paths in the worker, rather than relying on random bytes.
+#[derive(Arbitrary, Debug)]
+pub enum StructuredPpiEntry {
+    /// A `PPI_TCP_IP_CHECKSUM` (type 0) entry with a fuzzed
+    /// `TxTcpIpChecksumInfo` value (packed as a `u32`).
+    ChecksumInfo {
+        /// Raw `TxTcpIpChecksumInfo` bits — flags for IPv4/IPv6, TCP/UDP
+        /// checksum, IP header checksum, and tcp_header_offset.
+        info: u32,
+    },
+    /// A `PPI_LSO` (type 2) entry with a fuzzed `TcpLsoInfo` value
+    /// (packed as a `u32`).
+    LsoInfo {
+        /// Raw `TcpLsoInfo` bits — MSS (bits 0-19), tcp_header_offset
+        /// (bits 20-29), IPv4/IPv6 flag (bit 31).
+        info: u32,
+    },
+    /// An unknown PPI type with arbitrary payload. This exercises the
+    /// `_ => {}` fallthrough in the PPI parsing loop.
+    Unknown {
+        /// PPI type value (should differ from 0 and 2 for true unknown).
+        typ: u32,
+        /// Arbitrary payload data.
+        data: Vec<u8>,
+    },
+    /// A fully fuzzed PPI entry with arbitrary `PerPacketInfo` header fields.
+    /// This exercises error paths: zero size, offset > size, undersized
+    /// payloads, etc.
+    Malformed {
+        /// Fuzzed PPI header (via the `Arbitrary` derive on `PerPacketInfo`).
+        header: rndisprot::PerPacketInfo,
+        /// Arbitrary trailing data.
+        data: Vec<u8>,
+    },
+}
+
+/// Serialize a slice of [`StructuredPpiEntry`] values into a contiguous PPI
+/// byte buffer suitable for passing to [`build_structured_rndis_packet`].
+pub fn serialize_ppi_chain(entries: &[StructuredPpiEntry]) -> Vec<u8> {
+    let ppi_header_size = size_of::<rndisprot::PerPacketInfo>() as u32; // 12
+    let mut buf = Vec::new();
+    for entry in entries {
+        match entry {
+            StructuredPpiEntry::ChecksumInfo { info } => {
+                let header = rndisprot::PerPacketInfo {
+                    size: ppi_header_size + size_of::<u32>() as u32, // 16
+                    typ: rndisprot::PPI_TCP_IP_CHECKSUM,
+                    per_packet_information_offset: ppi_header_size,
+                };
+                buf.extend_from_slice(header.as_bytes());
+                buf.extend_from_slice(info.as_bytes());
+            }
+            StructuredPpiEntry::LsoInfo { info } => {
+                let header = rndisprot::PerPacketInfo {
+                    size: ppi_header_size + size_of::<u32>() as u32, // 16
+                    typ: rndisprot::PPI_LSO,
+                    per_packet_information_offset: ppi_header_size,
+                };
+                buf.extend_from_slice(header.as_bytes());
+                buf.extend_from_slice(info.as_bytes());
+            }
+            StructuredPpiEntry::Unknown { typ, data } => {
+                let header = rndisprot::PerPacketInfo {
+                    size: ppi_header_size + data.len() as u32,
+                    typ: *typ,
+                    per_packet_information_offset: ppi_header_size,
+                };
+                buf.extend_from_slice(header.as_bytes());
+                buf.extend_from_slice(data);
+            }
+            StructuredPpiEntry::Malformed { header, data } => {
+                buf.extend_from_slice(header.as_bytes());
+                buf.extend_from_slice(data);
+            }
+        }
+    }
+    buf
+}
+
+/// Build a single LSO PPI entry as raw bytes. Constructs `TcpLsoInfo` from
+/// the MSS, tcp_header_offset, and IPv4/IPv6 flag, then wraps it in a
+/// well-formed `PerPacketInfo` header.
+pub fn build_lso_ppi_entry(mss: u32, tcp_header_offset: u16, is_ipv6: bool) -> Vec<u8> {
+    let ppi_header_size = size_of::<rndisprot::PerPacketInfo>() as u32;
+    // TcpLsoInfo layout: bits 0-19 = MSS, bits 20-29 = tcp_header_offset,
+    // bit 31 = 1 for IPv6 (0 for IPv4).
+    let lso_bits = (mss & 0xfffff)
+        | (((tcp_header_offset as u32) & 0x3ff) << 20)
+        | (if is_ipv6 { 1u32 << 31 } else { 0 });
+    let header = rndisprot::PerPacketInfo {
+        size: ppi_header_size + size_of::<u32>() as u32,
+        typ: rndisprot::PPI_LSO,
+        per_packet_information_offset: ppi_header_size,
+    };
+    let mut buf = Vec::with_capacity(header.size as usize);
+    buf.extend_from_slice(header.as_bytes());
+    buf.extend_from_slice(lso_bits.as_bytes());
+    buf
+}
+
+/// Build a single checksum PPI entry as raw bytes. Wraps the raw
+/// `TxTcpIpChecksumInfo` bits in a well-formed `PerPacketInfo` header.
+pub fn build_checksum_ppi_entry(checksum_info: u32) -> Vec<u8> {
+    let ppi_header_size = size_of::<rndisprot::PerPacketInfo>() as u32;
+    let header = rndisprot::PerPacketInfo {
+        size: ppi_header_size + size_of::<u32>() as u32,
+        typ: rndisprot::PPI_TCP_IP_CHECKSUM,
+        per_packet_information_offset: ppi_header_size,
+    };
+    let mut buf = Vec::with_capacity(header.size as usize);
+    buf.extend_from_slice(header.as_bytes());
+    buf.extend_from_slice(checksum_info.as_bytes());
+    buf
+}
+
+// ===========================================================================
+// Send path helpers
+// ===========================================================================
+
+/// Build a structured RNDIS packet (MessageHeader + Packet + PPI + frame data)
+/// from component parts. This is used by both the synthetic datapath and
+/// interop fuzz targets.
+pub fn build_structured_rndis_packet(ppi_bytes: &[u8], frame_data: &[u8]) -> Vec<u8> {
+    let ppi_len = ppi_bytes.len();
+    let data_offset = (size_of::<rndisprot::Packet>() + ppi_len) as u32;
+    let data_len = frame_data.len() as u32;
+    let total_rndis_len = size_of::<rndisprot::MessageHeader>()
+        + size_of::<rndisprot::Packet>()
+        + ppi_len
+        + frame_data.len();
+
+    let rndis_header = rndisprot::MessageHeader {
+        message_type: rndisprot::MESSAGE_TYPE_PACKET_MSG,
+        message_length: total_rndis_len as u32,
+    };
+    let rndis_packet = rndisprot::Packet {
+        data_offset,
+        data_length: data_len,
+        oob_data_offset: 0,
+        oob_data_length: 0,
+        num_oob_data_elements: 0,
+        per_packet_info_offset: if ppi_len > 0 {
+            size_of::<rndisprot::Packet>() as u32
+        } else {
+            0
+        },
+        per_packet_info_length: ppi_len as u32,
+        vc_handle: 0,
+        reserved: 0,
+    };
+
+    let mut buf = Vec::with_capacity(total_rndis_len);
+    buf.extend_from_slice(rndis_header.as_bytes());
+    buf.extend_from_slice(rndis_packet.as_bytes());
+    buf.extend_from_slice(ppi_bytes);
+    buf.extend_from_slice(frame_data);
+    buf
+}
+
+// ===========================================================================
+// Arbitrary generators
+// ===========================================================================
+
+/// Generate a random [`OutgoingPacketType`] for fuzz actions.
+pub fn arbitrary_outgoing_packet_type(
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<OutgoingPacketType<'static>> {
+    Ok(match u.arbitrary::<u8>()? % 3 {
+        0 => OutgoingPacketType::InBandNoCompletion,
+        1 => OutgoingPacketType::InBandWithCompletion,
+        _ => OutgoingPacketType::Completion,
+    })
+}
+
+/// Generate a random [`protocol::Message1SendReceiveBuffer`] with an
+/// arbitrary GPADL handle.
+pub fn arbitrary_send_receive_buffer_message(
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<protocol::Message1SendReceiveBuffer> {
+    Ok(protocol::Message1SendReceiveBuffer {
+        gpadl_handle: GpadlId(u.arbitrary::<u32>()?),
+        id: u.arbitrary::<u16>()?,
+        reserved: u.arbitrary::<u16>()?,
+    })
+}
+
+/// Generate a random [`protocol::Message1SendSendBuffer`] with an
+/// arbitrary GPADL handle.
+pub fn arbitrary_send_send_buffer_message(
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<protocol::Message1SendSendBuffer> {
+    Ok(protocol::Message1SendSendBuffer {
+        gpadl_handle: GpadlId(u.arbitrary::<u32>()?),
+        id: u.arbitrary::<u16>()?,
+        reserved: u.arbitrary::<u16>()?,
+    })
+}
+
+/// Generate a mostly valid Ethernet II frame suitable for exercising
+/// backend-driven RX parsing paths.
+pub fn arbitrary_valid_ethernet_frame(u: &mut Unstructured<'_>) -> arbitrary::Result<Vec<u8>> {
+    let mut frame = Vec::new();
+
+    let dst: [u8; 6] = u.arbitrary()?;
+    let src: [u8; 6] = u.arbitrary()?;
+    frame.extend_from_slice(&dst);
+    frame.extend_from_slice(&src);
+
+    let ethertype = match u.int_in_range::<u8>(0..=4)? {
+        0 => 0x0800u16,
+        1 => 0x86DDu16,
+        2 => 0x0806u16,
+        3 => 0x8100u16,
+        _ => 0x88A8u16,
+    };
+    frame.extend_from_slice(&ethertype.to_be_bytes());
+
+    let payload_len = u.int_in_range::<usize>(46..=512)?;
+    frame.extend_from_slice(u.bytes(payload_len)?);
+
+    if frame.len() < 60 {
+        frame.resize(60, 0);
+    }
+
+    Ok(frame)
+}
+
+// ===========================================================================
+// FuzzGuestOsId
+// ===========================================================================
+
+/// Fuzz-selected guest OS identity for exercising all branches of
+/// `can_use_ring_opt` and other guest-OS-dependent code paths.
+///
+/// The seven variants map 1-to-1 to the seven outcomes of `can_use_ring_opt`:
+/// - `None`            → no OS ID reported → returns `false`
+/// - `Proprietary`     → Windows / non-open-source → returns `true`
+/// - `LinuxOld`        → Linux version < 199424 → returns `false`
+/// - `LinuxNew`        → Linux version ≥ 199424 → returns `true`
+/// - `FreeBsdOld`      → FreeBSD version < 1400097 → returns `false`
+/// - `FreeBsdNew`      → FreeBSD version ≥ 1400097 → returns `true`
+/// - `OtherOpenSource` → Xen / Illumos / etc. → returns `true`
+#[derive(Clone, Copy, Debug, Arbitrary)]
+pub enum FuzzGuestOsId {
+    None,
+    Proprietary,
+    LinuxOld,
+    LinuxNew,
+    FreeBsdOld,
+    FreeBsdNew,
+    OtherOpenSource,
+}
+
+impl FuzzGuestOsId {
+    /// Convert to the `Option<HvGuestOsId>` expected by [`FuzzNicConfig`].
+    pub fn to_hv_guest_os_id(self) -> Option<HvGuestOsId> {
+        use hvdef::hypercall::HvGuestOsMicrosoft;
+        use hvdef::hypercall::HvGuestOsMicrosoftIds;
+        use hvdef::hypercall::HvGuestOsOpenSource;
+        use hvdef::hypercall::HvGuestOsOpenSourceType;
+
+        match self {
+            FuzzGuestOsId::None => None,
+            FuzzGuestOsId::Proprietary => {
+                // Windows NT: is_open_source bit is 0.
+                let os = HvGuestOsMicrosoft::new()
+                    .with_os_id(HvGuestOsMicrosoftIds::WINDOWS_NT.0)
+                    .with_vendor_id(1);
+                Some(HvGuestOsId::from(u64::from(os)))
+            }
+            FuzzGuestOsId::LinuxOld => {
+                // Linux 3.10.0 (version 199168) — below the 199424 threshold.
+                let os = HvGuestOsOpenSource::new()
+                    .with_is_open_source(true)
+                    .with_os_type(HvGuestOsOpenSourceType::LINUX.0)
+                    .with_version(199168);
+                Some(HvGuestOsId::from(u64::from(os)))
+            }
+            FuzzGuestOsId::LinuxNew => {
+                // Linux 3.11.0 (version 199424) — at the threshold.
+                let os = HvGuestOsOpenSource::new()
+                    .with_is_open_source(true)
+                    .with_os_type(HvGuestOsOpenSourceType::LINUX.0)
+                    .with_version(199424);
+                Some(HvGuestOsId::from(u64::from(os)))
+            }
+            FuzzGuestOsId::FreeBsdOld => {
+                // FreeBSD version 1400096 — just below the 1400097 threshold.
+                let os = HvGuestOsOpenSource::new()
+                    .with_is_open_source(true)
+                    .with_os_type(HvGuestOsOpenSourceType::FREEBSD.0)
+                    .with_version(1400096);
+                Some(HvGuestOsId::from(u64::from(os)))
+            }
+            FuzzGuestOsId::FreeBsdNew => {
+                // FreeBSD version 1400097 — at the threshold.
+                let os = HvGuestOsOpenSource::new()
+                    .with_is_open_source(true)
+                    .with_os_type(HvGuestOsOpenSourceType::FREEBSD.0)
+                    .with_version(1400097);
+                Some(HvGuestOsId::from(u64::from(os)))
+            }
+            FuzzGuestOsId::OtherOpenSource => {
+                // Xen — neither Linux nor FreeBSD, hits the `_ => true` arm.
+                let os = HvGuestOsOpenSource::new()
+                    .with_is_open_source(true)
+                    .with_os_type(HvGuestOsOpenSourceType::XEN.0)
+                    .with_version(1);
+                Some(HvGuestOsId::from(u64::from(os)))
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// Fuzz loop boilerplate
+// ===========================================================================
+
+/// Yield control to the async executor `n` times.
+///
+/// After NVSP negotiation the Worker sends `CoordinatorMessage::Restart` and
+/// enters `WaitingForCoordinator`.  The coordinator needs several poll rounds
+/// to: (1) receive the `Restart`, (2) stop the worker, (3) transition it to
+/// `Ready`, (4) execute `restart_queues` (which sets up `QueueState`), and
+/// (5) re-start the worker so it enters `main_loop`.  Yielding here gives
+/// those tasks the CPU time they need in the single-threaded executor.
+pub async fn yield_to_executor(n: usize) {
+    for _ in 0..n {
+        let mut yielded = false;
+        poll_fn(|cx: &mut Context<'_>| {
+            if !yielded {
+                yielded = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        })
+        .await;
+    }
+}
+
+/// Try reading a single packet from the queue, returning true iff it is a completion packet.
+pub fn try_read_one_completion(queue: &mut Queue<GpadlRingMem>) -> bool {
+    let (mut reader, _) = queue.split();
+    match reader.try_read() {
+        Ok(packet) => matches!(&*packet, IncomingPacket::Completion(_)),
+        Err(_) => false,
+    }
+}
+
+/// Drain all pending packets from the queue. Useful to avoid ring-full
+/// deadlocks between fuzz actions.
+pub fn drain_queue(queue: &mut Queue<GpadlRingMem>) {
+    loop {
+        let (mut reader, _) = queue.split();
+        if reader.try_read().is_err() {
+            break;
+        }
+    }
+}
+
+/// Drain all pending packets from the queue, yielding to the executor once
+/// per packet so the NIC worker and coordinator tasks can make progress
+/// in the single-threaded fuzz executor.
+///
+/// Use this between fuzz actions to prevent ring-full deadlocks: each
+/// yield gives background tasks CPU time to process ring data and
+/// produce new completions.
+///
+/// For a synchronous (non-yielding) drain, use [`drain_queue`] instead.
+pub async fn drain_queue_async(queue: &mut Queue<GpadlRingMem>) {
+    loop {
+        let (mut reader, _) = queue.split();
+        if reader.try_read().is_err() {
+            break;
+        }
+        // Yield once per packet so background tasks can process.
+        yield_to_executor(1).await;
+    }
+}
+
+// ===========================================================================
+// Fuzz loop entry points
+// ===========================================================================
+
+/// Run the standard fuzz loop boilerplate: set up a NIC, run a fuzz
+/// callback with a timeout, and report the outcome.
+///
+/// This eliminates the repeated `do_fuzz` / `fuzz_target!` pattern
+/// across fuzz targets.
+pub fn run_fuzz_loop<F>(input: &[u8], layout: &PageLayout, fuzz_loop: F)
+where
+    F: for<'a> FnOnce(
+        &'a mut Unstructured<'_>,
+        nic_setup::FuzzNicSetup,
+    )
+        -> std::pin::Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + 'a>>,
+{
+    run_fuzz_loop_with_config(
+        input,
+        layout,
+        nic_setup::FuzzNicConfig::default(),
+        fuzz_loop,
+    )
+}
+
+/// Run the standard fuzz loop boilerplate with a custom NIC configuration.
+///
+/// A [`FuzzGuestOsId`] is consumed from the `Unstructured` input to override
+/// `config.get_guest_os_id`, so every target that flows through this function
+/// automatically exercises all `can_use_ring_opt` branches.
+pub fn run_fuzz_loop_with_config<F>(
+    input: &[u8],
+    layout: &PageLayout,
+    mut config: nic_setup::FuzzNicConfig,
+    fuzz_loop: F,
+) where
+    F: for<'a> FnOnce(
+        &'a mut Unstructured<'_>,
+        nic_setup::FuzzNicSetup,
+    )
+        -> std::pin::Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + 'a>>,
+{
+    xtask_fuzz::init_tracing_if_repro();
+
+    let mut u = Unstructured::new(input);
+
+    // Fuzz-select the guest OS identity so every target automatically covers
+    // all `can_use_ring_opt` branches (None / proprietary / Linux old/new /
+    // FreeBSD old/new / other open-source).
+    if let Ok(fuzz_os) = u.arbitrary::<FuzzGuestOsId>() {
+        config.get_guest_os_id = fuzz_os.to_hv_guest_os_id();
+    }
+
+    pal_async::DefaultPool::run_with(async |driver| {
+        nic_setup::setup_fuzz_nic_with_config(&driver, layout, config, |setup| async {
+            let fuzz_result = mesh::CancelContext::new()
+                .with_timeout(Duration::from_millis(500))
+                .until_cancelled(fuzz_loop(&mut u, setup))
+                .await;
+
+            match fuzz_result {
+                Ok(Ok(())) => {
+                    fuzz_eprintln!("fuzz: test case exhausted arbitrary data");
+                }
+                Ok(Err(e)) => {
+                    if e.downcast_ref::<arbitrary::Error>().is_some() {
+                        fuzz_eprintln!("fuzz: arbitrary data exhausted: {e:#}");
+                    } else if e.downcast_ref::<RingFullError>().is_some() {
+                        fuzz_eprintln!("fuzz: ring full (backpressure), stopping");
+                    } else {
+                        panic!("fuzz: action error: {e:#}");
+                    }
+                }
+                Err(_) => {
+                    panic!("fuzz: timed out after 500ms");
+                }
+            }
+            Ok(())
+        })
+        .await
+    })
+    .expect("fuzz pool failed to run");
+}

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/mod.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/mod.rs
@@ -814,7 +814,7 @@ pub async fn negotiate_to_ready_full(
     // Without this yield, the single-threaded executor never polls the
     // coordinator, so the worker stays in WaitingForCoordinator and
     // main_loop is never entered.
-    yield_to_executor(20).await;
+    yield_to_executor(10).await;
 
     Ok(())
 }
@@ -1312,12 +1312,22 @@ pub fn try_read_one_completion(queue: &mut Queue<GpadlRingMem>) -> bool {
 /// Drain all pending packets from the queue. Useful to avoid ring-full
 /// deadlocks between fuzz actions.
 pub fn drain_queue(queue: &mut Queue<GpadlRingMem>) {
+    let _ = drain_queue_once(queue);
+}
+
+/// Drain all currently pending packets from the queue once.
+///
+/// Returns `true` if at least one packet was drained.
+fn drain_queue_once(queue: &mut Queue<GpadlRingMem>) -> bool {
+    let mut drained_any = false;
     loop {
         let (mut reader, _) = queue.split();
-        if reader.try_read().is_err() {
-            break;
+        match reader.try_read() {
+            Ok(_) => drained_any = true,
+            Err(_) => break,
         }
     }
+    drained_any
 }
 
 /// Drain all pending packets from the queue, yielding to the executor
@@ -1328,17 +1338,24 @@ pub fn drain_queue(queue: &mut Queue<GpadlRingMem>) {
 ///
 /// For a synchronous (non-yielding) drain, use [`drain_queue`] instead.
 pub async fn drain_queue_async(queue: &mut Queue<GpadlRingMem>) {
-    // Yield first so the NIC worker gets CPU time to process packets
-    // already in the guest→host ring and write responses to the
-    // host→guest ring.
-    yield_to_executor(1).await;
-    loop {
-        let (mut reader, _) = queue.split();
-        if reader.try_read().is_err() {
-            break;
-        }
-        // Yield once per packet so background tasks can process.
+    // Yield so the NIC worker gets CPU time to process packets already
+    // in the guest→host ring and write responses to the host→guest ring.
+    // Repeat until we observe two consecutive empty drains (quiescent),
+    // with a hard cap to keep each fuzz action bounded.
+    const MAX_DRAIN_ROUNDS: usize = 16;
+    const QUIESCENT_EMPTY_ROUNDS: usize = 2;
+
+    let mut consecutive_empty_rounds = 0;
+    for _ in 0..MAX_DRAIN_ROUNDS {
         yield_to_executor(1).await;
+        if drain_queue_once(queue) {
+            consecutive_empty_rounds = 0;
+        } else {
+            consecutive_empty_rounds += 1;
+            if consecutive_empty_rounds >= QUIESCENT_EMPTY_ROUNDS {
+                break;
+            }
+        }
     }
 }
 

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/mod.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/mod.rs
@@ -1320,16 +1320,18 @@ pub fn drain_queue(queue: &mut Queue<GpadlRingMem>) {
     }
 }
 
-/// Drain all pending packets from the queue, yielding to the executor once
-/// per packet so the NIC worker and coordinator tasks can make progress
-/// in the single-threaded fuzz executor.
+/// Drain all pending packets from the queue, yielding to the executor
+/// so the NIC worker and coordinator tasks can make progress in the
+/// single-threaded fuzz executor.
 ///
-/// Use this between fuzz actions to prevent ring-full deadlocks: each
-/// yield gives background tasks CPU time to process ring data and
-/// produce new completions.
+/// Use this between fuzz actions to prevent ring-full deadlocks.
 ///
 /// For a synchronous (non-yielding) drain, use [`drain_queue`] instead.
 pub async fn drain_queue_async(queue: &mut Queue<GpadlRingMem>) {
+    // Yield first so the NIC worker gets CPU time to process packets
+    // already in the guest→host ring and write responses to the
+    // host→guest ring.
+    yield_to_executor(1).await;
     loop {
         let (mut reader, _) = queue.split();
         if reader.try_read().is_err() {

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/nic_setup.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/nic_setup.rs
@@ -1,0 +1,580 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! NIC setup, teardown, and subchannel opener for fuzz targets.
+//!
+//! This module wires together the mock VMBus, endpoint, and VF to create
+//! a fully functional NIC device on a mock VMBus channel.
+
+use super::PageLayout;
+use super::RECV_BUF_PAGES;
+use super::RING_PAGES;
+use super::endpoint::FuzzEndpoint;
+use super::endpoint::FuzzEndpointConfig;
+use super::vmbus::FuzzMockVmbus;
+use super::vmbus::MultiChannelMockVmbus;
+use guestmem::GuestMemory;
+use guid::Guid;
+use hvdef::hypercall::HvGuestOsId;
+use mesh::rpc::Rpc;
+use mesh::rpc::RpcSend;
+use net_backend::Endpoint;
+use netvsp::Nic;
+use netvsp::VirtualFunction;
+use netvsp::test_helpers::gpadl_test_guest_channel;
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use vmbus_async::queue::Queue;
+use vmbus_channel::bus::ChannelRequest;
+use vmbus_channel::bus::GpadlRequest;
+use vmbus_channel::bus::ModifyRequest;
+use vmbus_channel::bus::OfferInput;
+use vmbus_channel::bus::OpenData;
+use vmbus_channel::bus::OpenRequest;
+use vmbus_channel::channel::ChannelHandle;
+use vmbus_channel::channel::offer_channel;
+use vmbus_channel::gpadl::GpadlId;
+use vmbus_channel::gpadl::GpadlMap;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use vmbus_core::protocol::UserDefinedData;
+use vmbus_ring::PAGE_SIZE;
+use vmbus_ring::gparange::MultiPagedRangeBuf;
+use vmcore::interrupt::Interrupt;
+use vmcore::slim_event::SlimEvent;
+use vmcore::vm_task::SingleDriverBackend;
+use vmcore::vm_task::VmTaskDriverSource;
+use zerocopy::FromZeros;
+
+/// Result of setting up a NIC on a mock VMBus, ready for fuzzing.
+pub struct FuzzNicSetup {
+    pub queue: Queue<GpadlRingMem>,
+    /// Guest memory backing the VMBus ring and buffers.
+    pub mem: GuestMemory,
+    pub recv_buf_gpadl_id: GpadlId,
+    pub send_buf_gpadl_id: GpadlId,
+    /// Present when `max_subchannels > 0` in [`FuzzNicConfig`]. Call
+    /// [`SubchannelOpener::open_pending`] after sending a subchannel
+    /// allocation request and draining the primary queue to open the
+    /// resulting subchannel rings.
+    pub subchannel_opener: Option<SubchannelOpener>,
+}
+
+/// GPADL allocation configuration for a single buffer region.
+struct GpadlAlloc {
+    gpadl_id: GpadlId,
+    pages: Vec<u64>,
+}
+
+pub struct FuzzNicConfig {
+    /// The network endpoint to use.
+    /// Either `LoopbackEndpoint` or `FuzzEndpoint`.
+    pub endpoint: Box<dyn Endpoint>,
+    /// Optional virtual function for VF state fuzzing. Default: None.
+    pub virtual_function: Option<Box<dyn VirtualFunction>>,
+    /// Optional guest OS ID for exercising `can_use_ring_opt` and related
+    /// guest-OS-specific code paths. Default: None.
+    pub get_guest_os_id: Option<HvGuestOsId>,
+    /// Maximum number of subchannels the device may open. When non-zero, a
+    /// [`MultiChannelMockVmbus`] is used and a [`SubchannelOpener`] is placed
+    /// in [`FuzzNicSetup`] so the fuzz loop can open real subchannel rings.
+    /// Default: 0 (single-channel mode).
+    pub max_subchannels: u16,
+}
+
+impl Default for FuzzNicConfig {
+    fn default() -> Self {
+        use hvdef::hypercall::HvGuestOsOpenSource;
+        use hvdef::hypercall::HvGuestOsOpenSourceType;
+
+        // Default to Linux 3.11 (version 199424) which is at the
+        // can_use_ring_opt threshold, exercising guest-OS-specific code.
+        let os_id = HvGuestOsOpenSource::new()
+            .with_is_open_source(true)
+            .with_os_type(HvGuestOsOpenSourceType::LINUX.0)
+            .with_version(199424)
+            .with_build_no(0);
+        Self {
+            endpoint: Box::new(FuzzEndpoint::new(FuzzEndpointConfig::default()).0),
+            virtual_function: None,
+            get_guest_os_id: Some(HvGuestOsId::from(u64::from(os_id))),
+            max_subchannels: 0,
+        }
+    }
+}
+
+/// Internal state produced during NIC setup. Consumed by the two public
+/// entry-points: [`setup_fuzz_nic_with_config`] and
+/// [`create_nic_with_channel`].
+struct NicInternals {
+    channel: ChannelHandle<Nic>,
+    offer_input: OfferInput,
+    setup: FuzzNicSetup,
+    subchannel_opened: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+    pending_offers: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+}
+
+/// Allocate guest memory, register GPADLs, open the primary channel ring, and
+/// return all the pieces needed to either run a normal fuzz loop or call
+/// `save`/`restore` on the channel device.
+async fn build_nic_internals(
+    driver: &pal_async::DefaultDriver,
+    layout: &PageLayout,
+    config: FuzzNicConfig,
+) -> anyhow::Result<NicInternals> {
+    let max_subchannels = config.max_subchannels;
+    let total_guest_pages = layout.total_pages() + RING_PAGES * max_subchannels as usize;
+    let recv_buf_page_count = RECV_BUF_PAGES;
+    let send_buf_page_count = layout.send_buf_pages;
+    let mock_vmbus = MultiChannelMockVmbus::new(total_guest_pages);
+    let mem = mock_vmbus.memory.clone();
+    let subchannel_pending = mock_vmbus.pending_offers_arc();
+    let subchannel_opened: Arc<futures::lock::Mutex<Vec<OfferInput>>> =
+        Arc::new(futures::lock::Mutex::new(Vec::new()));
+
+    let fuzz_vmbus = FuzzMockVmbus::new(mock_vmbus.clone(), driver.clone());
+
+    let mut builder = Nic::builder();
+    if let Some(vf) = config.virtual_function {
+        builder = builder.virtual_function(vf);
+    }
+    if let Some(os_id) = config.get_guest_os_id {
+        builder = builder.get_guest_os_id(Box::new(move || os_id));
+    }
+
+    let nic = builder.build(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        Guid::new_random(),
+        config.endpoint,
+        [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF].into(),
+        0,
+    );
+
+    let channel = offer_channel(driver, &fuzz_vmbus, nic)
+        .await
+        .expect("offer_channel failed");
+
+    let offer_input = {
+        let mut offers = mock_vmbus.drain_pending_offers().await;
+        assert!(!offers.is_empty(), "no primary offer input from VMBus");
+        offers.remove(0)
+    };
+
+    let gpadl_map = GpadlMap::new();
+    let mut next_page = 0usize;
+    let mut next_gpadl_id = 1u32;
+
+    let alloc_gpadl =
+        |page_count: usize, next_page: &mut usize, next_gpadl_id: &mut u32| -> GpadlAlloc {
+            let gpadl_id = GpadlId(*next_gpadl_id);
+            *next_gpadl_id += 1;
+            let pages: Vec<u64> = std::iter::once((page_count * PAGE_SIZE) as u64)
+                .chain((*next_page..*next_page + page_count).map(|p| p as u64))
+                .collect();
+            *next_page += page_count;
+            GpadlAlloc { gpadl_id, pages }
+        };
+
+    // Ring buffer (4 pages).
+    let ring = alloc_gpadl(4, &mut next_page, &mut next_gpadl_id);
+    let ring_gpadl_id = ring.gpadl_id;
+    assert!(
+        offer_input
+            .request_send
+            .call(
+                ChannelRequest::Gpadl,
+                GpadlRequest {
+                    id: ring.gpadl_id,
+                    count: 1,
+                    buf: ring.pages.clone(),
+                },
+            )
+            .await
+            .expect("ring gpadl request"),
+        "ring gpadl was not accepted"
+    );
+    gpadl_map.add(
+        ring.gpadl_id,
+        MultiPagedRangeBuf::from_range_buffer(1, ring.pages).unwrap(),
+    );
+
+    // Receive buffer.
+    let recv = alloc_gpadl(recv_buf_page_count, &mut next_page, &mut next_gpadl_id);
+    let recv_buf_gpadl_id = recv.gpadl_id;
+    assert!(
+        offer_input
+            .request_send
+            .call(
+                ChannelRequest::Gpadl,
+                GpadlRequest {
+                    id: recv.gpadl_id,
+                    count: 1,
+                    buf: recv.pages.clone(),
+                },
+            )
+            .await
+            .expect("recv buf gpadl request"),
+        "recv buf gpadl was not accepted"
+    );
+    gpadl_map.add(
+        recv.gpadl_id,
+        MultiPagedRangeBuf::from_range_buffer(1, recv.pages).unwrap(),
+    );
+
+    // Send buffer.
+    let send = alloc_gpadl(send_buf_page_count, &mut next_page, &mut next_gpadl_id);
+    let send_buf_gpadl_id = send.gpadl_id;
+    assert!(
+        offer_input
+            .request_send
+            .call(
+                ChannelRequest::Gpadl,
+                GpadlRequest {
+                    id: send.gpadl_id,
+                    count: 1,
+                    buf: send.pages.clone(),
+                },
+            )
+            .await
+            .expect("send buf gpadl request"),
+        "send buf gpadl was not accepted"
+    );
+    gpadl_map.add(
+        send.gpadl_id,
+        MultiPagedRangeBuf::from_range_buffer(1, send.pages).unwrap(),
+    );
+
+    // Snapshot the GPADL ID counter after primary allocations; subchannels
+    // will continue from here.
+    let subchannel_next_gpadl_id = next_gpadl_id;
+
+    // NOTE: ChannelServerRequest::Restore handling for ALL channels (primary
+    // and subchannels) is done by FuzzMockVmbus::add_child which spawns
+    // auto-responder tasks.  No per-channel handler created here.
+
+    // Open the channel.
+    let host_to_guest_event = Arc::new(SlimEvent::new());
+    let host_to_guest_interrupt = {
+        let event = host_to_guest_event.clone();
+        Interrupt::from_fn(move || event.signal())
+    };
+
+    let open_request = OpenRequest {
+        open_data: OpenData {
+            target_vp: 0,
+            ring_offset: 2,
+            ring_gpadl_id,
+            event_flag: 1,
+            connection_id: 1,
+            user_data: UserDefinedData::new_zeroed(),
+        },
+        interrupt: host_to_guest_interrupt,
+        use_confidential_ring: false,
+        use_confidential_external_memory: false,
+    };
+
+    let open_result = offer_input
+        .request_send
+        .call::<_, _, bool>(ChannelRequest::Open, open_request)
+        .await
+        .expect("open request");
+
+    assert!(
+        open_result,
+        "channel open failed unexpectedly in fuzz setup"
+    );
+    fuzz_vmbus.set_restore_ring_gpadl(ring.gpadl_id);
+
+    let guest_to_host_interrupt = offer_input.event.clone();
+    let gpadl_map_view = gpadl_map.view();
+    let done = Arc::new(AtomicBool::new(false));
+    let raw_channel = gpadl_test_guest_channel(
+        &mem,
+        &gpadl_map_view,
+        ring_gpadl_id,
+        2,
+        host_to_guest_event,
+        guest_to_host_interrupt,
+        done,
+    );
+    let queue = Queue::new(raw_channel).unwrap();
+
+    let subchannel_opener = if max_subchannels > 0 {
+        Some(SubchannelOpener {
+            pending: subchannel_pending.clone(),
+            opened: subchannel_opened.clone(),
+            mem: mem.clone(),
+            // Subchannel rings start in guest memory immediately after the
+            // primary layout (ring + recv_buf + send_buf + data pages).
+            next_page: layout.total_pages(),
+            next_gpadl_id: subchannel_next_gpadl_id,
+        })
+    } else {
+        None
+    };
+
+    let setup = FuzzNicSetup {
+        queue,
+        mem,
+        recv_buf_gpadl_id,
+        send_buf_gpadl_id,
+        subchannel_opener,
+    };
+
+    Ok(NicInternals {
+        channel,
+        offer_input,
+        setup,
+        subchannel_opened,
+        pending_offers: subchannel_pending,
+    })
+}
+
+/// Tear down everything created by [`build_nic_internals`]: drop offer inputs
+/// to release request senders, then revoke the device handle. The revoke
+/// triggers the `Device::run_channel` cleanup which closes any channels that
+/// are still open.
+///
+/// Intentionally avoid sending explicit `ChannelRequest::Close` messages
+/// because a prior `restore()` call may have changed the device's view of
+/// which channels are open, and closing an already-closed channel would trip
+/// an assertion inside `Device::handle_close`.
+async fn cleanup_nic_internals(
+    offer_input: OfferInput,
+    subchannel_opened: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+    pending_offers: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+    channel: ChannelHandle<Nic>,
+) {
+    // Drop subchannel offer inputs to release their request senders.
+    subchannel_opened.lock().await.clear();
+
+    // Drop any subchannel OfferInputs that were created by
+    // `Device::enable_channels` during a `restore()` call but never opened
+    // by the fuzz target.  Their `request_send` senders keep the Device's
+    // request streams alive, which would hang the revoke wait loop.
+    pending_offers.lock().await.clear();
+
+    // Drop the primary offer input so the request stream inside the channel
+    // task can drain.
+    drop(offer_input);
+    let _ = channel.revoke().await;
+}
+
+/// A handle returned by [`create_nic_with_channel`] that owns the
+/// [`ChannelHandle<Nic>`] alongside the cleanup state.  Call
+/// [`NicSetupHandle::cleanup`] when the fuzz loop is done.
+pub struct NicSetupHandle {
+    /// The VMBus channel device handle. Use this to call `start()`, `stop()`,
+    /// `save()`, and `restore()` from within the fuzz loop.
+    pub channel: ChannelHandle<Nic>,
+    offer_input: OfferInput,
+    subchannel_opened: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+    pending_offers: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+}
+
+impl NicSetupHandle {
+    /// Tear down the NIC: close subchannels, close the primary channel, and
+    /// revoke the device handle.  Must be called after the fuzz loop finishes.
+    pub async fn cleanup(self) {
+        cleanup_nic_internals(
+            self.offer_input,
+            self.subchannel_opened,
+            self.pending_offers,
+            self.channel,
+        )
+        .await;
+    }
+
+    /// Send a [`ChannelRequest::Close`] to the device, simulating the host
+    /// closing the primary VMBus channel.
+    pub fn send_close(&self) {
+        self.offer_input
+            .request_send
+            .send(ChannelRequest::Close(Rpc::detached(())));
+    }
+
+    /// Send a [`ChannelRequest::Modify`] with [`ModifyRequest::TargetVp`] to
+    /// the device, simulating a VP retarget of the primary channel.
+    pub fn send_retarget_vp(&self, target_vp: u32) {
+        self.offer_input
+            .request_send
+            .send(ChannelRequest::Modify(Rpc::detached(
+                ModifyRequest::TargetVp { target_vp },
+            )));
+    }
+}
+
+/// Set up a NIC with the specified page layout and custom configuration,
+/// returning a ready-to-use queue and GPADL IDs.
+pub async fn setup_fuzz_nic_with_config<F, Fut>(
+    driver: &pal_async::DefaultDriver,
+    layout: &PageLayout,
+    config: FuzzNicConfig,
+    fuzz_loop: F,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(FuzzNicSetup) -> Fut,
+    Fut: Future<Output = anyhow::Result<()>>,
+{
+    let NicInternals {
+        channel,
+        offer_input,
+        setup,
+        subchannel_opened,
+        pending_offers,
+    } = build_nic_internals(driver, layout, config).await?;
+
+    channel.start();
+    let fuzz_result = fuzz_loop(setup).await;
+    cleanup_nic_internals(offer_input, subchannel_opened, pending_offers, channel).await;
+    fuzz_result
+}
+
+/// Like [`setup_fuzz_nic_with_config`] but returns the [`ChannelHandle<Nic>`]
+/// alongside the [`FuzzNicSetup`] so that `save()` / `restore()` can be called
+/// from the fuzz loop.
+///
+/// The caller is responsible for calling [`NicSetupHandle::cleanup`] after the
+/// fuzz loop finishes and for calling `channel.start()` before sending any
+/// VMBus traffic.
+pub async fn create_nic_with_channel(
+    driver: &pal_async::DefaultDriver,
+    layout: &PageLayout,
+    config: FuzzNicConfig,
+) -> anyhow::Result<(NicSetupHandle, FuzzNicSetup)> {
+    let NicInternals {
+        channel,
+        offer_input,
+        setup,
+        subchannel_opened,
+        pending_offers,
+    } = build_nic_internals(driver, layout, config).await?;
+
+    let handle = NicSetupHandle {
+        channel,
+        offer_input,
+        subchannel_opened,
+        pending_offers,
+    };
+
+    Ok((handle, setup))
+}
+
+// ===========================================================================
+// SubchannelOpener
+// ===========================================================================
+
+/// Drives the opening of VMBus subchannels after the device calls
+/// `enable_subchannels`. Call [`SubchannelOpener::open_pending`] after
+/// draining the primary queue to let the device process any subchannel
+/// requests, then receive guest-side `Queue` handles for each opened
+/// subchannel ring.
+///
+/// Only present in [`FuzzNicSetup`] when `max_subchannels > 0` in
+/// [`FuzzNicConfig`].
+pub struct SubchannelOpener {
+    /// Pending offers pushed by [`MultiChannelMockVmbus::add_child`].
+    pending: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+    /// Opened offer inputs, shared with setup cleanup.
+    opened: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+    mem: GuestMemory,
+    /// Next page index in guest memory for subchannel ring allocation.
+    next_page: usize,
+    /// Next GPADL ID to hand out for subchannel rings.
+    next_gpadl_id: u32,
+}
+
+impl SubchannelOpener {
+    /// Open all subchannels the device has requested since the last call.
+    ///
+    /// Drains any [`OfferInput`] entries queued by the
+    /// [`MultiChannelMockVmbus`], registers GPADL and Open requests on each,
+    /// and returns a guest-side `Queue<GpadlRingMem>` per newly opened
+    /// subchannel ring. Returns an empty vec if no subchannels are pending.
+    pub async fn open_pending(&mut self) -> Vec<Queue<GpadlRingMem>> {
+        let new_offers: Vec<OfferInput> = self.pending.lock().await.drain(..).collect();
+        let mut queues = Vec::new();
+        for offer_input in new_offers {
+            let ring_page_start = self.next_page;
+            self.next_page += RING_PAGES;
+            let gpadl_id = GpadlId(self.next_gpadl_id);
+            self.next_gpadl_id += 1;
+
+            // Page list encoding: first element is the byte length of the
+            // range, rest are the page-frame numbers (same as primary setup).
+            let pages: Vec<u64> = std::iter::once((RING_PAGES * PAGE_SIZE) as u64)
+                .chain((ring_page_start..ring_page_start + RING_PAGES).map(|p| p as u64))
+                .collect();
+
+            // Register the ring GPADL with this subchannel.
+            let accepted = offer_input
+                .request_send
+                .call(
+                    ChannelRequest::Gpadl,
+                    GpadlRequest {
+                        id: gpadl_id,
+                        count: 1,
+                        buf: pages.clone(),
+                    },
+                )
+                .await
+                .unwrap_or(false);
+
+            if !accepted {
+                self.opened.lock().await.push(offer_input);
+                continue;
+            }
+
+            // Build a dedicated GPADL map for this subchannel's ring.
+            let sub_gpadl_map = GpadlMap::new();
+            sub_gpadl_map.add(
+                gpadl_id,
+                MultiPagedRangeBuf::from_range_buffer(1, pages).unwrap(),
+            );
+
+            // Open the subchannel.
+            let host_to_guest_event = Arc::new(SlimEvent::new());
+            let host_to_guest_interrupt = {
+                let event = host_to_guest_event.clone();
+                Interrupt::from_fn(move || event.signal())
+            };
+            let open_request = OpenRequest {
+                open_data: OpenData {
+                    target_vp: 0,
+                    ring_offset: 2,
+                    ring_gpadl_id: gpadl_id,
+                    event_flag: 1,
+                    connection_id: 1,
+                    user_data: UserDefinedData::new_zeroed(),
+                },
+                interrupt: host_to_guest_interrupt,
+                use_confidential_ring: false,
+                use_confidential_external_memory: false,
+            };
+            let open_result = offer_input
+                .request_send
+                .call::<_, _, bool>(ChannelRequest::Open, open_request)
+                .await
+                .unwrap_or(false);
+
+            if open_result {
+                let guest_to_host_interrupt = offer_input.event.clone();
+                let done = Arc::new(AtomicBool::new(false));
+                let raw_channel = gpadl_test_guest_channel(
+                    &self.mem,
+                    &sub_gpadl_map.view(),
+                    gpadl_id,
+                    2,
+                    host_to_guest_event,
+                    guest_to_host_interrupt,
+                    done,
+                );
+                queues.push(Queue::new(raw_channel).unwrap());
+            }
+
+            // Retain for cleanup.
+            self.opened.lock().await.push(offer_input);
+        }
+        queues
+    }
+}

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/nic_setup.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/nic_setup.rs
@@ -261,7 +261,7 @@ async fn build_nic_internals(
 
     let open_request = OpenRequest {
         open_data: OpenData {
-            target_vp: 0,
+            target_vp: Some(0),
             ring_offset: 2,
             ring_gpadl_id,
             event_flag: 1,
@@ -540,7 +540,7 @@ impl SubchannelOpener {
             };
             let open_request = OpenRequest {
                 open_data: OpenData {
-                    target_vp: 0,
+                    target_vp: Some(0),
                     ring_offset: 2,
                     ring_gpadl_id: gpadl_id,
                     event_flag: 1,

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/vf.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/vf.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use async_trait::async_trait;
+use mesh::rpc::Rpc;
+use netvsp::VirtualFunction;
+use parking_lot::Mutex;
+
+/// A fuzzer-controlled [`VirtualFunction`] implementation.
+///
+/// The fuzzer can control:
+/// - What `id()` returns (via `id_send`)
+/// - When `wait_for_state_change()` completes (via `state_change_send`)
+pub struct FuzzVirtualFunction {
+    id_recv: Mutex<mesh::Receiver<Option<u32>>>,
+    state_change_recv: mesh::Receiver<Rpc<(), ()>>,
+    current_id: Mutex<Option<u32>>,
+}
+
+/// Handles for controlling a [`FuzzVirtualFunction`] from the fuzz loop.
+pub struct FuzzVfHandles {
+    /// Send VF ID updates. The VF will return the latest value from `id()`.
+    pub id_send: mesh::Sender<Option<u32>>,
+    /// Send an RPC to trigger `wait_for_state_change()` completion.
+    pub state_change_send: mesh::Sender<Rpc<(), ()>>,
+}
+
+impl FuzzVirtualFunction {
+    /// Create a new fuzz VF with an initial ID and its control handles.
+    pub fn new(initial_id: Option<u32>) -> (Self, FuzzVfHandles) {
+        let (id_send, id_recv) = mesh::channel();
+        let (state_change_send, state_change_recv) = mesh::channel();
+        (
+            Self {
+                id_recv: Mutex::new(id_recv),
+                state_change_recv,
+                current_id: Mutex::new(initial_id),
+            },
+            FuzzVfHandles {
+                id_send,
+                state_change_send,
+            },
+        )
+    }
+
+    /// Drain any pending ID updates from the channel, keeping only the latest.
+    fn drain_id_updates(&self) {
+        let mut latest = None;
+        {
+            let mut id_recv = self.id_recv.lock();
+            while let Ok(id) = id_recv.try_recv() {
+                latest = Some(id);
+            }
+        }
+        if let Some(id) = latest {
+            *self.current_id.lock() = id;
+        }
+    }
+}
+
+#[async_trait]
+impl VirtualFunction for FuzzVirtualFunction {
+    async fn id(&self) -> Option<u32> {
+        self.drain_id_updates();
+        *self.current_id.lock()
+    }
+
+    async fn guest_ready_for_device(&mut self) {
+        // No-op: the fuzzer controls state changes via the channel.
+    }
+
+    async fn wait_for_state_change(&mut self) -> Rpc<(), ()> {
+        // Wait for the fuzzer to signal a state change.
+        // If the channel is closed (all senders dropped), pend forever
+        // so that the coordinator's `until_stopped` can observe the stop
+        // signal instead of spinning in a tight loop.
+        let rpc = match self.state_change_recv.recv().await {
+            Ok(rpc) => rpc,
+            Err(_) => std::future::pending().await,
+        };
+        self.drain_id_updates();
+        // Return a real RPC provided by the fuzz loop so the coordinator's
+        // `rpc.handle(...)` path performs an actual completion.
+        rpc
+    }
+}

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/vmbus.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/vmbus.rs
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Mock VMBus implementations for fuzz targets.
+//!
+//! [`MultiChannelMockVmbus`] accumulates channel offers into a shared queue,
+//! enabling subchannel support. [`FuzzMockVmbus`] wraps it with auto-handling
+//! of `ChannelServerRequest::Restore` RPCs so that `save`/`restore` fuzz
+//! paths don't hang.
+
+use async_trait::async_trait;
+use guestmem::GuestMemory;
+use pal_async::task::Spawn;
+use std::sync::Arc;
+use vmbus_channel::bus::ChannelServerRequest;
+use vmbus_channel::bus::OfferInput;
+use vmbus_channel::bus::OfferResources;
+use vmbus_channel::bus::OpenData;
+use vmbus_channel::bus::OpenRequest;
+use vmbus_channel::bus::ParentBus;
+use vmbus_channel::bus::RestoreResult;
+use vmbus_channel::gpadl::GpadlId;
+use vmbus_core::protocol::UserDefinedData;
+use vmbus_ring::PAGE_SIZE;
+use vmcore::interrupt::Interrupt;
+use zerocopy::FromZeros;
+
+/// A [`ParentBus`] implementation that supports multiple channels by
+/// accumulating every [`OfferInput`] into a shared `Vec`. This allows
+/// subchannels to be individually opened after the device calls
+/// `enable_subchannels`, unlocking multi-queue code paths.
+#[derive(Clone)]
+pub(super) struct MultiChannelMockVmbus {
+    /// Guest memory shared by all channels.
+    pub(super) memory: GuestMemory,
+    pending_offers: Arc<futures::lock::Mutex<Vec<OfferInput>>>,
+}
+
+impl MultiChannelMockVmbus {
+    /// Create a new mock VMBus with `guest_page_count` pages of guest memory.
+    pub(super) fn new(guest_page_count: usize) -> Self {
+        Self {
+            memory: GuestMemory::allocate(guest_page_count * PAGE_SIZE),
+            pending_offers: Arc::new(futures::lock::Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Drain and return all accumulated [`OfferInput`] entries. The first
+    /// entry is the primary channel; subsequent entries are subchannels.
+    pub(super) async fn drain_pending_offers(&self) -> Vec<OfferInput> {
+        self.pending_offers.lock().await.drain(..).collect()
+    }
+
+    /// Return a reference-counted handle to the pending-offers queue.
+    /// Pass this to a `SubchannelOpener` so it can poll for new subchannel
+    /// offers as the device calls `enable_subchannels`.
+    pub(super) fn pending_offers_arc(&self) -> Arc<futures::lock::Mutex<Vec<OfferInput>>> {
+        self.pending_offers.clone()
+    }
+}
+
+#[async_trait]
+impl ParentBus for MultiChannelMockVmbus {
+    async fn add_child(&self, request: OfferInput) -> anyhow::Result<OfferResources> {
+        self.pending_offers.lock().await.push(request);
+        Ok(OfferResources::new(self.memory.clone(), None))
+    }
+
+    fn clone_bus(&self) -> Box<dyn ParentBus> {
+        Box::new(self.clone())
+    }
+
+    fn use_event(&self) -> bool {
+        false
+    }
+}
+
+/// A [`ParentBus`] wrapper around [`MultiChannelMockVmbus`] that automatically
+/// spawns a background task to handle [`ChannelServerRequest::Restore`] RPCs
+/// for **every** channel (primary + subchannels).  Without this, any call to
+/// `ChannelHandle::restore()` would hang because nobody processes the
+/// server-side receiver.
+#[derive(Clone)]
+pub(super) struct FuzzMockVmbus {
+    inner: MultiChannelMockVmbus,
+    driver: pal_async::DefaultDriver,
+    /// Ring GPADL ID for the primary channel, set by `build_nic_internals`
+    /// after the channel is successfully opened.  Shared with all clones and
+    /// with the spawned server-request handler task.
+    ring_gpadl_for_restore: Arc<parking_lot::Mutex<Option<GpadlId>>>,
+}
+
+impl FuzzMockVmbus {
+    pub(super) fn new(inner: MultiChannelMockVmbus, driver: pal_async::DefaultDriver) -> Self {
+        Self {
+            inner,
+            driver,
+            ring_gpadl_for_restore: Arc::new(parking_lot::Mutex::new(None)),
+        }
+    }
+
+    /// Record the ring GPADL ID that was used when opening the primary channel.
+    /// Must be called after a successful `ChannelRequest::Open` so that
+    /// subsequent `ChannelServerRequest::Restore` responses contain the correct
+    /// GPADL ID for `make_rings` to look up.
+    pub(super) fn set_restore_ring_gpadl(&self, id: GpadlId) {
+        *self.ring_gpadl_for_restore.lock() = Some(id);
+    }
+}
+
+#[async_trait]
+impl ParentBus for FuzzMockVmbus {
+    async fn add_child(&self, mut request: OfferInput) -> anyhow::Result<OfferResources> {
+        // Extract the server_request_recv and replace with a dummy so the
+        // OfferInput stored in pending_offers never gets polled.
+        let server_request_recv = std::mem::replace(
+            &mut request.server_request_recv,
+            mesh::channel::<ChannelServerRequest>().1,
+        );
+        let ring_gpadl_for_restore = self.ring_gpadl_for_restore.clone();
+
+        // Spawn a detached task that auto-responds to Restore/Revoke RPCs.
+        self.driver
+            .spawn("fuzz-vmbus-server-request-handler", async move {
+                let mut recv = server_request_recv;
+                while let Ok(req) = recv.recv().await {
+                    match req {
+                        ChannelServerRequest::Restore(rpc) => {
+                            let open = *rpc.input();
+                            let ring_gpadl_id = ring_gpadl_for_restore.lock().unwrap_or(GpadlId(0));
+                            let open_request = if open {
+                                Some(OpenRequest {
+                                    open_data: OpenData {
+                                        target_vp: 0,
+                                        ring_offset: 2,
+                                        ring_gpadl_id,
+                                        event_flag: 1,
+                                        connection_id: 1,
+                                        user_data: UserDefinedData::new_zeroed(),
+                                    },
+                                    interrupt: Interrupt::from_fn(|| {}),
+                                    use_confidential_ring: false,
+                                    use_confidential_external_memory: false,
+                                })
+                            } else {
+                                None
+                            };
+                            rpc.complete(Ok(RestoreResult {
+                                open_request,
+                                gpadls: vec![],
+                            }));
+                        }
+                        ChannelServerRequest::Revoke(rpc) => rpc.complete(()),
+                    }
+                }
+            })
+            .detach();
+
+        self.inner.add_child(request).await
+    }
+
+    fn clone_bus(&self) -> Box<dyn ParentBus> {
+        Box::new(self.clone())
+    }
+
+    fn use_event(&self) -> bool {
+        self.inner.use_event()
+    }
+}

--- a/vm/devices/net/netvsp/fuzz/fuzz_helpers/vmbus.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_helpers/vmbus.rs
@@ -131,7 +131,7 @@ impl ParentBus for FuzzMockVmbus {
                             let open_request = if open {
                                 Some(OpenRequest {
                                     open_data: OpenData {
-                                        target_vp: 0,
+                                        target_vp: Some(0),
                                         ring_offset: 2,
                                         ring_gpadl_id,
                                         event_flag: 1,

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_control.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_control.rs
@@ -1,0 +1,487 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzer for NVSP control messages processed by the NetVSP implementation.
+//!
+//! This fuzzer exercises the NVSP protocol state machine by sending arbitrary
+//! sequences of NVSP control messages through a VMBus channel to a NetVSP
+//! instance. It performs protocol negotiation first (version init, NDIS
+//! config, NDIS version, receive/send buffer setup), then runs fuzz actions.
+//!
+//! ## NVSP protocol messages tested
+//!
+//! Setup (via `negotiate_to_ready_full`):
+//! - `MESSAGE_TYPE_INIT` — version negotiation (fuzz-selected pair from V2–V61)
+//! - `MESSAGE2_TYPE_SEND_NDIS_CONFIG` — MTU and capabilities
+//! - `MESSAGE1_TYPE_SEND_NDIS_VERSION` — NDIS version (6.30)
+//! - `MESSAGE1_TYPE_SEND_RECEIVE_BUFFER` — receive buffer GPADL registration
+//! - `MESSAGE1_TYPE_SEND_SEND_BUFFER` — send buffer GPADL registration
+//!
+//! Fuzz actions (NVSP control):
+//! - `MESSAGE_TYPE_INIT` — arbitrary version values
+//! - `MESSAGE2_TYPE_SEND_NDIS_CONFIG` — arbitrary MTU and capabilities
+//! - `MESSAGE1_TYPE_SEND_NDIS_VERSION` — arbitrary NDIS version numbers
+//! - `MESSAGE1_TYPE_SEND_RECEIVE_BUFFER` — arbitrary GPADL handle and ID
+//! - `MESSAGE1_TYPE_SEND_SEND_BUFFER` — arbitrary GPADL handle and ID
+//! - `MESSAGE1_TYPE_REVOKE_RECEIVE_BUFFER` — revoke receive buffer
+//! - `MESSAGE1_TYPE_REVOKE_SEND_BUFFER` — revoke send buffer
+//! - `MESSAGE4_TYPE_SWITCH_DATA_PATH` — data path switching
+//! - `MESSAGE5_TYPE_SUB_CHANNEL` — subchannel allocation requests
+//! - `MESSAGE5_TYPE_OID_QUERY_EX` — NVSP-level OID queries
+//! - Arbitrary raw NVSP message types and payloads
+//! - Arbitrary raw VMBus packet types
+//!
+//! Fuzz actions (RNDIS via GpaDirect):
+//! - `MESSAGE_TYPE_INITIALIZE_MSG` — RNDIS initialize with fuzzed version/transfer size
+//! - `MESSAGE_TYPE_KEEPALIVE_MSG` — RNDIS keepalive messages
+//! - `MESSAGE_TYPE_RESET_MSG` — RNDIS reset messages
+//! - Arbitrary RNDIS data and control payloads via GpaDirect
+//!
+//! Fuzz actions (completions and send buffer):
+//! - `MESSAGE4_TYPE_SEND_VF_ASSOCIATION` completion (TID `0x8000000000000000`)
+//! - `MESSAGE4_TYPE_SWITCH_DATA_PATH` completion (TID `0x8000000000000001`)
+//! - Completion packets with arbitrary transaction IDs
+//! - `MESSAGE1_TYPE_SEND_RNDIS_PACKET` with adversarial send buffer section indices
+//! - Flood control messages to exercise the `TooManyControlMessages` error path
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::SWITCH_DATA_PATH_TRANSACTION_ID;
+use fuzz_helpers::VF_ASSOCIATION_TRANSACTION_ID;
+use fuzz_helpers::build_rndis_message;
+use fuzz_helpers::drain_queue_async;
+use fuzz_helpers::negotiate_to_ready_full;
+use fuzz_helpers::pick_version_pair;
+use fuzz_helpers::run_fuzz_loop;
+use fuzz_helpers::send_completion_packet;
+use fuzz_helpers::send_inband_nvsp;
+use fuzz_helpers::send_rndis_gpadirect;
+use fuzz_helpers::send_rndis_via_direct_path;
+use fuzz_helpers::try_read_one_completion;
+use fuzz_helpers::write_packet;
+use guestmem::GuestMemory;
+use netvsp::protocol;
+use netvsp::rndisprot;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use vmbus_ring::OutgoingPacketType;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+use zerocopy::IntoBytes;
+
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 1,
+    data_pages: DATA_PAGES,
+};
+
+// ---- Fuzz actions ----
+
+/// Actions the fuzzer can take after (optional) protocol negotiation.
+#[derive(Arbitrary, Debug)]
+enum ControlAction {
+    /// Send an arbitrary packet payload with a fuzzed packet type.
+    SendRawPacket {
+        #[arbitrary(with = fuzz_helpers::arbitrary_outgoing_packet_type)]
+        packet_type: OutgoingPacketType<'static>,
+        payload: Vec<u8>,
+    },
+    /// Send a raw NVSP message with arbitrary type and payload.
+    SendRawInBand {
+        message_type: u32,
+        payload: Vec<u8>,
+        with_completion: bool,
+    },
+    /// Send a structured Init message with arbitrary version values.
+    SendInit { init: protocol::MessageInit },
+    /// Send an NDIS version message with arbitrary version numbers.
+    SendNdisVersion {
+        version: protocol::Message1SendNdisVersion,
+    },
+    /// Send NDIS config with arbitrary MTU and capabilities.
+    SendNdisConfig {
+        config: protocol::Message2SendNdisConfig,
+    },
+    /// Send a receive buffer message.
+    SendReceiveBuffer {
+        #[arbitrary(with = fuzz_helpers::arbitrary_send_receive_buffer_message)]
+        msg: protocol::Message1SendReceiveBuffer,
+    },
+    /// Send a send buffer message.
+    SendSendBuffer {
+        #[arbitrary(with = fuzz_helpers::arbitrary_send_send_buffer_message)]
+        msg: protocol::Message1SendSendBuffer,
+    },
+    /// Send a revoke receive buffer message.
+    RevokeReceiveBuffer {
+        msg: protocol::Message1RevokeReceiveBuffer,
+    },
+    /// Send a revoke send buffer message.
+    RevokeSendBuffer {
+        msg: protocol::Message1RevokeSendBuffer,
+    },
+    /// Send a switch data path message.
+    SwitchDataPath {
+        msg: protocol::Message4SwitchDataPath,
+    },
+    /// Send a subchannel request.
+    SubChannelRequest {
+        request: protocol::Message5SubchannelRequest,
+    },
+    /// Send an OID query.
+    OidQueryEx { msg: protocol::Message5OidQueryEx },
+    /// Read a completion/response from the host.
+    ReadCompletion,
+    /// Send a VF association completion (TID 0x8000000000000000).
+    SendVfAssociationCompletion,
+    /// Send a switch data path completion (TID 0x8000000000000001).
+    SendSwitchDataPathCompletion,
+    /// Send a completion packet with an arbitrary transaction ID and payload.
+    SendRawCompletion { tid: u64, payload: Vec<u8> },
+    /// Send an arbitrary RNDIS packet via GpaDirect on the data channel.
+    SendRndisPacketDirect { payload: Vec<u8> },
+    /// Send an arbitrary RNDIS control message via GpaDirect on the control channel.
+    SendRndisControlDirect { payload: Vec<u8> },
+    /// Send an RNDIS INITIALIZE message with a fully fuzzed InitializeRequest.
+    /// This exercises arbitrary version numbers and max_transfer_size values.
+    SendRndisInitialize {
+        request: rndisprot::InitializeRequest,
+    },
+    /// Send an RNDIS keepalive message to exercise keepalive handling.
+    SendRndisKeepalive { request_id: u32 },
+    /// Send an RNDIS RESET message to exercise the reset handling path.
+    SendRndisReset { reserved: u32 },
+    /// Send a raw MESSAGE1_TYPE_SEND_RNDIS_PACKET with adversarial
+    /// send_buffer_section_index and send_buffer_section_size values.
+    SendRawSendBufferPacket {
+        send_buffer_section_index: u32,
+        send_buffer_section_size: u32,
+        channel_type: u32,
+    },
+    /// Flood the NIC with many RNDIS control messages without draining the
+    /// completion queue. This exercises the `TooManyControlMessages` error
+    /// path, which triggers when the queued control message bytes exceed
+    /// 100 KB.
+    FloodControlMessages {
+        // How many messages to send in the burst (clamped to 15–40).
+        count: u8,
+    },
+}
+
+/// Execute one fuzz action by sending a message through the vmbus channel.
+///
+/// Returns `Ok(true)` if the fuzz loop should continue, or `Ok(false)` if
+/// the NIC may have terminated (e.g. after a standalone buffer revocation)
+/// and the fuzz loop should exit cleanly.
+async fn execute_next_action(
+    input: &mut Unstructured<'_>,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    next_transaction_id: &mut u64,
+) -> Result<bool, anyhow::Error> {
+    let action = input.arbitrary::<ControlAction>()?;
+    fuzz_eprintln!("action: {action:?}");
+    match action {
+        ControlAction::SendRawPacket {
+            packet_type,
+            payload,
+        } => {
+            write_packet(queue, next_transaction_id, packet_type, &[&payload]).await?;
+        }
+        ControlAction::SendRawInBand {
+            message_type,
+            payload: raw_payload,
+            with_completion,
+        } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                message_type,
+                &raw_payload,
+                with_completion,
+            )
+            .await?;
+        }
+        ControlAction::SendInit { init } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE_TYPE_INIT,
+                init.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::SendNdisVersion { version } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE1_TYPE_SEND_NDIS_VERSION,
+                version.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::SendNdisConfig { config } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE2_TYPE_SEND_NDIS_CONFIG,
+                config.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::SendReceiveBuffer { msg } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE1_TYPE_SEND_RECEIVE_BUFFER,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::SendSendBuffer { msg } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE1_TYPE_SEND_SEND_BUFFER,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::RevokeReceiveBuffer { msg } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE1_TYPE_REVOKE_RECEIVE_BUFFER,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+            // A matching revoke (id == 0) terminates the NIC worker.
+            // Drain any pending completions and signal the caller to stop
+            // the fuzz loop so we don't hang writing to a dead ring.
+            fuzz_helpers::drain_queue(queue);
+            return Ok(false);
+        }
+        ControlAction::RevokeSendBuffer { msg } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE1_TYPE_REVOKE_SEND_BUFFER,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+            // See RevokeReceiveBuffer comment above.
+            fuzz_helpers::drain_queue(queue);
+            return Ok(false);
+        }
+        ControlAction::SwitchDataPath { msg } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE4_TYPE_SWITCH_DATA_PATH,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::SubChannelRequest { request } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE5_TYPE_SUB_CHANNEL,
+                request.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::OidQueryEx { msg } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE5_TYPE_OID_QUERY_EX,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::ReadCompletion => {
+            // Try to read a completion from the host side. This is important
+            // for forward progress of various code paths.
+            let _ = try_read_one_completion(queue);
+        }
+        ControlAction::SendVfAssociationCompletion => {
+            send_completion_packet(queue, VF_ASSOCIATION_TRANSACTION_ID, &[]).await?;
+        }
+        ControlAction::SendSwitchDataPathCompletion => {
+            send_completion_packet(queue, SWITCH_DATA_PATH_TRANSACTION_ID, &[]).await?;
+        }
+        ControlAction::SendRawCompletion { tid, payload } => {
+            send_completion_packet(queue, tid, &[&payload]).await?;
+        }
+        ControlAction::SendRndisPacketDirect { payload } => {
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &payload,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        ControlAction::SendRndisControlDirect { payload } => {
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &payload,
+                protocol::CONTROL_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        ControlAction::SendRndisInitialize { request } => {
+            let rndis_bytes =
+                build_rndis_message(rndisprot::MESSAGE_TYPE_INITIALIZE_MSG, request.as_bytes());
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_bytes,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        ControlAction::SendRndisKeepalive { request_id } => {
+            let keepalive = rndisprot::KeepaliveRequest { request_id };
+            let rndis_bytes =
+                build_rndis_message(rndisprot::MESSAGE_TYPE_KEEPALIVE_MSG, keepalive.as_bytes());
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_bytes,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        ControlAction::SendRndisReset { reserved } => {
+            let rndis_bytes =
+                build_rndis_message(rndisprot::MESSAGE_TYPE_RESET_MSG, &reserved.to_le_bytes());
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_bytes,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        ControlAction::SendRawSendBufferPacket {
+            send_buffer_section_index,
+            send_buffer_section_size,
+            channel_type,
+        } => {
+            let msg = protocol::Message1SendRndisPacket {
+                channel_type,
+                send_buffer_section_index,
+                send_buffer_section_size,
+            };
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        ControlAction::FloodControlMessages { count } => {
+            // Clamp count to [15, 40] to send enough messages to approach
+            // the 100KB control message queue threshold without timing out.
+            // 15 × 8192 = 120KB, enough to trigger the limit.
+            let n = 15 + (count as usize % 26); // 15..=40
+            let big_payload = vec![0xABu8; 8192];
+            let rndis_bytes = build_rndis_message(rndisprot::MESSAGE_TYPE_QUERY_MSG, &big_payload);
+            // Yield every 3 messages: often enough to keep the ring from
+            // filling up (the 16KB ring only holds a few GpaDirect packets),
+            // but infrequent enough to avoid switching overhead and timeouts.
+            for i in 0..n {
+                let result = send_rndis_gpadirect(
+                    queue,
+                    mem,
+                    &rndis_bytes,
+                    protocol::CONTROL_CHANNEL_TYPE,
+                    LAYOUT.data_page_start(),
+                    LAYOUT.data_pages,
+                    next_transaction_id,
+                )
+                .await;
+                match result {
+                    Ok(()) => {}
+                    Err(e) if e.downcast_ref::<fuzz_helpers::RingFullError>().is_some() => break,
+                    Err(e) => return Err(e),
+                }
+                if (i + 1) % 3 == 0 {
+                    fuzz_helpers::yield_to_executor(1).await;
+                }
+            }
+            // Final yield + drain to avoid interfering with subsequent actions.
+            fuzz_helpers::yield_to_executor(1).await;
+            drain_queue_async(queue).await;
+        }
+    }
+    Ok(true)
+}
+
+fuzz_target!(|input: &[u8]| {
+    run_fuzz_loop(input, &LAYOUT, |fuzzer_input, setup| {
+        Box::pin(async move {
+            let mut queue = setup.queue;
+            let mem = setup.mem;
+            let mut next_transaction_id = 1u64;
+
+            // Pick a fuzzer-driven protocol version pair.
+            let version_init = pick_version_pair(fuzzer_input)?;
+
+            negotiate_to_ready_full(
+                &mut queue,
+                &mut next_transaction_id,
+                setup.recv_buf_gpadl_id,
+                setup.send_buf_gpadl_id,
+                protocol::NdisConfigCapabilities::new(),
+                version_init,
+            )
+            .await?;
+
+            // Run fuzz actions until input is exhausted or the NIC terminates.
+            while !fuzzer_input.is_empty() {
+                let should_continue =
+                    execute_next_action(fuzzer_input, &mut queue, &mem, &mut next_transaction_id)
+                        .await?;
+                if !should_continue {
+                    break;
+                }
+                drain_queue_async(&mut queue).await;
+            }
+            Ok(())
+        })
+    });
+});

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_control.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_control.rs
@@ -451,7 +451,7 @@ async fn execute_next_action(
     Ok(true)
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     run_fuzz_loop(input, &LAYOUT, |fuzzer_input, setup| {
         Box::pin(async move {
             let mut queue = setup.queue;
@@ -484,4 +484,6 @@ fuzz_target!(|input: &[u8]| {
             Ok(())
         })
     });
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_interop.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_interop.rs
@@ -1,0 +1,1112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Interop fuzzer that combines control, OID, TX, RX, link status, and
+//! device lifecycle actions. The fuzzer performs NVSP/RNDIS negotiation first,
+//! then runs interleaved actions from all domains.
+//!
+//! This can find bugs that only manifest when different subsystems interact —
+//! for example, sending data packets while OID sets are in flight, injecting
+//! link status changes during TX processing, or closing the VMBus channel
+//! mid-transfer.
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use crate::fuzz_helpers::RingFullError;
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::FuzzGuestOsId;
+use fuzz_helpers::KNOWN_CONFIG_PARAM_NAMES;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::SWITCH_DATA_PATH_TRANSACTION_ID;
+use fuzz_helpers::StructuredPpiEntry;
+use fuzz_helpers::StructuredRndisMessage;
+use fuzz_helpers::StructuredRndisPacketMessage;
+use fuzz_helpers::VF_ASSOCIATION_TRANSACTION_ID;
+use fuzz_helpers::build_checksum_ppi_entry;
+use fuzz_helpers::build_concatenated_rndis_messages;
+use fuzz_helpers::build_lso_ppi_entry;
+use fuzz_helpers::build_rndis_config_parameter;
+use fuzz_helpers::build_rndis_message;
+use fuzz_helpers::build_rndis_oid_query;
+use fuzz_helpers::build_rndis_oid_set;
+use fuzz_helpers::build_rss_oid_set;
+use fuzz_helpers::build_structured_rndis_packet;
+use fuzz_helpers::endpoint::FuzzRxMetadata;
+use fuzz_helpers::negotiate_to_ready;
+use fuzz_helpers::nic_setup::FuzzNicConfig;
+use fuzz_helpers::nic_setup::NicSetupHandle;
+use fuzz_helpers::nic_setup::create_nic_with_channel;
+use fuzz_helpers::page_boundary_frame_size;
+use fuzz_helpers::rndis_initialize;
+use fuzz_helpers::rndis_set_packet_filter;
+use fuzz_helpers::send_completion_packet;
+use fuzz_helpers::send_inband_nvsp;
+use fuzz_helpers::send_rndis_control;
+use fuzz_helpers::send_rndis_gpadirect;
+use fuzz_helpers::send_rndis_via_direct_path;
+use fuzz_helpers::send_rndis_via_send_buffer;
+use fuzz_helpers::send_tx_rndis_completion;
+use fuzz_helpers::serialize_ppi_chain;
+use fuzz_helpers::serialize_structured_rndis_packet_message;
+use fuzz_helpers::try_read_one_completion;
+use fuzz_helpers::write_packet;
+use guestmem::GuestMemory;
+use inspect::InspectionBuilder;
+use net_backend::EndpointAction;
+use netvsp::protocol;
+use netvsp::rndisprot;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use vmbus_ring::OutgoingPacketType;
+use vmbus_ring::PAGE_SIZE;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+use zerocopy::IntoBytes;
+
+/// Use the most demanding layout: send buffer for the send-buffer path,
+/// data pages for GpaDirect RNDIS messages.
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 4,
+    data_pages: DATA_PAGES,
+};
+
+// ---- Combined interop actions ----
+
+/// Actions spanning all three fuzzing domains: control, OID, and data path.
+#[derive(Arbitrary, Debug)]
+enum InteropAction {
+    // ==== NVSP Control actions ====
+    /// Send an arbitrary packet payload with a fuzzed packet type.
+    ControlSendRawPacket {
+        #[arbitrary(with = fuzz_helpers::arbitrary_outgoing_packet_type)]
+        packet_type: OutgoingPacketType<'static>,
+        payload: Vec<u8>,
+    },
+    /// Send a raw NVSP message with arbitrary type and payload.
+    ControlSendRawInBand {
+        message_type: u32,
+        payload: Vec<u8>,
+        with_completion: bool,
+    },
+    /// Send a well-formed Init message with arbitrary version.
+    ControlSendInit { init: protocol::MessageInit },
+    /// Send an NDIS version message with arbitrary version numbers.
+    ControlSendNdisVersion {
+        version: protocol::Message1SendNdisVersion,
+    },
+    /// Send NDIS config with arbitrary MTU and capabilities.
+    ControlSendNdisConfig {
+        config: protocol::Message2SendNdisConfig,
+    },
+    /// Send a receive buffer message.
+    ControlSendReceiveBuffer {
+        #[arbitrary(with = fuzz_helpers::arbitrary_send_receive_buffer_message)]
+        msg: protocol::Message1SendReceiveBuffer,
+    },
+    /// Send a send buffer message.
+    ControlSendSendBuffer {
+        #[arbitrary(with = fuzz_helpers::arbitrary_send_send_buffer_message)]
+        msg: protocol::Message1SendSendBuffer,
+    },
+    /// Send a revoke receive buffer message.
+    ControlRevokeReceiveBuffer {
+        msg: protocol::Message1RevokeReceiveBuffer,
+    },
+    /// Send a revoke send buffer message.
+    ControlRevokeSendBuffer {
+        msg: protocol::Message1RevokeSendBuffer,
+    },
+    /// Send a switch data path message.
+    ControlSwitchDataPath {
+        msg: protocol::Message4SwitchDataPath,
+    },
+    /// Send a subchannel request.
+    ControlSubChannelRequest {
+        request: protocol::Message5SubchannelRequest,
+    },
+    /// Send an OID query via the NVSP OidQueryEx message.
+    ControlOidQueryEx { msg: protocol::Message5OidQueryEx },
+    /// Send a raw RNDIS packet payload via GpaDirect on the data channel
+    /// without any structured RNDIS header.
+    SendRndisPacketDirect { payload: Vec<u8> },
+    /// Send a raw RNDIS control payload via GpaDirect on the control channel
+    /// without any structured RNDIS header.
+    SendRndisControlDirect { payload: Vec<u8> },
+
+    // ==== RNDIS OID actions ====
+    /// Send a structured OID query with a specific OID value.
+    OidQuery {
+        oid: rndisprot::Oid,
+        extra_data: Vec<u8>,
+    },
+    /// Send a structured OID set with a specific OID value and payload.
+    OidSet {
+        oid: rndisprot::Oid,
+        payload: Vec<u8>,
+    },
+    /// Send a structured OID set for OID_TCP_OFFLOAD_PARAMETERS.
+    OidSetOffloadParameters {
+        params: rndisprot::NdisOffloadParameters,
+    },
+    /// Send a structured OID set for OID_OFFLOAD_ENCAPSULATION.
+    OidSetOffloadEncapsulation {
+        encap: rndisprot::NdisOffloadEncapsulation,
+    },
+    /// Send a structured OID set for OID_GEN_RNDIS_CONFIG_PARAMETER.
+    OidSetRndisConfigParameter {
+        info: rndisprot::RndisConfigParameterInfo,
+        extra_data: Vec<u8>,
+    },
+    /// Send a structured OID set for OID_GEN_RECEIVE_SCALE_PARAMETERS.
+    OidSetRssParameters {
+        params: rndisprot::NdisReceiveScaleParameters,
+        extra_data: Vec<u8>,
+    },
+    /// Send a structured OID set for OID_GEN_CURRENT_PACKET_FILTER.
+    OidSetPacketFilter { filter: u32 },
+    /// Send a well-formed RSS OID set with valid offsets, hash key, and a
+    /// properly clamped indirection table (via `build_rss_oid_set()`).
+    OidSetWellFormedRss {
+        hash_information: u32,
+        indirection_entries: Vec<u32>,
+        flags: u16,
+    },
+    /// Send a well-formed RNDIS config parameter OID set with proper
+    /// UTF-16LE encoding (via `build_rndis_config_parameter()`).
+    OidSetWellFormedConfigParameter {
+        /// Index into `KNOWN_CONFIG_PARAM_NAMES` (clamped).
+        name_index: u8,
+        /// Parameter type (STRING, INTEGER, etc.).
+        param_type: rndisprot::NdisParameterType,
+        /// Raw value payload.
+        value_bytes: Vec<u8>,
+    },
+
+    // ==== TX path actions ====
+    /// Send a single RNDIS packet message via GpaDirect with fuzzed content.
+    DataSendRndisPacket {
+        rndis: StructuredRndisPacketMessage,
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a well-formed RNDIS packet with fuzzed PPI and data via GpaDirect.
+    DataSendStructuredRndisPacket {
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a structured RNDIS packet with fuzzed PPI and a mostly valid
+    /// Ethernet frame via GpaDirect.
+    DataSendStructuredValidEthernetFrame {
+        ppi_bytes: Vec<u8>,
+        #[arbitrary(with = fuzz_helpers::arbitrary_valid_ethernet_frame)]
+        frame_data: Vec<u8>,
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a well-formed RNDIS packet with a structured PPI chain
+    /// containing properly formatted checksum and/or LSO entries.
+    DataSendWithStructuredPpi {
+        ppi_entries: Vec<StructuredPpiEntry>,
+        frame_data: Vec<u8>,
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a packet with a specific LSO PPI entry.
+    DataSendLsoPacket {
+        mss: u32,
+        tcp_header_offset: u16,
+        is_ipv6: bool,
+        frame_data: Vec<u8>,
+    },
+    /// Send a packet with a specific checksum PPI entry to exercise
+    /// all flag combinations.
+    DataSendChecksumEdgeCase {
+        checksum_info: u32,
+        frame_data: Vec<u8>,
+    },
+    /// Send multiple concatenated RNDIS packets in one GpaDirect message.
+    DataSendMultipleRndisPackets {
+        messages: Vec<StructuredRndisMessage>,
+    },
+    /// Send RNDIS data via the send buffer path.
+    DataSendViaSendBuffer {
+        rndis: StructuredRndisPacketMessage,
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a TX completion with an arbitrary transaction ID.
+    DataSendTxCompletion {
+        transaction_id: u64,
+        completion: protocol::Message1SendRndisPacketComplete,
+    },
+    /// Send an RNDIS control message (INITIALIZE, QUERY, SET, etc.) via
+    /// GpaDirect on the control channel.
+    DataSendRndisControl {
+        header: rndisprot::MessageHeader,
+        payload: Vec<u8>,
+    },
+    /// Inject a `TxError::TryRestart` on the next `tx_poll`, then send a
+    /// packet to trigger `process_endpoint_tx`. Exercises the restart path.
+    InjectTxRestart {
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+    },
+    /// Inject a `TxError::Fatal` on the next `tx_poll`, then send a packet
+    /// to trigger `process_endpoint_tx`. Exercises the fatal error path.
+    InjectTxFatal {
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+    },
+
+    // ==== Common actions ====
+    /// Drain completions from the host.
+    ReadCompletion,
+    /// Send an RNDIS HALT message to test halt interleaved with other operations.
+    SendRndisHalt,
+    /// Send a VF association completion (TID 0x8000000000000000).
+    SendVfAssociationCompletion,
+    /// Send a switch data path completion (TID 0x8000000000000001).
+    SendSwitchDataPathCompletion,
+    /// Send a completion packet with an arbitrary transaction ID and payload.
+    SendRawCompletion { tid: u64, payload: Vec<u8> },
+    /// Send multiple concatenated RNDIS packets via GpaDirect (not send buffer).
+    DataSendMultipleRndisPacketsDirect {
+        messages: Vec<StructuredRndisMessage>,
+    },
+
+    // ==== RX path actions ====
+    /// Send a burst of TX packets to stress RX buffer handling.
+    RxBurstTxForLoopback { frames: Vec<Vec<u8>> },
+    /// Send an empty TX frame to exercise RX edge handling.
+    RxSendEmptyFrame,
+    /// Send an oversized TX frame to exercise RX oversized handling.
+    RxSendOversizedFrame { size: u16 },
+    /// Send an RNDIS control message while RX is active.
+    RxSendRndisControl { payload: Vec<u8>, message_type: u32 },
+    /// Send a frame whose size targets page-boundary edge cases in the
+    /// RX buffer `write_at()` / `write_header()` code paths.
+    RxSendPageBoundaryFrame {
+        /// Selects the target size (see RX fuzzer for variant mapping).
+        variant: u8,
+    },
+    /// Send a frame of exactly 1514 bytes (standard Ethernet MTU + header)
+    /// to exercise the most common real-world RX hot path.
+    RxSendMtuSizedFrame,
+
+    /// Inject one raw Ethernet payload from host/backend into guest RX path.
+    InjectHostRxPacket {
+        packet: Vec<u8>,
+        metadata: FuzzRxMetadata,
+    },
+    /// Inject a burst of raw packets into guest RX path.
+    InjectHostRxBurst {
+        packets: Vec<(Vec<u8>, FuzzRxMetadata)>,
+    },
+    /// Inject a mostly valid Ethernet frame from host/backend.
+    InjectHostValidEthernet {
+        #[arbitrary(with = fuzz_helpers::arbitrary_valid_ethernet_frame)]
+        frame_data: Vec<u8>,
+        metadata: FuzzRxMetadata,
+    },
+    /// Inject a large host/backend RX frame to stress RX buffer handling.
+    InjectHostOversized { size: u16, metadata: FuzzRxMetadata },
+    /// Trigger endpoint action notifications while interleaving RX traffic.
+    NotifyLinkStatus { up: bool },
+    /// Inject a rapid sequence of link up/down toggles to stress the link
+    /// state machine under concurrent traffic.
+    LinkRapidToggle {
+        /// Number of toggles (clamped to 1..=20).
+        count: u8,
+    },
+    /// Inject a `RestartRequired` endpoint action.
+    NotifyRestartRequired,
+
+    // ==== RNDIS keepalive/reset/init actions ====
+    /// Send an RNDIS INITIALIZE message with a fully fuzzed InitializeRequest.
+    /// This exercises arbitrary version numbers and max_transfer_size values.
+    SendRndisInitialize {
+        request: rndisprot::InitializeRequest,
+    },
+    /// Send an RNDIS keepalive message to exercise keepalive handling.
+    SendRndisKeepalive { request_id: u32 },
+    /// Send an RNDIS RESET message to exercise the reset code path.
+    SendRndisReset { reserved: u32 },
+
+    // ==== Send buffer adversarial section indices ====
+    /// Send a raw MESSAGE1_TYPE_SEND_RNDIS_PACKET with adversarial
+    /// send_buffer_section_index and send_buffer_section_size values to
+    /// exercise the section-index validation and try_subrange() arithmetic
+    /// in the product code.
+    DataSendRawSendBufferPacket {
+        send_buffer_section_index: u32,
+        send_buffer_section_size: u32,
+        channel_type: u32,
+    },
+
+    // ==== Device lifecycle actions ====
+    /// Inspect the device state via the inspect infrastructure.
+    InspectDevice,
+    /// Retarget the primary channel to a different VP.
+    RetargetVp { target_vp: u32 },
+    /// Close the primary VMBus channel. This is a terminal action — the fuzz
+    /// loop must stop after this.
+    ClosePrimaryChannel,
+}
+
+/// Result of executing one interop action, signaling whether the fuzz loop
+/// should continue or must stop.
+enum ActionResult {
+    /// Continue with the next action.
+    Continue,
+    /// The primary channel was closed; the fuzz loop must stop.
+    ChannelClosed,
+}
+
+// ---- Action execution ----
+
+/// Execute one interop fuzz action.
+async fn execute_next_action(
+    input: &mut Unstructured<'_>,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    next_transaction_id: &mut u64,
+    rx_packet_sender: &mesh::Sender<(Vec<u8>, FuzzRxMetadata)>,
+    endpoint_action_sender: &mesh::Sender<EndpointAction>,
+    handle: &NicSetupHandle,
+    tx_error_mode: &Option<Arc<AtomicU8>>,
+) -> Result<ActionResult, anyhow::Error> {
+    let action = input.arbitrary::<InteropAction>()?;
+    fuzz_eprintln!("action: {action:?}");
+    let tid = next_transaction_id;
+    let rx_send = rx_packet_sender;
+    let action_send = endpoint_action_sender;
+    match action {
+        // ==== NVSP Control ====
+        InteropAction::ControlSendRawPacket {
+            packet_type,
+            payload,
+        } => {
+            write_packet(queue, tid, packet_type, &[&payload]).await?;
+        }
+        InteropAction::ControlSendRawInBand {
+            message_type,
+            payload,
+            with_completion,
+        } => {
+            send_inband_nvsp(queue, tid, message_type, &payload, with_completion).await?;
+        }
+        InteropAction::ControlSendInit { init } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE_TYPE_INIT,
+                init.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlSendNdisVersion { version } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE1_TYPE_SEND_NDIS_VERSION,
+                version.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlSendNdisConfig { config } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE2_TYPE_SEND_NDIS_CONFIG,
+                config.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlSendReceiveBuffer { msg } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE1_TYPE_SEND_RECEIVE_BUFFER,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlSendSendBuffer { msg } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE1_TYPE_SEND_SEND_BUFFER,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlRevokeReceiveBuffer { msg } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE1_TYPE_REVOKE_RECEIVE_BUFFER,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlRevokeSendBuffer { msg } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE1_TYPE_REVOKE_SEND_BUFFER,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlSwitchDataPath { msg } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE4_TYPE_SWITCH_DATA_PATH,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlSubChannelRequest { request } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE5_TYPE_SUB_CHANNEL,
+                request.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::ControlOidQueryEx { msg } => {
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE5_TYPE_OID_QUERY_EX,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        InteropAction::SendRndisPacketDirect { payload } => {
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &payload,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::SendRndisControlDirect { payload } => {
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &payload,
+                protocol::CONTROL_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+
+        // ==== RNDIS OID ====
+        InteropAction::OidQuery { oid, extra_data } => {
+            let rndis_bytes = build_rndis_oid_query(oid, &extra_data);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::OidSet { oid, payload } => {
+            let rndis_bytes = build_rndis_oid_set(oid, &payload);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::OidSetOffloadParameters { params } => {
+            let rndis_bytes = build_rndis_oid_set(
+                rndisprot::Oid::OID_TCP_OFFLOAD_PARAMETERS,
+                params.as_bytes(),
+            );
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::OidSetOffloadEncapsulation { encap } => {
+            let rndis_bytes =
+                build_rndis_oid_set(rndisprot::Oid::OID_OFFLOAD_ENCAPSULATION, encap.as_bytes());
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::OidSetRndisConfigParameter { info, extra_data } => {
+            let mut payload = Vec::new();
+            payload.extend_from_slice(info.as_bytes());
+            payload.extend_from_slice(&extra_data);
+            let rndis_bytes =
+                build_rndis_oid_set(rndisprot::Oid::OID_GEN_RNDIS_CONFIG_PARAMETER, &payload);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::OidSetRssParameters { params, extra_data } => {
+            let mut payload = Vec::new();
+            payload.extend_from_slice(params.as_bytes());
+            payload.extend_from_slice(&extra_data);
+            let rndis_bytes =
+                build_rndis_oid_set(rndisprot::Oid::OID_GEN_RECEIVE_SCALE_PARAMETERS, &payload);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::OidSetPacketFilter { filter } => {
+            let rndis_bytes = build_rndis_oid_set(
+                rndisprot::Oid::OID_GEN_CURRENT_PACKET_FILTER,
+                filter.as_bytes(),
+            );
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::OidSetWellFormedRss {
+            hash_information,
+            indirection_entries,
+            flags,
+        } => {
+            let rndis_bytes = build_rss_oid_set(
+                hash_information,
+                &indirection_entries,
+                1, // max_queues — single queue in this fuzzer
+                flags,
+            );
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::OidSetWellFormedConfigParameter {
+            name_index,
+            param_type,
+            value_bytes,
+        } => {
+            let name =
+                KNOWN_CONFIG_PARAM_NAMES[name_index as usize % KNOWN_CONFIG_PARAM_NAMES.len()];
+            let rndis_bytes = build_rndis_config_parameter(name, param_type, &value_bytes);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+
+        // ==== TX path ====
+        InteropAction::DataSendRndisPacket {
+            mut rndis,
+            nvsp_msg,
+        } => {
+            let rndis_bytes = serialize_structured_rndis_packet_message(&mut rndis);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_bytes,
+                nvsp_msg.channel_type,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::DataSendStructuredRndisPacket {
+            ppi_bytes,
+            frame_data,
+            nvsp_msg,
+        } => {
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(queue, mem, &rndis_buf, nvsp_msg.channel_type, &LAYOUT, tid)
+                .await?;
+        }
+        InteropAction::DataSendStructuredValidEthernetFrame {
+            ppi_bytes,
+            frame_data,
+            nvsp_msg,
+        } => {
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(queue, mem, &rndis_buf, nvsp_msg.channel_type, &LAYOUT, tid)
+                .await?;
+        }
+        InteropAction::DataSendWithStructuredPpi {
+            ppi_entries,
+            frame_data,
+            nvsp_msg,
+        } => {
+            let ppi_bytes = serialize_ppi_chain(&ppi_entries);
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(queue, mem, &rndis_buf, nvsp_msg.channel_type, &LAYOUT, tid)
+                .await?;
+        }
+        InteropAction::DataSendLsoPacket {
+            mss,
+            tcp_header_offset,
+            is_ipv6,
+            frame_data,
+        } => {
+            let ppi_bytes = build_lso_ppi_entry(mss, tcp_header_offset, is_ipv6);
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::DataSendChecksumEdgeCase {
+            checksum_info,
+            frame_data,
+        } => {
+            let ppi_bytes = build_checksum_ppi_entry(checksum_info);
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::DataSendMultipleRndisPackets { messages } => {
+            let rndis_buf = build_concatenated_rndis_messages(&messages);
+
+            if !rndis_buf.is_empty() {
+                send_rndis_via_direct_path(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    tid,
+                )
+                .await?;
+            }
+        }
+        InteropAction::DataSendViaSendBuffer {
+            mut rndis,
+            nvsp_msg,
+        } => {
+            let rndis_bytes = serialize_structured_rndis_packet_message(&mut rndis);
+            send_rndis_via_send_buffer(queue, mem, &rndis_bytes, &nvsp_msg, &LAYOUT, tid).await?;
+        }
+        InteropAction::DataSendTxCompletion {
+            transaction_id,
+            completion,
+        } => {
+            send_tx_rndis_completion(queue, transaction_id, &completion).await?;
+        }
+        InteropAction::DataSendRndisControl { header, payload } => {
+            let rndis_buf = build_rndis_message(header.message_type, &payload);
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::InjectTxRestart {
+            ppi_bytes,
+            frame_data,
+        } => {
+            if let Some(mode) = tx_error_mode {
+                mode.store(1, Ordering::Relaxed);
+                let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+                let _ = send_rndis_via_direct_path(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    tid,
+                )
+                .await;
+                fuzz_helpers::yield_to_executor(20).await;
+                fuzz_helpers::drain_queue_async(queue).await;
+            }
+        }
+        InteropAction::InjectTxFatal {
+            ppi_bytes,
+            frame_data,
+        } => {
+            if let Some(mode) = tx_error_mode {
+                mode.store(2, Ordering::Relaxed);
+                let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+                let _ = send_rndis_via_direct_path(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    tid,
+                )
+                .await;
+                fuzz_helpers::yield_to_executor(10).await;
+            }
+        }
+
+        // ==== Common ====
+        InteropAction::ReadCompletion => {
+            let _ = try_read_one_completion(queue);
+        }
+        InteropAction::SendRndisHalt => {
+            let rndis_bytes = build_rndis_message(rndisprot::MESSAGE_TYPE_HALT_MSG, &[]);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::SendVfAssociationCompletion => {
+            send_completion_packet(queue, VF_ASSOCIATION_TRANSACTION_ID, &[]).await?;
+        }
+        InteropAction::SendSwitchDataPathCompletion => {
+            send_completion_packet(queue, SWITCH_DATA_PATH_TRANSACTION_ID, &[]).await?;
+        }
+        InteropAction::SendRawCompletion {
+            tid: raw_tid,
+            payload,
+        } => {
+            send_completion_packet(queue, raw_tid, &[&payload]).await?;
+        }
+        InteropAction::DataSendMultipleRndisPacketsDirect { messages } => {
+            let rndis_buf = build_concatenated_rndis_messages(&messages);
+
+            if !rndis_buf.is_empty() {
+                send_rndis_gpadirect(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    LAYOUT.data_page_start(),
+                    LAYOUT.data_pages,
+                    tid,
+                )
+                .await?;
+            }
+        }
+
+        // ==== RX path ====
+        InteropAction::RxBurstTxForLoopback { frames } => {
+            for frame_data in &frames {
+                let rndis_buf = build_structured_rndis_packet(&[], frame_data);
+                send_rndis_via_direct_path(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    tid,
+                )
+                .await?;
+            }
+        }
+        InteropAction::RxSendEmptyFrame => {
+            let rndis_buf = build_structured_rndis_packet(&[], &[]);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::RxSendOversizedFrame { size } => {
+            let actual_size = (size as usize).clamp(1500, DATA_PAGES * PAGE_SIZE);
+            let frame_data = vec![0xAB; actual_size];
+            let rndis_buf = build_structured_rndis_packet(&[], &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::RxSendRndisControl {
+            payload,
+            message_type,
+        } => {
+            let rndis_buf = build_rndis_message(message_type, &payload);
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::InjectHostRxPacket { packet, metadata } => {
+            rx_send.send((packet, metadata));
+        }
+        InteropAction::InjectHostRxBurst { packets } => {
+            for (packet, metadata) in packets {
+                rx_send.send((packet, metadata));
+            }
+        }
+        InteropAction::InjectHostValidEthernet {
+            frame_data,
+            metadata,
+        } => {
+            rx_send.send((frame_data, metadata));
+        }
+        InteropAction::InjectHostOversized { size, metadata } => {
+            let payload_len = (size as usize).clamp(1536, PAGE_SIZE * DATA_PAGES);
+            rx_send.send((vec![0xA5; payload_len], metadata));
+        }
+        InteropAction::NotifyLinkStatus { up } => {
+            action_send.send(EndpointAction::LinkStatusNotify(up));
+        }
+        InteropAction::LinkRapidToggle { count } => {
+            let n = (count % 20) + 1;
+            for i in 0..n {
+                action_send.send(EndpointAction::LinkStatusNotify(i % 2 == 0));
+            }
+        }
+        InteropAction::NotifyRestartRequired => {
+            action_send.send(EndpointAction::RestartRequired);
+        }
+        InteropAction::RxSendPageBoundaryFrame { variant } => {
+            let frame_data = vec![0xBB; page_boundary_frame_size(variant)];
+            let rndis_buf = build_structured_rndis_packet(&[], &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        InteropAction::RxSendMtuSizedFrame => {
+            let frame_data = vec![0xDD; 1514];
+            let rndis_buf = build_structured_rndis_packet(&[], &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+
+        // ==== RNDIS keepalive/reset/init ====
+        InteropAction::SendRndisInitialize { request } => {
+            let rndis_bytes =
+                build_rndis_message(rndisprot::MESSAGE_TYPE_INITIALIZE_MSG, request.as_bytes());
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::SendRndisKeepalive { request_id } => {
+            let keepalive = rndisprot::KeepaliveRequest { request_id };
+            let rndis_bytes =
+                build_rndis_message(rndisprot::MESSAGE_TYPE_KEEPALIVE_MSG, keepalive.as_bytes());
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+        InteropAction::SendRndisReset { reserved } => {
+            let rndis_bytes =
+                build_rndis_message(rndisprot::MESSAGE_TYPE_RESET_MSG, &reserved.to_le_bytes());
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, tid).await?;
+        }
+
+        // ==== Send buffer adversarial section indices ====
+        InteropAction::DataSendRawSendBufferPacket {
+            send_buffer_section_index,
+            send_buffer_section_size,
+            channel_type,
+        } => {
+            let msg = protocol::Message1SendRndisPacket {
+                channel_type,
+                send_buffer_section_index,
+                send_buffer_section_size,
+            };
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+
+        // ==== Device lifecycle ====
+        InteropAction::InspectDevice => {
+            let mut inspection = InspectionBuilder::new("")
+                .depth(Some(2))
+                .inspect(&handle.channel);
+            inspection.resolve().await;
+            let _ = inspection.results();
+        }
+        InteropAction::RetargetVp { target_vp } => {
+            handle.send_retarget_vp(target_vp);
+        }
+        InteropAction::ClosePrimaryChannel => {
+            handle.send_close();
+            return Ok(ActionResult::ChannelClosed);
+        }
+    }
+    Ok(ActionResult::Continue)
+}
+
+fuzz_target!(|input: &[u8]| {
+    xtask_fuzz::init_tracing_if_repro();
+
+    // Parse a loopback metadata template from the front of the input so that
+    // TX→RX loopback packets exercise varied checksum-flag branches in
+    // `write_header()` (48 combinations).
+    let mut pre = Unstructured::new(input);
+    let loopback_meta = pre.arbitrary::<FuzzRxMetadata>().unwrap_or_default();
+
+    // Fuzz-select the guest OS identity so this target also covers all
+    // `can_use_ring_opt` branches.
+    let fuzz_os = pre.arbitrary::<FuzzGuestOsId>().ok();
+    let remaining_start = input.len() - pre.len();
+    let fuzz_input = &input[remaining_start..];
+
+    let (mut endpoint, handles) =
+        fuzz_helpers::endpoint::FuzzEndpoint::new(fuzz_helpers::endpoint::FuzzEndpointConfig {
+            enable_rx_injection: true,
+            enable_action_injection: true,
+            enable_tx_error_injection: true,
+            enable_async_tx: true,
+            ..fuzz_helpers::endpoint::FuzzEndpointConfig::default()
+        });
+    endpoint.loopback_metadata = loopback_meta;
+    let rx_send = handles
+        .rx_send
+        .expect("rx injection must be enabled for interop fuzzing");
+    let action_send = handles
+        .action_send
+        .expect("action injection must be enabled for interop fuzzing");
+    let tx_error_mode = handles.tx_error_mode;
+    let mut config = FuzzNicConfig {
+        endpoint: Box::new(endpoint),
+        virtual_function: None,
+        ..FuzzNicConfig::default()
+    };
+    if let Some(os) = fuzz_os {
+        config.get_guest_os_id = os.to_hv_guest_os_id();
+    }
+
+    pal_async::DefaultPool::run_with(async |driver| {
+        let (handle, setup) = match create_nic_with_channel(&driver, &LAYOUT, config).await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+
+        let fuzz_result = mesh::CancelContext::new()
+            .with_timeout(std::time::Duration::from_millis(500))
+            .until_cancelled(run_interop_loop(
+                fuzz_input,
+                handle,
+                setup,
+                &rx_send,
+                &action_send,
+                &tx_error_mode,
+            ))
+            .await;
+
+        match fuzz_result {
+            Ok(Ok(())) => {
+                fuzz_eprintln!("fuzz: test case exhausted arbitrary data");
+            }
+            Ok(Err(e)) => {
+                if e.downcast_ref::<arbitrary::Error>().is_some() {
+                    fuzz_eprintln!("fuzz: arbitrary data exhausted: {e:#}");
+                } else if e.downcast_ref::<RingFullError>().is_some() {
+                    fuzz_eprintln!("fuzz: ring full (backpressure), stopping");
+                } else {
+                    panic!("fuzz: action error: {e:#}");
+                }
+            }
+            Err(_) => {
+                panic!("fuzz: timed out after 500ms");
+            }
+        }
+    });
+});
+
+async fn run_interop_loop(
+    fuzz_input: &[u8],
+    handle: NicSetupHandle,
+    setup: fuzz_helpers::nic_setup::FuzzNicSetup,
+    rx_send: &mesh::Sender<(Vec<u8>, FuzzRxMetadata)>,
+    action_send: &mesh::Sender<EndpointAction>,
+    tx_error_mode: &Option<Arc<AtomicU8>>,
+) -> anyhow::Result<()> {
+    let mut queue = setup.queue;
+    let mem = setup.mem;
+    let mut next_transaction_id = 1u64;
+    let mut actions_since_drain = 0u32;
+    let mut fuzzer_input = Unstructured::new(fuzz_input);
+
+    handle.channel.start();
+
+    negotiate_to_ready(
+        &mut queue,
+        &mut next_transaction_id,
+        setup.recv_buf_gpadl_id,
+        setup.send_buf_gpadl_id,
+    )
+    .await?;
+
+    // Initialize RNDIS 90% of the time to reach
+    // Operational state. The remaining 10% tests interactions
+    // before RNDIS initialization.
+    if fuzzer_input.ratio(9, 10)? {
+        rndis_initialize(
+            &mut queue,
+            &mem,
+            LAYOUT.data_page_start(),
+            LAYOUT.data_pages,
+            &mut next_transaction_id,
+        )
+        .await?;
+
+        // Set the packet filter so RX packets are actually delivered
+        // instead of being silently dropped in process_endpoint_rx.
+        rndis_set_packet_filter(&mut queue, &mem, &LAYOUT, &mut next_transaction_id).await?;
+    }
+
+    // Run interleaved actions until input is exhausted.
+    while !fuzzer_input.is_empty() {
+        let result = execute_next_action(
+            &mut fuzzer_input,
+            &mut queue,
+            &mem,
+            &mut next_transaction_id,
+            rx_send,
+            action_send,
+            &handle,
+            tx_error_mode,
+        )
+        .await?;
+
+        match result {
+            ActionResult::ChannelClosed => break,
+            ActionResult::Continue => {}
+        }
+
+        // Allow actions to build up in the queue, but drain periodically
+        // so all subsequent actions don't hit a full ring and fail.
+        // The optimal drain frequency may need tuning.
+        actions_since_drain += 1;
+        if actions_since_drain >= 4 {
+            fuzz_helpers::drain_queue_async(&mut queue).await;
+            actions_since_drain = 0;
+        }
+    }
+
+    handle.cleanup().await;
+    Ok(())
+}

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_interop.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_interop.rs
@@ -255,12 +255,6 @@ enum InteropAction {
         ppi_bytes: Vec<u8>,
         frame_data: Vec<u8>,
     },
-    /// Inject a `TxError::Fatal` on the next `tx_poll`, then send a packet
-    /// to trigger `process_endpoint_tx`. Exercises the fatal error path.
-    InjectTxFatal {
-        ppi_bytes: Vec<u8>,
-        frame_data: Vec<u8>,
-    },
 
     // ==== Common actions ====
     /// Drain completions from the host.
@@ -729,26 +723,6 @@ async fn execute_next_action(
                 fuzz_helpers::drain_queue_async(queue).await;
             }
         }
-        InteropAction::InjectTxFatal {
-            ppi_bytes,
-            frame_data,
-        } => {
-            if let Some(mode) = tx_error_mode {
-                mode.store(2, Ordering::Relaxed);
-                let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
-                let _ = send_rndis_via_direct_path(
-                    queue,
-                    mem,
-                    &rndis_buf,
-                    protocol::DATA_CHANNEL_TYPE,
-                    &LAYOUT,
-                    tid,
-                )
-                .await;
-                fuzz_helpers::yield_to_executor(10).await;
-            }
-        }
-
         // ==== Common ====
         InteropAction::ReadCompletion => {
             let _ = try_read_one_completion(queue);

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_interop.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_interop.rs
@@ -958,7 +958,7 @@ async fn execute_next_action(
     Ok(ActionResult::Continue)
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     xtask_fuzz::init_tracing_if_repro();
 
     // Parse a loopback metadata template from the front of the input so that
@@ -1034,7 +1034,9 @@ fuzz_target!(|input: &[u8]| {
             }
         }
     });
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));
 
 async fn run_interop_loop(
     fuzz_input: &[u8],

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_interop.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_interop.rs
@@ -452,6 +452,10 @@ async fn execute_next_action(
                 true,
             )
             .await?;
+            // A matching revoke terminates the NIC worker. Drain
+            // synchronously and signal the caller to stop.
+            fuzz_helpers::drain_queue(queue);
+            return Ok(ActionResult::ChannelClosed);
         }
         InteropAction::ControlRevokeSendBuffer { msg } => {
             send_inband_nvsp(
@@ -462,6 +466,10 @@ async fn execute_next_action(
                 true,
             )
             .await?;
+            // A matching revoke terminates the NIC worker. Drain
+            // synchronously and signal the caller to stop.
+            fuzz_helpers::drain_queue(queue);
+            return Ok(ActionResult::ChannelClosed);
         }
         InteropAction::ControlSwitchDataPath { msg } => {
             send_inband_nvsp(

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_link_status.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_link_status.rs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzer for link status change handling in NetVSP.
+//!
+//! This fuzzer exercises the coordinator link-status notification path by
+//! injecting `EndpointAction::LinkStatusNotify` and
+//! `EndpointAction::RestartRequired` events via a [`FuzzEndpoint`], while
+//! interleaving normal NVSP control and data path operations.
+//!
+//! ## RNDIS protocol messages tested
+//!
+//! Indirectly exercised (host-to-guest, triggered by link events):
+//! - `MESSAGE_TYPE_INDICATE_STATUS_MSG` with `STATUS_MEDIA_CONNECT` — link up
+//! - `MESSAGE_TYPE_INDICATE_STATUS_MSG` with `STATUS_MEDIA_DISCONNECT` — link
+//!   down
+//!
+//! ## Endpoint actions tested
+//!
+//! - `EndpointAction::LinkStatusNotify(true)` — link up notification
+//! - `EndpointAction::LinkStatusNotify(false)` — link down notification
+//! - `EndpointAction::RestartRequired` — restart signal
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::build_structured_rndis_packet;
+use fuzz_helpers::drain_queue;
+use fuzz_helpers::drain_queue_async;
+use fuzz_helpers::endpoint::FuzzEndpoint;
+use fuzz_helpers::endpoint::FuzzEndpointConfig;
+use fuzz_helpers::negotiate_to_ready;
+use fuzz_helpers::nic_setup::FuzzNicConfig;
+use fuzz_helpers::rndis_initialize;
+use fuzz_helpers::run_fuzz_loop_with_config;
+use fuzz_helpers::send_inband_nvsp;
+use fuzz_helpers::send_rndis_via_direct_path;
+use fuzz_helpers::try_read_one_completion;
+use guestmem::GuestMemory;
+use net_backend::EndpointAction;
+use netvsp::protocol;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+use zerocopy::IntoBytes;
+
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 1,
+    data_pages: DATA_PAGES,
+};
+
+/// Actions the fuzzer can take to exercise link status handling.
+#[derive(Arbitrary, Debug)]
+enum LinkAction {
+    /// Inject a link-up notification from the endpoint.
+    LinkUp,
+    /// Inject a link-down notification from the endpoint.
+    LinkDown,
+    /// Inject a rapid sequence of link up/down toggles.
+    RapidToggle {
+        /// Number of toggles (clamped to a reasonable range).
+        count: u8,
+    },
+    /// Inject a `RestartRequired` action from the endpoint.
+    RestartRequired,
+    /// Send an arbitrary NVSP control message while link changes are
+    /// being processed.
+    SendControlMessage {
+        message_type: u32,
+        payload: Vec<u8>,
+        with_completion: bool,
+    },
+    /// Send a structured RNDIS data packet via GpaDirect to exercise
+    /// TX during link state transitions.
+    SendRndisPacket {
+        /// Fuzzed per-packet-info bytes.
+        ppi_bytes: Vec<u8>,
+        /// Fuzzed ethernet frame data.
+        frame_data: Vec<u8>,
+    },
+    /// Send an NVSP init message (may cause protocol re-negotiation
+    /// interleaved with link changes).
+    SendInit { init: protocol::MessageInit },
+    /// Read one completion/notification from the host.
+    ReadCompletion,
+    /// Drain all pending packets from the queue.
+    DrainQueue,
+}
+
+/// Execute one link fuzz action.
+async fn execute_next_action(
+    input: &mut Unstructured<'_>,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    next_transaction_id: &mut u64,
+    endpoint_action_sender: &mesh::Sender<EndpointAction>,
+) -> Result<(), anyhow::Error> {
+    let action = input.arbitrary::<LinkAction>()?;
+    fuzz_eprintln!("action: {action:?}");
+    match action {
+        LinkAction::LinkUp => {
+            endpoint_action_sender.send(EndpointAction::LinkStatusNotify(true));
+        }
+        LinkAction::LinkDown => {
+            endpoint_action_sender.send(EndpointAction::LinkStatusNotify(false));
+        }
+        LinkAction::RapidToggle { count } => {
+            let n = (count % 20) + 1;
+            for i in 0..n {
+                endpoint_action_sender.send(EndpointAction::LinkStatusNotify(i % 2 == 0));
+            }
+        }
+        LinkAction::RestartRequired => {
+            endpoint_action_sender.send(EndpointAction::RestartRequired);
+        }
+        LinkAction::SendControlMessage {
+            message_type,
+            payload,
+            with_completion,
+        } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                message_type,
+                &payload,
+                with_completion,
+            )
+            .await?;
+        }
+        LinkAction::SendRndisPacket {
+            ppi_bytes,
+            frame_data,
+        } => {
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        LinkAction::SendInit { init } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE_TYPE_INIT,
+                init.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        LinkAction::ReadCompletion => {
+            let _ = try_read_one_completion(queue);
+        }
+        LinkAction::DrainQueue => {
+            drain_queue(queue);
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|input: &[u8]| {
+    let (endpoint, handles) = FuzzEndpoint::new(FuzzEndpointConfig {
+        enable_rx_injection: false,
+        enable_action_injection: true,
+        ..FuzzEndpointConfig::default()
+    });
+    let action_send = handles.action_send.expect("action injection enabled");
+
+    let config = FuzzNicConfig {
+        endpoint: Box::new(endpoint),
+        virtual_function: None,
+        ..FuzzNicConfig::default()
+    };
+
+    run_fuzz_loop_with_config(input, &LAYOUT, config, |fuzzer_input, setup| {
+        Box::pin(async move {
+            let mut queue = setup.queue;
+            let mem = setup.mem;
+            let mut next_transaction_id = 1u64;
+
+            negotiate_to_ready(
+                &mut queue,
+                &mut next_transaction_id,
+                setup.recv_buf_gpadl_id,
+                setup.send_buf_gpadl_id,
+            )
+            .await?;
+
+            // Initialize RNDIS 90% of the time.
+            if fuzzer_input.ratio(9, 10)? {
+                rndis_initialize(
+                    &mut queue,
+                    &mem,
+                    LAYOUT.data_page_start(),
+                    LAYOUT.data_pages,
+                    &mut next_transaction_id,
+                )
+                .await?;
+            }
+
+            // Run link-focused fuzz actions until input is exhausted.
+            while !fuzzer_input.is_empty() {
+                execute_next_action(
+                    fuzzer_input,
+                    &mut queue,
+                    &mem,
+                    &mut next_transaction_id,
+                    &action_send,
+                )
+                .await?;
+                drain_queue_async(&mut queue).await;
+            }
+            Ok(())
+        })
+    });
+});

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_link_status.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_link_status.rs
@@ -168,7 +168,7 @@ async fn execute_next_action(
     Ok(())
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     let (endpoint, handles) = FuzzEndpoint::new(FuzzEndpointConfig {
         enable_rx_injection: false,
         enable_action_injection: true,
@@ -223,4 +223,6 @@ fuzz_target!(|input: &[u8]| {
             Ok(())
         })
     });
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_oid.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_oid.rs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzer for RNDIS OID query and OID set operations in NetVSP.
+//!
+//! ## RNDIS protocol messages tested
+//!
+//! - `MESSAGE_TYPE_QUERY_MSG` — structured OID queries with arbitrary OID values
+//!   and raw queries with arbitrary payloads
+//! - `MESSAGE_TYPE_SET_MSG` — structured OID sets with arbitrary OID values
+//!   and raw sets with arbitrary payloads
+//!
+//! ## OIDs targeted
+//!
+//! - `OID_TCP_OFFLOAD_PARAMETERS` — TCP offload configuration
+//! - `OID_OFFLOAD_ENCAPSULATION` — offload encapsulation settings
+//! - `OID_GEN_RNDIS_CONFIG_PARAMETER` — RNDIS configuration parameters
+//! - `OID_GEN_RECEIVE_SCALE_PARAMETERS` — RSS hash key and indirection table
+//! - `OID_GEN_CURRENT_PACKET_FILTER` — packet filter bitmask
+//! - Arbitrary `Oid` values via structured query/set actions
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::build_rndis_config_parameter;
+use fuzz_helpers::build_rndis_message;
+use fuzz_helpers::build_rndis_oid_query;
+use fuzz_helpers::build_rndis_oid_set;
+use fuzz_helpers::drain_queue_async;
+use fuzz_helpers::negotiate_to_ready;
+use fuzz_helpers::rndis_initialize;
+use fuzz_helpers::run_fuzz_loop;
+use fuzz_helpers::send_rndis_control;
+use fuzz_helpers::try_read_one_completion;
+use guestmem::GuestMemory;
+use netvsp::rndisprot;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+use zerocopy::IntoBytes;
+
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 1,
+    data_pages: DATA_PAGES,
+};
+
+/// Actions the fuzzer can take to exercise OID query/set handling.
+#[derive(Arbitrary, Debug)]
+enum OidAction {
+    /// Send a structured OID query with a specific OID value.
+    OidQuery {
+        /// The OID to query.
+        oid: rndisprot::Oid,
+        /// Extra data to append after the QueryRequest struct.
+        extra_data: Vec<u8>,
+    },
+    /// Send an OID query with a fully fuzzed QueryRequest struct.
+    /// This exercises arbitrary request_id, device_vc_handle, and
+    /// potentially malformed buffer offset/length values.
+    OidQueryFull {
+        request: rndisprot::QueryRequest,
+        extra_data: Vec<u8>,
+    },
+    /// Send a structured OID set with a specific OID value and payload.
+    OidSet {
+        /// The OID to set.
+        oid: rndisprot::Oid,
+        /// The information buffer payload for the OID set.
+        payload: Vec<u8>,
+    },
+    /// Send an OID set with a fully fuzzed SetRequest struct.
+    /// This exercises arbitrary request_id, device_vc_handle, and
+    /// potentially malformed buffer offset/length values.
+    OidSetFull {
+        request: rndisprot::SetRequest,
+        payload: Vec<u8>,
+    },
+    /// Send a structured OID set for OID_TCP_OFFLOAD_PARAMETERS.
+    SetOffloadParameters {
+        /// Fuzzed offload parameters (includes NdisObjectHeader).
+        params: rndisprot::NdisOffloadParameters,
+    },
+    /// Send a structured OID set for OID_OFFLOAD_ENCAPSULATION.
+    SetOffloadEncapsulation {
+        /// Fuzzed encapsulation settings (includes NdisObjectHeader).
+        encap: rndisprot::NdisOffloadEncapsulation,
+    },
+    /// Send a structured OID set for OID_GEN_RNDIS_CONFIG_PARAMETER.
+    SetRndisConfigParameter {
+        /// Fuzzed config parameter info header.
+        info: rndisprot::RndisConfigParameterInfo,
+        /// Extra data appended after the info struct (name + value data).
+        extra_data: Vec<u8>,
+    },
+    /// Send a structured OID set for OID_GEN_RECEIVE_SCALE_PARAMETERS.
+    SetRssParameters {
+        /// Fuzzed RSS parameters (includes NdisObjectHeader).
+        params: rndisprot::NdisReceiveScaleParameters,
+        /// Extra trailing data (hash key, indirection table).
+        extra_data: Vec<u8>,
+    },
+    /// Send a structured OID set for OID_GEN_CURRENT_PACKET_FILTER.
+    SetPacketFilter {
+        /// The packet filter value.
+        filter: u32,
+    },
+    /// Read one completion/notification from the host.
+    ReadCompletion,
+    /// Send an RNDIS HALT message to test halt-during-OID-processing.
+    SendRndisHalt,
+    /// Send a well-formed `OID_GEN_RNDIS_CONFIG_PARAMETER` SET with a known
+    /// parameter name (e.g. `*IPChecksumOffloadIPv4`) and fuzzed type/value.
+    /// This exercises the named match arms in `oid_set_rndis_config_parameter`
+    /// that raw fuzzing cannot easily reach because they require properly
+    /// UTF-16LE–encoded parameter names.
+    SendKnownConfigParameter {
+        /// Index into `KNOWN_CONFIG_PARAM_NAMES` (wrapped mod length).
+        name_idx: u8,
+        /// Parameter type: 0 = INTEGER, 2 = STRING, other = arbitrary.
+        param_type: u32,
+        /// Raw value bytes.  For STRING, these are fuzzed UTF-16LE; for
+        /// INTEGER, 4 bytes of a u32.
+        value_bytes: Vec<u8>,
+    },
+}
+
+/// Execute one OID fuzz action.
+async fn execute_next_action(
+    input: &mut Unstructured<'_>,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    next_transaction_id: &mut u64,
+) -> Result<(), anyhow::Error> {
+    let action = input.arbitrary::<OidAction>()?;
+    fuzz_eprintln!("action: {action:?}");
+    match action {
+        OidAction::OidQuery { oid, extra_data } => {
+            let rndis_bytes = build_rndis_oid_query(oid, &extra_data);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::OidQueryFull {
+            request,
+            extra_data,
+        } => {
+            let mut body = Vec::new();
+            body.extend_from_slice(request.as_bytes());
+            body.extend_from_slice(&extra_data);
+            let rndis_bytes = build_rndis_message(rndisprot::MESSAGE_TYPE_QUERY_MSG, &body);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::OidSet { oid, payload } => {
+            let rndis_bytes = build_rndis_oid_set(oid, &payload);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::OidSetFull { request, payload } => {
+            let mut body = Vec::new();
+            body.extend_from_slice(request.as_bytes());
+            body.extend_from_slice(&payload);
+            let rndis_bytes = build_rndis_message(rndisprot::MESSAGE_TYPE_SET_MSG, &body);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::SetOffloadParameters { params } => {
+            let rndis_bytes = build_rndis_oid_set(
+                rndisprot::Oid::OID_TCP_OFFLOAD_PARAMETERS,
+                params.as_bytes(),
+            );
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::SetOffloadEncapsulation { encap } => {
+            let rndis_bytes =
+                build_rndis_oid_set(rndisprot::Oid::OID_OFFLOAD_ENCAPSULATION, encap.as_bytes());
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::SetRndisConfigParameter { info, extra_data } => {
+            let mut payload = Vec::new();
+            payload.extend_from_slice(info.as_bytes());
+            payload.extend_from_slice(&extra_data);
+            let rndis_bytes =
+                build_rndis_oid_set(rndisprot::Oid::OID_GEN_RNDIS_CONFIG_PARAMETER, &payload);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::SetRssParameters { params, extra_data } => {
+            let mut payload = Vec::new();
+            payload.extend_from_slice(params.as_bytes());
+            payload.extend_from_slice(&extra_data);
+            let rndis_bytes =
+                build_rndis_oid_set(rndisprot::Oid::OID_GEN_RECEIVE_SCALE_PARAMETERS, &payload);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::SetPacketFilter { filter } => {
+            let rndis_bytes = build_rndis_oid_set(
+                rndisprot::Oid::OID_GEN_CURRENT_PACKET_FILTER,
+                filter.as_bytes(),
+            );
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::ReadCompletion => {
+            let _ = try_read_one_completion(queue);
+        }
+        OidAction::SendRndisHalt => {
+            let rndis_bytes = build_rndis_message(rndisprot::MESSAGE_TYPE_HALT_MSG, &[]);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::SendKnownConfigParameter {
+            name_idx,
+            param_type,
+            value_bytes,
+        } => {
+            let names = fuzz_helpers::KNOWN_CONFIG_PARAM_NAMES;
+            let name = names[name_idx as usize % names.len()];
+            let param_type = rndisprot::NdisParameterType(param_type);
+            let rndis_bytes = build_rndis_config_parameter(name, param_type, &value_bytes);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|input: &[u8]| {
+    run_fuzz_loop(input, &LAYOUT, |fuzzer_input, setup| {
+        Box::pin(async move {
+            let mut queue = setup.queue;
+            let mem = setup.mem;
+            let mut next_transaction_id = 1u64;
+
+            // Negotiate NVSP protocol to the ready state.
+            negotiate_to_ready(
+                &mut queue,
+                &mut next_transaction_id,
+                setup.recv_buf_gpadl_id,
+                setup.send_buf_gpadl_id,
+            )
+            .await?;
+
+            // 90% of the time, initialize RNDIS to reach Operational state.
+            // The remaining 10% tests OID handling before the initialize handshake.
+            if fuzzer_input.ratio(9, 10)? {
+                rndis_initialize(
+                    &mut queue,
+                    &mem,
+                    LAYOUT.data_page_start(),
+                    LAYOUT.data_pages,
+                    &mut next_transaction_id,
+                )
+                .await?;
+            }
+
+            // Run OID fuzz actions until input is exhausted.
+            while !fuzzer_input.is_empty() {
+                execute_next_action(fuzzer_input, &mut queue, &mem, &mut next_transaction_id)
+                    .await?;
+                drain_queue_async(&mut queue).await;
+            }
+            Ok(())
+        })
+    });
+});

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_oid.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_oid.rs
@@ -222,7 +222,7 @@ async fn execute_next_action(
     Ok(())
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     run_fuzz_loop(input, &LAYOUT, |fuzzer_input, setup| {
         Box::pin(async move {
             let mut queue = setup.queue;
@@ -260,4 +260,6 @@ fuzz_target!(|input: &[u8]| {
             Ok(())
         })
     });
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_oid.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_oid.rs
@@ -128,6 +128,54 @@ enum OidAction {
         /// INTEGER, 4 bytes of a u32.
         value_bytes: Vec<u8>,
     },
+    /// Set offload parameters with structured valid-range enum values.
+    ///
+    /// Unlike `SetOffloadParameters` which fuzzes the raw struct bytes, this
+    /// variant constructs `NdisOffloadParameters` with each checksum field
+    /// drawn from the valid `OffloadParametersChecksum` discriminants (0–4)
+    /// and each LSO field from valid `OffloadParametersSimple` discriminants
+    /// (0–2). This ensures the `tx_rx()` and `enable()` methods are
+    /// exercised across all their match arms.
+    SetStructuredOffloadParameters {
+        ipv4_checksum: u8,
+        tcp4_checksum: u8,
+        udp4_checksum: u8,
+        tcp6_checksum: u8,
+        udp6_checksum: u8,
+        lsov1: u8,
+        lsov2_ipv4: u8,
+        lsov2_ipv6: u8,
+    },
+    /// Query the hardware offload capabilities via
+    /// `OID_TCP_OFFLOAD_HARDWARE_CAPABILITIES`.
+    QueryOffloadHardwareCapabilities,
+    /// Set offload encapsulation with specific valid/invalid combinations.
+    ///
+    /// Exercises both the success path (IEEE 802.3 encapsulation with
+    /// correct header size) and the error paths (wrong encapsulation type
+    /// or header size) in `oid_set_offload_encapsulation`.
+    SetStructuredOffloadEncapsulation {
+        ipv4_enabled: u32,
+        ipv4_encap_type: u32,
+        ipv4_header_size: u32,
+        ipv6_enabled: u32,
+        ipv6_encap_type: u32,
+        ipv6_header_size: u32,
+    },
+    /// Set offload parameters then immediately query the current config.
+    ///
+    /// Exercises the state update in `oid_set_offload_parameters` followed
+    /// by the readback in `OID_TCP_OFFLOAD_CURRENT_CONFIG`, ensuring the
+    /// `ndis_offload()` serialization path is covered after each mutation.
+    SetThenQueryOffload {
+        ipv4_checksum: u8,
+        tcp4_checksum: u8,
+        udp4_checksum: u8,
+        tcp6_checksum: u8,
+        udp6_checksum: u8,
+        lsov2_ipv4: u8,
+        lsov2_ipv6: u8,
+    },
 }
 
 /// Execute one OID fuzz action.
@@ -218,8 +266,133 @@ async fn execute_next_action(
             let rndis_bytes = build_rndis_config_parameter(name, param_type, &value_bytes);
             send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
         }
+        OidAction::SetStructuredOffloadParameters {
+            ipv4_checksum,
+            tcp4_checksum,
+            udp4_checksum,
+            tcp6_checksum,
+            udp6_checksum,
+            lsov1,
+            lsov2_ipv4,
+            lsov2_ipv6,
+        } => {
+            let params = build_structured_offload_params(
+                ipv4_checksum,
+                tcp4_checksum,
+                udp4_checksum,
+                tcp6_checksum,
+                udp6_checksum,
+                lsov1,
+                lsov2_ipv4,
+                lsov2_ipv6,
+            );
+            let rndis_bytes = build_rndis_oid_set(
+                rndisprot::Oid::OID_TCP_OFFLOAD_PARAMETERS,
+                params.as_bytes(),
+            );
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::QueryOffloadHardwareCapabilities => {
+            let rndis_bytes =
+                build_rndis_oid_query(rndisprot::Oid::OID_TCP_OFFLOAD_HARDWARE_CAPABILITIES, &[]);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::SetStructuredOffloadEncapsulation {
+            ipv4_enabled,
+            ipv4_encap_type,
+            ipv4_header_size,
+            ipv6_enabled,
+            ipv6_encap_type,
+            ipv6_header_size,
+        } => {
+            let encap = rndisprot::NdisOffloadEncapsulation {
+                header: rndisprot::NdisObjectHeader {
+                    object_type: rndisprot::NdisObjectType::OFFLOAD_ENCAPSULATION,
+                    revision: 1,
+                    size: rndisprot::NDIS_SIZEOF_OFFLOAD_ENCAPSULATION_REVISION_1 as u16,
+                },
+                ipv4_enabled,
+                ipv4_encapsulation_type: ipv4_encap_type,
+                ipv4_header_size,
+                ipv6_enabled,
+                ipv6_encapsulation_type: ipv6_encap_type,
+                ipv6_header_size,
+            };
+            let rndis_bytes =
+                build_rndis_oid_set(rndisprot::Oid::OID_OFFLOAD_ENCAPSULATION, encap.as_bytes());
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
+        OidAction::SetThenQueryOffload {
+            ipv4_checksum,
+            tcp4_checksum,
+            udp4_checksum,
+            tcp6_checksum,
+            udp6_checksum,
+            lsov2_ipv4,
+            lsov2_ipv6,
+        } => {
+            // Set offload parameters with valid-range values.
+            let params = build_structured_offload_params(
+                ipv4_checksum,
+                tcp4_checksum,
+                udp4_checksum,
+                tcp6_checksum,
+                udp6_checksum,
+                0, // lsov1 = NO_CHANGE
+                lsov2_ipv4,
+                lsov2_ipv6,
+            );
+            let rndis_bytes = build_rndis_oid_set(
+                rndisprot::Oid::OID_TCP_OFFLOAD_PARAMETERS,
+                params.as_bytes(),
+            );
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+            drain_queue_async(queue).await;
+
+            // Query back the current config to exercise ndis_offload() serialization.
+            let rndis_bytes =
+                build_rndis_oid_query(rndisprot::Oid::OID_TCP_OFFLOAD_CURRENT_CONFIG, &[]);
+            send_rndis_control(queue, mem, &rndis_bytes, &LAYOUT, next_transaction_id).await?;
+        }
     }
     Ok(())
+}
+
+/// Build `NdisOffloadParameters` with each field clamped to its valid
+/// discriminant range so that `tx_rx()` and `enable()` are exercised
+/// across all match arms rather than falling through to `None`.
+fn build_structured_offload_params(
+    ipv4_checksum: u8,
+    tcp4_checksum: u8,
+    udp4_checksum: u8,
+    tcp6_checksum: u8,
+    udp6_checksum: u8,
+    lsov1: u8,
+    lsov2_ipv4: u8,
+    lsov2_ipv6: u8,
+) -> rndisprot::NdisOffloadParameters {
+    rndisprot::NdisOffloadParameters {
+        header: rndisprot::NdisObjectHeader {
+            object_type: rndisprot::NdisObjectType::DEFAULT,
+            revision: 1,
+            size: rndisprot::NDIS_SIZEOF_OFFLOAD_PARAMETERS_REVISION_1 as u16,
+        },
+        // OffloadParametersChecksum valid range: 0..=4
+        ipv4_checksum: rndisprot::OffloadParametersChecksum(ipv4_checksum % 5),
+        tcp4_checksum: rndisprot::OffloadParametersChecksum(tcp4_checksum % 5),
+        udp4_checksum: rndisprot::OffloadParametersChecksum(udp4_checksum % 5),
+        tcp6_checksum: rndisprot::OffloadParametersChecksum(tcp6_checksum % 5),
+        udp6_checksum: rndisprot::OffloadParametersChecksum(udp6_checksum % 5),
+        // OffloadParametersSimple valid range: 0..=2
+        lsov1: rndisprot::OffloadParametersSimple(lsov1 % 3),
+        ipsec_v1: 0,
+        lsov2_ipv4: rndisprot::OffloadParametersSimple(lsov2_ipv4 % 3),
+        lsov2_ipv6: rndisprot::OffloadParametersSimple(lsov2_ipv6 % 3),
+        tcp_connection_ipv4: 0,
+        tcp_connection_ipv6: 0,
+        reserved: 0,
+        flags: 0,
+    }
 }
 
 fn do_fuzz(input: &[u8]) {

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_rx_path.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_rx_path.rs
@@ -1,0 +1,332 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzer for the NetVSP RX (host-to-guest receive) path.
+//!
+//! ## NVSP protocol messages tested
+//!
+//! Indirectly exercised (host-to-guest responses):
+//! - `MESSAGE1_TYPE_SEND_RNDIS_PACKET` — host-side RX packet delivery via
+//!   receive buffer (triggered by loopback reflecting TX packets)
+//! - `MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE` — TX completion from host
+//!
+//! ## RNDIS protocol messages tested
+//!
+//! - `MESSAGE_TYPE_PACKET_MSG` — structured RNDIS data packets via GpaDirect
+//!   (fuzzed `Packet` fields, PPI chains, frame data)
+//! - `MESSAGE_TYPE_PACKET_MSG` — zero-length, oversized, and burst packets
+//! - `MESSAGE_TYPE_PACKET_MSG` — packets with valid Ethernet II frames
+//! - `MESSAGE_TYPE_PACKET_MSG` — page-boundary edge-case frames that stress
+//!   cross-page write logic in `write_at()` / `write_header()`
+//! - `MESSAGE_TYPE_PACKET_MSG` — MTU-sized frames (1514 bytes)
+//! - Arbitrary RNDIS control messages interleaved with RX traffic
+//!
+//! Indirectly exercised (host-to-guest, in receive buffer):
+//! - `MESSAGE_TYPE_INDICATE_STATUS_MSG` — status indications
+//! - `MESSAGE_TYPE_PACKET_MSG` — loopback-reflected RX packets
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::StructuredRndisPacketMessage;
+use fuzz_helpers::build_structured_rndis_packet;
+use fuzz_helpers::drain_queue;
+use fuzz_helpers::drain_queue_async;
+use fuzz_helpers::endpoint::FuzzEndpoint;
+use fuzz_helpers::endpoint::FuzzEndpointConfig;
+use fuzz_helpers::endpoint::FuzzRxMetadata;
+use fuzz_helpers::negotiate_to_ready_full;
+use fuzz_helpers::nic_setup::FuzzNicConfig;
+use fuzz_helpers::page_boundary_frame_size;
+use fuzz_helpers::pick_version_pair;
+use fuzz_helpers::rndis_initialize;
+use fuzz_helpers::rndis_set_packet_filter;
+use fuzz_helpers::run_fuzz_loop_with_config;
+use fuzz_helpers::send_rndis_via_direct_path;
+use fuzz_helpers::serialize_structured_rndis_packet_message;
+use fuzz_helpers::try_read_one_completion;
+use guestmem::GuestMemory;
+use netvsp::protocol;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use vmbus_ring::PAGE_SIZE;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 1,
+    data_pages: DATA_PAGES,
+};
+
+/// Actions the fuzzer can take to exercise the RX path.
+#[derive(Arbitrary, Debug)]
+enum RxAction {
+    /// Send a TX packet via GpaDirect. The loopback endpoint will reflect
+    /// it back as an RX packet, exercising the full TX-to-loopback-to-RX path.
+    SendTxPacketForLoopback {
+        /// Fuzzed per-packet-info bytes (PPI chain).
+        ppi_bytes: Vec<u8>,
+        /// Fuzzed ethernet frame data.
+        frame_data: Vec<u8>,
+    },
+    /// Send a TX packet with a mostly valid Ethernet frame for loopback.
+    SendValidFrameForLoopback {
+        /// Fuzzed per-packet-info bytes.
+        ppi_bytes: Vec<u8>,
+        /// Mostly valid Ethernet II frame.
+        #[arbitrary(with = fuzz_helpers::arbitrary_valid_ethernet_frame)]
+        frame_data: Vec<u8>,
+    },
+    /// Send multiple TX packets in rapid succession to stress RX buffer
+    /// allocation under load.
+    BurstTxForLoopback {
+        /// Multiple frames to send back-to-back.
+        frames: Vec<Vec<u8>>,
+    },
+    /// Send a zero-length frame to test edge cases in the RX path.
+    SendEmptyFrame,
+    /// Send a very large frame (> MTU) to test oversized packet handling.
+    SendOversizedFrame {
+        /// Size of the frame (clamped to data page capacity).
+        size: u16,
+    },
+    /// Send a structured RNDIS packet with fuzzed fields via GpaDirect.
+    SendRndisPacket {
+        rndis: StructuredRndisPacketMessage,
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send an RNDIS control message while RX is active to test
+    /// interleaving of control and data paths.
+    SendRndisControl {
+        /// Raw payload after the RNDIS MessageHeader.
+        payload: Vec<u8>,
+        /// RNDIS message type.
+        message_type: u32,
+    },
+    /// Read one completion/notification from the host.
+    ReadCompletion,
+    /// Drain all pending packets from the queue.
+    DrainQueue,
+    /// Send a frame whose size is chosen to hit page-boundary edge cases
+    /// in `write_at()` and `write_header()`. This exercises the cross-page
+    /// write logic in `buffers.rs` with sizes near 4096-byte boundaries.
+    SendPageBoundaryFrame {
+        /// 0 = PAGE_SIZE - 1, 1 = PAGE_SIZE, 2 = PAGE_SIZE + 1,
+        /// 3 = PAGE_SIZE - RX_HEADER_LEN, 4 = 2 * PAGE_SIZE - RX_HEADER_LEN,
+        /// 5+ = arbitrary small offset from PAGE_SIZE.
+        variant: u8,
+    },
+    /// Send a frame of exactly MTU size to exercise the capacity boundary.
+    SendMtuSizedFrame,
+}
+
+/// Execute one RX fuzz action.
+async fn execute_next_action(
+    input: &mut Unstructured<'_>,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    next_transaction_id: &mut u64,
+) -> Result<(), anyhow::Error> {
+    let action = input.arbitrary::<RxAction>()?;
+    fuzz_eprintln!("action: {action:?}");
+    match action {
+        RxAction::SendTxPacketForLoopback {
+            ppi_bytes,
+            frame_data,
+        }
+        | RxAction::SendValidFrameForLoopback {
+            ppi_bytes,
+            frame_data,
+        } => {
+            // Both variants produce the same packet — the difference is in
+            // `#[arbitrary(with = ...)]` on the enum definition, which controls
+            // how `frame_data` is generated (fully random vs. valid Ethernet).
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        RxAction::BurstTxForLoopback { frames } => {
+            for frame_data in &frames {
+                let rndis_buf = build_structured_rndis_packet(&[], frame_data);
+                send_rndis_via_direct_path(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    next_transaction_id,
+                )
+                .await?;
+            }
+        }
+        RxAction::SendEmptyFrame => {
+            let rndis_buf = build_structured_rndis_packet(&[], &[]);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        RxAction::SendOversizedFrame { size } => {
+            // Create a frame larger than a typical MTU.
+            let actual_size = (size as usize).clamp(1500, DATA_PAGES * PAGE_SIZE);
+            let frame_data = vec![0xAB; actual_size];
+            let rndis_buf = build_structured_rndis_packet(&[], &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        RxAction::SendRndisPacket {
+            mut rndis,
+            nvsp_msg,
+        } => {
+            let rndis_bytes = serialize_structured_rndis_packet_message(&mut rndis);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_bytes,
+                nvsp_msg.channel_type,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        RxAction::SendRndisControl {
+            payload,
+            message_type,
+        } => {
+            let rndis_buf = fuzz_helpers::build_rndis_message(message_type, &payload);
+            fuzz_helpers::send_rndis_control(queue, mem, &rndis_buf, &LAYOUT, next_transaction_id)
+                .await?;
+        }
+        RxAction::ReadCompletion => {
+            let _ = try_read_one_completion(queue);
+        }
+        RxAction::DrainQueue => {
+            drain_queue(queue);
+        }
+        RxAction::SendPageBoundaryFrame { variant } => {
+            let frame_data = vec![0xBB; page_boundary_frame_size(variant)];
+            let rndis_buf = build_structured_rndis_packet(&[], &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        RxAction::SendMtuSizedFrame => {
+            // Send a frame of exactly 1514 bytes (standard Ethernet MTU +
+            // header), the most common real-world frame size, to ensure the
+            // hot path is well-covered.
+            let frame_data = vec![0xDD; 1514];
+            let rndis_buf = build_structured_rndis_packet(&[], &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|input: &[u8]| {
+    // Parse a loopback metadata template from the front of the input so that
+    // TX→RX loopback packets exercise varied checksum-flag branches in
+    // `write_header()` (48 combinations of IP checksum × L4 protocol × L4
+    // checksum state).
+    let mut pre = Unstructured::new(input);
+    let loopback_meta = pre.arbitrary::<FuzzRxMetadata>().unwrap_or_default();
+    let remaining_start = input.len() - pre.len();
+    let fuzz_input = &input[remaining_start..];
+
+    // Use the FuzzEndpoint so that the loopback reflects TX-to-RX.
+    let (mut endpoint, _handles) = FuzzEndpoint::new(FuzzEndpointConfig {
+        enable_rx_injection: false,
+        enable_action_injection: false,
+        ..FuzzEndpointConfig::default()
+    });
+    endpoint.loopback_metadata = loopback_meta;
+    let config = FuzzNicConfig {
+        endpoint: Box::new(endpoint),
+        virtual_function: None,
+        ..FuzzNicConfig::default()
+    };
+
+    run_fuzz_loop_with_config(fuzz_input, &LAYOUT, config, |fuzzer_input, setup| {
+        Box::pin(async move {
+            let mut queue = setup.queue;
+            let mem = setup.mem;
+            let mut next_transaction_id = 1u64;
+
+            // Pick a fuzzer-driven protocol version pair.
+            let version_init = pick_version_pair(fuzzer_input)?;
+
+            // Negotiate to the ready state first.
+            negotiate_to_ready_full(
+                &mut queue,
+                &mut next_transaction_id,
+                setup.recv_buf_gpadl_id,
+                setup.send_buf_gpadl_id,
+                protocol::NdisConfigCapabilities::new(),
+                version_init,
+            )
+            .await?;
+
+            // 90% of the time, initialize RNDIS to reach Operational state.
+            if fuzzer_input.ratio(9, 10)? {
+                rndis_initialize(
+                    &mut queue,
+                    &mem,
+                    LAYOUT.data_page_start(),
+                    LAYOUT.data_pages,
+                    &mut next_transaction_id,
+                )
+                .await?;
+
+                // Set the packet filter so RX packets are actually delivered
+                // instead of being silently dropped in process_endpoint_rx.
+                rndis_set_packet_filter(&mut queue, &mem, &LAYOUT, &mut next_transaction_id)
+                    .await?;
+            }
+
+            // Run RX-focused fuzz actions until input is exhausted.
+            while !fuzzer_input.is_empty() {
+                execute_next_action(fuzzer_input, &mut queue, &mem, &mut next_transaction_id)
+                    .await?;
+                drain_queue_async(&mut queue).await;
+            }
+            Ok(())
+        })
+    });
+});

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_rx_path.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_rx_path.rs
@@ -260,7 +260,7 @@ async fn execute_next_action(
     Ok(())
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     // Parse a loopback metadata template from the front of the input so that
     // TX→RX loopback packets exercise varied checksum-flag branches in
     // `write_header()` (48 combinations of IP checksum × L4 protocol × L4
@@ -329,4 +329,6 @@ fuzz_target!(|input: &[u8]| {
             Ok(())
         })
     });
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_rx_path.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_rx_path.rs
@@ -123,6 +123,23 @@ enum RxAction {
     },
     /// Send a frame of exactly MTU size to exercise the capacity boundary.
     SendMtuSizedFrame,
+    /// Inject a raw packet from the host/backend into the guest RX path.
+    /// This goes through `process_endpoint_rx` → `poll_ready` → `rx_poll`,
+    /// bypassing the TX→loopback roundtrip.
+    InjectHostRxPacket {
+        packet: Vec<u8>,
+        metadata: FuzzRxMetadata,
+    },
+    /// Inject a burst of raw packets from the host/backend.
+    InjectHostRxBurst {
+        packets: Vec<(Vec<u8>, FuzzRxMetadata)>,
+    },
+    /// Inject a mostly valid Ethernet frame from the host/backend.
+    InjectHostValidEthernet {
+        #[arbitrary(with = fuzz_helpers::arbitrary_valid_ethernet_frame)]
+        frame_data: Vec<u8>,
+        metadata: FuzzRxMetadata,
+    },
 }
 
 /// Execute one RX fuzz action.
@@ -131,6 +148,7 @@ async fn execute_next_action(
     queue: &mut Queue<GpadlRingMem>,
     mem: &GuestMemory,
     next_transaction_id: &mut u64,
+    rx_send: &mesh::Sender<(Vec<u8>, FuzzRxMetadata)>,
 ) -> Result<(), anyhow::Error> {
     let action = input.arbitrary::<RxAction>()?;
     fuzz_eprintln!("action: {action:?}");
@@ -256,6 +274,20 @@ async fn execute_next_action(
             )
             .await?;
         }
+        RxAction::InjectHostRxPacket { packet, metadata } => {
+            rx_send.send((packet, metadata));
+        }
+        RxAction::InjectHostRxBurst { packets } => {
+            for (packet, metadata) in packets {
+                rx_send.send((packet, metadata));
+            }
+        }
+        RxAction::InjectHostValidEthernet {
+            frame_data,
+            metadata,
+        } => {
+            rx_send.send((frame_data, metadata));
+        }
     }
     Ok(())
 }
@@ -270,13 +302,15 @@ fn do_fuzz(input: &[u8]) {
     let remaining_start = input.len() - pre.len();
     let fuzz_input = &input[remaining_start..];
 
-    // Use the FuzzEndpoint so that the loopback reflects TX-to-RX.
-    let (mut endpoint, _handles) = FuzzEndpoint::new(FuzzEndpointConfig {
-        enable_rx_injection: false,
+    // Use the FuzzEndpoint so that the loopback reflects TX-to-RX and
+    // the fuzzer can inject host-side RX packets directly.
+    let (mut endpoint, handles) = FuzzEndpoint::new(FuzzEndpointConfig {
+        enable_rx_injection: true,
         enable_action_injection: false,
         ..FuzzEndpointConfig::default()
     });
     endpoint.loopback_metadata = loopback_meta;
+    let rx_send = handles.rx_send.expect("rx injection enabled");
     let config = FuzzNicConfig {
         endpoint: Box::new(endpoint),
         virtual_function: None,
@@ -322,7 +356,7 @@ fn do_fuzz(input: &[u8]) {
 
             // Run RX-focused fuzz actions until input is exhausted.
             while !fuzzer_input.is_empty() {
-                execute_next_action(fuzzer_input, &mut queue, &mem, &mut next_transaction_id)
+                execute_next_action(fuzzer_input, &mut queue, &mem, &mut next_transaction_id, &rx_send)
                     .await?;
                 drain_queue_async(&mut queue).await;
             }

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_rx_path.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_rx_path.rs
@@ -356,8 +356,14 @@ fn do_fuzz(input: &[u8]) {
 
             // Run RX-focused fuzz actions until input is exhausted.
             while !fuzzer_input.is_empty() {
-                execute_next_action(fuzzer_input, &mut queue, &mem, &mut next_transaction_id, &rx_send)
-                    .await?;
+                execute_next_action(
+                    fuzzer_input,
+                    &mut queue,
+                    &mem,
+                    &mut next_transaction_id,
+                    &rx_send,
+                )
+                .await?;
                 drain_queue_async(&mut queue).await;
             }
             Ok(())

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_save_restore.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_save_restore.rs
@@ -1,0 +1,491 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzer for the netvsp save/restore code path.
+//!
+//! The `save()` / `restore()` implementation processes data from the
+//! host/root — a trust boundary in OpenHCL — and includes complex state-
+//! machine reconstruction for VF state, pending TX completions, RSS config,
+//! and GPADL remapping.
+//!
+//! ## Two complementary modes
+//!
+//! - **`ArbitraryRestore`**: construct a completely arbitrary
+//!   [`saved_state::SavedState`], encode it, and call `restore()` without any
+//!   prior live negotiation.  Exercises all error branches with structurally
+//!   valid but semantically impossible states (unknown GPADL IDs, unsupported
+//!   versions, invalid VF state, oversized channel lists, …).
+//!
+//! - **`SnapshotMutate`**: negotiate to the Ready state, take a live snapshot
+//!   via `save()`, parse the snapshot into a `SavedState`, apply fuzzer-driven
+//!   *structural* mutations (which keep GPADL IDs valid so `restore_state()`
+//!   proceeds past the GPADL-lookup checks), then call `restore()`.  Exercises
+//!   the deeper state-machine reconstruction logic where most of the complex
+//!   code lives.
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::FuzzGuestOsId;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::RingFullError;
+use fuzz_helpers::build_rndis_oid_query;
+use fuzz_helpers::build_rndis_oid_set;
+use fuzz_helpers::build_structured_rndis_packet;
+use fuzz_helpers::drain_queue_async;
+use fuzz_helpers::negotiate_to_ready;
+use fuzz_helpers::nic_setup::FuzzNicConfig;
+use fuzz_helpers::nic_setup::FuzzNicSetup;
+use fuzz_helpers::nic_setup::NicSetupHandle;
+use fuzz_helpers::nic_setup::create_nic_with_channel;
+use fuzz_helpers::send_inband_nvsp;
+use fuzz_helpers::send_rndis_gpadirect;
+use fuzz_helpers::send_rndis_via_direct_path;
+use guestmem::GuestMemory;
+use netvsp::protocol;
+use netvsp::rndisprot;
+use netvsp::saved_state;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl::GpadlId;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use vmcore::save_restore::SavedStateBlob;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 1,
+    data_pages: DATA_PAGES,
+};
+
+/// A fuzzer-driven structural mutation applied to a live `ReadyPrimary`
+/// snapshot. Each mutation keeps the recv/send GPADL IDs intact so that
+/// `restore_state()` proceeds past the GPADL-lookup checks and into deeper
+/// state-machine reconstruction code — exactly the code that runs in OpenHCL
+/// when restoring from a host-supplied blob.
+#[derive(Arbitrary, Debug)]
+enum SnapshotMutation {
+    /// Replace all channel entries with fuzzer-supplied ones. Tests pending TX
+    /// completion draining and in-use RX buffer registration on restore.
+    SetChannels(Vec<Option<saved_state::Channel>>),
+    /// Overwrite the guest VF state. Tests the VF state-machine
+    /// reconstruction path including `DataPathSwitchPending`.
+    SetGuestVfState(saved_state::GuestVfState),
+    /// Overwrite the RNDIS state.
+    SetRndisState(saved_state::RndisState),
+    /// Overwrite the RSS state. Tests indirection-table parsing.
+    SetRssState(Option<saved_state::RssState>),
+    /// Overwrite the pending control messages. Tests the control-message
+    /// replay path on restore.
+    SetControlMessages(Vec<saved_state::IncomingControlMessage>),
+    /// Overwrite the NDIS version.
+    SetNdisVersion(saved_state::NdisVersion),
+    /// Overwrite the NDIS config (MTU, capabilities).
+    SetNdisConfig(saved_state::NdisConfig),
+    /// Overwrite the offload config.
+    SetOffloadConfig(saved_state::OffloadConfig),
+    /// Toggle `pending_offload_change`.
+    SetPendingOffloadChange(bool),
+    /// Toggle `guest_link_down`.
+    SetGuestLinkDown(bool),
+    /// Set the pending link action.
+    SetPendingLinkAction(Option<bool>),
+    /// Set the packet filter.
+    SetPacketFilter(Option<u32>),
+    /// Replace the entire `ReadyPrimary`. The recv/send GPADL IDs are patched
+    /// with the real values afterwards so that GPADL lookup succeeds.
+    ReplaceReady(Box<saved_state::ReadyPrimary>),
+    /// Overwrite the protocol version. Tests version-mismatch handling on
+    /// restore (e.g. V2 state restored with V5 version, or completely
+    /// invalid version numbers).
+    SetVersion(u32),
+    /// Toggle `tx_spread_sent`.
+    SetTxSpreadSent(bool),
+    /// Overwrite the receive buffer sub_allocation_size. Tests the
+    /// sub-allocation size validation path on restore.
+    SetReceiveBufferSubAllocationSize(u32),
+    /// Overwrite the send buffer with an arbitrary (or None) value. Tests
+    /// the send-buffer-optional path on restore.
+    SetSendBuffer(Option<saved_state::SendBuffer>),
+}
+
+/// Apply a single [`SnapshotMutation`] to the `ReadyPrimary` inside `state`.
+/// The `recv_gpadl` and `send_gpadl` values are the real IDs from the fuzz
+/// setup; they are used to fix up GPADL references after mutations that
+/// replace the struct wholesale.
+fn apply_snapshot_mutation(
+    state: &mut saved_state::SavedState,
+    mutation: SnapshotMutation,
+    recv_gpadl: GpadlId,
+    send_gpadl: GpadlId,
+) {
+    let ready = match state.open.as_mut().and_then(|o| {
+        if let saved_state::Primary::Ready(r) = &mut o.primary {
+            Some(r)
+        } else {
+            None
+        }
+    }) {
+        Some(r) => r,
+        None => return,
+    };
+
+    match mutation {
+        SnapshotMutation::SetChannels(ch) => ready.channels = ch,
+        SnapshotMutation::SetGuestVfState(s) => ready.guest_vf_state = s,
+        SnapshotMutation::SetRndisState(s) => ready.rndis_state = s,
+        SnapshotMutation::SetRssState(s) => ready.rss_state = s,
+        SnapshotMutation::SetControlMessages(m) => ready.control_messages = m,
+        SnapshotMutation::SetNdisVersion(v) => ready.ndis_version = v,
+        SnapshotMutation::SetNdisConfig(c) => ready.ndis_config = c,
+        SnapshotMutation::SetOffloadConfig(o) => ready.offload_config = o,
+        SnapshotMutation::SetPendingOffloadChange(v) => ready.pending_offload_change = v,
+        SnapshotMutation::SetGuestLinkDown(v) => ready.guest_link_down = v,
+        SnapshotMutation::SetPendingLinkAction(v) => ready.pending_link_action = v,
+        SnapshotMutation::SetPacketFilter(v) => ready.packet_filter = v,
+        SnapshotMutation::ReplaceReady(mut new_ready) => {
+            // Preserve real GPADL IDs so restore_state can look them up.
+            new_ready.receive_buffer.gpadl_id = recv_gpadl;
+            if let Some(sb) = &mut new_ready.send_buffer {
+                sb.gpadl_id = send_gpadl;
+            }
+            *ready = *new_ready;
+        }
+        SnapshotMutation::SetVersion(v) => ready.version = v,
+        SnapshotMutation::SetTxSpreadSent(v) => ready.tx_spread_sent = v,
+        SnapshotMutation::SetReceiveBufferSubAllocationSize(v) => {
+            ready.receive_buffer.sub_allocation_size = v;
+        }
+        SnapshotMutation::SetSendBuffer(sb) => {
+            // Patch GPADL ID if present so GPADL lookup can succeed.
+            let mut sb = sb;
+            if let Some(ref mut s) = sb {
+                s.gpadl_id = send_gpadl;
+            }
+            ready.send_buffer = sb;
+        }
+    }
+}
+
+/// Actions that can be taken after a successful restore + start to validate
+/// that the restored state machine handles real traffic correctly.
+#[derive(Arbitrary, Debug)]
+enum PostRestoreAction {
+    /// Send an RNDIS data packet to exercise the TX path with restored state.
+    SendRndisPacket {
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+    },
+    /// Send an RNDIS OID query to validate restored OID handling state.
+    SendOidQuery { oid: u32 },
+    /// Send an RNDIS OID set to validate restored offload/config state.
+    SendOidSet { oid: u32, value: Vec<u8> },
+    /// Send an NVSP control message post-restore.
+    SendControlMessage { message_type: u32, payload: Vec<u8> },
+    /// Drain the queue to process any pending completions.
+    DrainQueue,
+}
+
+/// Two complementary fuzzing modes for `save()` / `restore()`.
+#[derive(Arbitrary, Debug)]
+enum FuzzMode {
+    /// Entirely arbitrary `SavedState`: no prior negotiation, immediate
+    /// `restore()`. Reaches all error-handling branches (unknown GPADL IDs,
+    /// unsupported versions, absurd channel counts, …).
+    ArbitraryRestore {
+        state: saved_state::SavedState,
+        /// When `true`, patch the GPADL IDs in `state` to the real values
+        /// from the fuzz setup before calling `restore()`. This lets GPADL
+        /// lookup succeed so `restore_state()` proceeds further into the
+        /// `ReadyPrimary` (or `Init`) reconstruction code rather than
+        /// returning early on a lookup failure.
+        use_real_gpadl_ids: bool,
+    },
+    /// Live snapshot then field-level mutation before `restore()`. Exercises
+    /// the deeper state-machine reconstruction logic with structurally valid
+    /// protobuf that still contains semantically impossible state.
+    SnapshotMutate {
+        mutations: Vec<SnapshotMutation>,
+        /// If `true` and `restore()` succeeds, call `start()` and drain the
+        /// queue to exercise the restarted state machine.
+        restart_after_restore: bool,
+        /// Actions to run after a successful restore + start. Exercises the
+        /// restored state machine with real NVSP/RNDIS traffic rather than
+        /// just a passive drain.
+        post_restore_actions: Vec<PostRestoreAction>,
+    },
+}
+
+fuzz_target!(|input: &[u8]| {
+    xtask_fuzz::init_tracing_if_repro();
+    let mut u = Unstructured::new(input);
+
+    // Fuzz-select the guest OS identity so this target also covers all
+    // `can_use_ring_opt` branches.
+    let mut config = FuzzNicConfig::default();
+    if let Ok(fuzz_os) = u.arbitrary::<FuzzGuestOsId>() {
+        config.get_guest_os_id = fuzz_os.to_hv_guest_os_id();
+    }
+
+    pal_async::DefaultPool::run_with(async |driver| {
+        // Build the NIC internals but do NOT start the channel yet; the fuzz
+        // mode may call restore() before start(), so we control sequencing.
+        let (handle, setup) = match create_nic_with_channel(&driver, &LAYOUT, config).await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+
+        let mode = match u.arbitrary::<FuzzMode>() {
+            Ok(m) => m,
+            Err(_) => {
+                handle.cleanup().await;
+                return;
+            }
+        };
+
+        let fuzz_result = mesh::CancelContext::new()
+            .with_timeout(std::time::Duration::from_millis(500))
+            .until_cancelled(run_mode(&mut u, handle, setup, mode))
+            .await;
+
+        match fuzz_result {
+            Ok(Ok(())) => {
+                fuzz_eprintln!("fuzz: test case exhausted arbitrary data");
+            }
+            Ok(Err(e)) => {
+                if e.downcast_ref::<arbitrary::Error>().is_some() {
+                    fuzz_eprintln!("fuzz: arbitrary data exhausted: {e:#}");
+                } else if e.downcast_ref::<RingFullError>().is_some() {
+                    fuzz_eprintln!("fuzz: ring full (backpressure), stopping");
+                } else {
+                    panic!("fuzz: action error: {e:#}");
+                }
+            }
+            Err(_) => {
+                panic!("fuzz: timed out after 500ms");
+            }
+        }
+    });
+});
+
+async fn run_mode(
+    u: &mut Unstructured<'_>,
+    handle: NicSetupHandle,
+    setup: FuzzNicSetup,
+    mode: FuzzMode,
+) -> anyhow::Result<()> {
+    let FuzzNicSetup {
+        mut queue,
+        mem,
+        recv_buf_gpadl_id,
+        send_buf_gpadl_id,
+        ..
+    } = setup;
+
+    match mode {
+        FuzzMode::ArbitraryRestore {
+            mut state,
+            use_real_gpadl_ids,
+        } => {
+            // Optionally patch GPADL IDs so the restore proceeds into deeper
+            // branches rather than failing on GPADL lookup.
+            if use_real_gpadl_ids {
+                patch_state_gpadl_ids(&mut state, recv_buf_gpadl_id, send_buf_gpadl_id);
+            }
+
+            let blob = SavedStateBlob::new(state);
+
+            // The channel is in "not started" state — restore() can be called
+            // directly without stop() because the device task hasn't started.
+            // Must not panic regardless of whether restore returns Ok or Err.
+            let _ = handle.channel.restore(blob).await;
+        }
+
+        FuzzMode::SnapshotMutate {
+            mutations,
+            restart_after_restore,
+            post_restore_actions,
+        } => {
+            // Advance to Ready so save() captures a meaningful blob.
+            let mut tid = 1u64;
+            handle.channel.start();
+            negotiate_to_ready(&mut queue, &mut tid, recv_buf_gpadl_id, send_buf_gpadl_id).await?;
+
+            // Initialize RNDIS to reach Operational state — this ensures the
+            // saved state captures richer state (offload config, RNDIS
+            // initialized flag, pending control messages, etc.) rather than
+            // just the NVSP negotiation state.
+            fuzz_helpers::rndis_initialize(
+                &mut queue,
+                &mem,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                &mut tid,
+            )
+            .await?;
+
+            // Send a TX packet to exercise the data path before saving, so
+            // the saved state may contain in-flight TX completion state.
+            let rndis_buf = build_structured_rndis_packet(&[], &[0xAA; 64]);
+            send_rndis_via_direct_path(
+                &mut queue,
+                &mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                &mut tid,
+            )
+            .await?;
+
+            drain_queue_async(&mut queue).await;
+
+            // Stop the channel before save/restore.
+            handle.channel.stop().await;
+
+            if let Some(blob) = handle.channel.save().await? {
+                // Parse the snapshot, apply structural mutations, re-encode.
+                if let Ok(mut state) = blob.parse::<saved_state::SavedState>() {
+                    for mutation in mutations {
+                        apply_snapshot_mutation(
+                            &mut state,
+                            mutation,
+                            recv_buf_gpadl_id,
+                            send_buf_gpadl_id,
+                        );
+                    }
+                    let mutated_blob = SavedStateBlob::new(state);
+
+                    // Restore from the mutated blob. Must not panic.
+                    let restore_ok = handle.channel.restore(mutated_blob).await.is_ok();
+
+                    if restore_ok && restart_after_restore {
+                        handle.channel.start();
+                        // Yield so the coordinator/worker tasks can restart.
+                        fuzz_helpers::yield_to_executor(20).await;
+                        // Brief drain to exercise the restarted state machine.
+                        drain_queue_async(&mut queue).await;
+
+                        // Run post-restore actions to validate that the
+                        // restored state machine handles real NVSP/RNDIS
+                        // traffic correctly, not just a passive drain.
+                        for action in post_restore_actions {
+                            execute_post_restore_action(&action, &mut queue, &mem, &mut tid)
+                                .await?;
+                        }
+
+                        handle.channel.stop().await;
+                    }
+                }
+            }
+        }
+    }
+
+    handle.cleanup().await;
+
+    // Suppress unused-variable warning when `u` has nothing left to consume.
+    let _ = u;
+    Ok(())
+}
+
+/// Execute a single post-restore action against the restarted NIC.
+///
+/// These actions validate that the restored state machine handles real
+/// NVSP/RNDIS protocol messages correctly — exercising paths like TX
+/// processing with restored offload config, OID handling with restored RSS
+/// state, and control messages with restored VF/link state.
+async fn execute_post_restore_action(
+    action: &PostRestoreAction,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    tid: &mut u64,
+) -> anyhow::Result<()> {
+    fuzz_eprintln!("action: {action:?}");
+    match action {
+        PostRestoreAction::SendRndisPacket {
+            ppi_bytes,
+            frame_data,
+        } => {
+            let rndis_buf = build_structured_rndis_packet(ppi_bytes, frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+            drain_queue_async(queue).await;
+        }
+        PostRestoreAction::SendOidQuery { oid } => {
+            let rndis_buf = build_rndis_oid_query(rndisprot::Oid(*oid), &[]);
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                tid,
+            )
+            .await?;
+            drain_queue_async(queue).await;
+        }
+        PostRestoreAction::SendOidSet { oid, value } => {
+            let rndis_buf = build_rndis_oid_set(rndisprot::Oid(*oid), value);
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                tid,
+            )
+            .await?;
+            drain_queue_async(queue).await;
+        }
+        PostRestoreAction::SendControlMessage {
+            message_type,
+            payload,
+        } => {
+            send_inband_nvsp(queue, tid, *message_type, payload, true).await?;
+            drain_queue_async(queue).await;
+        }
+        PostRestoreAction::DrainQueue => {
+            drain_queue_async(queue).await;
+        }
+    }
+    Ok(())
+}
+
+/// Patch all GPADL ID fields in a `SavedState` to use the real recv/send
+/// buffer GPADL IDs from the fuzz setup.  This is needed for
+/// `ArbitraryRestore` mode when the fuzzer wants `restore_state()` to succeed
+/// at GPADL lookup and proceed into deeper state-machine reconstruction.
+fn patch_state_gpadl_ids(state: &mut saved_state::SavedState, recv: GpadlId, send: GpadlId) {
+    let primary = match state.open.as_mut().map(|o| &mut o.primary) {
+        Some(p) => p,
+        None => return,
+    };
+    match primary {
+        saved_state::Primary::Ready(r) => {
+            r.receive_buffer.gpadl_id = recv;
+            if let Some(sb) = &mut r.send_buffer {
+                sb.gpadl_id = send;
+            }
+        }
+        saved_state::Primary::Init(i) => {
+            if let Some(rb) = &mut i.receive_buffer {
+                rb.gpadl_id = recv;
+            }
+            if let Some(sb) = &mut i.send_buffer {
+                sb.gpadl_id = send;
+            }
+        }
+        saved_state::Primary::Version => {}
+    }
+}

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_save_restore.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_save_restore.rs
@@ -219,7 +219,7 @@ enum FuzzMode {
     },
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     xtask_fuzz::init_tracing_if_repro();
     let mut u = Unstructured::new(input);
 
@@ -269,7 +269,9 @@ fuzz_target!(|input: &[u8]| {
             }
         }
     });
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));
 
 async fn run_mode(
     u: &mut Unstructured<'_>,

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_subchannel.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_subchannel.rs
@@ -1,0 +1,508 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzer for NetVSP subchannel handling and multi-queue code paths.
+//!
+//! This fuzzer exercises the subchannel allocation and multi-queue paths end-
+//! to-end using [`MultiChannelMockVmbus`]. When the guest sends a successful
+//! `MESSAGE5_TYPE_SUB_CHANNEL` request, `restart_queues()` runs, calls
+//! `enable_subchannels()`, and [`SubchannelOpener::open_pending`] completes
+//! the ring handshake for each new subchannel. This unlocks code paths that
+//! are unreachable with a single-channel mock:
+//!
+//! - `Nic::open()` subchannel branch (coordinator stop, `WorkerState::Ready`
+//!   construction, "all subchannels opened" check)
+//! - `restart_queues()` multi-queue loop (per-queue `QueueConfig`, RX buffer
+//!   partitioning via `RxBufferRanges::new`)
+//! - `RxBufferRange::send_if_remote()` cross-queue RX buffer routing
+//! - `Coordinator::process()` subworker start loop (`workers[1..].start()`)
+//! - RSS-driven queue distribution and indirection table application
+//!
+//! ## NVSP protocol messages tested
+//!
+//! - `MESSAGE5_TYPE_SUB_CHANNEL` — subchannel allocation
+//! - `MESSAGE5_TYPE_SEND_INDIRECTION_TABLE` — indirection table updates
+//! - `MESSAGE4_TYPE_SWITCH_DATA_PATH` — data path switching
+//! - `MESSAGE1_TYPE_SEND_RNDIS_PACKET` — data via primary and subchannel rings
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::build_rss_oid_set;
+use fuzz_helpers::build_structured_rndis_packet;
+use fuzz_helpers::drain_queue;
+use fuzz_helpers::drain_queue_async;
+use fuzz_helpers::negotiate_to_ready;
+use fuzz_helpers::nic_setup::FuzzNicConfig;
+use fuzz_helpers::nic_setup::SubchannelOpener;
+use fuzz_helpers::nvsp_payload;
+use fuzz_helpers::rndis_initialize;
+use fuzz_helpers::run_fuzz_loop_with_config;
+use fuzz_helpers::send_inband_nvsp;
+use fuzz_helpers::send_rndis_gpadirect;
+use fuzz_helpers::send_rndis_via_direct_path;
+use fuzz_helpers::try_read_one_completion;
+use guestmem::GuestMemory;
+use netvsp::protocol;
+use netvsp::rndisprot;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use vmbus_ring::OutgoingPacketType;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+use zerocopy::IntoBytes;
+
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 1,
+    data_pages: DATA_PAGES,
+};
+
+/// Maximum subchannels the multi-channel mock will support. Four gives enough
+/// coverage for all partitioning logic without inflating memory or runtime.
+const MAX_FUZZ_SUBCHANNELS: u16 = 4;
+
+/// Actions the fuzzer can take to exercise subchannel and multi-queue handling.
+#[derive(Arbitrary, Debug)]
+enum SubchannelAction {
+    /// Request subchannel allocation with a specific count.
+    RequestSubchannels {
+        request: protocol::Message5SubchannelRequest,
+    },
+    /// Request 1–4 subchannels (within the mock's supported range).
+    RequestFewSubchannels { count: u8 },
+    /// Request an arbitrary number of subchannels.
+    RequestManySubchannels { count: u16 },
+    /// Send a raw subchannel message with arbitrary bytes.
+    RawSubchannelMessage { payload: Vec<u8> },
+    /// Send an indirection table update message.
+    SendIndirectionTable {
+        /// Fuzzed indirection table entries.
+        entries: Vec<u32>,
+    },
+    /// Send an NVSP control message interleaved with subchannel operations.
+    SendControlMessage {
+        message_type: u32,
+        payload: Vec<u8>,
+        with_completion: bool,
+    },
+    /// Send a data path switch message (may interact with subchannel state).
+    SendSwitchDataPath {
+        msg: protocol::Message4SwitchDataPath,
+    },
+    /// Send an RNDIS data packet on the primary channel.
+    SendRndisPacket {
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+    },
+    /// Drain the primary queue and open any subchannels the device has
+    /// requested via `enable_subchannels` since the last call.
+    ///
+    /// This is the key action that makes multi-queue code reachable: after a
+    /// successful `RequestSubchannels`, drain the queue (allowing the device to
+    /// process the request and call `restart_queues`), then call this action
+    /// to complete the ring handshake for each new subchannel.
+    OpenPendingSubchannels,
+    /// Read one completion/notification from a subchannel ring.
+    ReadSubchannelCompletion {
+        /// Which subchannel to read from (wrapped mod number of open ones).
+        idx: u8,
+    },
+    /// Send an RNDIS data packet on a subchannel ring.
+    SendDataToSubchannel {
+        /// Which subchannel to send on (wrapped mod number of open ones).
+        idx: u8,
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+    },
+    /// Read one completion/notification from the primary channel.
+    ReadCompletion,
+    /// Drain all pending packets from the primary queue.
+    DrainQueue,
+    /// Release a receive buffer ID on a subchannel that belongs to a different
+    /// queue's range.  This exercises the `send_if_remote()` cross-queue
+    /// routing path in `release_recv_buffers()`, which is otherwise
+    /// unreachable because the loopback endpoint never creates cross-queue RX
+    /// traffic.
+    ///
+    /// The `buffer_id` is the raw RX buffer sub-allocation index.  When sent
+    /// as a completion `transaction_id` on a subchannel whose `RxBufferRange`
+    /// does not own that ID, `send_if_remote()` redirects the buffer release
+    /// to the correct queue via the cross-queue channel.
+    ReleaseRemoteBufferId {
+        /// Which subchannel to send the completion on (wrapped mod open).
+        subchannel_idx: u8,
+        /// Raw buffer ID to release.  Should be outside the target
+        /// subchannel's `id_range` to trigger the remote-redirect path.
+        buffer_id: u32,
+    },
+    /// Send an RSS OID SET (`OID_GEN_RECEIVE_SCALE_PARAMETERS`) with a valid
+    /// hash key and indirection table via GpaDirect. This exercises the
+    /// `oid_set_rss_parameters` code path and, combined with subchannel
+    /// allocation, the RSS-driven queue distribution in `restart_queues()`.
+    SetRssParameters {
+        /// Hash information flags (hash function | hash type). Use Toeplitz
+        /// combined with IPv4/TCP/UDP/IPv6 hash types.
+        hash_information: u32,
+        /// Indirection table entries. Clamped to `max_queues`.
+        indirection_entries: Vec<u32>,
+        /// RSS parameter flags (e.g. DISABLE_RSS).
+        flags: u16,
+    },
+    /// Send an RSS DISABLE to clear RSS state, then re-enable. Tests the
+    /// `NDIS_RSS_PARAM_FLAG_DISABLE_RSS` path.
+    DisableRss,
+    /// Change the RSS indirection table to redirect traffic to different
+    /// queues than the current configuration.  When subchannels are open,
+    /// this forces cross-queue buffer redistribution through
+    /// `remote_buffer_id_recv` in the main loop, exercising the
+    /// `send_if_remote()` path that is otherwise unreachable.
+    ChangeRssIndirection {
+        /// Seed for building a shuffled indirection table.  Each entry is
+        /// forced to a different queue than the previous table so that the
+        /// NIC must redistribute RX buffers.
+        seed: u32,
+    },
+}
+
+/// Execute one subchannel fuzz action.
+#[allow(clippy::too_many_arguments)]
+async fn execute_next_action(
+    input: &mut Unstructured<'_>,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    next_transaction_id: &mut u64,
+    opener: &mut SubchannelOpener,
+    open_queues: &mut Vec<Queue<GpadlRingMem>>,
+) -> Result<(), anyhow::Error> {
+    let action = input.arbitrary::<SubchannelAction>()?;
+    fuzz_eprintln!("action: {action:?}");
+    match action {
+        SubchannelAction::RequestSubchannels { request } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE5_TYPE_SUB_CHANNEL,
+                request.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        SubchannelAction::RequestFewSubchannels { count } => {
+            let request = protocol::Message5SubchannelRequest {
+                operation: protocol::SubchannelOperation::ALLOCATE,
+                num_sub_channels: ((count % MAX_FUZZ_SUBCHANNELS as u8) + 1) as u32,
+            };
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE5_TYPE_SUB_CHANNEL,
+                request.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        SubchannelAction::RequestManySubchannels { count } => {
+            let request = protocol::Message5SubchannelRequest {
+                operation: protocol::SubchannelOperation::ALLOCATE,
+                num_sub_channels: count as u32,
+            };
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE5_TYPE_SUB_CHANNEL,
+                request.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        SubchannelAction::RawSubchannelMessage { payload } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE5_TYPE_SUB_CHANNEL,
+                &payload,
+                true,
+            )
+            .await?;
+        }
+        SubchannelAction::SendIndirectionTable { entries } => {
+            let header = protocol::Message5SendIndirectionTable {
+                table_entry_count: entries.len() as u32,
+                table_offset: size_of::<protocol::Message5SendIndirectionTable>() as u32,
+            };
+            let mut payload = Vec::new();
+            payload.extend_from_slice(header.as_bytes());
+            for entry in &entries {
+                payload.extend_from_slice(entry.as_bytes());
+            }
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE5_TYPE_SEND_INDIRECTION_TABLE,
+                &payload,
+                true,
+            )
+            .await?;
+        }
+        SubchannelAction::SendControlMessage {
+            message_type,
+            payload,
+            with_completion,
+        } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                message_type,
+                &payload,
+                with_completion,
+            )
+            .await?;
+        }
+        SubchannelAction::SendSwitchDataPath { msg } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE4_TYPE_SWITCH_DATA_PATH,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        SubchannelAction::SendRndisPacket {
+            ppi_bytes,
+            frame_data,
+        } => {
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        SubchannelAction::OpenPendingSubchannels => {
+            // Drain the primary queue first so the device can process any
+            // outstanding subchannel requests and call enable_subchannels.
+            drain_queue(queue);
+            let new_queues = opener.open_pending().await;
+            open_queues.extend(new_queues);
+        }
+        SubchannelAction::ReadSubchannelCompletion { idx } => {
+            if !open_queues.is_empty() {
+                let i = idx as usize % open_queues.len();
+                let q = &mut open_queues[i];
+                let _ = try_read_one_completion(q);
+            }
+        }
+        SubchannelAction::SendDataToSubchannel {
+            idx,
+            ppi_bytes,
+            frame_data,
+        } => {
+            if !open_queues.is_empty() {
+                let i = idx as usize % open_queues.len();
+                let q = &mut open_queues[i];
+                let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+                // Reuse the primary layout's data pages for RNDIS content;
+                // the subchannel ring sends GpaDirect references into the same
+                // guest memory as the primary channel.
+                send_rndis_via_direct_path(
+                    q,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    next_transaction_id,
+                )
+                .await?;
+            }
+        }
+        SubchannelAction::ReadCompletion => {
+            let _ = try_read_one_completion(queue);
+        }
+        SubchannelAction::DrainQueue => {
+            drain_queue(queue);
+        }
+        SubchannelAction::ReleaseRemoteBufferId {
+            subchannel_idx,
+            buffer_id,
+        } => {
+            if !open_queues.is_empty() {
+                let i = subchannel_idx as usize % open_queues.len();
+                let q = &mut open_queues[i];
+                // Build an NVSP MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE
+                // completion and send it with `transaction_id` set to the
+                // target buffer_id. Because the subchannel's RxBufferRange
+                // doesn't own this buffer_id, `send_if_remote()` will redirect
+                // the buffer release to the owning queue.
+                let completion = protocol::Message1SendRndisPacketComplete {
+                    status: protocol::Status::SUCCESS,
+                };
+                let payload = nvsp_payload(
+                    protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE,
+                    completion.as_bytes(),
+                );
+                let (_, mut writer) = q.split();
+                writer
+                    .write(vmbus_async::queue::OutgoingPacket {
+                        transaction_id: buffer_id as u64,
+                        packet_type: OutgoingPacketType::Completion,
+                        payload: &[&payload],
+                    })
+                    .await?;
+            }
+        }
+        SubchannelAction::SetRssParameters {
+            hash_information,
+            indirection_entries,
+            flags,
+        } => {
+            // Max queues = primary + open subchannels.
+            let max_queues = 1 + open_queues.len() as u32;
+            // Ensure at least 4 indirection entries (RSS requires non-empty).
+            let entries: Vec<u32> = if indirection_entries.is_empty() {
+                vec![0; 4]
+            } else {
+                indirection_entries
+            };
+            let rndis_buf = build_rss_oid_set(hash_information, &entries, max_queues, flags);
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        SubchannelAction::DisableRss => {
+            // Send RSS params with DISABLE flag set.
+            let rndis_buf = build_rss_oid_set(
+                0, // hash_information (function mask = 0 also triggers disable)
+                &[0; 4],
+                1,
+                rndisprot::NDIS_RSS_PARAM_FLAG_DISABLE_RSS,
+            );
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        SubchannelAction::ChangeRssIndirection { seed } => {
+            // Only meaningful when subchannels are open.
+            if !open_queues.is_empty() {
+                let max_queues = 1 + open_queues.len() as u32;
+                // Build an indirection table that maps each entry to a
+                // different queue than a simple round-robin.  Use the seed
+                // to deterministically permute the mapping so that
+                // different fuzz inputs produce different redistribution
+                // patterns making cross-queue buffer returns likely.
+                let table_size = 16u32; // standard indirection table size
+                let entries: Vec<u32> = (0..table_size)
+                    .map(|i| {
+                        // XOR each index with the seed, then wrap to a
+                        // valid queue.  This ensures non-trivial shuffling.
+                        (i ^ seed) % max_queues
+                    })
+                    .collect();
+
+                // Use Toeplitz + IPv4/TCP hash type to enable RSS.
+                let hash_info: u32 = 0x0000_0001 // NDIS_HASH_FUNCTION_TOEPLITZ
+                    | 0x0000_0100; // NDIS_HASH_IPV4
+                let rndis_buf = build_rss_oid_set(hash_info, &entries, max_queues, 0);
+                send_rndis_gpadirect(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::CONTROL_CHANNEL_TYPE,
+                    LAYOUT.data_page_start(),
+                    LAYOUT.data_pages,
+                    next_transaction_id,
+                )
+                .await?;
+
+                // Yield and drain to let the NIC process the RSS change and
+                // redistribute buffers across queues.
+                fuzz_helpers::yield_to_executor(10).await;
+                drain_queue(queue);
+            }
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|input: &[u8]| {
+    run_fuzz_loop_with_config(
+        input,
+        &LAYOUT,
+        FuzzNicConfig {
+            max_subchannels: MAX_FUZZ_SUBCHANNELS,
+            ..FuzzNicConfig::default()
+        },
+        |fuzzer_input, setup| {
+            Box::pin(async move {
+                let mut queue = setup.queue;
+                let mem = setup.mem;
+                let mut next_transaction_id = 1u64;
+                let mut opener = setup
+                    .subchannel_opener
+                    .expect("SubchannelOpener must be present when max_subchannels > 0");
+                let mut open_queues: Vec<Queue<GpadlRingMem>> = Vec::new();
+
+                // Always negotiate to the ready state — subchannel requests are
+                // only valid after negotiation to version >= 5.
+                negotiate_to_ready(
+                    &mut queue,
+                    &mut next_transaction_id,
+                    setup.recv_buf_gpadl_id,
+                    setup.send_buf_gpadl_id,
+                )
+                .await?;
+
+                // 90% of the time, also initialize RNDIS so that data-path
+                // actions on subchannels are meaningful.
+                if fuzzer_input.ratio(9, 10)? {
+                    rndis_initialize(
+                        &mut queue,
+                        &mem,
+                        LAYOUT.data_page_start(),
+                        LAYOUT.data_pages,
+                        &mut next_transaction_id,
+                    )
+                    .await?;
+                }
+
+                // Run subchannel-focused fuzz actions until input is exhausted.
+                while !fuzzer_input.is_empty() {
+                    execute_next_action(
+                        fuzzer_input,
+                        &mut queue,
+                        &mem,
+                        &mut next_transaction_id,
+                        &mut opener,
+                        &mut open_queues,
+                    )
+                    .await?;
+                    drain_queue_async(&mut queue).await;
+                }
+                Ok(())
+            })
+        },
+    );
+});

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_subchannel.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_subchannel.rs
@@ -447,7 +447,7 @@ async fn execute_next_action(
     Ok(())
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     run_fuzz_loop_with_config(
         input,
         &LAYOUT,
@@ -505,4 +505,6 @@ fuzz_target!(|input: &[u8]| {
             })
         },
     );
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_subchannel.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_subchannel.rs
@@ -33,6 +33,7 @@ use arbitrary::Arbitrary;
 use arbitrary::Unstructured;
 use fuzz_helpers::DATA_PAGES;
 use fuzz_helpers::PageLayout;
+use fuzz_helpers::RingFullError;
 use fuzz_helpers::build_rss_oid_set;
 use fuzz_helpers::build_structured_rndis_packet;
 use fuzz_helpers::drain_queue;
@@ -351,13 +352,19 @@ async fn execute_next_action(
                     completion.as_bytes(),
                 );
                 let (_, mut writer) = q.split();
-                writer
-                    .write(vmbus_async::queue::OutgoingPacket {
-                        transaction_id: buffer_id as u64,
-                        packet_type: OutgoingPacketType::Completion,
-                        payload: &[&payload],
-                    })
-                    .await?;
+                match writer.try_write(&vmbus_async::queue::OutgoingPacket {
+                    transaction_id: buffer_id as u64,
+                    packet_type: OutgoingPacketType::Completion,
+                    payload: &[&payload],
+                }) {
+                    Ok(()) => {}
+                    Err(vmbus_async::queue::TryWriteError::Full(_)) => {
+                        anyhow::bail!(RingFullError);
+                    }
+                    Err(vmbus_async::queue::TryWriteError::Queue(err)) => {
+                        return Err(err.into());
+                    }
+                }
             }
         }
         SubchannelAction::SetRssParameters {

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_tx_path.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_tx_path.rs
@@ -1,0 +1,470 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzer for the NVSP TX path (RNDIS packet messages).
+//!
+//! This fuzzer exercises the guest-to-host transmit path by sending arbitrary
+//! RNDIS data packets through a VMBus channel to a connected NetVSP instance.
+//! It performs protocol negotiation first, then sends fuzzed
+//! RNDIS packet messages via GpaDirect, including:
+//!
+//! - Malformed RNDIS headers (bad message_type, message_length)
+//! - Malformed rndisprot::Packet fields (data_offset, data_length, PPI)
+//! - Arbitrary per-packet info (PPI) chains (checksum, LSO, unknown types)
+//! - Structured PPI chains with valid `PerPacketInfo` headers and fuzzed
+//!   offload payloads (`TxTcpIpChecksumInfo`, `TcpLsoInfo`)
+//! - LSO edge cases: MSS of 0, 1, max (0xFFFFF), tcp_header_offset < 14
+//! - Checksum edge cases: all flag combinations, tcp_header_offset < 14
+//! - Multiple concatenated RNDIS packets in one VMBus message
+//! - Send buffer path with arbitrary section indices
+//! - TX completion messages with arbitrary transaction IDs
+//!
+//! ## NVSP protocol messages tested
+//!
+//! - `MESSAGE1_TYPE_SEND_RNDIS_PACKET` — RNDIS packet via send buffer path
+//! - `MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE` — TX completion with arbitrary
+//!   transaction ID
+//!
+//! ## RNDIS protocol messages tested
+//!
+//! - `MESSAGE_TYPE_PACKET_MSG` — structured RNDIS data packets
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::StructuredPpiEntry;
+use fuzz_helpers::StructuredRndisMessage;
+use fuzz_helpers::StructuredRndisPacketMessage;
+use fuzz_helpers::build_checksum_ppi_entry;
+use fuzz_helpers::build_concatenated_rndis_messages;
+use fuzz_helpers::build_lso_ppi_entry;
+use fuzz_helpers::build_rndis_message;
+use fuzz_helpers::build_structured_rndis_packet;
+use fuzz_helpers::drain_queue_async;
+use fuzz_helpers::endpoint::FuzzEndpointConfig;
+use fuzz_helpers::negotiate_to_ready;
+use fuzz_helpers::nic_setup::FuzzNicConfig;
+use fuzz_helpers::rndis_initialize;
+use fuzz_helpers::run_fuzz_loop_with_config;
+use fuzz_helpers::send_inband_nvsp;
+use fuzz_helpers::send_rndis_gpadirect;
+use fuzz_helpers::send_rndis_via_direct_path;
+use fuzz_helpers::send_rndis_via_send_buffer;
+use fuzz_helpers::send_tx_rndis_completion;
+use fuzz_helpers::serialize_ppi_chain;
+use fuzz_helpers::serialize_structured_rndis_packet_message;
+use fuzz_helpers::try_read_one_completion;
+use guestmem::GuestMemory;
+use netvsp::protocol;
+use netvsp::rndisprot;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+use zerocopy::IntoBytes;
+
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 4,
+    data_pages: DATA_PAGES,
+};
+
+/// Actions the fuzzer can take on the data path.
+#[derive(Arbitrary, Debug)]
+enum DataPathAction {
+    /// Send a single RNDIS packet message via GpaDirect with fuzzed content.
+    SendRndisPacket {
+        /// Structured RNDIS packet message.
+        rndis: StructuredRndisPacketMessage,
+        /// NVSP RNDIS packet metadata.
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a structured RNDIS packet with fuzzed PPI and frame data via GpaDirect.
+    SendStructuredRndisPacket {
+        /// Fuzzed per-packet-info bytes (PPI chain).
+        ppi_bytes: Vec<u8>,
+        /// Fuzzed ethernet frame data.
+        frame_data: Vec<u8>,
+        /// NVSP RNDIS packet metadata.
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a structured RNDIS packet with fuzzed PPI and a mostly valid
+    /// Ethernet frame to drive backend RX parsing paths.
+    SendStructuredValidEthernetFrame {
+        /// Fuzzed per-packet-info bytes (PPI chain).
+        ppi_bytes: Vec<u8>,
+        /// Mostly valid Ethernet II frame.
+        #[arbitrary(with = fuzz_helpers::arbitrary_valid_ethernet_frame)]
+        frame_data: Vec<u8>,
+        /// NVSP RNDIS packet metadata.
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a structured RNDIS packet with a PPI chain
+    /// containing properly formatted checksum and/or LSO entries.
+    SendWithStructuredPpi {
+        /// Structured PPI entries to serialize into the PPI region.
+        ppi_entries: Vec<StructuredPpiEntry>,
+        /// Fuzzed ethernet frame data.
+        frame_data: Vec<u8>,
+        /// NVSP RNDIS packet metadata.
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a packet with a specific LSO PPI entry. Fuzzed fields cover
+    /// edge cases: MSS of 0, 1, max (0xFFFFF), tcp_header_offset < 14
+    /// (triggers `InvalidTcpHeaderOffset`), and large offsets.
+    SendLsoPacket {
+        /// MSS value (bits 0-19 of TcpLsoInfo). Fuzzed u32 covers 0, 1,
+        /// 0xFFFFF and all values in between.
+        mss: u32,
+        /// TCP header offset. Values < 14 trigger an error path.
+        tcp_header_offset: u16,
+        /// Whether this is IPv6 (true) or IPv4 (false).
+        is_ipv6: bool,
+        /// Fuzzed ethernet frame data.
+        frame_data: Vec<u8>,
+    },
+    /// Send a packet with a specific checksum PPI entry to exercise
+    /// all flag combinations: IPv4/IPv6, TCP/UDP checksum, IP header
+    /// checksum, and various tcp_header_offset values (including < 14
+    /// to test the IHL-parsing fallback path).
+    SendChecksumEdgeCase {
+        /// Raw `TxTcpIpChecksumInfo` bits.
+        checksum_info: u32,
+        /// Fuzzed ethernet frame data.
+        frame_data: Vec<u8>,
+    },
+    /// Send multiple concatenated RNDIS packets in one GpaDirect message.
+    SendMultipleRndisPackets {
+        /// Each entry is one structured RNDIS message.
+        messages: Vec<StructuredRndisMessage>,
+    },
+    /// Send RNDIS data via the send buffer path (section index != 0xFFFFFFFF).
+    SendViaSendBuffer {
+        /// Structured RNDIS packet message to place in the send buffer.
+        rndis: StructuredRndisPacketMessage,
+        /// NVSP RNDIS packet metadata.
+        nvsp_msg: protocol::Message1SendRndisPacket,
+    },
+    /// Send a TX completion with an arbitrary transaction ID (fuzz
+    /// release_recv_buffers / completion handling).
+    SendTxCompletion {
+        transaction_id: u64,
+        completion: protocol::Message1SendRndisPacketComplete,
+    },
+    /// Send an RNDIS control message (INITIALIZE, QUERY, SET, etc.).
+    SendRndisControl {
+        /// RNDIS message header.
+        header: rndisprot::MessageHeader,
+        /// Payload after the RNDIS MessageHeader.
+        payload: Vec<u8>,
+    },
+    /// Drain completions from the host.
+    ReadCompletion,
+    /// Send a raw MESSAGE1_TYPE_SEND_RNDIS_PACKET with adversarial
+    /// send_buffer_section_index and send_buffer_section_size values to
+    /// exercise the section-index arithmetic and `try_subrange()` validation.
+    /// Does NOT use the `send_rndis_via_send_buffer` helper (which clamps
+    /// the write), so the device-side validation must handle the raw values.
+    SendRawSendBufferPacket {
+        /// Adversarial section index (e.g. u32::MAX, 0, section_count+1).
+        send_buffer_section_index: u32,
+        /// Adversarial section size.
+        send_buffer_section_size: u32,
+        /// Channel type (data or control).
+        channel_type: u32,
+    },
+    /// Inject a `TxError::TryRestart` on the next `tx_poll`, then send a
+    /// packet to trigger `process_endpoint_tx`.  This exercises the
+    /// `TryRestart` error handling path that completes pending TXs and
+    /// signals `CoordinatorMessage::Restart`.
+    InjectTxRestart {
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+    },
+    /// Inject a `TxError::Fatal` on the next `tx_poll`, then send a packet
+    /// to trigger `process_endpoint_tx`.  This exercises the `Fatal` error
+    /// path that propagates `WorkerError::Endpoint`.
+    InjectTxFatal {
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+    },
+}
+
+/// Execute one fuzz action on the data path.
+async fn execute_next_action(
+    input: &mut Unstructured<'_>,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    next_transaction_id: &mut u64,
+    tx_error_mode: &Option<Arc<AtomicU8>>,
+) -> Result<(), anyhow::Error> {
+    let action = input.arbitrary::<DataPathAction>()?;
+    fuzz_eprintln!("action: {action:?}");
+    let tid = next_transaction_id;
+    match action {
+        DataPathAction::SendRndisPacket {
+            mut rndis,
+            nvsp_msg,
+        } => {
+            let rndis_bytes = serialize_structured_rndis_packet_message(&mut rndis);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_bytes,
+                nvsp_msg.channel_type,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        DataPathAction::SendStructuredRndisPacket {
+            ppi_bytes,
+            frame_data,
+            nvsp_msg,
+        } => {
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(queue, mem, &rndis_buf, nvsp_msg.channel_type, &LAYOUT, tid)
+                .await?;
+        }
+        DataPathAction::SendStructuredValidEthernetFrame {
+            ppi_bytes,
+            frame_data,
+            nvsp_msg,
+        } => {
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(queue, mem, &rndis_buf, nvsp_msg.channel_type, &LAYOUT, tid)
+                .await?;
+        }
+        DataPathAction::SendWithStructuredPpi {
+            ppi_entries,
+            frame_data,
+            nvsp_msg,
+        } => {
+            let ppi_bytes = serialize_ppi_chain(&ppi_entries);
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(queue, mem, &rndis_buf, nvsp_msg.channel_type, &LAYOUT, tid)
+                .await?;
+        }
+        DataPathAction::SendLsoPacket {
+            mss,
+            tcp_header_offset,
+            is_ipv6,
+            frame_data,
+        } => {
+            let ppi_bytes = build_lso_ppi_entry(mss, tcp_header_offset, is_ipv6);
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        DataPathAction::SendChecksumEdgeCase {
+            checksum_info,
+            frame_data,
+        } => {
+            let ppi_bytes = build_checksum_ppi_entry(checksum_info);
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                tid,
+            )
+            .await?;
+        }
+        DataPathAction::SendMultipleRndisPackets { messages } => {
+            let rndis_buf = build_concatenated_rndis_messages(&messages);
+
+            if !rndis_buf.is_empty() {
+                send_rndis_via_direct_path(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    tid,
+                )
+                .await?;
+            }
+        }
+        DataPathAction::SendViaSendBuffer {
+            mut rndis,
+            nvsp_msg,
+        } => {
+            let rndis_bytes = serialize_structured_rndis_packet_message(&mut rndis);
+            send_rndis_via_send_buffer(queue, mem, &rndis_bytes, &nvsp_msg, &LAYOUT, tid).await?;
+        }
+        DataPathAction::SendTxCompletion {
+            transaction_id,
+            completion,
+        } => {
+            send_tx_rndis_completion(queue, transaction_id, &completion).await?;
+        }
+        DataPathAction::SendRndisControl { header, payload } => {
+            // Send an RNDIS control message with arbitrary message type
+            // and payload via GpaDirect.
+            let rndis_buf = build_rndis_message(header.message_type, &payload);
+            send_rndis_gpadirect(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::CONTROL_CHANNEL_TYPE,
+                LAYOUT.data_page_start(),
+                LAYOUT.data_pages,
+                tid,
+            )
+            .await?;
+        }
+        DataPathAction::ReadCompletion => {
+            let _ = try_read_one_completion(queue);
+        }
+        DataPathAction::SendRawSendBufferPacket {
+            send_buffer_section_index,
+            send_buffer_section_size,
+            channel_type,
+        } => {
+            // Send a raw RNDIS packet message with adversarial section
+            // index/size. This bypasses the send_rndis_via_send_buffer
+            // helper's clamping to exercise the device-side validation of
+            // the section index × 6144 multiplication and try_subrange().
+            let msg = protocol::Message1SendRndisPacket {
+                channel_type,
+                send_buffer_section_index,
+                send_buffer_section_size,
+            };
+            send_inband_nvsp(
+                queue,
+                tid,
+                protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        DataPathAction::InjectTxRestart {
+            ppi_bytes,
+            frame_data,
+        } => {
+            if let Some(mode) = tx_error_mode {
+                // Arm the TryRestart error for the next tx_poll.
+                mode.store(1, Ordering::Relaxed);
+                // Send a packet to trigger tx_avail → tx_poll.
+                let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+                let _ = send_rndis_via_direct_path(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    tid,
+                )
+                .await;
+                // Yield so the worker can process the error and restart.
+                fuzz_helpers::yield_to_executor(20).await;
+                // Drain to let the coordinator finish restarting.
+                drain_queue_async(queue).await;
+            }
+        }
+        DataPathAction::InjectTxFatal {
+            ppi_bytes,
+            frame_data,
+        } => {
+            if let Some(mode) = tx_error_mode {
+                // Arm the Fatal error for the next tx_poll.
+                mode.store(2, Ordering::Relaxed);
+                // Send a packet to trigger tx_avail → tx_poll.
+                let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+                let _ = send_rndis_via_direct_path(
+                    queue,
+                    mem,
+                    &rndis_buf,
+                    protocol::DATA_CHANNEL_TYPE,
+                    &LAYOUT,
+                    tid,
+                )
+                .await;
+                // Yield so the worker can process the fatal error.
+                fuzz_helpers::yield_to_executor(10).await;
+            }
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|input: &[u8]| {
+    // Create a FuzzEndpoint with TX error injection enabled.
+    let (endpoint, handles) = fuzz_helpers::endpoint::FuzzEndpoint::new(FuzzEndpointConfig {
+        enable_tx_error_injection: true,
+        enable_async_tx: true,
+        ..FuzzEndpointConfig::default()
+    });
+    let tx_error_mode = handles.tx_error_mode;
+
+    run_fuzz_loop_with_config(
+        input,
+        &LAYOUT,
+        FuzzNicConfig {
+            endpoint: Box::new(endpoint),
+            ..FuzzNicConfig::default()
+        },
+        |fuzzer_input, setup| {
+            Box::pin(async move {
+                let mut queue = setup.queue;
+                let mem = setup.mem;
+                let mut next_transaction_id = 1u64;
+
+                // Always negotiate to the ready state first — data path messages are
+                // only processed once the NIC is fully initialized.
+                negotiate_to_ready(
+                    &mut queue,
+                    &mut next_transaction_id,
+                    setup.recv_buf_gpadl_id,
+                    setup.send_buf_gpadl_id,
+                )
+                .await?;
+
+                // 90% of the time, initialize RNDIS to reach Operational state.
+                // The remaining 10% tests behavior when RNDIS packets arrive
+                // before the initialize handshake.
+                if fuzzer_input.ratio(9, 10)? {
+                    rndis_initialize(
+                        &mut queue,
+                        &mem,
+                        LAYOUT.data_page_start(),
+                        LAYOUT.data_pages,
+                        &mut next_transaction_id,
+                    )
+                    .await?;
+                }
+
+                // Run data path actions until input is exhausted.
+                while !fuzzer_input.is_empty() {
+                    execute_next_action(
+                        fuzzer_input,
+                        &mut queue,
+                        &mem,
+                        &mut next_transaction_id,
+                        &tx_error_mode,
+                    )
+                    .await?;
+                    drain_queue_async(&mut queue).await;
+                }
+                Ok(())
+            })
+        },
+    );
+});

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_tx_path.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_tx_path.rs
@@ -405,7 +405,7 @@ async fn execute_next_action(
     Ok(())
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     // Create a FuzzEndpoint with TX error injection enabled.
     let (endpoint, handles) = fuzz_helpers::endpoint::FuzzEndpoint::new(FuzzEndpointConfig {
         enable_tx_error_injection: true,
@@ -467,4 +467,6 @@ fuzz_target!(|input: &[u8]| {
             })
         },
     );
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_vf_state.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_vf_state.rs
@@ -1,0 +1,334 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Fuzzer for the NetVSP Virtual Function (VF / SR-IOV) state machine.
+//!
+//! This fuzzer exercises the VF state machine by using a
+//! [`FuzzVirtualFunction`] that provides fuzzer-controlled VF ID values and
+//! state change signals.
+//!
+//! The VF state machine has 12+ states with complex transitions, and this
+//! fuzzer aims to exercise all reachable state transitions including error
+//! paths and unexpected message orderings.
+//!
+//! ## NVSP protocol messages tested
+//!
+//! - `MESSAGE4_TYPE_SEND_VF_ASSOCIATION` — VF association completion (guest-to-host
+//!   acknowledgement with transaction ID `0x8000000000000000`)
+//! - `MESSAGE4_TYPE_SWITCH_DATA_PATH` — data path switch request
+//!   (synthetic to VF) and completion (guest-to-host acknowledgement with
+//!   transaction ID `0x8000000000000001`)
+//! - Arbitrary raw NVSP message types and payloads
+//!
+//! Indirectly exercised (host-to-guest, triggered by VF state changes):
+//! - `MESSAGE4_TYPE_SEND_VF_ASSOCIATION` — host notifying guest of VF
+//!   availability
+//! - `MESSAGE4_TYPE_SWITCH_DATA_PATH` — host requesting data path switch
+//!
+//! ## RNDIS protocol messages tested
+//!
+//! - `MESSAGE_TYPE_PACKET_MSG` — structured RNDIS data packets via GpaDirect
+//!   during VF state transitions
+//!
+//! ## VF state machine transitions exercised
+//!
+//! - VF ID changes (available-to-unavailable and vice versa)
+//! - `VirtualFunction::wait_for_state_change()` notifications
+
+#![cfg_attr(all(target_os = "linux", target_env = "gnu"), no_main)]
+
+mod fuzz_helpers;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use fuzz_helpers::DATA_PAGES;
+use fuzz_helpers::PageLayout;
+use fuzz_helpers::SWITCH_DATA_PATH_TRANSACTION_ID;
+use fuzz_helpers::VF_ASSOCIATION_TRANSACTION_ID;
+use fuzz_helpers::build_structured_rndis_packet;
+use fuzz_helpers::drain_queue;
+use fuzz_helpers::drain_queue_async;
+use fuzz_helpers::endpoint::FuzzEndpoint;
+use fuzz_helpers::endpoint::FuzzEndpointConfig;
+use fuzz_helpers::negotiate_to_ready_with_capabilities;
+use fuzz_helpers::nic_setup::FuzzNicConfig;
+use fuzz_helpers::nvsp_payload;
+use fuzz_helpers::rndis_initialize;
+use fuzz_helpers::run_fuzz_loop_with_config;
+use fuzz_helpers::send_completion_packet;
+use fuzz_helpers::send_inband_nvsp;
+use fuzz_helpers::send_rndis_via_direct_path;
+use fuzz_helpers::try_read_one_completion;
+use fuzz_helpers::vf::FuzzVirtualFunction;
+use guestmem::GuestMemory;
+use mesh::rpc::RpcSend;
+use netvsp::protocol;
+use vmbus_async::queue::Queue;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use xtask_fuzz::fuzz_eprintln;
+use xtask_fuzz::fuzz_target;
+use zerocopy::IntoBytes;
+
+const LAYOUT: PageLayout = PageLayout {
+    send_buf_pages: 1,
+    data_pages: DATA_PAGES,
+};
+
+/// Actions the fuzzer can take to exercise VF state transitions.
+#[derive(Arbitrary, Debug)]
+enum VfAction {
+    /// Update the VF ID (simulates VF becoming available or unavailable).
+    ChangeVfId {
+        /// New VF ID, or None to indicate VF is unavailable.
+        id: Option<u32>,
+    },
+    /// Trigger a VF state change notification.
+    TriggerStateChange,
+    /// Send a VF association completion from the guest side.
+    /// This acknowledges the host's `SEND_VF_ASSOCIATION` message.
+    SendVfAssociationCompletion,
+    /// Send a switch data path request from the guest (synthetic -to- VF or
+    /// VF -to- synthetic).
+    SendSwitchDataPath {
+        /// Whether to switch to the VF data path (true) or synthetic (false).
+        use_vf: bool,
+    },
+    /// Send a switch data path completion from the guest side.
+    /// This acknowledges the host's `SWITCH_DATA_PATH` message.
+    SendSwitchDataPathCompletion,
+    /// Send a raw NVSP control message to interleave with VF operations.
+    SendControlMessage {
+        message_type: u32,
+        payload: Vec<u8>,
+        with_completion: bool,
+    },
+    /// Send an RNDIS data packet to interleave TX with VF state changes.
+    SendRndisPacket {
+        ppi_bytes: Vec<u8>,
+        frame_data: Vec<u8>,
+    },
+    /// Read one completion/notification from the host.
+    ReadCompletion,
+    /// Drain all pending packets from the queue.
+    DrainQueue,
+    /// Schedule a VF ID change, then immediately trigger a state change. This
+    /// tests the combined path where the coordinator processes a new VF ID and
+    /// a state change notification in quick succession.
+    ChangeIdAndTriggerStateChange { id: Option<u32> },
+    /// Full VF lifecycle sequence: set ID → trigger state change → send VF
+    /// association completion → switch data path → switch data path completion.
+    /// Tests the complete VF bring-up flow in a single action.
+    FullVfBringUp { vf_id: u32, use_vf: bool },
+    /// Send a VF association completion with a raw/adversarial payload.
+    SendRawVfAssociationCompletion { payload: Vec<u8> },
+}
+
+/// Execute one VF fuzz action.
+async fn execute_next_action(
+    input: &mut Unstructured<'_>,
+    queue: &mut Queue<GpadlRingMem>,
+    mem: &GuestMemory,
+    next_transaction_id: &mut u64,
+    vf_handles: &fuzz_helpers::vf::FuzzVfHandles,
+) -> Result<(), anyhow::Error> {
+    let action = input.arbitrary::<VfAction>()?;
+    fuzz_eprintln!("action: {action:?}");
+    match action {
+        VfAction::ChangeVfId { id } => {
+            vf_handles.id_send.send(id);
+        }
+        VfAction::TriggerStateChange => {
+            let pending = vf_handles.state_change_send.call(|rpc| rpc, ());
+            // Usually wait for completion so the coordinator's RPC handling is
+            // exercised; occasionally skip waiting to preserve event pressure.
+            if input.ratio(4, 5)? {
+                let _ = pending.await;
+            }
+        }
+        VfAction::SendVfAssociationCompletion => {
+            let payload = nvsp_payload(protocol::MESSAGE4_TYPE_SEND_VF_ASSOCIATION, &[]);
+            send_completion_packet(queue, VF_ASSOCIATION_TRANSACTION_ID, &[&payload]).await?;
+        }
+        VfAction::SendSwitchDataPath { use_vf } => {
+            let msg = protocol::Message4SwitchDataPath {
+                active_data_path: if use_vf {
+                    protocol::DataPath::VF.0
+                } else {
+                    protocol::DataPath::SYNTHETIC.0
+                },
+            };
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE4_TYPE_SWITCH_DATA_PATH,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+        }
+        VfAction::SendSwitchDataPathCompletion => {
+            let payload = nvsp_payload(protocol::MESSAGE4_TYPE_SWITCH_DATA_PATH, &[]);
+            send_completion_packet(queue, SWITCH_DATA_PATH_TRANSACTION_ID, &[&payload]).await?;
+        }
+        VfAction::SendControlMessage {
+            message_type,
+            payload,
+            with_completion,
+        } => {
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                message_type,
+                &payload,
+                with_completion,
+            )
+            .await?;
+        }
+        VfAction::SendRndisPacket {
+            ppi_bytes,
+            frame_data,
+        } => {
+            let rndis_buf = build_structured_rndis_packet(&ppi_bytes, &frame_data);
+            send_rndis_via_direct_path(
+                queue,
+                mem,
+                &rndis_buf,
+                protocol::DATA_CHANNEL_TYPE,
+                &LAYOUT,
+                next_transaction_id,
+            )
+            .await?;
+        }
+        VfAction::ReadCompletion => {
+            let _ = try_read_one_completion(queue);
+        }
+        VfAction::DrainQueue => {
+            drain_queue(queue);
+        }
+        VfAction::ChangeIdAndTriggerStateChange { id } => {
+            // Set ID first, then trigger state change — exercises the path
+            // where wait_for_state_change drains pending ID updates.
+            vf_handles.id_send.send(id);
+            let pending = vf_handles.state_change_send.call(|rpc| rpc, ());
+            let _ = pending.await;
+        }
+        VfAction::FullVfBringUp { vf_id, use_vf } => {
+            // 1. Make VF available.
+            vf_handles.id_send.send(Some(vf_id));
+            let pending = vf_handles.state_change_send.call(|rpc| rpc, ());
+            let _ = pending.await;
+            drain_queue(queue);
+
+            // 2. Send VF association completion.
+            let payload = nvsp_payload(protocol::MESSAGE4_TYPE_SEND_VF_ASSOCIATION, &[]);
+            send_completion_packet(queue, VF_ASSOCIATION_TRANSACTION_ID, &[&payload]).await?;
+            drain_queue(queue);
+
+            // 3. Switch data path.
+            let msg = protocol::Message4SwitchDataPath {
+                active_data_path: if use_vf {
+                    protocol::DataPath::VF.0
+                } else {
+                    protocol::DataPath::SYNTHETIC.0
+                },
+            };
+            send_inband_nvsp(
+                queue,
+                next_transaction_id,
+                protocol::MESSAGE4_TYPE_SWITCH_DATA_PATH,
+                msg.as_bytes(),
+                true,
+            )
+            .await?;
+            drain_queue(queue);
+
+            // 4. Send switch data path completion.
+            let payload = nvsp_payload(protocol::MESSAGE4_TYPE_SWITCH_DATA_PATH, &[]);
+            send_completion_packet(queue, SWITCH_DATA_PATH_TRANSACTION_ID, &[&payload]).await?;
+            drain_queue(queue);
+        }
+        VfAction::SendRawVfAssociationCompletion { payload } => {
+            send_completion_packet(queue, VF_ASSOCIATION_TRANSACTION_ID, &[&payload]).await?;
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|input: &[u8]| {
+    // Create a FuzzVirtualFunction with no initial VF ID — VF presence is
+    // signaled later via ChangeVfId actions, after protocol negotiation.
+    // Starting with None avoids the NIC trying to send VF_ASSOCIATION
+    // during startup before the guest has negotiated.
+    let (vf, vf_handles) = FuzzVirtualFunction::new(None);
+
+    // Fuzz-select whether VF switch should fail, exercising both
+    // DataPathSynthetic (failure) and DataPathSwitched (success) states.
+    // Use the last byte of input to avoid consuming bytes from the main
+    // Unstructured stream.
+    let fail_vf = input.last().is_some_and(|b| b % 4 == 0);
+
+    let (endpoint, _handles) = FuzzEndpoint::new(FuzzEndpointConfig {
+        enable_rx_injection: false,
+        enable_action_injection: false,
+        fail_vf_switch: fail_vf,
+        ..FuzzEndpointConfig::default()
+    });
+
+    let config = FuzzNicConfig {
+        endpoint: Box::new(endpoint),
+        virtual_function: Some(Box::new(vf)),
+        ..FuzzNicConfig::default()
+    };
+
+    run_fuzz_loop_with_config(input, &LAYOUT, config, |fuzzer_input, setup| {
+        Box::pin(async move {
+            let mut queue = setup.queue;
+            let mem = setup.mem;
+            let mut next_transaction_id = 1u64;
+
+            // Always negotiate to the ready state with SR-IOV enabled — VF
+            // messages are only sent when the guest advertises sriov support.
+            negotiate_to_ready_with_capabilities(
+                &mut queue,
+                &mut next_transaction_id,
+                setup.recv_buf_gpadl_id,
+                setup.send_buf_gpadl_id,
+                protocol::NdisConfigCapabilities::new().with_sriov(true),
+            )
+            .await?;
+
+            // 90% of the time, also initialize RNDIS.
+            if fuzzer_input.ratio(9, 10)? {
+                rndis_initialize(
+                    &mut queue,
+                    &mem,
+                    LAYOUT.data_page_start(),
+                    LAYOUT.data_pages,
+                    &mut next_transaction_id,
+                )
+                .await?;
+            }
+
+            // Run VF-focused fuzz actions until input is exhausted.
+            while !fuzzer_input.is_empty() {
+                execute_next_action(
+                    fuzzer_input,
+                    &mut queue,
+                    &mem,
+                    &mut next_transaction_id,
+                    &vf_handles,
+                )
+                .await?;
+                drain_queue_async(&mut queue).await;
+            }
+
+            // Explicitly drop the VF handles so their sender channels close.
+            // This allows FuzzVirtualFunction::wait_for_state_change() to
+            // pend forever, which lets the NIC's coordinator observe the
+            // stop signal from channel revoke instead of busy-looping.
+            drop(vf_handles);
+
+            Ok(())
+        })
+    });
+});

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_vf_state.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_vf_state.rs
@@ -254,7 +254,7 @@ async fn execute_next_action(
     Ok(())
 }
 
-fuzz_target!(|input: &[u8]| {
+fn do_fuzz(input: &[u8]) {
     // Create a FuzzVirtualFunction with no initial VF ID — VF presence is
     // signaled later via ChangeVfId actions, after protocol negotiation.
     // Starting with None avoids the NIC trying to send VF_ASSOCIATION
@@ -331,4 +331,6 @@ fuzz_target!(|input: &[u8]| {
             Ok(())
         })
     });
-});
+}
+
+fuzz_target!(|input: &[u8]| do_fuzz(input));

--- a/vm/devices/net/netvsp/fuzz/fuzz_netvsp_vf_state.rs
+++ b/vm/devices/net/netvsp/fuzz/fuzz_netvsp_vf_state.rs
@@ -263,9 +263,10 @@ fn do_fuzz(input: &[u8]) {
 
     // Fuzz-select whether VF switch should fail, exercising both
     // DataPathSynthetic (failure) and DataPathSwitched (success) states.
-    // Use the last byte of input to avoid consuming bytes from the main
-    // Unstructured stream.
-    let fail_vf = input.last().is_some_and(|b| b % 4 == 0);
+    let mut pre = Unstructured::new(input);
+    let fail_vf = pre.arbitrary::<bool>().unwrap_or(false);
+    let remaining_start = input.len() - pre.len();
+    let fuzz_input = &input[remaining_start..];
 
     let (endpoint, _handles) = FuzzEndpoint::new(FuzzEndpointConfig {
         enable_rx_injection: false,
@@ -280,7 +281,7 @@ fn do_fuzz(input: &[u8]) {
         ..FuzzNicConfig::default()
     };
 
-    run_fuzz_loop_with_config(input, &LAYOUT, config, |fuzzer_input, setup| {
+    run_fuzz_loop_with_config(fuzz_input, &LAYOUT, config, |fuzzer_input, setup| {
         Box::pin(async move {
             let mut queue = setup.queue;
             let mem = setup.mem;

--- a/vm/devices/net/netvsp/fuzz/netvsp_rndis.dict
+++ b/vm/devices/net/netvsp/fuzz/netvsp_rndis.dict
@@ -1,0 +1,401 @@
+# Shared dictionary for NetVSP/NVSP/RNDIS fuzz targets.
+#
+# Usage example:
+#   cargo xtask fuzz run fuzz_netvsp_interop -- -- -dict=vm/devices/net/netvsp/fuzz/netvsp_rndis.dict
+
+# =============================================================================
+# NVSP PROTOCOL VERSION NUMBERS (little-endian u32)
+# =============================================================================
+"nvsp_version_v1"="\x00\x00\x02\x00"
+"nvsp_version_v2"="\x02\x00\x03\x00"
+"nvsp_version_v4"="\x00\x00\x04\x00"
+"nvsp_version_v5"="\x00\x00\x05\x00"
+"nvsp_version_v6"="\x00\x00\x06\x00"
+"nvsp_version_v61"="\x01\x00\x06\x00"
+"nvsp_version_invalid"="\xFF\xFF\xFF\xFF"
+
+# =============================================================================
+# NVSP MESSAGE TYPE dwords (little-endian u32)
+# =============================================================================
+# V0 / core messages
+"nvsp_msg_none"="\x00\x00\x00\x00"
+"nvsp_msg_init"="\x01\x00\x00\x00"
+"nvsp_msg_init_complete"="\x02\x00\x00\x00"
+
+# V1 messages (100..108)
+"nvsp_msg_send_ndis_version"="\x64\x00\x00\x00"
+"nvsp_msg_send_receive_buffer"="\x65\x00\x00\x00"
+"nvsp_msg_send_receive_buffer_complete"="\x66\x00\x00\x00"
+"nvsp_msg_revoke_receive_buffer"="\x67\x00\x00\x00"
+"nvsp_msg_send_send_buffer"="\x68\x00\x00\x00"
+"nvsp_msg_send_send_buffer_complete"="\x69\x00\x00\x00"
+"nvsp_msg_revoke_send_buffer"="\x6A\x00\x00\x00"
+"nvsp_msg_send_rndis_packet"="\x6B\x00\x00\x00"
+"nvsp_msg_send_rndis_packet_complete"="\x6C\x00\x00\x00"
+
+# V2 messages (109..127) — only send_ndis_config (125) is implemented
+"nvsp_msg_send_chimney_delegated_buffer"="\x6D\x00\x00\x00"
+"nvsp_msg_send_ndis_config"="\x7D\x00\x00\x00"
+
+# V4 messages
+"nvsp_msg_send_vf_association"="\x80\x00\x00\x00"
+"nvsp_msg_switch_data_path"="\x81\x00\x00\x00"
+
+# V5 messages (131..134)
+"nvsp_msg_oid_query_ex"="\x83\x00\x00\x00"
+"nvsp_msg_oid_query_ex_complete"="\x84\x00\x00\x00"
+"nvsp_msg_sub_channel"="\x85\x00\x00\x00"
+"nvsp_msg_send_indirection_table"="\x86\x00\x00\x00"
+
+# V6 messages (135..136)
+"nvsp_msg_pd_api"="\x87\x00\x00\x00"
+"nvsp_msg_pd_post_batch"="\x88\x00\x00\x00"
+
+# =============================================================================
+# NVSP STATUS VALUES (little-endian u32)
+# =============================================================================
+"nvsp_status_none"="\x00\x00\x00\x00"
+"nvsp_status_success"="\x01\x00\x00\x00"
+"nvsp_status_failure"="\x02\x00\x00\x00"
+"nvsp_status_invalid_rndis_packet"="\x05\x00\x00\x00"
+"nvsp_status_busy"="\x06\x00\x00\x00"
+"nvsp_status_protocol_version_unsupported"="\x07\x00\x00\x00"
+
+# =============================================================================
+# NVSP FIELD VALUES
+# =============================================================================
+"nvsp_channel_data"="\x00\x00\x00\x00"
+"nvsp_channel_control"="\x01\x00\x00\x00"
+"nvsp_data_path_synthetic"="\x00\x00\x00\x00"
+"nvsp_data_path_vf"="\x01\x00\x00\x00"
+"nvsp_subchannel_op_none"="\x00\x00\x00\x00"
+"nvsp_subchannel_op_allocate"="\x01\x00\x00\x00"
+"nvsp_section_index_direct"="\xFF\xFF\xFF\xFF"
+
+# NVSP packet sizes
+"nvsp_packet_size_v1"="\x1C\x00\x00\x00"
+"nvsp_packet_size_v61"="\x28\x00\x00\x00"
+
+# Operational status
+"nvsp_op_status_ok"="\x00\x00\x00\x00"
+"nvsp_op_status_degraded"="\x01\x00\x00\x00"
+"nvsp_op_status_nonrecoverable"="\x02\x00\x00\x00"
+"nvsp_op_status_no_contact"="\x03\x00\x00\x00"
+"nvsp_op_status_lost_comm"="\x04\x00\x00\x00"
+
+# =============================================================================
+# Canonical NVSP handshake payloads (header + body, 8-byte aligned)
+# =============================================================================
+"nvsp_pkt_init_v5_v6"="\x01\x00\x00\x00\x00\x00\x05\x00\x00\x00\x06\x00\x00\x00\x00\x00"
+"nvsp_pkt_init_v61"="\x01\x00\x00\x00\x01\x00\x06\x00\x00\x00\x06\x00\x00\x00\x00\x00"
+"nvsp_pkt_init_v1"="\x01\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x00\x00"
+"nvsp_pkt_ndis_config_mtu1500"="\x7D\x00\x00\x00\xDC\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+"nvsp_pkt_ndis_config_sriov"="\x7D\x00\x00\x00\xDC\x05\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+"nvsp_pkt_ndis_version_6_30"="\x64\x00\x00\x00\x06\x00\x00\x00\x1E\x00\x00\x00\x00\x00\x00\x00"
+"nvsp_pkt_send_receive_buffer_gpadl1"="\x65\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+"nvsp_pkt_send_send_buffer_gpadl2"="\x68\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+"nvsp_pkt_revoke_receive_buffer_id0"="\x67\x00\x00\x00\x00\x00\x00\x00"
+"nvsp_pkt_revoke_send_buffer_id0"="\x6A\x00\x00\x00\x00\x00\x00\x00"
+"nvsp_pkt_switch_to_synthetic"="\x81\x00\x00\x00\x00\x00\x00\x00"
+"nvsp_pkt_switch_to_vf"="\x81\x00\x00\x00\x01\x00\x00\x00"
+"nvsp_pkt_subchannel_alloc_1"="\x85\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00"
+
+# VF completion transaction IDs used by product code
+"nvsp_tid_vf_association"="\x00\x00\x00\x00\x00\x00\x00\x80"
+"nvsp_tid_switch_data_path"="\x01\x00\x00\x00\x00\x00\x00\x80"
+
+# Send buffer section size (6144 = 0x1800)
+"send_buffer_section_size"="\x00\x18\x00\x00"
+
+# =============================================================================
+# RNDIS MESSAGE TYPE dwords (little-endian u32)
+# =============================================================================
+"rndis_msg_packet"="\x01\x00\x00\x00"
+"rndis_msg_initialize"="\x02\x00\x00\x00"
+"rndis_msg_halt"="\x03\x00\x00\x00"
+"rndis_msg_query"="\x04\x00\x00\x00"
+"rndis_msg_set"="\x05\x00\x00\x00"
+"rndis_msg_reset"="\x06\x00\x00\x00"
+"rndis_msg_indicate_status"="\x07\x00\x00\x00"
+"rndis_msg_keepalive"="\x08\x00\x00\x00"
+"rndis_msg_set_ex"="\x09\x00\x00\x00"
+"rndis_msg_initialize_cmplt"="\x02\x00\x00\x80"
+"rndis_msg_query_cmplt"="\x04\x00\x00\x80"
+"rndis_msg_set_cmplt"="\x05\x00\x00\x80"
+"rndis_msg_reset_cmplt"="\x06\x00\x00\x80"
+"rndis_msg_keepalive_cmplt"="\x08\x00\x00\x80"
+"rndis_msg_set_ex_cmplt"="\x09\x00\x00\x80"
+"rndis_msg_bus"="\x01\x00\x00\xFF"
+
+# RNDIS version/medium/device flags
+"rndis_major_version"="\x01\x00\x00\x00"
+"rndis_minor_version"="\x00\x00\x00\x00"
+"rndis_medium_802_3"="\x00\x00\x00\x00"
+"rndis_medium_802_5"="\x01\x00\x00\x00"
+"rndis_medium_fddi"="\x02\x00\x00\x00"
+"rndis_medium_wan"="\x03\x00\x00\x00"
+"rndis_medium_local_talk"="\x04\x00\x00\x00"
+"rndis_medium_arcnet_raw"="\x06\x00\x00\x00"
+"rndis_medium_arcnet878_2"="\x07\x00\x00\x00"
+"rndis_medium_atm"="\x08\x00\x00\x00"
+"rndis_medium_wireless_wan"="\x09\x00\x00\x00"
+"rndis_medium_irda"="\x0A\x00\x00\x00"
+"rndis_medium_co_wan"="\x0B\x00\x00\x00"
+"rndis_medium_max"="\x0D\x00\x00\x00"
+"rndis_df_connectionless"="\x01\x00\x00\x00"
+"rndis_df_connection_oriented"="\x02\x00\x00\x00"
+"rndis_df_raw_data"="\x04\x00\x00\x00"
+"rndis_media_state_connected"="\x00\x00\x00\x00"
+"rndis_media_state_disconnected"="\x01\x00\x00\x00"
+
+# =============================================================================
+# RNDIS / NDIS STATUS CODES (little-endian u32)
+# =============================================================================
+"ndis_status_success"="\x00\x00\x00\x00"
+"ndis_status_pending"="\x03\x01\x00\x00"
+"ndis_status_not_recognized"="\x01\x00\x01\x00"
+"ndis_status_not_copied"="\x02\x00\x01\x00"
+"ndis_status_not_accepted"="\x03\x00\x01\x00"
+"ndis_status_call_active"="\x07\x00\x01\x00"
+"ndis_status_online"="\x03\x00\x01\x40"
+"ndis_status_reset_start"="\x04\x00\x01\x40"
+"ndis_status_reset_end"="\x05\x00\x01\x40"
+"ndis_status_media_connect"="\x0B\x00\x01\x40"
+"ndis_status_media_disconnect"="\x0C\x00\x01\x40"
+"ndis_status_link_speed_change"="\x13\x00\x01\x40"
+"ndis_status_task_offload_current_config"="\x06\x00\x02\x40"
+"ndis_status_buffer_overflow"="\x05\x00\x00\x80"
+"ndis_status_failure"="\x01\x00\x00\xC0"
+"ndis_status_resources"="\x9A\x00\x00\xC0"
+"ndis_status_not_supported"="\xBB\x00\x00\xC0"
+"ndis_status_closing"="\x02\x00\x01\xC0"
+"ndis_status_bad_version"="\x04\x00\x01\xC0"
+"ndis_status_request_aborted"="\x0C\x00\x01\xC0"
+"ndis_status_reset_in_progress"="\x0D\x00\x01\xC0"
+"ndis_status_invalid_packet"="\x0F\x00\x01\xC0"
+"ndis_status_invalid_length"="\x14\x00\x01\xC0"
+"ndis_status_invalid_data"="\x15\x00\x01\xC0"
+"ndis_status_buffer_too_short"="\x16\x00\x01\xC0"
+"ndis_status_invalid_oid"="\x17\x00\x01\xC0"
+
+# =============================================================================
+# OIDs – General (little-endian u32)
+# =============================================================================
+"oid_gen_supported_list"="\x01\x01\x01\x00"
+"oid_gen_hardware_status"="\x02\x01\x01\x00"
+"oid_gen_media_supported"="\x03\x01\x01\x00"
+"oid_gen_media_in_use"="\x04\x01\x01\x00"
+"oid_gen_maximum_lookahead"="\x05\x01\x01\x00"
+"oid_gen_maximum_frame_size"="\x06\x01\x01\x00"
+"oid_gen_link_speed"="\x07\x01\x01\x00"
+"oid_gen_transmit_buffer_space"="\x08\x01\x01\x00"
+"oid_gen_receive_buffer_space"="\x09\x01\x01\x00"
+"oid_gen_transmit_block_size"="\x0A\x01\x01\x00"
+"oid_gen_receive_block_size"="\x0B\x01\x01\x00"
+"oid_gen_vendor_id"="\x0C\x01\x01\x00"
+"oid_gen_vendor_description"="\x0D\x01\x01\x00"
+"oid_gen_current_packet_filter"="\x0E\x01\x01\x00"
+"oid_gen_current_lookahead"="\x0F\x01\x01\x00"
+"oid_gen_driver_version"="\x10\x01\x01\x00"
+"oid_gen_maximum_total_size"="\x11\x01\x01\x00"
+"oid_gen_protocol_options"="\x12\x01\x01\x00"
+"oid_gen_mac_options"="\x13\x01\x01\x00"
+"oid_gen_media_connect_status"="\x14\x01\x01\x00"
+"oid_gen_maximum_send_packets"="\x15\x01\x01\x00"
+"oid_gen_vendor_driver_version"="\x16\x01\x01\x00"
+"oid_gen_network_layer_addresses"="\x18\x01\x01\x00"
+"oid_gen_transport_header_offset"="\x19\x01\x01\x00"
+
+# OIDs – General v2 (RSS, config, etc.)
+"oid_gen_receive_scale_capabilities"="\x03\x02\x01\x00"
+"oid_gen_receive_scale_parameters"="\x04\x02\x01\x00"
+"oid_gen_max_link_speed"="\x06\x02\x01\x00"
+"oid_gen_link_state"="\x07\x02\x01\x00"
+"oid_gen_link_parameters"="\x08\x02\x01\x00"
+"oid_gen_rndis_config_parameter"="\x1B\x02\x01\x00"
+"oid_gen_friendly_name"="\x16\x02\x02\x00"
+"oid_gen_bytes_rcv"="\x19\x02\x02\x00"
+"oid_gen_bytes_xmit"="\x1A\x02\x02\x00"
+
+# OIDs – 802.3
+"oid_802_3_permanent_address"="\x01\x01\x01\x01"
+"oid_802_3_current_address"="\x02\x01\x01\x01"
+"oid_802_3_multicast_list"="\x03\x01\x01\x01"
+"oid_802_3_maximum_list_size"="\x04\x01\x01\x01"
+"oid_802_3_rcv_error_alignment"="\x01\x01\x02\x01"
+"oid_802_3_xmit_one_collision"="\x02\x01\x02\x01"
+"oid_802_3_xmit_more_collisions"="\x03\x01\x02\x01"
+
+# OIDs – Offload
+"oid_offload_encapsulation"="\x0A\x01\x01\x01"
+"oid_tcp_offload_current_config"="\x0B\x02\x01\xFC"
+"oid_tcp_offload_parameters"="\x0C\x02\x01\xFC"
+"oid_tcp_offload_hardware_capabilities"="\x0D\x02\x01\xFC"
+
+# =============================================================================
+# PACKET FILTER VALUES (little-endian u32)
+# =============================================================================
+"packet_filter_none"="\x00\x00\x00\x00"
+"packet_filter_directed"="\x01\x00\x00\x00"
+"packet_filter_multicast"="\x02\x00\x00\x00"
+"packet_filter_all_multicast"="\x04\x00\x00\x00"
+"packet_filter_broadcast"="\x08\x00\x00\x00"
+"packet_filter_nproto"="\x0D\x00\x00\x00"
+
+# =============================================================================
+# RSS / HASH CONSTANTS (little-endian u32)
+# =============================================================================
+"ndis_hash_function_toeplitz"="\x01\x00\x00\x00"
+"ndis_hash_ipv4"="\x00\x01\x00\x00"
+"ndis_hash_tcp_ipv4"="\x00\x02\x00\x00"
+"ndis_hash_ipv6"="\x00\x04\x00\x00"
+"ndis_hash_ipv6_ex"="\x00\x08\x00\x00"
+"ndis_hash_tcp_ipv6"="\x00\x10\x00\x00"
+"ndis_hash_tcp_ipv6_ex"="\x00\x20\x00\x00"
+"ndis_hash_udp_ipv4"="\x00\x40\x00\x00"
+"ndis_hash_udp_ipv6"="\x00\x80\x00\x00"
+"ndis_hash_udp_ipv6_ex"="\x00\x00\x01\x00"
+
+# RSS parameter flags (u16)
+"ndis_rss_flag_base_cpu_unchanged"="\x01\x00"
+"ndis_rss_flag_hash_info_unchanged"="\x02\x00"
+"ndis_rss_flag_itable_unchanged"="\x04\x00"
+"ndis_rss_flag_hash_key_unchanged"="\x08\x00"
+"ndis_rss_flag_disable_rss"="\x10\x00"
+"ndis_rss_flag_default_processor_unchanged"="\x20\x00"
+
+# RSS size constants
+"ndis_rss_indirection_table_size"="\x80\x00\x00\x00"
+"ndis_rss_hash_secret_key_size"="\x28\x00\x00\x00"
+"nvsp_max_indirection_table_entries"="\x80\x00\x00\x00"
+"nvsp_max_send_indirection_table_entries"="\x10\x00\x00\x00"
+
+# =============================================================================
+# NDIS OBJECT HEADERS (Type bytes + struct sizes as u16 LE)
+# =============================================================================
+"ndis_obj_type_default"="\x80"
+"ndis_obj_type_rss_capabilities"="\x88"
+"ndis_obj_type_rss_parameters"="\x89"
+"ndis_obj_type_oid_request"="\x96"
+"ndis_obj_type_offload"="\xA7"
+"ndis_obj_type_offload_encapsulation"="\xA8"
+
+# Struct sizes (little-endian u16, for NdisObjectHeader.size field)
+"ndis_sizeof_rss_caps_rev2"="\x12\x00"
+"ndis_sizeof_rss_params_rev1"="\x1C\x00"
+"ndis_sizeof_rss_params_rev2"="\x28\x00"
+"ndis_sizeof_rss_params_rev3"="\x2C\x00"
+"ndis_sizeof_offload_rev1"="\x70\x00"
+"ndis_sizeof_offload_rev3"="\x9C\x00"
+"ndis_sizeof_offload_encap_rev1"="\x1C\x00"
+"ndis_sizeof_offload_params_rev1"="\x14\x00"
+
+# Revision numbers (u8)
+"ndis_revision_1"="\x01"
+"ndis_revision_2"="\x02"
+"ndis_revision_3"="\x03"
+
+# =============================================================================
+# OFFLOAD CONSTANTS
+# =============================================================================
+"ndis_encapsulation_ieee_802_3"="\x02\x00\x00\x00"
+"ndis_offload_not_supported"="\x00\x00\x00\x00"
+"ndis_offload_supported"="\x01\x00\x00\x00"
+"ndis_offload_set_on"="\x01\x00\x00\x00"
+"ndis_offload_set_off"="\x02\x00\x00\x00"
+"lso_min_segment_count"="\x02\x00\x00\x00"
+"lso_max_offload_size"="\x3C\xF5\x00\x00"
+
+# Offload parameter checksum enum (u8)
+"offload_checksum_no_change"="\x00"
+"offload_checksum_tx_rx_disabled"="\x01"
+"offload_checksum_tx_enabled_rx_disabled"="\x02"
+"offload_checksum_rx_enabled_tx_disabled"="\x03"
+"offload_checksum_tx_rx_enabled"="\x04"
+
+# Offload parameter simple enum (u8)
+"offload_simple_no_change"="\x00"
+"offload_simple_disabled"="\x01"
+"offload_simple_enabled"="\x02"
+
+# NDIS config parameter types
+"ndis_param_type_integer"="\x00\x00\x00\x00"
+"ndis_param_type_hex_integer"="\x01\x00\x00\x00"
+"ndis_param_type_string"="\x02\x00\x00\x00"
+"ndis_param_type_multi_string"="\x03\x00\x00\x00"
+"ndis_param_type_binary"="\x04\x00\x00\x00"
+
+# NDIS config parameter names (UTF-16LE) for oid_set_rndis_config_parameter()
+# These exact strings are matched in handle_oid_set to configure offloads.
+"utf16_rndis_config_ipchecksumoffloadipv4"="\x2A\x00\x49\x00\x50\x00\x43\x00\x68\x00\x65\x00\x63\x00\x6B\x00\x73\x00\x75\x00\x6D\x00\x4F\x00\x66\x00\x66\x00\x6C\x00\x6F\x00\x61\x00\x64\x00\x49\x00\x50\x00\x76\x00\x34\x00"
+"utf16_rndis_config_lsov2ipv4"="\x2A\x00\x4C\x00\x73\x00\x6F\x00\x56\x00\x32\x00\x49\x00\x50\x00\x76\x00\x34\x00"
+"utf16_rndis_config_lsov2ipv6"="\x2A\x00\x4C\x00\x73\x00\x6F\x00\x56\x00\x32\x00\x49\x00\x50\x00\x76\x00\x36\x00"
+"utf16_rndis_config_tcpchecksumoffloadipv4"="\x2A\x00\x54\x00\x43\x00\x50\x00\x43\x00\x68\x00\x65\x00\x63\x00\x6B\x00\x73\x00\x75\x00\x6D\x00\x4F\x00\x66\x00\x66\x00\x6C\x00\x6F\x00\x61\x00\x64\x00\x49\x00\x50\x00\x76\x00\x34\x00"
+"utf16_rndis_config_tcpchecksumoffloadipv6"="\x2A\x00\x54\x00\x43\x00\x50\x00\x43\x00\x68\x00\x65\x00\x63\x00\x6B\x00\x73\x00\x75\x00\x6D\x00\x4F\x00\x66\x00\x66\x00\x6C\x00\x6F\x00\x61\x00\x64\x00\x49\x00\x50\x00\x76\x00\x36\x00"
+"utf16_rndis_config_udpchecksumoffloadipv4"="\x2A\x00\x55\x00\x44\x00\x50\x00\x43\x00\x68\x00\x65\x00\x63\x00\x6B\x00\x73\x00\x75\x00\x6D\x00\x4F\x00\x66\x00\x66\x00\x6C\x00\x6F\x00\x61\x00\x64\x00\x49\x00\x50\x00\x76\x00\x34\x00"
+"utf16_rndis_config_udpchecksumoffloadipv6"="\x2A\x00\x55\x00\x44\x00\x50\x00\x43\x00\x68\x00\x65\x00\x63\x00\x6B\x00\x73\x00\x75\x00\x6D\x00\x4F\x00\x66\x00\x66\x00\x6C\x00\x6F\x00\x61\x00\x64\x00\x49\x00\x50\x00\x76\x00\x36\x00"
+
+# UTF-16LE config parameter values: "0" to "4" (offload enable/disable)
+"utf16_value_0"="\x30\x00"
+"utf16_value_1"="\x31\x00"
+"utf16_value_2"="\x32\x00"
+"utf16_value_3"="\x33\x00"
+"utf16_value_4"="\x34\x00"
+
+# =============================================================================
+# MTU / FRAME SIZE CONSTANTS
+# =============================================================================
+"ethernet_header_len"="\x0E\x00\x00\x00"
+"default_mtu"="\xEA\x05\x00\x00"
+"min_mtu_minus_one"="\xE9\x05\x00\x00"
+"max_mtu"="\x00\x24\x00\x00"
+"max_mtu_plus_one"="\x01\x24\x00\x00"
+"sub_alloc_size_default_mtu"="\x0E\x07\x00\x00"
+
+# =============================================================================
+# PACKET INFO FLAGS (u8)
+# =============================================================================
+"pkt_info_flags_multi_suballoc"="\x01"
+"pkt_info_flags_first_fragment"="\x02"
+"pkt_info_flags_last_fragment"="\x04"
+"pkt_info_id_version_v1"="\x01"
+
+# =============================================================================
+# Canonical RNDIS handshake/control packets (header + body)
+# =============================================================================
+"rndis_pkt_initialize_request"="\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+"rndis_pkt_query_packet_filter"="\x04\x00\x00\x00\x1C\x00\x00\x00\x01\x00\x00\x00\x0E\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+"rndis_pkt_set_packet_filter_directed"="\x05\x00\x00\x00\x20\x00\x00\x00\x01\x00\x00\x00\x0E\x01\x01\x00\x04\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00"
+"rndis_pkt_set_packet_filter_promisc"="\x05\x00\x00\x00\x20\x00\x00\x00\x01\x00\x00\x00\x0E\x01\x01\x00\x04\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x20\x00\x00\x00"
+"rndis_pkt_halt"="\x03\x00\x00\x00\x0C\x00\x00\x00\x01\x00\x00\x00"
+"rndis_pkt_reset"="\x06\x00\x00\x00\x0C\x00\x00\x00\x00\x00\x00\x00"
+"rndis_pkt_keepalive"="\x08\x00\x00\x00\x0C\x00\x00\x00\x01\x00\x00\x00"
+
+# =============================================================================
+# RNDIS PACKET / PPI VALUES for datapath
+# =============================================================================
+"rndis_ppi_type_checksum"="\x00\x00\x00\x00"
+"rndis_ppi_type_lso"="\x02\x00\x00\x00"
+"rndis_packet_msg_len_44"="\x2C\x00\x00\x00"
+"rndis_packet_header_len"="\x24\x00\x00\x00"
+
+# Common RNDIS message lengths
+"rndis_msg_len_24"="\x18\x00\x00\x00"
+"rndis_msg_len_28"="\x1C\x00\x00\x00"
+"rndis_msg_len_32"="\x20\x00\x00\x00"
+"rndis_msg_len_12"="\x0C\x00\x00\x00"
+
+# =============================================================================
+# BOUNDARY / EDGE-CASE VALUES useful for mutation
+# =============================================================================
+"zero_u32"="\x00\x00\x00\x00"
+"one_u32"="\x01\x00\x00\x00"
+"max_u32"="\xFF\xFF\xFF\xFF"
+"max_u16"="\xFF\xFF"
+"zero_u64"="\x00\x00\x00\x00\x00\x00\x00\x00"
+"max_u64"="\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
+"nvsp_max_subchannels"="\x40\x00"
+"nvsp_max_packets_per_receive"="\x77\x01\x00\x00"
+"rx_reserved_control_buffers"="\x10\x00\x00\x00"
+"rx_reserved_minus_one"="\x0F\x00\x00\x00"
+"rx_reserved_plus_one"="\x11\x00\x00\x00"

--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -19,6 +19,7 @@ use net_backend::RxMetadata;
 use safeatomic::AtomicSliceOps;
 use std::ops::Range;
 use std::sync::Arc;
+use thiserror::Error;
 use vmbus_channel::gpadl::GpadlView;
 use zerocopy::FromZeros;
 use zerocopy::Immutable;
@@ -27,6 +28,19 @@ use zerocopy::KnownLayout;
 
 const PAGE_SIZE: usize = 4096;
 const PAGE_SIZE32: u32 = 4096;
+
+/// Error returned when a write to the receive buffer would exceed the locked
+/// page range.
+#[derive(Debug, Error)]
+#[error(
+    "rx buffer write overflow: offset={offset} len={len} \
+     total_size={total_size}"
+)]
+struct RxBufferWriteOverflow {
+    offset: usize,
+    len: usize,
+    total_size: usize,
+}
 
 /// A type providing access to the netvsp receive buffer.
 pub struct GuestBuffers {
@@ -80,8 +94,23 @@ impl GuestBuffers {
         })
     }
 
-    fn write_at(&self, offset: u32, mut buf: &[u8]) {
+    fn write_at(&self, offset: u32, buf: &[u8]) -> Result<(), RxBufferWriteOverflow> {
         let mut offset = offset as usize;
+        let total_size = self.locked_pages.pages().len() * PAGE_SIZE;
+        // Check for arithmetic overflow.
+        let end = offset.checked_add(buf.len()).ok_or(RxBufferWriteOverflow {
+            offset,
+            len: buf.len(),
+            total_size,
+        })?;
+        if end > total_size {
+            return Err(RxBufferWriteOverflow {
+                offset,
+                len: buf.len(),
+                total_size,
+            });
+        }
+        let mut buf = buf;
         while !buf.is_empty() {
             let len = (PAGE_SIZE - offset % PAGE_SIZE).min(buf.len());
             let (this, next) = buf.split_at(len);
@@ -90,6 +119,7 @@ impl GuestBuffers {
             buf = next;
             offset += len;
         }
+        Ok(())
     }
 }
 
@@ -156,7 +186,14 @@ impl BufferAccess for BufferPool {
     }
 
     fn write_data(&mut self, id: RxId, data: &[u8]) {
-        self.buffers.write_at(self.offset(id) + RX_HEADER_LEN, data);
+        if let Err(err) = self.buffers.write_at(self.offset(id) + RX_HEADER_LEN, data) {
+            tracelimit::warn_ratelimited!(
+                error = &err as &dyn std::error::Error,
+                rx_id = id.0,
+                data_len = data.len(),
+                "rx buffer write overflow in write_data",
+            );
+        }
     }
 
     fn write_header(&mut self, id: RxId, metadata: &RxMetadata) {
@@ -231,7 +268,13 @@ impl BufferAccess for BufferPool {
             },
         };
 
-        self.buffers.write_at(self.offset(id), header.as_bytes());
+        if let Err(err) = self.buffers.write_at(self.offset(id), header.as_bytes()) {
+            tracelimit::warn_ratelimited!(
+                error = &err as &dyn std::error::Error,
+                rx_id = id.0,
+                "rx buffer write overflow in write_header",
+            );
+        }
     }
 }
 

--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -96,7 +96,16 @@ impl GuestBuffers {
 
     fn write_at(&self, offset: u32, buf: &[u8]) -> Result<(), RxBufferWriteOverflow> {
         let mut offset = offset as usize;
-        let total_size = self.locked_pages.pages().len() * PAGE_SIZE;
+        let total_size = self
+            .locked_pages
+            .pages()
+            .len()
+            .checked_mul(PAGE_SIZE)
+            .ok_or(RxBufferWriteOverflow {
+                offset,
+                len: buf.len(),
+                total_size: usize::MAX,
+            })?;
         // Check for arithmetic overflow.
         let end = offset.checked_add(buf.len()).ok_or(RxBufferWriteOverflow {
             offset,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -7,12 +7,25 @@
 #![forbid(unsafe_code)]
 
 mod buffers;
+#[cfg(feature = "test")]
+pub mod protocol;
+#[cfg(not(feature = "test"))]
 mod protocol;
 pub mod resolver;
+#[cfg(feature = "test")]
+pub mod rndisprot;
+#[cfg(not(feature = "test"))]
 mod rndisprot;
 mod rx_bufs;
+#[cfg(feature = "test")]
+pub mod saved_state;
+#[cfg(not(feature = "test"))]
 mod saved_state;
 mod test;
+#[cfg(feature = "test")]
+pub mod test_helpers;
+#[cfg(not(feature = "test"))]
+mod test_helpers;
 
 use crate::buffers::GuestBuffers;
 use crate::protocol::VMS_SWITCH_RSS_MAX_SEND_INDIRECTION_TABLE_ENTRIES;
@@ -57,8 +70,8 @@ use net_backend_resources::mac_address::MacAddress;
 use pal_async::timer::Instant;
 use pal_async::timer::PolledTimer;
 use ring::gparange::MultiPagedRangeIter;
+use rx_bufs::RxBufAllocateError;
 use rx_bufs::RxBuffers;
-use rx_bufs::SubAllocationInUse;
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::future::pending;
@@ -403,7 +416,8 @@ struct RxBufferRanges {
 
 impl RxBufferRanges {
     fn new(buffer_count: u32, queue_count: u32) -> (Self, Vec<mpsc::UnboundedReceiver<u32>>) {
-        let buffers_per_queue = (buffer_count - RX_RESERVED_CONTROL_BUFFERS) / queue_count;
+        let buffers_per_queue =
+            buffer_count.saturating_sub(RX_RESERVED_CONTROL_BUFFERS) / queue_count;
         #[expect(clippy::disallowed_methods)] // TODO
         let (send, recv): (Vec<_>, Vec<_>) = (0..queue_count).map(|_| mpsc::unbounded()).unzip();
         (
@@ -1250,7 +1264,9 @@ impl VmbusDevice for Nic {
     }
 
     fn max_subchannels(&self) -> u16 {
-        self.adapter.max_queues
+        // max_queues includes the primary channel, so the number of
+        // *sub*channels is one less.
+        self.adapter.max_queues.saturating_sub(1)
     }
 
     fn install(&mut self, resources: DeviceResources) {
@@ -1314,7 +1330,20 @@ impl VmbusDevice for Nic {
 
         // Stop and remove the channel worker.
         {
-            let worker = &mut self.coordinator.state_mut().unwrap().workers[channel_idx as usize];
+            let workers = &mut self.coordinator.state_mut().unwrap().workers;
+            if channel_idx as usize >= workers.len() {
+                tracing::error!(
+                    channel_idx,
+                    workers_len = workers.len(),
+                    instance_id = %self.instance_id,
+                    "Close called with channel_idx out of range"
+                );
+                if restart {
+                    self.coordinator.start();
+                }
+                return;
+            }
+            let worker = &mut workers[channel_idx as usize];
             worker.stop().await;
             if worker.has_state() {
                 worker.remove();
@@ -1539,13 +1568,19 @@ enum NetRestoreError {
     #[error(transparent)]
     ReceiveBuffer(#[from] BufferError),
     #[error(transparent)]
-    SuballocationMisconfigured(#[from] SubAllocationInUse),
+    SuballocationMisconfigured(#[from] RxBufAllocateError),
     #[error(transparent)]
     Open(#[from] OpenError),
+    #[error("saved state has {count} channels but max_queues is {max}")]
+    TooManyChannels { count: usize, max: usize },
     #[error("invalid rss key size")]
     InvalidRssKeySize,
     #[error("reduced indirection table size")]
     ReducedIndirectionTableSize,
+    #[error("ready state must have at least one channel (primary)")]
+    EmptyChannels,
+    #[error("primary channel (channels[0]) must be present in ready state")]
+    MissingPrimaryChannel,
 }
 
 impl From<NetRestoreError> for RestoreError {
@@ -1566,6 +1601,18 @@ impl Nic {
                 saved_state::Primary::Version => vec![true],
                 saved_state::Primary::Init(_) => vec![true],
                 saved_state::Primary::Ready(ready) => {
+                    if ready.channels.is_empty() {
+                        return Err(NetRestoreError::EmptyChannels);
+                    }
+                    if ready.channels[0].is_none() {
+                        return Err(NetRestoreError::MissingPrimaryChannel);
+                    }
+                    if ready.channels.len() > self.adapter.max_queues as usize {
+                        return Err(NetRestoreError::TooManyChannels {
+                            count: ready.channels.len(),
+                            max: self.adapter.max_queues as usize,
+                        });
+                    }
                     ready.channels.iter().map(|x| x.is_some()).collect()
                 }
             };
@@ -1722,6 +1769,19 @@ impl Nic {
                         }));
                     }
                 }
+            }
+
+            // Clean up any existing coordinator and workers from a prior
+            // open().  In normal operation the caller creates a fresh Nic for
+            // each restore cycle, but defensive cleanup here keeps the code
+            // robust if restore is called on an already-opened instance (e.g.
+            // from a fuzz test).
+            if self.coordinator.has_state() {
+                self.coordinator.stop().await;
+                if let Some(coordinator) = self.coordinator.state_mut() {
+                    coordinator.stop_workers().await;
+                }
+                self.coordinator.remove();
             }
 
             // Insert the coordinator and mark that it should try to start the
@@ -1970,8 +2030,6 @@ enum WorkerError {
     Queue(#[from] queue::Error),
     #[error("too many control messages")]
     TooManyControlMessages,
-    #[error("invalid rndis packet completion")]
-    InvalidRndisPacketCompletion,
     #[error("missing transaction id")]
     MissingTransactionId,
     #[error("invalid gpadl")]
@@ -1980,6 +2038,13 @@ enum WorkerError {
     GpadlError(#[source] GuestMemoryError),
     #[error("gpa direct error")]
     GpaDirectError(#[source] GuestMemoryError),
+    #[error("MTU {mtu} exceeds maximum allowed value {max}")]
+    InvalidMtu { mtu: u32, max: u32 },
+    #[error(
+        "recv buffer sub_allocation_size {size} is too small for MTU {mtu} \
+         (minimum {min})"
+    )]
+    SubAllocationTooSmall { size: u32, mtu: u32, min: u32 },
     #[error("endpoint")]
     Endpoint(#[source] anyhow::Error),
     #[error("message not supported on sub channel: {0}")]
@@ -2046,8 +2111,6 @@ enum PacketOrderError {
     SendReceiveBufferMissingMTU,
     #[error("SendSendBuffer already exists")]
     SendSendBufferExists,
-    #[error("SwitchDataPathCompletion during PrimaryChannelState")]
-    SwitchDataPathCompletionPrimaryChannelState,
 }
 
 #[derive(Debug)]
@@ -2293,6 +2356,8 @@ struct ReceiveBuffer {
 enum BufferError {
     #[error("unsupported suballocation size {0}")]
     UnsupportedSuballocationSize(u32),
+    #[error("too few sub-allocations ({count}) for required reserved buffers ({reserved})")]
+    TooFewSubAllocations { count: u32, reserved: u32 },
     #[error("unaligned gpadl")]
     UnalignedGpadl,
     #[error("unknown gpadl ID")]
@@ -2320,6 +2385,14 @@ impl ReceiveBuffer {
             return Err(BufferError::UnsupportedSuballocationSize(
                 sub_allocation_size,
             ));
+        }
+        // The receive buffer must have enough sub-allocations for reserved
+        // control buffers plus at least one data buffer.
+        if num_sub_allocations <= RX_RESERVED_CONTROL_BUFFERS {
+            return Err(BufferError::TooFewSubAllocations {
+                count: num_sub_allocations,
+                reserved: RX_RESERVED_CONTROL_BUFFERS,
+            });
         }
         let recv_buffer = Self {
             gpadl,
@@ -3148,13 +3221,26 @@ impl<T: RingMem> NetChannel<T> {
 
             if let Some(message) = primary.control_messages.pop_front() {
                 primary.control_messages_len -= message.data.len();
-                self.handle_rndis_control_message(
+                if let Err(err) = self.handle_rndis_control_message(
                     primary,
                     buffers,
                     message.message_type,
                     message.data.as_ref(),
                     id.0,
-                )?;
+                ) {
+                    tracelimit::error_ratelimited!(
+                        error = &err as &dyn std::error::Error,
+                        message_type = message.message_type,
+                        "failed to handle RNDIS control message, skipping"
+                    );
+                    // Free the receive buffer and return the control buffer
+                    // since either no response was sent or the response send
+                    // failed. If a response was already sent to the guest
+                    // before this error, the guest's completion will find
+                    // the buffer already freed and be handled gracefully.
+                    drop(state.rx_bufs.free(id.0));
+                    primary.free_control_buffers.push(id);
+                }
             } else if primary.pending_offload_change
                 && primary.rndis_state == RndisState::Operational
             {
@@ -3578,7 +3664,7 @@ impl Adapter {
         if params.hash_secret_key_size != 40 {
             return Err(OidError::InvalidInput("hash_secret_key_size"));
         }
-        if params.indirection_table_size % 4 != 0 {
+        if params.indirection_table_size % 4 != 0 || params.indirection_table_size == 0 {
             return Err(OidError::InvalidInput("indirection_table_size"));
         }
         let indirection_table_size =
@@ -3738,7 +3824,12 @@ impl Adapter {
                 let value = value.read_n::<u16>(info.value_length as usize / 2)?;
                 let value =
                     String::from_utf16(&value).map_err(|_| OidError::InvalidInput("value"))?;
-                let as_num = value.as_bytes().first().map_or(0, |c| c - b'0');
+                let as_num = value
+                    .as_bytes()
+                    .first()
+                    .map(|c| c.wrapping_sub(b'0'))
+                    .filter(|&c| c <= 9)
+                    .ok_or(OidError::InvalidInput("value as num"))?;
                 let tx = as_num & 1 != 0;
                 let rx = as_num & 2 != 0;
 
@@ -4471,6 +4562,20 @@ impl Coordinator {
         let mut rx_buffers = Vec::new();
         {
             let buffers = &state.buffers;
+            if buffers.ndis_config.mtu > MAX_MTU {
+                return Err(WorkerError::InvalidMtu {
+                    mtu: buffers.ndis_config.mtu,
+                    max: MAX_MTU,
+                });
+            }
+            let sub_alloc_min = sub_allocation_size_for_mtu(buffers.ndis_config.mtu);
+            if buffers.recv_buffer.sub_allocation_size < sub_alloc_min {
+                return Err(WorkerError::SubAllocationTooSmall {
+                    size: buffers.recv_buffer.sub_allocation_size,
+                    mtu: buffers.ndis_config.mtu,
+                    min: sub_alloc_min,
+                });
+            }
             let guest_buffers = Arc::new(
                 GuestBuffers::new(
                     buffers.mem.clone(),
@@ -4751,8 +4856,16 @@ impl<T: 'static + RingMem> NetChannel<T> {
     ) -> Result<Option<Packet<'a>>, WorkerError> {
         let (mut read, _) = self.queue.split();
         let packet = match read.try_read() {
-            Ok(packet) => parse_packet(&packet, send_buffer, version, external_data)
-                .map_err(WorkerError::Packet)?,
+            Ok(packet) => match parse_packet(&packet, send_buffer, version, external_data) {
+                Ok(p) => p,
+                Err(err) => {
+                    tracelimit::error_ratelimited!(
+                        error = &err as &dyn std::error::Error,
+                        "failed to parse packet, skipping"
+                    );
+                    return Ok(None);
+                }
+            },
             Err(queue::TryReadError::Empty) => return Ok(None),
             Err(queue::TryReadError::Queue(err)) => return Err(err.into()),
         };
@@ -4893,12 +5006,37 @@ impl<T: 'static + RingMem> NetChannel<T> {
 
                         let sub_allocation_size = sub_allocation_size_for_mtu(mtu);
 
-                        let recv_buffer = ReceiveBuffer::new(
+                        let recv_buffer = match ReceiveBuffer::new(
                             &self.gpadl_map,
                             message.gpadl_handle,
                             message.id,
                             sub_allocation_size,
-                        )?;
+                        ) {
+                            Ok(buf) => buf,
+                            Err(err) => {
+                                tracelimit::error_ratelimited!(
+                                    error = &err as &dyn std::error::Error,
+                                    "failed to set up receive buffer"
+                                );
+                                self.send_completion(
+                                    packet.transaction_id,
+                                    Some(&self.message(
+                                        protocol::MESSAGE1_TYPE_SEND_RECEIVE_BUFFER_COMPLETE,
+                                        protocol::Message1SendReceiveBufferComplete {
+                                            status: protocol::Status::FAILURE,
+                                            num_sections: 0,
+                                            sections: [protocol::ReceiveBufferSection {
+                                                offset: 0,
+                                                sub_allocation_size: 0,
+                                                num_sub_allocations: 0,
+                                                end_offset: 0,
+                                            }],
+                                        },
+                                    )),
+                                )?;
+                                continue;
+                            }
+                        };
 
                         self.send_completion(
                             packet.transaction_id,
@@ -4926,7 +5064,27 @@ impl<T: 'static + RingMem> NetChannel<T> {
                             ));
                         }
 
-                        let send_buffer = SendBuffer::new(&self.gpadl_map, message.gpadl_handle)?;
+                        let send_buffer =
+                            match SendBuffer::new(&self.gpadl_map, message.gpadl_handle) {
+                                Ok(buf) => buf,
+                                Err(err) => {
+                                    tracelimit::error_ratelimited!(
+                                        error = &err as &dyn std::error::Error,
+                                        "failed to set up send buffer"
+                                    );
+                                    self.send_completion(
+                                        packet.transaction_id,
+                                        Some(&self.message(
+                                            protocol::MESSAGE1_TYPE_SEND_SEND_BUFFER_COMPLETE,
+                                            protocol::Message1SendSendBufferComplete {
+                                                status: protocol::Status::FAILURE,
+                                                section_size: 0,
+                                            },
+                                        )),
+                                    )?;
+                                    continue;
+                                }
+                            };
                         self.send_completion(
                             packet.transaction_id,
                             Some(&self.message(
@@ -5431,7 +5589,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
                 }
                 PacketData::RndisPacketComplete(_completion) => {
                     data.rx_done.clear();
-                    state
+                    if state
                         .release_recv_buffers(
                             packet
                                 .transaction_id
@@ -5439,7 +5597,16 @@ impl<T: 'static + RingMem> NetChannel<T> {
                             &queue_state.rx_buffer_range,
                             &mut data.rx_done,
                         )
-                        .ok_or(WorkerError::InvalidRndisPacketCompletion)?;
+                        .is_none()
+                    {
+                        // Transaction ID did not map to a valid receive buffer. Nothing gets freed.
+                        // If the guest sends enough invalid completions, it could eventually starve itself.
+                        tracelimit::error_ratelimited!(
+                            transaction_id = packet.transaction_id,
+                            "invalid RNDIS packet completion from guest, skipping"
+                        );
+                        continue;
+                    }
                     queue_state.queue.rx_avail(&data.rx_done);
                 }
                 PacketData::SubChannelRequest(request) if state.primary.is_some() => {
@@ -5517,10 +5684,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
                     )?;
                 }
                 p => {
-                    tracing::warn!(request = ?p, "unexpected packet");
-                    return Err(WorkerError::UnexpectedPacketOrder(
-                        PacketOrderError::SwitchDataPathCompletionPrimaryChannelState,
-                    ));
+                    tracelimit::warn_ratelimited!(request = ?p, "unexpected packet, skipping");
                 }
             }
         }

--- a/vm/devices/net/netvsp/src/protocol.rs
+++ b/vm/devices/net/netvsp/src/protocol.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![expect(dead_code)]
+#![cfg_attr(not(feature = "test"), expect(dead_code))]
 
 use crate::rndisprot;
 use bitfield_struct::bitfield;
@@ -206,6 +206,7 @@ pub const MESSAGE6_MAX: u32 = MESSAGE6_TYPE_PD_POST_BATCH;
 
 open_enum::open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub enum Status: u32 {
         NONE = 0,
         SUCCESS = 1,
@@ -238,6 +239,7 @@ pub struct MessageHeader {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MessageInit {
     pub protocol_version: u32,  // was MinProtocolVersion
     pub protocol_version2: u32, // was MaxProtocolVersion
@@ -269,6 +271,7 @@ pub const INVALID_PROTOCOL_VERSION: u32 = 0xffffffff;
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message1SendNdisVersion {
     pub ndis_major_version: u32,
     pub ndis_minor_version: u32,
@@ -316,6 +319,7 @@ pub struct Message1SendReceiveBufferComplete {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message1RevokeReceiveBuffer {
     pub id: u16,
 }
@@ -359,6 +363,7 @@ pub struct Message1SendSendBufferComplete {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message1RevokeSendBuffer {
     pub id: u16,
 }
@@ -368,6 +373,7 @@ pub struct Message1RevokeSendBuffer {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message1SendRndisPacket {
     //
     // This field is specified by RNIDS. They assume there's
@@ -397,6 +403,7 @@ pub struct Message1SendRndisPacket {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message1SendRndisPacketComplete {
     pub status: Status,
 }
@@ -408,6 +415,7 @@ pub struct Message1SendRndisPacketComplete {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message2SendNdisConfig {
     pub mtu: u32,
     pub reserved: u32,
@@ -417,6 +425,7 @@ pub struct Message2SendNdisConfig {
 #[derive(Inspect)]
 #[bitfield(u64)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NdisConfigCapabilities {
     #[inspect(safe)]
     pub vmq: bool,
@@ -470,6 +479,7 @@ open_enum::open_enum! {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message4SwitchDataPath {
     /// Specifies the current data path that is active in the VM
     pub active_data_path: u32,
@@ -480,6 +490,7 @@ pub struct Message4SwitchDataPath {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message5OidQueryEx {
     /// Header information for the Query OID
     header: rndisprot::NdisObjectHeader,
@@ -505,6 +516,7 @@ pub struct Message5OidQueryExComplete {
 //
 open_enum::open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub enum SubchannelOperation: u32 {
         NONE = 0,
         ALLOCATE = 1,
@@ -516,6 +528,7 @@ open_enum::open_enum! {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Message5SubchannelRequest {
     /// The subchannel operation
     pub operation: SubchannelOperation,

--- a/vm/devices/net/netvsp/src/protocol.rs
+++ b/vm/devices/net/netvsp/src/protocol.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![cfg_attr(feature = "test", allow(dead_code))]
 #![cfg_attr(not(feature = "test"), expect(dead_code))]
 
 use crate::rndisprot;

--- a/vm/devices/net/netvsp/src/rndisprot.rs
+++ b/vm/devices/net/netvsp/src/rndisprot.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![expect(dead_code)]
+#![cfg_attr(not(feature = "test"), expect(dead_code))]
+#![cfg_attr(feature = "test", allow(dead_code))]
 
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
@@ -108,6 +109,7 @@ pub const STATUS_TOKEN_RING_OPEN_ERROR: Status = 0xC0011000;
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub enum Oid: u32 {
         OID_GEN_SUPPORTED_LIST = 0x00010101,
         OID_GEN_HARDWARE_STATUS = 0x00010102,
@@ -315,6 +317,7 @@ pub struct LinkSpeed {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InitializeRequest {
     pub request_id: RequestId,
     pub major_version: u32,
@@ -367,6 +370,7 @@ pub struct HaltRequest {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct QueryRequest {
     pub request_id: RequestId,
     pub oid: Oid,
@@ -392,6 +396,7 @@ pub struct QueryComplete {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SetRequest {
     pub request_id: RequestId,
     pub oid: Oid,
@@ -481,6 +486,7 @@ pub struct DiagnosticInfo {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct KeepaliveRequest {
     pub request_id: RequestId,
 }
@@ -503,6 +509,7 @@ pub struct KeepaliveComplete {
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Packet {
     pub data_offset: u32,
     pub data_length: u32,
@@ -546,6 +553,7 @@ const PACKET_INFO_ID: u16 = 1;
 //  Packet extension field contents associated with a Data message.
 //
 #[repr(C)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct PerPacketInfo {
     pub size: u32,
@@ -737,6 +745,7 @@ pub const CONFIG_PARAM_TYPE_STRING: u32 = 2;
 //
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MessageHeader {
     pub message_type: u32,
 
@@ -747,6 +756,7 @@ pub struct MessageHeader {
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub enum NdisObjectType: u8 {
         DEFAULT = 0x80,
         RSS_CAPABILITIES = 0x88,
@@ -759,6 +769,7 @@ open_enum! {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NdisObjectHeader {
     pub object_type: NdisObjectType,
     pub revision: u8,
@@ -780,6 +791,7 @@ pub const NDIS_SIZEOF_RECEIVE_SCALE_CAPABILITIES_REVISION_2: usize = 18;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NdisReceiveScaleParameters {
     pub header: NdisObjectHeader,
 
@@ -984,6 +996,7 @@ pub struct Ipv6LsoFlags {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NdisOffloadEncapsulation {
     pub header: NdisObjectHeader,
     pub ipv4_enabled: u32,
@@ -1005,6 +1018,7 @@ pub const NDIS_OFFLOAD_SET_OFF: u32 = 2;
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NdisOffloadParameters {
     pub header: NdisObjectHeader,
     pub ipv4_checksum: OffloadParametersChecksum,
@@ -1026,6 +1040,7 @@ pub const NDIS_SIZEOF_OFFLOAD_PARAMETERS_REVISION_1: usize = 20;
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub enum OffloadParametersChecksum: u8 {
         NO_CHANGE = 0,
         TX_RX_DISABLED = 1,
@@ -1049,6 +1064,7 @@ impl OffloadParametersChecksum {
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub enum OffloadParametersSimple: u8 {
         NO_CHANGE = 0,
         DISABLED = 1,
@@ -1068,7 +1084,8 @@ impl OffloadParametersSimple {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RndisConfigParameterInfo {
     pub name_offset: u32,
     pub name_length: u32,
@@ -1079,6 +1096,7 @@ pub struct RndisConfigParameterInfo {
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub enum NdisParameterType: u32 {
         INTEGER = 0,
         HEX_INTEGER = 1,

--- a/vm/devices/net/netvsp/src/rx_bufs.rs
+++ b/vm/devices/net/netvsp/src/rx_bufs.rs
@@ -19,9 +19,24 @@ const START_MASK: u32 = 0x80000000;
 const INVALID: u32 = !START_MASK;
 const END: u32 = !1 & !START_MASK;
 
+/// Error returned by [`RxBuffers::allocate`].
 #[derive(Debug, Error)]
-#[error("suballocation is already in use")]
-pub struct SubAllocationInUse;
+pub enum RxBufAllocateError {
+    /// A buffer ID in the allocation is already in use.
+    #[error("suballocation is already in use")]
+    SubAllocationInUse,
+    /// The allocation is empty.
+    #[error("empty allocation")]
+    EmptyAllocation,
+    /// A buffer ID is out of range for the configured receive buffer count.
+    #[error("rx buffer id {id} is out of range (max {max})")]
+    IdOutOfRange {
+        /// The offending buffer ID.
+        id: u32,
+        /// The number of receive buffers configured.
+        max: u32,
+    },
+}
 
 impl RxBuffers {
     pub fn new(count: u32) -> Self {
@@ -37,16 +52,25 @@ impl RxBuffers {
     pub fn allocate<I: Iterator<Item = u32> + Clone>(
         &mut self,
         ids: impl IntoIterator<Item = u32, IntoIter = I>,
-    ) -> Result<(), SubAllocationInUse> {
+    ) -> Result<(), RxBufAllocateError> {
         let ids = ids.into_iter();
-        let first = ids.clone().next().unwrap();
+        let Some(first) = ids.clone().next() else {
+            return Err(RxBufAllocateError::EmptyAllocation);
+        };
+        let count = self.state.len() as u32;
+        // Validate all IDs are in range before modifying state.
+        for id in ids.clone() {
+            if id as usize >= self.state.len() {
+                return Err(RxBufAllocateError::IdOutOfRange { id, max: count });
+            }
+        }
         let next_ids = ids.clone().skip(1).chain(std::iter::once(END));
         for (n, (id, next_id)) in ids.clone().zip(next_ids).enumerate() {
             if self.state[id as usize] != INVALID {
                 for id in ids.take(n) {
                     self.state[id as usize] = INVALID;
                 }
-                return Err(SubAllocationInUse);
+                return Err(RxBufAllocateError::SubAllocationInUse);
             }
             self.state[id as usize] = next_id;
         }

--- a/vm/devices/net/netvsp/src/rx_bufs.rs
+++ b/vm/devices/net/netvsp/src/rx_bufs.rs
@@ -29,12 +29,12 @@ pub enum RxBufAllocateError {
     #[error("empty allocation")]
     EmptyAllocation,
     /// A buffer ID is out of range for the configured receive buffer count.
-    #[error("rx buffer id {id} is out of range (max {max})")]
+    #[error("rx buffer id {id} is out of range (count {count})")]
     IdOutOfRange {
         /// The offending buffer ID.
         id: u32,
         /// The number of receive buffers configured.
-        max: u32,
+        count: u32,
     },
 }
 
@@ -61,7 +61,7 @@ impl RxBuffers {
         // Validate all IDs are in range before modifying state.
         for id in ids.clone() {
             if id as usize >= self.state.len() {
-                return Err(RxBufAllocateError::IdOutOfRange { id, max: count });
+                return Err(RxBufAllocateError::IdOutOfRange { id, count });
             }
         }
         let next_ids = ids.clone().skip(1).chain(std::iter::once(END));

--- a/vm/devices/net/netvsp/src/saved_state.rs
+++ b/vm/devices/net/netvsp/src/saved_state.rs
@@ -8,6 +8,7 @@ use vmbus_channel::gpadl::GpadlId;
 use vmcore::save_restore::SavedStateRoot;
 
 #[derive(Debug, Protobuf, SavedStateRoot)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct SavedState {
     #[mesh(1)]
@@ -15,6 +16,7 @@ pub struct SavedState {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct OpenState {
     #[mesh(1)]
@@ -22,6 +24,7 @@ pub struct OpenState {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub enum Primary {
     #[mesh(1)]
@@ -33,6 +36,7 @@ pub enum Primary {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct InitPrimary {
     #[mesh(1)]
@@ -48,6 +52,7 @@ pub struct InitPrimary {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct NdisVersion {
     #[mesh(1)]
@@ -57,6 +62,7 @@ pub struct NdisVersion {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct NdisConfig {
     #[mesh(1)]
@@ -66,6 +72,7 @@ pub struct NdisConfig {
 }
 
 #[derive(Copy, Clone, Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub enum GuestVfState {
     #[mesh(1)]
@@ -88,6 +95,7 @@ pub enum GuestVfState {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct ReadyPrimary {
     #[mesh(1)]
@@ -125,6 +133,7 @@ pub struct ReadyPrimary {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub enum RndisState {
     #[mesh(1)]
@@ -136,6 +145,7 @@ pub enum RndisState {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct OffloadConfig {
     #[mesh(1)]
@@ -149,6 +159,7 @@ pub struct OffloadConfig {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct ChecksumOffloadConfig {
     #[mesh(1)]
@@ -164,6 +175,7 @@ pub struct ChecksumOffloadConfig {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct RssState {
     #[mesh(1)]
@@ -173,12 +185,20 @@ pub struct RssState {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct IncomingControlMessage {
     #[mesh(1)]
     pub message_type: u32,
     #[mesh(2)]
     pub data: Vec<u8>,
+}
+
+/// `GpadlId` does not implement `Arbitrary` upstream; we supply a manual
+/// implementation here so the containing structs can derive it.
+#[cfg(feature = "arbitrary")]
+fn arbitrary_gpadl_id(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<GpadlId> {
+    Ok(GpadlId(u.arbitrary()?))
 }
 
 #[derive(Debug, Protobuf)]
@@ -192,6 +212,17 @@ pub struct ReceiveBuffer {
     pub sub_allocation_size: u32,
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for ReceiveBuffer {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            gpadl_id: arbitrary_gpadl_id(u)?,
+            id: u.arbitrary()?,
+            sub_allocation_size: u.arbitrary()?,
+        })
+    }
+}
+
 #[derive(Debug, Protobuf)]
 #[mesh(package = "net.netvsp")]
 pub struct SendBuffer {
@@ -199,7 +230,17 @@ pub struct SendBuffer {
     pub gpadl_id: GpadlId,
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for SendBuffer {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            gpadl_id: arbitrary_gpadl_id(u)?,
+        })
+    }
+}
+
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct Channel {
     #[mesh(1)]
@@ -209,6 +250,7 @@ pub struct Channel {
 }
 
 #[derive(Debug, Protobuf)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[mesh(package = "net.netvsp")]
 pub struct Rx {
     #[mesh(1)]

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -43,13 +43,11 @@ use std::sync::atomic::AtomicBool;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
+use test_helpers::gpadl_test_guest_channel;
 use test_with_tracing::test;
 use vmbus_async::queue::IncomingPacket;
 use vmbus_async::queue::OutgoingPacket;
 use vmbus_async::queue::Queue;
-use vmbus_channel::ChannelClosed;
-use vmbus_channel::RawAsyncChannel;
-use vmbus_channel::SignalVmbusChannel;
 use vmbus_channel::bus::ChannelRequest;
 use vmbus_channel::bus::GpadlRequest;
 use vmbus_channel::bus::ModifyRequest;
@@ -63,12 +61,8 @@ use vmbus_channel::channel::VmbusDevice;
 use vmbus_channel::channel::offer_channel;
 use vmbus_channel::gpadl::GpadlId;
 use vmbus_channel::gpadl::GpadlMap;
-use vmbus_channel::gpadl::GpadlMapView;
-use vmbus_channel::gpadl_ring::AlignedGpadlView;
 use vmbus_channel::gpadl_ring::GpadlRingMem;
 use vmbus_core::protocol::UserDefinedData;
-use vmbus_ring::IncomingRing;
-use vmbus_ring::OutgoingRing;
 use vmbus_ring::PAGE_SIZE;
 use vmbus_ring::gparange::MultiPagedRangeBuf;
 use vmcore::interrupt::Interrupt;
@@ -1793,63 +1787,6 @@ impl VirtualFunction for TestVirtualFunction {
         match self.recv_update.select_next_some().await {
             TestVirtualFunctionStateChange::Update(rpc) => rpc,
         }
-    }
-}
-
-fn make_test_guest_rings(
-    mem: &GuestMemory,
-    gpadl_map: &GpadlMapView,
-    gpadl_id: GpadlId,
-    ring_offset: u32,
-) -> (IncomingRing<GpadlRingMem>, OutgoingRing<GpadlRingMem>) {
-    let gpadl = AlignedGpadlView::new(gpadl_map.map(gpadl_id).unwrap()).unwrap();
-    let (out_gpadl, in_gpadl) = match gpadl.split(ring_offset) {
-        Ok(gpadls) => gpadls,
-        Err(_) => panic!("Failed gpadl.split"),
-    };
-    (
-        IncomingRing::new(GpadlRingMem::new(in_gpadl, mem).unwrap()).unwrap(),
-        OutgoingRing::new(GpadlRingMem::new(out_gpadl, mem).unwrap()).unwrap(),
-    )
-}
-
-pub fn gpadl_test_guest_channel(
-    mem: &GuestMemory,
-    gpadl_map: &GpadlMapView,
-    gpadl_id: GpadlId,
-    ring_offset: u32,
-    host_to_guest_event: Arc<SlimEvent>,
-    guest_to_host_interrupt: Interrupt,
-    done: Arc<AtomicBool>,
-) -> RawAsyncChannel<GpadlRingMem> {
-    let (in_ring, out_ring) = make_test_guest_rings(mem, gpadl_map, gpadl_id, ring_offset);
-    RawAsyncChannel {
-        in_ring,
-        out_ring,
-        signal: Box::new(EventWithDone {
-            local_event: host_to_guest_event,
-            remote_interrupt: guest_to_host_interrupt,
-            done,
-        }),
-    }
-}
-
-struct EventWithDone {
-    remote_interrupt: Interrupt,
-    local_event: Arc<SlimEvent>,
-    done: Arc<AtomicBool>,
-}
-
-impl SignalVmbusChannel for EventWithDone {
-    fn signal_remote(&self) {
-        self.remote_interrupt.deliver();
-    }
-
-    fn poll_for_signal(&self, cx: &mut Context<'_>) -> Poll<Result<(), ChannelClosed>> {
-        if self.done.load(Ordering::Relaxed) {
-            return Err(ChannelClosed).into();
-        }
-        self.local_event.poll_wait(cx).map(Ok)
     }
 }
 

--- a/vm/devices/net/netvsp/src/test_helpers.rs
+++ b/vm/devices/net/netvsp/src/test_helpers.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! NetVSP test helpers.
+//!
+//! These are used both by unit tests and by the fuzzer.
+
+#![allow(dead_code)]
+
+use guestmem::GuestMemory;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+use vmbus_channel::ChannelClosed;
+use vmbus_channel::RawAsyncChannel;
+use vmbus_channel::SignalVmbusChannel;
+use vmbus_channel::gpadl::GpadlId;
+use vmbus_channel::gpadl::GpadlMapView;
+use vmbus_channel::gpadl_ring::AlignedGpadlView;
+use vmbus_channel::gpadl_ring::GpadlRingMem;
+use vmbus_ring::IncomingRing;
+use vmbus_ring::OutgoingRing;
+use vmcore::interrupt::Interrupt;
+use vmcore::slim_event::SlimEvent;
+
+/// A [`SignalVmbusChannel`] implementation for test guest channels that
+/// supports cooperative shutdown via a shared `done` flag.
+pub struct EventWithDone {
+    /// Interrupt to signal the remote (host) side.
+    pub remote_interrupt: Interrupt,
+    /// Event to wait on for local (guest) signals from the host.
+    pub local_event: Arc<SlimEvent>,
+    /// When set to true, `poll_for_signal` returns `ChannelClosed`.
+    pub done: Arc<AtomicBool>,
+}
+
+impl SignalVmbusChannel for EventWithDone {
+    fn signal_remote(&self) {
+        self.remote_interrupt.deliver();
+    }
+
+    fn poll_for_signal(&self, cx: &mut Context<'_>) -> Poll<Result<(), ChannelClosed>> {
+        if self.done.load(Ordering::Relaxed) {
+            return Err(ChannelClosed).into();
+        }
+        self.local_event.poll_wait(cx).map(Ok)
+    }
+}
+
+/// Create the incoming and outgoing rings for a guest-side test channel backed
+/// by a GPADL.
+pub fn make_test_guest_rings(
+    mem: &GuestMemory,
+    gpadl_map: &GpadlMapView,
+    gpadl_id: GpadlId,
+    ring_offset: u32,
+) -> (IncomingRing<GpadlRingMem>, OutgoingRing<GpadlRingMem>) {
+    let gpadl = AlignedGpadlView::new(gpadl_map.map(gpadl_id).unwrap()).unwrap();
+    let (out_gpadl, in_gpadl) = match gpadl.split(ring_offset) {
+        Ok(gpadls) => gpadls,
+        Err(_) => panic!("Failed gpadl.split"),
+    };
+    (
+        IncomingRing::new(GpadlRingMem::new(in_gpadl, mem).unwrap()).unwrap(),
+        OutgoingRing::new(GpadlRingMem::new(out_gpadl, mem).unwrap()).unwrap(),
+    )
+}
+
+/// Build a [`RawAsyncChannel`] backed by GPADL ring memory, suitable for
+/// constructing a guest-side [`vmbus_async::queue::Queue`].
+pub fn gpadl_test_guest_channel(
+    mem: &GuestMemory,
+    gpadl_map: &GpadlMapView,
+    gpadl_id: GpadlId,
+    ring_offset: u32,
+    host_to_guest_event: Arc<SlimEvent>,
+    guest_to_host_interrupt: Interrupt,
+    done: Arc<AtomicBool>,
+) -> RawAsyncChannel<GpadlRingMem> {
+    let (in_ring, out_ring) = make_test_guest_rings(mem, gpadl_map, gpadl_id, ring_offset);
+    RawAsyncChannel {
+        in_ring,
+        out_ring,
+        signal: Box::new(EventWithDone {
+            local_event: host_to_guest_event,
+            remote_interrupt: guest_to_host_interrupt,
+            done,
+        }),
+    }
+}

--- a/vm/devices/vmbus/vmbus_channel/src/channel.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/channel.rs
@@ -752,6 +752,15 @@ impl Device {
         offer: &OfferParams,
         count: usize,
     ) -> anyhow::Result<()> {
+        // The `events` vector is sized to `max_subchannels + 1` at offer
+        // time, so any `count` larger than that means the caller supplied
+        // an invalid subchannel count. (ex. fuzz test save/restore)
+        anyhow::ensure!(
+            count <= self.events.len(),
+            "requested channel count ({count}) exceeds maximum ({})",
+            self.events.len(),
+        );
+
         // Offer new subchannels.
         let mut r = Ok(());
         for subchannel_idx in self.server_requests.len()..count {

--- a/xtask/src/tasks/fuzz/cargo_fuzz.rs
+++ b/xtask/src/tasks/fuzz/cargo_fuzz.rs
@@ -118,3 +118,32 @@ impl CargoFuzzCommand {
         matches!(self, CargoFuzzCommand::Run { .. })
     }
 }
+
+/// Determine the coverage binary path using the same layout as `cargo-fuzz`.
+///
+/// `cargo fuzz coverage` places binaries at:
+///   `<repo>/target/<triple>/coverage/<triple>/release/<target_name>`
+pub(super) fn coverage_binary_path(repo_root: &Path, target_name: &str) -> anyhow::Result<PathBuf> {
+    let triple = host_triple()?;
+    Ok(repo_root
+        .join("target")
+        .join(&triple)
+        .join("coverage")
+        .join(&triple)
+        .join("release")
+        .join(target_name))
+}
+
+fn host_triple() -> anyhow::Result<String> {
+    let output = std::process::Command::new("rustc")
+        .arg("-vV")
+        .output()
+        .context("failed to run `rustc -vV`")?;
+    let stdout = std::str::from_utf8(&output.stdout).context("rustc output was not utf-8")?;
+    for line in stdout.lines() {
+        if let Some(triple) = line.strip_prefix("host: ") {
+            return Ok(triple.to_owned());
+        }
+    }
+    anyhow::bail!("could not determine host triple from `rustc -vV` output")
+}

--- a/xtask/src/tasks/fuzz/cargo_fuzz.rs
+++ b/xtask/src/tasks/fuzz/cargo_fuzz.rs
@@ -139,6 +139,14 @@ fn host_triple() -> anyhow::Result<String> {
         .arg("-vV")
         .output()
         .context("failed to run `rustc -vV`")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "`rustc -vV` failed with {}: {}",
+            output.status,
+            stderr.trim()
+        );
+    }
     let stdout = std::str::from_utf8(&output.stdout).context("rustc output was not utf-8")?;
     for line in stdout.lines() {
         if let Some(triple) = line.strip_prefix("host: ") {

--- a/xtask/src/tasks/fuzz/html_coverage.rs
+++ b/xtask/src/tasks/fuzz/html_coverage.rs
@@ -4,9 +4,9 @@
 //! Glue to generate HTML LCOV-based coverage reports from `cargo-fuzz`
 //! `coverage.profdata` files.
 
+use super::cargo_fuzz::coverage_binary_path;
 use anyhow::Context;
 use std::path::Path;
-use std::path::PathBuf;
 
 pub(super) fn generate_html_coverage_report(
     ctx: &crate::XtaskCtx,
@@ -19,33 +19,14 @@ pub(super) fn generate_html_coverage_report(
         .join(target_name)
         .join("coverage.profdata");
 
-    // would be great if there was an easy way to find where the resulting
-    // `cargo fuzz coverage` bin gets dumped to... but this seems to work ok.
-    let coverage_bin = {
-        let mut coverage_bin: Option<PathBuf> = None;
-        for e in walkdir::WalkDir::new(ctx.root.join("target")) {
-            let e = e?;
-            if e.file_name() != target_name
-                || !e.path().components().any(|c| c.as_os_str() == "coverage")
-            {
-                continue;
-            }
-
-            // instead of immediately breaking, as a sanity check, keep looking
-            // for other matches, erroring out if there is a dupe (which would
-            // indicate that this logic needs some more tweaking)
-            if let Some(existing_bin) = &coverage_bin {
-                panic!(
-                    "xtask bug: found multiple potential coverage bins: {} and {}",
-                    existing_bin.display(),
-                    e.path().display()
-                )
-            } else {
-                coverage_bin = Some(e.into_path());
-            }
-        }
-        coverage_bin.expect("xtask bug: failed to find the coverage-instrumented fuzzer bin")
-    };
+    // Derive the coverage binary path using the same layout as cargo-fuzz:
+    //   target/<triple>/coverage/<triple>/release/<target_name>
+    let coverage_bin = coverage_binary_path(&ctx.root, target_name)?;
+    anyhow::ensure!(
+        coverage_bin.is_file(),
+        "xtask bug: coverage binary not found at {}. Was `cargo fuzz coverage` run first?",
+        coverage_bin.display()
+    );
 
     let llvm_tools_dir = 'llvm_tools_dir: {
         let output = std::process::Command::new("rustc")

--- a/xtask/src/tasks/fuzz/mod.rs
+++ b/xtask/src/tasks/fuzz/mod.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 mod cargo_fuzz;
 mod html_coverage;
 mod init_from_template;
+mod netvsp;
 mod onefuzz_schema;
 mod parse_fuzz_crate_toml;
 
@@ -190,6 +191,22 @@ enum FuzzCommand {
         /// Extra args to forward to `cargo fuzz coverage`.
         #[clap(raw(true))]
         extra: Vec<String>,
+    },
+    /// Run all NetVSP fuzz targets as one campaign.
+    Netvsp {
+        /// Campaign duration per target, in minutes.
+        #[clap(default_value_t = 5)]
+        duration_minutes: u64,
+
+        /// The Rust toolchain to use. Defaults to the environment's default toolchain.
+        #[clap(long)]
+        toolchain: Option<String>,
+    },
+    /// Collect and merge coverage across all NetVSP fuzz targets.
+    NetvspCoverage {
+        /// The Rust toolchain to use for `cargo fuzz coverage`.
+        #[clap(long)]
+        toolchain: Option<String>,
     },
     /// Build fuzzers and construct a Onefuzz-ready drop folder.
     Onefuzz {
@@ -385,6 +402,16 @@ impl Xtask for Fuzz {
                         &target_name,
                     )?;
                 }
+            }
+            FuzzCommand::Netvsp {
+                duration_minutes,
+                toolchain,
+            } => {
+                netvsp::run_netvsp_campaign(fuzz_targets, duration_minutes, toolchain)?;
+            }
+            FuzzCommand::NetvspCoverage { toolchain } => {
+                let nightly = netvsp::resolve_nightly_toolchain(toolchain.as_deref())?;
+                netvsp::run_netvsp_coverage(&ctx, fuzz_targets, toolchain, &nightly)?;
             }
             FuzzCommand::Onefuzz {
                 target,

--- a/xtask/src/tasks/fuzz/mod.rs
+++ b/xtask/src/tasks/fuzz/mod.rs
@@ -411,7 +411,7 @@ impl Xtask for Fuzz {
             }
             FuzzCommand::NetvspCoverage { toolchain } => {
                 let nightly = netvsp::resolve_nightly_toolchain(toolchain.as_deref())?;
-                netvsp::run_netvsp_coverage(&ctx, fuzz_targets, toolchain, &nightly)?;
+                netvsp::run_netvsp_coverage(&ctx, fuzz_targets, &nightly)?;
             }
             FuzzCommand::Onefuzz {
                 target,

--- a/xtask/src/tasks/fuzz/netvsp.rs
+++ b/xtask/src/tasks/fuzz/netvsp.rs
@@ -1,0 +1,707 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::cargo_fuzz::CargoFuzzCommand;
+use super::parse_fuzz_crate_toml::RepoFuzzTarget;
+use anyhow::Context;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::SystemTime;
+
+const NETVSP_TARGETS: [&str; 9] = [
+    "fuzz_netvsp_control",
+    "fuzz_netvsp_tx_path",
+    "fuzz_netvsp_oid",
+    "fuzz_netvsp_interop",
+    "fuzz_netvsp_rx_path",
+    "fuzz_netvsp_link_status",
+    "fuzz_netvsp_vf_state",
+    "fuzz_netvsp_subchannel",
+    "fuzz_netvsp_save_restore",
+];
+
+pub(super) fn run_netvsp_campaign(
+    fuzz_targets: BTreeMap<String, RepoFuzzTarget>,
+    duration_minutes: u64,
+    toolchain: Option<String>,
+) -> anyhow::Result<()> {
+    if duration_minutes == 0 {
+        anyhow::bail!("duration_minutes must be greater than 0");
+    }
+
+    let targets = select_netvsp_targets(fuzz_targets)?;
+
+    let first_target = targets
+        .first()
+        .context("internal error: netvsp target set is empty")?;
+    let fuzz_dir = first_target.1.fuzz_dir.clone();
+
+    let dict = fuzz_dir.join("netvsp_rndis.dict");
+    if !dict.is_file() {
+        anyhow::bail!("missing dictionary: {}", dict.display());
+    }
+
+    let log_dir = fuzz_dir.join("fuzz_logs");
+    fs_err::create_dir_all(&log_dir)?;
+
+    let max_total_time = duration_minutes.saturating_mul(60);
+    println!("==============================================");
+    println!(" NetVSP Fuzzing Campaign");
+    println!("==============================================");
+    println!(" Targets:         {}", targets.len());
+    println!(
+        " Duration:        {}m ({}s per target)",
+        duration_minutes, max_total_time
+    );
+    println!(" Workers/target:  1 (single process)");
+    println!(" Total workers:   {}", targets.len());
+    println!(" Dictionary:      {}", dict.display());
+    println!(" Sanitizers:      toolchain-dependent (ASAN on nightly/direct xtask)");
+    println!(" Value profile:   enabled (CMP-guided mutation)");
+    println!(" Max input len:   4096 bytes");
+    println!(" Log dir:         {}", log_dir.display());
+    println!(
+        " Artifacts:       {}/artifacts/<target>/",
+        fuzz_dir.display()
+    );
+    println!("==============================================");
+
+    println!();
+    println!("[*] Pre-building all {} fuzz targets...", targets.len());
+    let mut build_failed = 0u32;
+
+    for (target_name, target) in &targets {
+        println!("    Building {}...", target_name);
+        let extra = vec!["--".to_owned(), "-runs=0".to_owned()];
+
+        let result = CargoFuzzCommand::Run { artifact: None }.invoke(
+            target_name,
+            &target.fuzz_dir,
+            &target.target_options,
+            toolchain.as_deref(),
+            &extra,
+        );
+
+        match result {
+            Ok(()) => println!("    ✓ {} built", target_name),
+            Err(err) => {
+                println!("    ✗ {} failed to build", target_name);
+                log::error!("build failure for {}: {:#}", target_name, err);
+                build_failed += 1;
+            }
+        }
+    }
+
+    if build_failed > 0 {
+        anyhow::bail!(
+            "{} / {} targets failed to build. Aborting campaign.",
+            build_failed,
+            targets.len()
+        );
+    }
+
+    println!("[*] All targets built successfully.");
+
+    let campaign_start = SystemTime::now();
+
+    println!();
+    println!("[*] Launching all {} targets in parallel...", targets.len());
+
+    let mut handles = Vec::new();
+    for (target_name, target) in targets {
+        let toolchain = toolchain.clone();
+        let fuzz_dir = target.fuzz_dir.clone();
+        let target_options = target.target_options.clone();
+        let dict = dict.clone();
+        let target_name_for_thread = target_name.clone();
+
+        let handle = std::thread::spawn(move || -> anyhow::Result<()> {
+            let artifact_dir = fuzz_dir.join("artifacts").join(&target_name_for_thread);
+            fs_err::create_dir_all(&artifact_dir)?;
+
+            let extra = vec![
+                "--".to_owned(),
+                format!("-dict={}", dict.display()),
+                format!("-max_total_time={}", max_total_time),
+                "-timeout=10".to_owned(),
+                "-use_value_profile=1".to_owned(),
+                "-max_len=4096".to_owned(),
+                "-report_slow_units=1".to_owned(),
+                "-print_final_stats=1".to_owned(),
+                format!("-artifact_prefix={}/", artifact_dir.display()),
+            ];
+
+            CargoFuzzCommand::Run { artifact: None }.invoke(
+                &target_name_for_thread,
+                &fuzz_dir,
+                &target_options,
+                toolchain.as_deref(),
+                &extra,
+            )
+        });
+
+        handles.push((target_name, handle));
+    }
+
+    let mut failed = 0u32;
+    for (target_name, handle) in handles {
+        match handle.join() {
+            Ok(Ok(())) => println!("    ✓ {} completed successfully", target_name),
+            Ok(Err(err)) => {
+                println!("    ✗ {} failed", target_name);
+                log::error!("{} failed: {:#}", target_name, err);
+                failed += 1;
+            }
+            Err(_) => {
+                println!("    ✗ {} panicked", target_name);
+                failed += 1;
+            }
+        }
+    }
+
+    let mut total_counts = ArtifactCounts::default();
+    let mut crash_timeout_files = Vec::new();
+
+    println!();
+    println!("==============================================");
+    println!(" Campaign Complete");
+    println!("==============================================");
+
+    for target_name in NETVSP_TARGETS {
+        let artifact_dir = fuzz_dir.join("artifacts").join(target_name);
+        if !artifact_dir.exists() {
+            println!("  {}: no artifacts dir", target_name);
+            continue;
+        }
+
+        let (counts, files) = count_new_artifacts(&artifact_dir, campaign_start)?;
+        total_counts.add(&counts);
+        crash_timeout_files.extend(files);
+
+        if counts.total() == 0 {
+            println!("  {}: clean", target_name);
+        } else {
+            println!(
+                "  {}: {} crashes, {} timeouts, {} slow-units, {} OOM",
+                target_name, counts.crashes, counts.timeouts, counts.slow_units, counts.oom
+            );
+        }
+    }
+
+    println!();
+    println!(
+        " Total (new): {} crashes, {} timeouts, {} slow-units, {} OOM",
+        total_counts.crashes, total_counts.timeouts, total_counts.slow_units, total_counts.oom
+    );
+    println!(" Targets failed: {} / {}", failed, NETVSP_TARGETS.len());
+
+    if !crash_timeout_files.is_empty() {
+        println!();
+        println!("==============================================");
+        println!(" New Crash/Timeout Artifacts");
+        println!("==============================================");
+        for file in crash_timeout_files {
+            if let Ok(meta) = fs_err::metadata(&file) {
+                println!("  {} ({} bytes)", file.display(), meta.len());
+            } else {
+                println!("  {}", file.display());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn run_netvsp_coverage(
+    ctx: &crate::XtaskCtx,
+    fuzz_targets: BTreeMap<String, RepoFuzzTarget>,
+    toolchain: Option<String>,
+    nightly: &str,
+) -> anyhow::Result<()> {
+    let targets = select_netvsp_targets(fuzz_targets)?;
+    let first_target = targets
+        .first()
+        .context("internal error: netvsp target set is empty")?;
+    let fuzz_dir = first_target.1.fuzz_dir.clone();
+
+    let log_dir = fuzz_dir.join("fuzz_logs");
+    let coverage_dir = fuzz_dir.join("coverage");
+    let merged_dir = coverage_dir.join("merged");
+    let merged_lcov = merged_dir.join("merged_netvsp.lcov");
+    let text_report = merged_dir.join("coverage_report.txt");
+
+    fs_err::create_dir_all(&log_dir)?;
+    fs_err::create_dir_all(&merged_dir)?;
+
+    ensure_coverage_prereqs(nightly)?;
+
+    println!("==============================================");
+    println!(" NetVSP Fuzz Coverage Collection");
+    println!("==============================================");
+    println!(" Targets:    {}", targets.len());
+    println!(" Toolchain:  {}", nightly);
+    println!(" Output:     {}", text_report.display());
+    println!("==============================================");
+
+    for (target_name, target) in &targets {
+        println!("[*] Collecting coverage for {}...", target_name);
+        if let Err(err) = CargoFuzzCommand::Coverage.invoke(
+            target_name,
+            &target.fuzz_dir,
+            &target.target_options,
+            toolchain.as_deref(),
+            &[],
+        ) {
+            log::warn!("coverage collection failed for {}: {:#}", target_name, err);
+        }
+    }
+
+    let (llvm_cov, _) = find_llvm_cov_tools(nightly)?;
+
+    let mut filtered_files = Vec::new();
+    for (target_name, _target) in &targets {
+        let profdata = coverage_dir.join(target_name).join("coverage.profdata");
+        if !profdata.is_file() {
+            log::warn!("{}: no coverage.profdata found", target_name);
+            continue;
+        }
+
+        let Some(coverage_binary) = find_coverage_binary(&ctx.root, target_name)? else {
+            log::warn!("{}: no coverage binary found", target_name);
+            continue;
+        };
+
+        let raw_lcov = coverage_dir.join(target_name).join("coverage.lcov");
+        let filtered_tmp = coverage_dir
+            .join(target_name)
+            .join("coverage_netvsp.tmp.lcov");
+        let filtered_lcov = coverage_dir.join(target_name).join("coverage_netvsp.lcov");
+
+        fs_err::create_dir_all(
+            raw_lcov
+                .parent()
+                .context("failed to resolve coverage output directory")?,
+        )?;
+
+        let export_output = Command::new(&llvm_cov)
+            .arg("export")
+            .arg(format!("-instr-profile={}", profdata.display()))
+            .arg("-format=lcov")
+            .arg("-object")
+            .arg(&coverage_binary)
+            .arg("--ignore-filename-regex")
+            .arg("rustc")
+            .arg("--ignore-filename-regex")
+            .arg("openssl-sys")
+            .output()
+            .with_context(|| format!("failed to run {}", llvm_cov.display()))?;
+
+        if !export_output.status.success() {
+            log::warn!("{}: llvm-cov export failed", target_name);
+            continue;
+        }
+        fs_err::write(&raw_lcov, export_output.stdout)?;
+
+        let extract_status = Command::new("lcov")
+            .arg("--extract")
+            .arg(&raw_lcov)
+            .arg("*/vm/devices/net/netvsp/src/*")
+            .arg("--output-file")
+            .arg(&filtered_tmp)
+            .arg("--quiet")
+            .status()
+            .context("failed to invoke lcov --extract")?;
+        if !extract_status.success() {
+            log::warn!("{}: lcov --extract failed", target_name);
+            continue;
+        }
+
+        let remove_status = Command::new("lcov")
+            .arg("--remove")
+            .arg(&filtered_tmp)
+            .arg("*/test.rs")
+            .arg("*/test_helpers.rs")
+            .arg("--output-file")
+            .arg(&filtered_lcov)
+            .arg("--quiet")
+            .status()
+            .context("failed to invoke lcov --remove")?;
+        let _ = fs_err::remove_file(&filtered_tmp);
+
+        if !remove_status.success() {
+            log::warn!("{}: lcov --remove failed", target_name);
+            continue;
+        }
+
+        if filtered_lcov.is_file() && fs_err::metadata(&filtered_lcov)?.len() > 0 {
+            filtered_files.push(filtered_lcov);
+        }
+    }
+
+    if filtered_files.is_empty() {
+        anyhow::bail!("no LCOV data collected; merged report not generated");
+    }
+
+    let mut merge_cmd = Command::new("lcov");
+    for file in &filtered_files {
+        merge_cmd.arg("--add-tracefile").arg(file);
+    }
+    let merge_status = merge_cmd
+        .arg("--output-file")
+        .arg(&merged_lcov)
+        .arg("--quiet")
+        .status()
+        .context("failed to invoke lcov merge")?;
+    if !merge_status.success() {
+        anyhow::bail!("failed to merge lcov tracefiles");
+    }
+
+    write_coverage_report(&merged_lcov, &text_report)?;
+
+    println!("[*] Text report written to: {}", text_report.display());
+
+    Ok(())
+}
+
+fn ensure_coverage_prereqs(nightly: &str) -> anyhow::Result<()> {
+    if which::which("lcov").is_err() {
+        anyhow::bail!("missing prerequisite `lcov` (install via your package manager)");
+    }
+
+    let _ = find_llvm_cov_tools(nightly)?;
+    Ok(())
+}
+
+/// Try the user-supplied toolchain, then probe `nightly` and `ms-nightly`.
+pub(super) fn resolve_nightly_toolchain(user_toolchain: Option<&str>) -> anyhow::Result<String> {
+    if let Some(tc) = user_toolchain {
+        let status = Command::new("rustc")
+            .arg(format!("+{}", tc))
+            .arg("--print")
+            .arg("sysroot")
+            .status();
+        if matches!(status, Ok(s) if s.success()) {
+            return Ok(tc.to_owned());
+        }
+        anyhow::bail!(
+            "requested toolchain '{}' is not available (rustc +{} failed)",
+            tc,
+            tc
+        );
+    }
+
+    for candidate in ["nightly", "ms-nightly"] {
+        let status = Command::new("rustc")
+            .arg(format!("+{}", candidate))
+            .arg("--print")
+            .arg("sysroot")
+            .status();
+        if matches!(status, Ok(s) if s.success()) {
+            return Ok(candidate.to_owned());
+        }
+    }
+
+    anyhow::bail!(
+        "no nightly toolchain found. \
+         Install one with `rustup toolchain install nightly` or `msrustup update`."
+    );
+}
+
+fn find_llvm_cov_tools(nightly: &str) -> anyhow::Result<(PathBuf, PathBuf)> {
+    let sysroot = Command::new("rustc")
+        .arg(format!("+{}", nightly))
+        .arg("--print")
+        .arg("sysroot")
+        .output()
+        .with_context(|| format!("failed to invoke rustc +{} --print sysroot", nightly))?;
+
+    if !sysroot.status.success() {
+        anyhow::bail!("unable to determine nightly sysroot");
+    }
+
+    let sysroot = String::from_utf8(sysroot.stdout).context("sysroot output was not utf-8")?;
+    let sysroot = PathBuf::from(sysroot.trim());
+
+    let mut profdata: Option<PathBuf> = None;
+    for entry in walkdir::WalkDir::new(&sysroot)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        if entry.file_name() == "llvm-profdata" {
+            profdata = Some(entry.path().to_path_buf());
+            break;
+        }
+    }
+
+    let profdata = profdata.context("llvm-profdata was not found in nightly sysroot")?;
+    let llvm_cov = profdata
+        .parent()
+        .context("llvm-profdata had no parent")?
+        .join("llvm-cov");
+
+    if !llvm_cov.is_file() {
+        anyhow::bail!("llvm-cov was not found next to llvm-profdata");
+    }
+
+    Ok((llvm_cov, profdata))
+}
+
+fn find_coverage_binary(repo_root: &Path, target_name: &str) -> anyhow::Result<Option<PathBuf>> {
+    let target_root = repo_root.join("target");
+    if !target_root.exists() {
+        return Ok(None);
+    }
+
+    // Coverage binaries live under target/<triple>/coverage/<deps|build|...>/
+    // so depth 6 is more than sufficient and avoids walking the entire target tree.
+    for entry in walkdir::WalkDir::new(&target_root)
+        .max_depth(6)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|x| x.to_str()) else {
+            continue;
+        };
+
+        if file_name != target_name {
+            continue;
+        }
+
+        let full_path = path.to_string_lossy();
+        if full_path.contains("/coverage/") {
+            return Ok(Some(path.to_path_buf()));
+        }
+    }
+
+    Ok(None)
+}
+
+fn write_coverage_report(merged_lcov: &Path, text_report: &Path) -> anyhow::Result<()> {
+    let summary_output = Command::new("lcov")
+        .arg("--summary")
+        .arg(merged_lcov)
+        .output()
+        .context("failed to run lcov --summary")?;
+
+    let mut out = File::create(text_report)
+        .with_context(|| format!("failed to create {}", text_report.display()))?;
+
+    writeln!(out, "==============================================")?;
+    writeln!(out, " NetVSP Fuzz Coverage Report")?;
+    writeln!(out, "==============================================")?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        " Source filter: netvsp/src/* (excluding test.rs, test_helpers.rs)"
+    )?;
+    writeln!(out, " Targets: {}", NETVSP_TARGETS.join(" "))?;
+    writeln!(out)?;
+    writeln!(out, "----------------------------------------------")?;
+    writeln!(out, " Overall Summary")?;
+    writeln!(out, "----------------------------------------------")?;
+
+    if summary_output.status.success() {
+        let summary = String::from_utf8(summary_output.stdout)
+            .context("lcov --summary output was not utf-8")?;
+        write!(out, "{}", summary)?;
+    } else {
+        writeln!(out, "lcov --summary failed")?;
+    }
+
+    writeln!(out)?;
+    writeln!(out, "----------------------------------------------")?;
+    writeln!(out, " Per-File Coverage")?;
+    writeln!(out, "----------------------------------------------")?;
+    writeln!(out)?;
+
+    for item in parse_per_file_lcov(merged_lcov)? {
+        if item.line_total == 0 {
+            continue;
+        }
+
+        let line_pct = (item.line_hit as f64 / item.line_total as f64) * 100.0;
+        let fn_info = if item.fn_total > 0 {
+            let fn_pct = (item.fn_hit as f64 / item.fn_total as f64) * 100.0;
+            format!("{}/{} fn ({:.1}%)", item.fn_hit, item.fn_total, fn_pct)
+        } else {
+            "-".to_owned()
+        };
+
+        writeln!(
+            out,
+            "  {:<40} {:>4} / {:>4} lines ({:>5.1}%)  {}",
+            item.short_path, item.line_hit, item.line_total, line_pct, fn_info
+        )?;
+    }
+
+    writeln!(out)?;
+    writeln!(out, "----------------------------------------------")?;
+    writeln!(out, " LCOV data: {}", merged_lcov.display())?;
+    writeln!(out, "----------------------------------------------")?;
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct ArtifactCounts {
+    crashes: u32,
+    timeouts: u32,
+    slow_units: u32,
+    oom: u32,
+}
+
+impl ArtifactCounts {
+    fn add(&mut self, other: &Self) {
+        self.crashes += other.crashes;
+        self.timeouts += other.timeouts;
+        self.slow_units += other.slow_units;
+        self.oom += other.oom;
+    }
+
+    fn total(&self) -> u32 {
+        self.crashes + self.timeouts + self.slow_units + self.oom
+    }
+}
+
+fn count_new_artifacts(
+    artifact_dir: &Path,
+    campaign_start: SystemTime,
+) -> anyhow::Result<(ArtifactCounts, Vec<PathBuf>)> {
+    let mut counts = ArtifactCounts::default();
+    let mut crash_timeout_files = Vec::new();
+
+    for entry in walkdir::WalkDir::new(artifact_dir)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let modified = fs_err::metadata(path)
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        if modified <= campaign_start {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|x| x.to_str()) else {
+            continue;
+        };
+
+        if file_name.starts_with("crash-") {
+            counts.crashes += 1;
+            crash_timeout_files.push(path.to_path_buf());
+        } else if file_name.starts_with("timeout-") {
+            counts.timeouts += 1;
+            crash_timeout_files.push(path.to_path_buf());
+        } else if file_name.starts_with("slow-unit-") {
+            counts.slow_units += 1;
+        } else if file_name.starts_with("oom-") {
+            counts.oom += 1;
+        }
+    }
+
+    Ok((counts, crash_timeout_files))
+}
+
+fn select_netvsp_targets(
+    mut fuzz_targets: BTreeMap<String, RepoFuzzTarget>,
+) -> anyhow::Result<Vec<(String, RepoFuzzTarget)>> {
+    let mut targets = Vec::new();
+
+    for name in NETVSP_TARGETS {
+        let target = fuzz_targets
+            .remove(name)
+            .with_context(|| format!("missing expected NetVSP fuzz target: {name}"))?;
+        targets.push((name.to_owned(), target));
+    }
+
+    Ok(targets)
+}
+
+struct LcovFileCoverage {
+    short_path: String,
+    line_total: u64,
+    line_hit: u64,
+    fn_total: u64,
+    fn_hit: u64,
+}
+
+fn parse_per_file_lcov(path: &Path) -> anyhow::Result<Vec<LcovFileCoverage>> {
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut result = Vec::new();
+
+    let mut current_file: Option<String> = None;
+    let mut line_total = 0u64;
+    let mut line_hit = 0u64;
+    let mut fn_total = 0u64;
+    let mut fn_hit = 0u64;
+
+    for line in reader.lines() {
+        let line = line?;
+
+        if let Some(value) = line.strip_prefix("SF:") {
+            current_file = Some(value.to_owned());
+            line_total = 0;
+            line_hit = 0;
+            fn_total = 0;
+            fn_hit = 0;
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("LF:") {
+            line_total = value.parse().unwrap_or(0);
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("LH:") {
+            line_hit = value.parse().unwrap_or(0);
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("FNF:") {
+            fn_total = value.parse().unwrap_or(0);
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("FNH:") {
+            fn_hit = value.parse().unwrap_or(0);
+            continue;
+        }
+
+        if line == "end_of_record" {
+            if let Some(file) = current_file.take() {
+                let short_path = if let Some((_, suffix)) = file.rsplit_once("/netvsp/src/") {
+                    suffix.to_owned()
+                } else {
+                    file
+                };
+
+                result.push(LcovFileCoverage {
+                    short_path,
+                    line_total,
+                    line_hit,
+                    fn_total,
+                    fn_hit,
+                });
+            }
+        }
+    }
+
+    Ok(result)
+}

--- a/xtask/src/tasks/fuzz/netvsp.rs
+++ b/xtask/src/tasks/fuzz/netvsp.rs
@@ -187,23 +187,32 @@ pub(super) fn run_netvsp_campaign(
             println!("  {}: clean", target_name);
         } else {
             println!(
-                "  {}: {} crashes, {} timeouts, {} slow-units, {} OOM",
-                target_name, counts.crashes, counts.timeouts, counts.slow_units, counts.oom
+                "  {}: {} crashes, {} timeouts, {} slow-units, {} OOM, {} leaks",
+                target_name,
+                counts.crashes,
+                counts.timeouts,
+                counts.slow_units,
+                counts.oom,
+                counts.leaks
             );
         }
     }
 
     println!();
     println!(
-        " Total (new): {} crashes, {} timeouts, {} slow-units, {} OOM",
-        total_counts.crashes, total_counts.timeouts, total_counts.slow_units, total_counts.oom
+        " Total (new): {} crashes, {} timeouts, {} slow-units, {} OOM, {} leaks",
+        total_counts.crashes,
+        total_counts.timeouts,
+        total_counts.slow_units,
+        total_counts.oom,
+        total_counts.leaks
     );
     println!(" Targets failed: {} / {}", failed, NETVSP_TARGETS.len());
 
     if !crash_timeout_files.is_empty() {
         println!();
         println!("==============================================");
-        println!(" New Crash/Timeout Artifacts");
+        println!(" New Artifacts");
         println!("==============================================");
         for file in crash_timeout_files {
             if let Ok(meta) = fs_err::metadata(&file) {
@@ -566,6 +575,7 @@ struct ArtifactCounts {
     timeouts: u32,
     slow_units: u32,
     oom: u32,
+    leaks: u32,
 }
 
 impl ArtifactCounts {
@@ -574,10 +584,11 @@ impl ArtifactCounts {
         self.timeouts += other.timeouts;
         self.slow_units += other.slow_units;
         self.oom += other.oom;
+        self.leaks += other.leaks;
     }
 
     fn total(&self) -> u32 {
-        self.crashes + self.timeouts + self.slow_units + self.oom
+        self.crashes + self.timeouts + self.slow_units + self.oom + self.leaks
     }
 }
 
@@ -616,8 +627,13 @@ fn count_new_artifacts(
             crash_timeout_files.push(path.to_path_buf());
         } else if file_name.starts_with("slow-unit-") {
             counts.slow_units += 1;
+            crash_timeout_files.push(path.to_path_buf());
         } else if file_name.starts_with("oom-") {
             counts.oom += 1;
+            crash_timeout_files.push(path.to_path_buf());
+        } else if file_name.starts_with("leak-") {
+            counts.leaks += 1;
+            crash_timeout_files.push(path.to_path_buf());
         }
     }
 

--- a/xtask/src/tasks/fuzz/netvsp.rs
+++ b/xtask/src/tasks/fuzz/netvsp.rs
@@ -221,7 +221,6 @@ pub(super) fn run_netvsp_campaign(
 pub(super) fn run_netvsp_coverage(
     ctx: &crate::XtaskCtx,
     fuzz_targets: BTreeMap<String, RepoFuzzTarget>,
-    toolchain: Option<String>,
     nightly: &str,
 ) -> anyhow::Result<()> {
     let targets = select_netvsp_targets(fuzz_targets)?;
@@ -255,7 +254,7 @@ pub(super) fn run_netvsp_coverage(
             target_name,
             &target.fuzz_dir,
             &target.target_options,
-            toolchain.as_deref(),
+            Some(nightly),
             &[],
         ) {
             log::warn!("coverage collection failed for {}: {:#}", target_name, err);
@@ -409,7 +408,7 @@ pub(super) fn resolve_nightly_toolchain(user_toolchain: Option<&str>) -> anyhow:
 
     anyhow::bail!(
         "no nightly toolchain found. \
-         Install one with `rustup toolchain install nightly` or `msrustup update`."
+         Install one with `rustup toolchain install nightly`."
     );
 }
 

--- a/xtask/src/tasks/fuzz/netvsp.rs
+++ b/xtask/src/tasks/fuzz/netvsp.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use super::cargo_fuzz::CargoFuzzCommand;
+use super::cargo_fuzz::coverage_binary_path;
 use super::parse_fuzz_crate_toml::RepoFuzzTarget;
 use anyhow::Context;
 use std::collections::BTreeMap;
@@ -279,10 +280,14 @@ pub(super) fn run_netvsp_coverage(
             continue;
         }
 
-        let Some(coverage_binary) = find_coverage_binary(&ctx.root, target_name)? else {
-            log::warn!("{}: no coverage binary found", target_name);
-            continue;
-        };
+        // Derive the coverage binary path using the same layout as cargo-fuzz:
+        //   target/<triple>/coverage/<triple>/release/<target_name>
+        let coverage_bin = coverage_binary_path(&ctx.root, target_name)?;
+        anyhow::ensure!(
+            coverage_bin.is_file(),
+            "xtask bug: coverage binary not found at {}. Was `cargo fuzz coverage` run first?",
+            coverage_bin.display()
+        );
 
         let raw_lcov = coverage_dir.join(target_name).join("coverage.lcov");
         let filtered_tmp = coverage_dir
@@ -301,7 +306,7 @@ pub(super) fn run_netvsp_coverage(
             .arg(format!("-instr-profile={}", profdata.display()))
             .arg("-format=lcov")
             .arg("-object")
-            .arg(&coverage_binary)
+            .arg(&coverage_bin)
             .arg("--ignore-filename-regex")
             .arg("rustc")
             .arg("--ignore-filename-regex")
@@ -467,40 +472,6 @@ fn find_llvm_cov_tools(nightly: &str) -> anyhow::Result<(PathBuf, PathBuf)> {
     }
 
     Ok((llvm_cov, profdata))
-}
-
-fn find_coverage_binary(repo_root: &Path, target_name: &str) -> anyhow::Result<Option<PathBuf>> {
-    let target_root = repo_root.join("target");
-    if !target_root.exists() {
-        return Ok(None);
-    }
-
-    // Coverage binaries live under target/<triple>/coverage/<deps|build|...>/
-    // Use Path::components() to match "coverage" in any path component,
-    // which is platform-agnostic (no hardcoded path separators).
-    for entry in walkdir::WalkDir::new(&target_root)
-        .into_iter()
-        .filter_map(Result::ok)
-    {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-
-        let Some(file_name) = path.file_name().and_then(|x| x.to_str()) else {
-            continue;
-        };
-
-        if file_name != target_name {
-            continue;
-        }
-
-        if path.components().any(|c| c.as_os_str() == "coverage") {
-            return Ok(Some(path.to_path_buf()));
-        }
-    }
-
-    Ok(None)
 }
 
 fn write_coverage_report(merged_lcov: &Path, text_report: &Path) -> anyhow::Result<()> {

--- a/xtask/src/tasks/fuzz/netvsp.rs
+++ b/xtask/src/tasks/fuzz/netvsp.rs
@@ -78,14 +78,13 @@ pub(super) fn run_netvsp_campaign(
 
     for (target_name, target) in &targets {
         println!("    Building {}...", target_name);
-        let extra = vec!["--".to_owned(), "-runs=0".to_owned()];
 
-        let result = CargoFuzzCommand::Run { artifact: None }.invoke(
+        let result = CargoFuzzCommand::Build.invoke(
             target_name,
             &target.fuzz_dir,
             &target.target_options,
             toolchain.as_deref(),
-            &extra,
+            &[],
         );
 
         match result {
@@ -438,14 +437,24 @@ fn find_llvm_cov_tools(nightly: &str) -> anyhow::Result<(PathBuf, PathBuf)> {
         }
     }
 
-    let profdata = profdata.context("llvm-profdata was not found in nightly sysroot")?;
+    let profdata = profdata.with_context(|| {
+        format!(
+            "llvm-profdata was not found in the nightly sysroot. \
+             Install it with: rustup +{} component add llvm-tools-preview",
+            nightly
+        )
+    })?;
     let llvm_cov = profdata
         .parent()
         .context("llvm-profdata had no parent")?
         .join("llvm-cov");
 
     if !llvm_cov.is_file() {
-        anyhow::bail!("llvm-cov was not found next to llvm-profdata");
+        anyhow::bail!(
+            "llvm-cov was not found next to llvm-profdata. \
+             Install it with: rustup +{} component add llvm-tools-preview",
+            nightly
+        );
     }
 
     Ok((llvm_cov, profdata))
@@ -458,9 +467,9 @@ fn find_coverage_binary(repo_root: &Path, target_name: &str) -> anyhow::Result<O
     }
 
     // Coverage binaries live under target/<triple>/coverage/<deps|build|...>/
-    // so depth 6 is more than sufficient and avoids walking the entire target tree.
+    // Use Path::components() to match "coverage" in any path component,
+    // which is platform-agnostic (no hardcoded path separators).
     for entry in walkdir::WalkDir::new(&target_root)
-        .max_depth(6)
         .into_iter()
         .filter_map(Result::ok)
     {
@@ -477,8 +486,7 @@ fn find_coverage_binary(repo_root: &Path, target_name: &str) -> anyhow::Result<O
             continue;
         }
 
-        let full_path = path.to_string_lossy();
-        if full_path.contains("/coverage/") {
+        if path.components().any(|c| c.as_os_str() == "coverage") {
             return Ok(Some(path.to_path_buf()));
         }
     }


### PR DESCRIPTION
Adding fuzz tests for netvsp's processing of RNDIS messages, OIDS, traffic, and the handling of various external signals. Protocol structs and enums have been modified to derive Arbitrary crate. A bit of test code was refactored so that the fuzz tests could leverage it. Created a .dict, wrote up a markdown file, and created two xtasks for running the netvsp fuzz tests.

Fuzz tests added:

- fuzz_netvsp_interop - combination of actions from the other fuzz tests
- fuzz_netvsp_control - NetVSP control messages
- fuzz_netvsp_oid - RNDIS OID query + set
- fuzz_netvsp_tx_path - synthetic datapath send
- fuzz_netvsp_rx_path - synthetic datapath receive
- fuzz_netvsp_link_status - link up/down
- fuzz_netvsp_vf_state - VF association, and datapath switch
- fuzz_netvsp_subchannel - subchannel allocation
- fuzz_netvsp_save_restore - NIC save + restore

High-value Bugs Fixed - Worker panics on guest provided input:

- Unexpected packet type kills worker
- Invalid RNDIS packet completion kills worker
- Packet parse failure kills worker
- Failed RNDIS control message kills worker
- Config parameter parsing panics on non-digit byte
- Zero-size RSS indirection table (division by zero)
- Receive buffer write overflow (out-of-bounds page write)
- close() panics on out-of-range channel index

Medium-value Bugs Fixed
- max_subchannels() off-by-one
- RxBufferRanges::new() arithmetic underflow

Low-value Bugs Fixed - Invalid state

- Invalid save state is supplied, restore fails
- Invalid send/receive buffers are provided, initialization fails
- MTU/sub-allocation not validated during queue restart
- RxBuffers::allocate() accepts empty/OOB buffer IDs
- enable_channels() accepts counts exceeding event vector

```shell
 Per-File Coverage
----------------------------------------------

  buffers.rs                                116 /  153 lines ( 75.8%)  8/11 fn (72.7%)
  lib.rs                                   3054 / 3529 lines ( 86.5%)  205/218 fn (94.0%)
  protocol.rs                                 0 /    9 lines (  0.0%)  0/3 fn (0.0%)
  resolver.rs                                 0 /    2 lines (  0.0%)  0/1 fn (0.0%)
  rndisprot.rs                               85 /  147 lines ( 57.8%)  20/36 fn (55.6%)
  rx_bufs.rs                                 74 /   78 lines ( 94.9%)  11/11 fn (100.0%)
  saved_state.rs                             11 /   11 lines (100.0%)  3/3 fn (100.0%)
```
