### PR TITLE
ttrpc: make initrd optional for Linux direct boot

### DIFF
--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -419,10 +419,14 @@ impl VmService {
         {
             vmservice::vm_config::BootConfig::DirectBoot(boot) => {
                 let kernel = File::open(boot.kernel_path).context("failed to open kernel")?;
-                let initrd_file = File::open(boot.initrd_path).context("failed to open initrd")?;
+                let initrd = if boot.initrd_path.is_empty() {
+                    None
+                } else {
+                    Some(File::open(boot.initrd_path).context("failed to open initrd")?)
+                };
                 LoadMode::Linux {
                     kernel,
-                    initrd: Some(initrd_file),
+                    initrd,
                     cmdline: boot.kernel_cmdline,
                     custom_dsdt: None,
                     enable_serial: true,


### PR DESCRIPTION
The initrd_path was unconditionally opened via File::open in the ttrpc DirectBoot handler, causing a failure when no initrd was provided (empty string, the proto3 default). This is inconsistent with the CLI path and the LoadMode::Linux definition, which both treat initrd as optional.

Check for an empty initrd_path before attempting to open the file, and pass None when it is not provided.