### PR TITLE
Add debug_output_tracing crate to oss/support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,9 +1008,10 @@ dependencies = [
 name = "debug_output_tracing"
 version = "0.0.0"
 dependencies = [
+ "smallvec",
  "tracing",
  "tracing-subscriber",
- "winapi",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,6 @@ exclude = [
   "Guide/mdbook-openvmm-shim"
 ]
 
-[workspace.metadata.xtask.unused-deps]
-ignored = ["debug_output_tracing"]
-
 [workspace.package]
 rust-version = "1.93"
 edition = "2024"
@@ -109,7 +106,6 @@ ci_logger = { path = "support/ci_logger" }
 clap_dyn_complete = { path = "support/clap_dyn_complete" }
 console_relay = { path = "support/console_relay" }
 safe_intrinsics = { path = "support/safe_intrinsics" }
-debug_output_tracing = { path = "support/debug_output_tracing" }
 debug_ptr = { path = "support/debug_ptr" }
 user_driver_emulated_mock = { path = "vm/devices/user_driver_emulated_mock" }
 fast_memcpy = { path = "support/fast_memcpy" }

--- a/support/debug_output_tracing/Cargo.toml
+++ b/support/debug_output_tracing/Cargo.toml
@@ -7,9 +7,10 @@ edition.workspace = true
 rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
+smallvec.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-winapi = { workspace = true, features = ["debugapi"] }
+windows-sys = { workspace = true, features = ["Win32_System_Diagnostics_Debug"] }
 
 [lints]
 workspace = true

--- a/support/debug_output_tracing/src/lib.rs
+++ b/support/debug_output_tracing/src/lib.rs
@@ -53,11 +53,12 @@
 // UNSAFETY: Calling Win32 `OutputDebugStringA` and `IsDebuggerPresent`.
 #![expect(unsafe_code)]
 
+use smallvec::SmallVec;
 use tracing::Subscriber;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::layer::Filter;
-use winapi::um::debugapi::{IsDebuggerPresent, OutputDebugStringA};
+use windows_sys::Win32::System::Diagnostics::Debug::{IsDebuggerPresent, OutputDebugStringA};
 
 // ---------------------------------------------------------------------------
 // DebugOutputWriter
@@ -67,34 +68,26 @@ use winapi::um::debugapi::{IsDebuggerPresent, OutputDebugStringA};
 /// `OutputDebugStringA`.
 ///
 /// Suitable for use with `tracing_subscriber::fmt::layer().with_writer()`.
-#[derive(Default)]
-pub struct DebugOutputWriter;
+pub struct DebugOutputWriter {
+    _private: (),
+}
 
 impl DebugOutputWriter {
     /// Create a new writer.
     pub fn new() -> Self {
-        Self
+        Self { _private: () }
     }
 }
 
 impl std::io::Write for DebugOutputWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        // Use a stack buffer for typical messages to avoid a heap allocation.
-        // Only fall back to Vec for oversized output.
-        const STACK_BUF_SIZE: usize = 1024;
-        if buf.len() < STACK_BUF_SIZE {
-            let mut stack_buf = [0u8; STACK_BUF_SIZE];
-            stack_buf[..buf.len()].copy_from_slice(buf);
-            // stack_buf[buf.len()] is already 0 from the zero-init.
-            // SAFETY: The buffer is null-terminated and valid.
-            unsafe { OutputDebugStringA(stack_buf.as_ptr().cast::<i8>()) };
-        } else {
-            let mut null_terminated = Vec::with_capacity(buf.len() + 1);
-            null_terminated.extend_from_slice(buf);
-            null_terminated.push(b'\0');
-            // SAFETY: The buffer is null-terminated and valid.
-            unsafe { OutputDebugStringA(null_terminated.as_ptr().cast::<i8>()) };
-        }
+        // Use a SmallVec so typical messages stay on the stack and only
+        // spill to the heap for oversized output.
+        let mut null_terminated: SmallVec<[u8; 1024]> = SmallVec::with_capacity(buf.len() + 1);
+        null_terminated.extend_from_slice(buf);
+        null_terminated.push(b'\0');
+        // SAFETY: The buffer is null-terminated and valid.
+        unsafe { OutputDebugStringA(null_terminated.as_ptr()) };
         Ok(buf.len())
     }
 


### PR DESCRIPTION
Windows-only tracing infrastructure that routes tracing events to OutputDebugStringA with a per-layer filter that avoids formatting overhead when no debugger is attached.