### PR TITLE
CVM SNP: Secure AVIC support

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -30,8 +30,8 @@ pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.7";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.7";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.12";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.11";
 pub const OPENVMM_DEPS: &str = "0.1.0-20260401.1";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "6.12.52.7" else "6.12.52.7";
+  version = if is_dev then "6.12.52.12" else "6.12.52.11";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,21 +18,21 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-H0UOWFufD2NwtvANSQrj0z0mmaAz8wB4e8rJC7+471Y=";
-        arm64 = "sha256-X9WQj5C6MZy9QdIe43NR9AhxT9PZiOmM5ycpxGg2UoA=";
+        x64 = "sha256-vuXKGF5iIa3G8+4gqAzPbNjVw30RkW00d1tNf3M/eVg=";
+        arm64 = "sha256-Kx/nq8/bTA5UJIaiMdRREngqpf5bB41DifpvWgBMzOg=";
       };
       cvm = {
-        x64 = "sha256-5X4CwBw4+fbTmD1AVHZ9+SBPcMZRknl7+/mOU+YRqas=";
+        x64 = "sha256-L6sa70xnV7OU+zdYKJfyuhtsBk4SpRrR9RMMcvZb294=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };
     hcl-dev = {
       std = {
-        x64 = "sha256-q5RyCt3d+Zu5GBd8X0bHKLh7Av1qhA2Xjf/XTWHod6Y=";
-        arm64 = "sha256-xfbFgUKd0mec87E8z252LeknBMpvHcFfi9QXjDlfjjw=";
+        x64 = "sha256-7PRUo4igtRL1wFzp99YZlOK+y5OcPH7ZENIDBmV0sY0=";
+        arm64 = "sha256-lLVu13Y0fdz8RzhXs6QieZ76+0Y0ttQeuTjXLuxI9QQ=";
       };
       cvm = {
-        x64 = "sha256-o1XszcOWkpacpQKsp3AAOQuWtHnQrZfkdDuqyNh/UgU=";
+        x64 = "sha256-kbQEKm1/KNushR9rBuuL1LVfM77hG6t4F55vZvzPuAU=";
         arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
       };
     };

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -72,9 +72,10 @@ use std::sync::atomic::Ordering;
 use thiserror::Error;
 use user_driver::DmaClient;
 use user_driver::memory::MemoryBlock;
+use x86defs::snp::SevAvicPage;
 use x86defs::snp::SevVmsa;
 use x86defs::tdx::TdCallResultCode;
-use x86defs::vmx::ApicPage;
+use x86defs::vmx::VmxApicPage;
 use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 use zerocopy::Immutable;
@@ -104,8 +105,8 @@ pub enum Error {
     MmapVp(#[source] io::Error, Option<Vtl>),
     #[error("failed to set the poll file")]
     SetPollFile(#[source] nix::Error),
-    #[error("failed to check hcl capabilities")]
-    CheckExtensions(#[source] nix::Error),
+    #[error("failed to check hcl capabilities {0}")]
+    CheckExtensions(u32, #[source] nix::Error),
     #[error("failed to mmap the register page")]
     MmapRegPage(#[source] io::Error),
     #[error("failed to create vtl")]
@@ -359,6 +360,7 @@ pub(crate) mod ioctls {
     const MSHV_TLBSYNC: u16 = 0x37;
     const MSHV_KICKCPUS: u16 = 0x38;
     const MSHV_MAP_REDIRECTED_DEVICE_INTERRUPT: u16 = 0x39;
+    const MSHV_VTL_SECURE_AVIC_VTL0_PFN: u16 = 0x40;
 
     #[repr(C)]
     #[derive(Copy, Clone)]
@@ -554,6 +556,13 @@ pub(crate) mod ioctls {
         u64
     );
 
+    ioctl_readwrite!(
+        hcl_read_secure_avic_vtl0_pfn,
+        MSHV_IOCTL,
+        MSHV_VTL_SECURE_AVIC_VTL0_PFN,
+        u64
+    );
+
     pub const HCL_CAP_REGISTER_PAGE: u32 = 1;
     pub const HCL_CAP_VTL_RETURN_ACTION: u32 = 2;
     pub const HCL_CAP_DR6_SHARED: u32 = 3;
@@ -665,7 +674,8 @@ impl Mshv {
     fn check_extension(&self, cap: u32) -> Result<bool, Error> {
         // SAFETY: calling IOCTL as documented, with no special requirements.
         let supported = unsafe {
-            hcl_check_extension(self.file.as_raw_fd(), &cap).map_err(Error::CheckExtensions)?
+            hcl_check_extension(self.file.as_raw_fd(), &cap)
+                .map_err(|e| Error::CheckExtensions(cap, e))?
         };
         Ok(supported != 0)
     }
@@ -1392,9 +1402,12 @@ enum BackingState {
     },
     Snp {
         vmsa: VtlArray<MappedPage<SevVmsa>, 2>,
+        vtl0_apic_page: MappedPage<SevAvicPage>,
+        /// VTL1 runs with the alternate interrupt injection.
+        vtl1_apic_page: MemoryBlock,
     },
     Tdx {
-        vtl0_apic_page: MappedPage<ApicPage>,
+        vtl0_apic_page: MappedPage<VmxApicPage>,
         vtl1_apic_page: MemoryBlock,
     },
 }
@@ -1458,6 +1471,12 @@ impl HclVp {
                     .map_err(|e| Error::MmapVp(e, Some(Vtl::Vtl1)))?;
                 BackingState::Snp {
                     vmsa: [vmsa_vtl0, vmsa_vtl1].into(),
+                    vtl0_apic_page: MappedPage::new(fd, MSHV_APIC_PAGE_OFFSET | vp as i64)
+                        .map_err(|e| Error::MmapVp(e, Some(Vtl::Vtl0)))?,
+                    vtl1_apic_page: private_dma_client
+                        .ok_or(Error::MissingPrivateMemory)?
+                        .allocate_dma_buffer(HV_PAGE_SIZE as usize)
+                        .map_err(Error::AllocVp)?,
                 }
             }
             IsolationType::Tdx => BackingState::Tdx {
@@ -2350,6 +2369,27 @@ impl Hcl {
         }
 
         vp_pfn
+    }
+
+    /// Gets the PFN for the VTL 0 secure AVIC.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the Secure AVIC VTL 0 page was not mapped (i.e., Secure AVIC
+    /// is not enabled). Callers must ensure Secure AVIC is enabled before
+    /// calling this method.
+    pub fn secure_avic_vtl0_pfn(&self, cpu_index: u32) -> u64 {
+        let mut savic_pfn = cpu_index as u64; // input vp, output pfn
+
+        // SAFETY: The ioctl requires no prerequisites other than the Secure AVIC VTL 0
+        // should be mapped. This ioctl should never fail as long as the VTL 0
+        // Secure AVIC was mapped.
+        unsafe {
+            hcl_read_secure_avic_vtl0_pfn(self.mshv_vtl.file.as_raw_fd(), &mut savic_pfn)
+                .expect("should always succeed");
+        }
+
+        savic_pfn
     }
 
     /// Returns the isolation type for the partition.

--- a/openhcl/hcl/src/ioctl/register.rs
+++ b/openhcl/hcl/src/ioctl/register.rs
@@ -297,7 +297,14 @@ impl<'a, T: Backing<'a>> ProcessorRunner<'a, T> {
         let registers: Vec<HvRegisterAssoc> = values.into_iter().map(Into::into).collect();
 
         #[cfg(guest_arch = "x86_64")]
-        let per_arch = |name| matches!(name, HvArchRegisterName::CrInterceptControl);
+        let per_arch = |name| {
+            matches!(
+                name,
+                HvArchRegisterName::CrInterceptControl
+                    | HvArchRegisterName::SevAvicGpa
+                    | HvArchRegisterName::GuestVsmPartitionConfig
+            )
+        };
 
         #[cfg(guest_arch = "aarch64")]
         let per_arch = |_: HvArchRegisterName| false;

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -25,12 +25,14 @@ use sidecar_client::SidecarVp;
 use std::cell::UnsafeCell;
 use std::os::fd::AsRawFd;
 use thiserror::Error;
+use x86defs::snp::SevAvicPage;
 use x86defs::snp::SevRmpAdjust;
 use x86defs::snp::SevVmsa;
 
 /// Runner backing for SNP partitions.
 pub struct Snp<'a> {
     vmsa: VtlArray<&'a UnsafeCell<SevVmsa>, 2>,
+    avic_pages: VtlArray<&'a UnsafeCell<SevAvicPage>, 2>,
 }
 
 /// Error returned by failing SNP operations.
@@ -168,11 +170,21 @@ impl MshvVtl {
 impl<'a> super::private::BackingPrivate<'a> for Snp<'a> {
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'_>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
-        let super::BackingState::Snp { vmsa } = &vp.backing else {
+        let super::BackingState::Snp {
+            vtl0_apic_page,
+            vtl1_apic_page,
+            vmsa,
+        } = &vp.backing
+        else {
             return Err(NoRunner::MismatchedIsolation);
         };
 
+        // SAFETY: The mapping is held for the appropriate lifetime, and the
+        // APIC page is never accessed as any other type, or by any other location.
+        let vtl1_apic_page = unsafe { &*vtl1_apic_page.base().cast() };
+
         Ok(Self {
+            avic_pages: [vtl0_apic_page.as_ref(), vtl1_apic_page].into(),
             vmsa: vmsa.each_ref().map(|mp| mp.as_ref()),
         })
     }
@@ -233,5 +245,51 @@ impl<'a> ProcessorRunner<'a, Snp<'a>> {
                 VmsaWrapper::new(vmsa, &self.hcl.snp_register_bitmap)
             })
             .into_inner()
+    }
+
+    /// Gets a PFN of the VTL0 secure AVIC page.
+    /// TODO: Maybe there is a better way other than passing `cpu_index` here.
+    pub fn secure_avic_vtl0_pfn(&self, cpu_index: u32) -> u64 {
+        self.hcl.secure_avic_vtl0_pfn(cpu_index)
+    }
+
+    /// Gets a reference to the secure AVIC page for the given VTL.
+    pub fn secure_avic_page(&self, vtl: GuestVtl) -> &SevAvicPage {
+        // SAFETY: the APIC pages will not be concurrently accessed by the processor
+        // while this VP is in VTL2.
+        unsafe { &*self.state.avic_pages[vtl].get() }
+    }
+
+    /// Gets a mutable reference to the secure AVIC page for the given VTL.
+    pub fn secure_avic_page_mut(&mut self, vtl: GuestVtl) -> &mut SevAvicPage {
+        // SAFETY: the AVIC pages will not be concurrently accessed by the processor
+        // while this VP is in VTL2.
+        unsafe { &mut *self.state.avic_pages[vtl].get() }
+    }
+
+    /// Gets a mutable reference to the secure AVIC page for the given VTL.
+    pub fn secure_avic_page_vmsa_mut(
+        &mut self,
+        vtl: GuestVtl,
+    ) -> (&mut SevAvicPage, VmsaWrapper<'_, &mut SevVmsa>) {
+        // SAFETY: the AVIC pages will not be concurrently accessed by the processor
+        // while this VP is in VTL2.
+        let avic_page = unsafe { &mut *self.state.avic_pages[vtl].get() };
+        let vmsa = self.vmsa_mut(vtl);
+
+        (avic_page, vmsa)
+    }
+
+    /// Gets a mutable reference to the secure AVIC page and the proxy_irr_exit field
+    pub fn secure_avic_page_proxy_irr_exit_vtl0_mut(
+        &mut self,
+    ) -> (&mut SevAvicPage, &mut [u32; 8]) {
+        // SAFETY: the AVIC pages will not be concurrently accessed by the processor
+        // while this VP is in VTL2.
+        let avic_page = unsafe { &mut *self.state.avic_pages[GuestVtl::Vtl0].get() };
+        // SAFETY: The `proxy_irr_exit` field of the run page will not be concurrently updated.
+        let proxy_irr_vtl0 = unsafe { &mut (*self.run.get()).proxy_irr_exit };
+
+        (avic_page, proxy_irr_vtl0)
     }
 }

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -40,12 +40,12 @@ use x86defs::tdx::TdxGp;
 use x86defs::tdx::TdxL2Ctls;
 use x86defs::tdx::TdxL2EnterGuestState;
 use x86defs::tdx::TdxVmFlags;
-use x86defs::vmx::ApicPage;
 use x86defs::vmx::VmcsField;
+use x86defs::vmx::VmxApicPage;
 
 /// Runner backing for TDX partitions.
 pub struct Tdx<'a> {
-    apic_pages: VtlArray<&'a UnsafeCell<ApicPage>, 2>,
+    apic_pages: VtlArray<&'a UnsafeCell<VmxApicPage>, 2>,
 }
 
 impl MshvVtl {
@@ -126,14 +126,14 @@ impl<'a> ProcessorRunner<'a, Tdx<'a>> {
     }
 
     /// Gets a reference to the tdx APIC page for the given VTL.
-    pub fn tdx_apic_page(&self, vtl: GuestVtl) -> &ApicPage {
+    pub fn tdx_apic_page(&self, vtl: GuestVtl) -> &VmxApicPage {
         // SAFETY: the APIC pages will not be concurrently accessed by the processor
         // while this VP is in VTL2.
         unsafe { &*self.state.apic_pages[vtl].get() }
     }
 
     /// Gets a mutable reference to the tdx APIC page for the given VTL.
-    pub fn tdx_apic_page_mut(&mut self, vtl: GuestVtl) -> &mut ApicPage {
+    pub fn tdx_apic_page_mut(&mut self, vtl: GuestVtl) -> &mut VmxApicPage {
         // SAFETY: the APIC pages will not be concurrently accessed by the processor
         // while this VP is in VTL2.
         unsafe { &mut *self.state.apic_pages[vtl].get() }

--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -7,6 +7,7 @@
 use std::array;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use x86defs::snp::SecureAvicControl;
 use x86defs::snp::SevEventInjectInfo;
 use x86defs::snp::SevFeatures;
 use x86defs::snp::SevSelector;
@@ -267,6 +268,11 @@ reg_direct_mut!(v_intr_cntrl, v_intr_cntrl_mut, SevVirtualInterruptControl);
 reg_direct!(virtual_tom, set_virtual_tom, u64);
 reg_direct!(event_inject, set_event_inject, SevEventInjectInfo);
 reg_direct!(guest_error_code, set_guest_error_code, u64);
+reg_direct_mut!(
+    secure_avic_control,
+    secure_avic_control_mut,
+    SecureAvicControl
+);
 regss!(es, set_es);
 regss!(cs, set_cs);
 regss!(ss, set_ss);

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -97,6 +97,7 @@ pub enum CpuidResultsIsolationType<'a> {
         cpuid_pages: &'a [u8],
         access_vsm: bool,
         vtom: u64,
+        secure_avic: bool,
     },
     Tdx {
         topology: &'a ProcessorTopology<X86Topology>,
@@ -214,12 +215,13 @@ impl CpuidResults {
                 cpuid_pages,
                 access_vsm,
                 vtom,
+                secure_avic,
             } => {
                 assert!(
                     cpuid_pages.len() % size_of::<HvPspCpuidPage>() == 0 && !cpuid_pages.is_empty()
                 );
 
-                snp_init = SnpCpuidInitializer::new(cpuid_pages, access_vsm, vtom);
+                snp_init = SnpCpuidInitializer::new(cpuid_pages, access_vsm, vtom, secure_avic);
                 &snp_init as &dyn CpuidArchInitializer
             }
             CpuidResultsIsolationType::Tdx {

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -96,10 +96,11 @@ pub struct SnpCpuidInitializer {
     cpuid_pages: Vec<HvPspCpuidPage>,
     access_vsm: bool,
     vtom: u64,
+    secure_avic: bool,
 }
 
 impl SnpCpuidInitializer {
-    pub fn new(cpuid_pages_data: &[u8], access_vsm: bool, vtom: u64) -> Self {
+    pub fn new(cpuid_pages_data: &[u8], access_vsm: bool, vtom: u64, secure_avic: bool) -> Self {
         let mut cpuid_pages = vec![
             HvPspCpuidPage::new_zeroed();
             cpuid_pages_data.len() / size_of::<HvPspCpuidPage>()
@@ -113,6 +114,7 @@ impl SnpCpuidInitializer {
             cpuid_pages,
             access_vsm,
             vtom,
+            secure_avic,
         }
     }
 }
@@ -214,6 +216,7 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
                     .with_vmpl(true)
                     .with_rmp_query(true)
                     .with_tsc_aux_virtualization(true)
+                    .with_secure_avic(self.secure_avic)
                     .into(),
                 cpuid::ExtendedSevFeaturesEbx::new()
                     .with_cbit_position(0x3f)
@@ -429,12 +432,16 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             .with_use_ex_processor_masks(true)
             // If only xAPIC is supported, then the Hyper-V MSRs are
             // more efficient for EOIs.
+            //
             // If X2APIC is supported, then we can use the X2APIC MSRs. These
             // are as efficient as the Hyper-V MSRs, and they are
             // compatible with APIC hardware offloads.
             // However, Lazy EOI on SNP is beneficial and requires the
             // Hyper-V MSRs to function. Enable it here always.
-            .with_use_apic_msrs(true)
+            //
+            // When Secure AVIC is enabled, x2APIC MSR accesses are
+            // not intercepted. Secure AVIC accelerates EOIs (15.36.21.5 Guest APIC Accesses).
+            .with_use_apic_msrs(!self.secure_avic)
             .with_long_spin_wait_count(!0)
             .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
             .with_use_synthetic_cluster_ipi(true);

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/mod.rs
@@ -253,6 +253,7 @@ fn populate_and_filter() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -366,6 +367,7 @@ fn subleaf() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -420,6 +422,7 @@ fn invlpgb() {
             cpuid_pages: pages.as_slice().as_bytes(),
             access_vsm: false,
             vtom: 0x80000000,
+            secure_avic: false,
         }
         .build(),
         Err(CpuidResultsError::InvlpgbUnavailable)
@@ -455,6 +458,7 @@ fn extended_address_space_sizes() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -478,6 +482,7 @@ fn hypervisor_present() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -506,6 +511,7 @@ fn validate_required_snp() {
                 cpuid_pages: pages.as_slice().as_bytes().as_bytes(),
                 access_vsm: false,
                 vtom: 0x80000000,
+                secure_avic: false,
             }.build(),
             Err(CpuidResultsError::MissingRequiredResult(err_leaf, err_subleaf)) if (err_leaf == leaf && err_subleaf == subleaf)
         ));
@@ -543,6 +549,7 @@ fn zeros_unsupported_leaf() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -578,6 +585,7 @@ fn tsc_aux() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -1129,6 +1137,7 @@ fn real_values() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/topology.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/topology.rs
@@ -54,6 +54,7 @@ fn real_topology() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     })
     .unwrap();
 
@@ -161,6 +162,7 @@ fn initialize_topology(
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
 }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/xfem.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/xfem.rs
@@ -51,6 +51,7 @@ fn extended_state_enumeration_wrong_page() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -168,6 +169,7 @@ fn real_xfem() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -341,6 +343,7 @@ fn run_fake_xfem_test(
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -948,6 +951,7 @@ fn xfem_bounds() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();
@@ -1044,6 +1048,7 @@ fn xfem_missing_subleaf0() {
             cpuid_pages: pages.as_slice().as_bytes(),
             access_vsm: false,
             vtom: 0x80000000,
+            secure_avic: false,
         }
         .build(),
         Err(CpuidResultsError::MissingRequiredResult(
@@ -1094,6 +1099,7 @@ fn xfem_missing_subleaf1() {
             cpuid_pages: pages.as_slice().as_bytes(),
             access_vsm: false,
             vtom: 0x80000000,
+            secure_avic: false,
         }
         .build(),
         Err(CpuidResultsError::MissingRequiredResult(
@@ -1158,6 +1164,7 @@ fn xfem_missing_additional_subleaf() {
             cpuid_pages: pages.as_slice().as_bytes(),
             access_vsm: false,
             vtom: 0x80000000,
+            secure_avic: false,
         }
         .build(),
         Err(CpuidResultsError::MissingRequiredResult(
@@ -1225,6 +1232,7 @@ fn xfem_missing_support() {
         cpuid_pages: pages.as_slice().as_bytes(),
         access_vsm: false,
         vtom: 0x80000000,
+        secure_avic: false,
     }
     .build()
     .unwrap();

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1655,13 +1655,23 @@ impl<'a> UhProtoPartition<'a> {
 
         #[cfg(guest_arch = "x86_64")]
         let cpuid = match params.isolation {
-            IsolationType::Snp => cvm_cpuid::CpuidResultsIsolationType::Snp {
-                cpuid_pages: params.cvm_cpuid_info.unwrap(),
-                vtom: params.vtom.unwrap(),
-                access_vsm: guest_vsm_available,
+            IsolationType::Snp => {
+                let secure_avic = x86defs::snp::SevStatusMsr::from(
+                    MsrDevice::new(0)
+                        .expect("open msr")
+                        .read_msr(x86defs::X86X_AMD_MSR_SEV)
+                        .expect("read msr"),
+                )
+                .secure_avic();
+                cvm_cpuid::CpuidResultsIsolationType::Snp {
+                    cpuid_pages: params.cvm_cpuid_info.unwrap(),
+                    vtom: params.vtom.unwrap(),
+                    access_vsm: guest_vsm_available,
+                    secure_avic,
+                }
+                .build()
+                .map_err(Error::CvmCpuid)?
             }
-            .build()
-            .map_err(Error::CvmCpuid)?,
 
             IsolationType::Tdx => cvm_cpuid::CpuidResultsIsolationType::Tdx {
                 topology: params.topology,

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -23,11 +23,13 @@ use crate::UhCvmVpState;
 use crate::UhPartitionInner;
 use crate::UhPartitionNewParams;
 use crate::WakeReason;
+use crate::devmsr;
 use crate::processor::UhHypercallHandler;
 use crate::processor::UhProcessor;
 use crate::processor::hardware_cvm::apic::ApicBacking;
 use cvm_tracing::CVM_ALLOWED;
 use cvm_tracing::CVM_CONFIDENTIAL;
+use hcl::protocol::hcl_intr_offload_flags;
 use hcl::vmsa::VmsaWrapper;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::synic::ProcessorSynic;
@@ -69,7 +71,13 @@ use virt_support_x86emu::emulate::emulate_translate_gva;
 use virt_support_x86emu::translate::TranslationRegisters;
 use vmcore::vmtime::VmTimeAccess;
 use x86defs::RFlags;
+use x86defs::apic::X2APIC_MSR_BASE;
 use x86defs::cpuid::CpuidFunction;
+use x86defs::snp::SevAvicIncompleteIpiInfo1;
+use x86defs::snp::SevAvicIncompleteIpiInfo2;
+use x86defs::snp::SevAvicNoAccelInfo;
+use x86defs::snp::SevAvicPage;
+use x86defs::snp::SevAvicRegisterNumber;
 use x86defs::snp::SevEventInjectInfo;
 use x86defs::snp::SevExitCode;
 use x86defs::snp::SevInvlpgbEcx;
@@ -121,6 +129,7 @@ struct GeneralStats {
 #[derive(Inspect, Default)]
 struct ExitStats {
     automatic_exit: Counter,
+    bus_lock: Counter,
     cpuid: Counter,
     hlt: Counter,
     intr: Counter,
@@ -138,6 +147,8 @@ struct ExitStats {
     xsetbv: Counter,
     excp_db: Counter,
     secure_reg_write: Counter,
+    avic_no_accel: Counter,
+    avic_incomplete_ipi: Counter,
 }
 
 enum UhDirectOverlay {
@@ -353,7 +364,7 @@ impl HardwareIsolatedBacking for SnpBacked {
         check_rflags: bool,
         dev: &impl CpuIo,
     ) -> bool {
-        let vmsa = this.runner.vmsa_mut(vtl);
+        let (avic_page, vmsa) = this.runner.secure_avic_page_vmsa_mut(vtl);
         if vmsa.event_inject().valid()
             && vmsa.event_inject().interruption_type() == x86defs::snp::SEV_INTR_TYPE_NMI
         {
@@ -366,6 +377,7 @@ impl HardwareIsolatedBacking for SnpBacked {
             .access(&mut SnpApicClient {
                 partition: this.partition,
                 vmsa,
+                avic_page,
                 dev,
                 vmtime: &this.vmtime,
                 vtl,
@@ -414,6 +426,7 @@ pub struct SnpBackedShared {
     /// Accessor for managing lower VTL timer deadlines.
     #[inspect(skip)]
     guest_timer: hardware_cvm::VmTimeGuestTimer,
+    secure_avic: bool,
 }
 
 impl SnpBackedShared {
@@ -428,19 +441,21 @@ impl SnpBackedShared {
                 .result(CpuidFunction::ExtendedAddressSpaceSizes.0, 0, &[0; 4])[3],
         )
         .invlpgb_count_max();
-        let tsc_aux_virtualized = x86defs::cpuid::ExtendedSevFeaturesEax::from(
+        let extended_sev_features = x86defs::cpuid::ExtendedSevFeaturesEax::from(
             params
                 .cpuid
                 .result(CpuidFunction::ExtendedSevFeatures.0, 0, &[0; 4])[0],
-        )
-        .tsc_aux_virtualization();
+        );
+        let tsc_aux_virtualized = extended_sev_features.tsc_aux_virtualization();
 
         // Query the SEV_FEATURES MSR to determine the features enabled on VTL2's VMSA
-        // and use that to set btb_isolation, prevent_host_ibs, and VMSA register protection.
-        let msr = crate::MsrDevice::new(0).expect("open msr");
+        // and use that to set btb_isolation, prevent_host_ibs, VMSA register protection,
+        // and secure AVIC support.
+        let msr = devmsr::MsrDevice::new(0).expect("open msr");
         let sev_status =
             SevStatusMsr::from(msr.read_msr(x86defs::X86X_AMD_MSR_SEV).expect("read msr"));
         tracing::info!(CVM_ALLOWED, ?sev_status, "SEV status");
+        let secure_avic = sev_status.secure_avic();
 
         // Configure timer interface for lower VTLs.
         let guest_timer = hardware_cvm::VmTimeGuestTimer;
@@ -449,6 +464,7 @@ impl SnpBackedShared {
             sev_status,
             invlpgb_count_max,
             tsc_aux_virtualized,
+            secure_avic,
             cvm,
             guest_timer,
         })
@@ -546,6 +562,43 @@ impl BackingPrivate for SnpBacked {
         this.runner
             .set_vp_registers_hvcall(Vtl::Vtl0, values)
             .expect("set_vp_registers hypercall for direct overlays should succeed");
+
+        let using_secure_avic = this
+            .runner
+            .vmsa(GuestVtl::Vtl0)
+            .sev_features()
+            .secure_avic();
+        tracing::debug!(?using_secure_avic, "Using secure AVIC for VTL0");
+
+        if using_secure_avic {
+            let vtl0_avic_pfn = this.runner.secure_avic_vtl0_pfn(this.inner.cpu_index);
+            let mut vmsa = this.runner.vmsa_mut(GuestVtl::Vtl0);
+            let savic_ctrl = vmsa
+                .secure_avic_control()
+                .with_secure_avic_en(true)
+                .with_guest_apic_backing_page_ptr(vtl0_avic_pfn);
+            *(vmsa.secure_avic_control_mut()) = savic_ctrl;
+
+            this.set_apic_offload(GuestVtl::Vtl0, true);
+
+            this.runner
+                .set_vp_register(
+                    GuestVtl::Vtl0,
+                    HvX64RegisterName::SevAvicGpa,
+                    savic_ctrl.into_bits().into(),
+                )
+                .expect("set_vp_register hypercall for SAVIC GPA should succeed");
+        }
+
+        // No secure AVIC for VTL 1.
+        assert!(
+            !this
+                .runner
+                .vmsa(GuestVtl::Vtl1)
+                .sev_features()
+                .secure_avic()
+        );
+        this.set_apic_offload(GuestVtl::Vtl1, false);
     }
 
     type StateAccess<'p, 'a>
@@ -570,10 +623,54 @@ impl BackingPrivate for SnpBacked {
     }
 
     fn poll_apic(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl, scan_irr: bool) {
+        // TODO: If the APIC is offloaded, we need to process the IRRs
+        // from the offloaded page.
+
         // Clear any pending interrupt.
         this.runner.vmsa_mut(vtl).v_intr_cntrl_mut().set_irq(false);
 
-        hardware_cvm::apic::poll_apic_core(this, vtl, scan_irr)
+        hardware_cvm::apic::poll_apic_core(this, vtl, scan_irr);
+
+        // TODO: handle TMRs.
+        if this.backing.cvm.lapics[vtl].lapic.is_offloaded() {
+            debug_assert!(vtl == GuestVtl::Vtl0);
+
+            match this.backing.cvm.lapics[vtl]
+                .lapic
+                .push_to_offload(|irr, isr, tmr| {
+                    let (apic_page, proxy_irr_vtl0) =
+                        this.runner.secure_avic_page_proxy_irr_exit_vtl0_mut();
+
+                    for (((((irr, page_irr), isr), page_isr), tmr), proxy_irr_vtl0) in irr
+                        .iter()
+                        .zip(&mut apic_page.irr)
+                        .zip(isr)
+                        .zip(&mut apic_page.isr)
+                        .zip(tmr)
+                        .zip(proxy_irr_vtl0)
+                    {
+                        page_irr.value |= *irr;
+                        page_isr.value |= *isr;
+                        *proxy_irr_vtl0 = *tmr;
+                    }
+                }) {
+                Ok(_) => {}
+                Err(virt_support_apic::OffloadNotSupported) => {
+                    tracelimit::error_ratelimited!("push_to_offload failed: offload not supported");
+                }
+            }
+
+            // If there is a pending interrupt, clear the halted and idle state.
+            // TODO SNP: There are few other bits to take into account, such as the VintCtrl.GIF
+            // and the RFLAGS.IF ones as well as running in the interrupt shadow.
+            // Shouldn't be of concern for now as the guests account for these.
+            if matches!(
+                this.backing.cvm.lapics[vtl].activity,
+                MpState::Halted | MpState::Idle
+            ) {
+                this.backing.cvm.lapics[vtl].activity = MpState::Running;
+            }
+        }
     }
 
     fn request_extint_readiness(_this: &mut UhProcessor<'_, Self>) {
@@ -651,6 +748,39 @@ impl BackingPrivate for SnpBacked {
     }
 }
 
+impl UhProcessor<'_, SnpBacked> {
+    fn access_apic_without_offload<R>(
+        &mut self,
+        vtl: GuestVtl,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let offloaded = self.backing.cvm.lapics[vtl].lapic.is_offloaded();
+        self.set_apic_offload(vtl, false);
+        let r = f(self);
+        self.set_apic_offload(vtl, offloaded);
+        r
+    }
+
+    fn set_apic_offload(&mut self, vtl: GuestVtl, offload: bool) {
+        let offloaded = self.backing.cvm.lapics[vtl].lapic.is_offloaded();
+        if !offload {
+            if offloaded {
+                debug_assert!(vtl == GuestVtl::Vtl0);
+
+                let (irr, isr) = pull_apic_offload(self.runner.secure_avic_page_mut(vtl));
+                self.backing.cvm.lapics[vtl]
+                    .lapic
+                    .disable_offload(&irr, &isr);
+            }
+        } else {
+            debug_assert!(vtl == GuestVtl::Vtl0);
+            if !offloaded {
+                self.backing.cvm.lapics[vtl].lapic.enable_offload();
+            }
+        }
+    }
+}
+
 fn virt_seg_to_snp(val: SegmentRegister) -> SevSelector {
     SevSelector {
         selector: val.selector,
@@ -706,13 +836,20 @@ fn init_vmsa(
     vmsa.sev_features_mut().set_vtom(vtom.is_some());
     vmsa.set_virtual_tom(vtom.unwrap_or(0));
 
-    // Enable alternate injection and VC reflection to enable the paravisor to
-    // handle injection and intercepts using trustworthy information.
-    vmsa.sev_features_mut().set_alternate_injection(true);
+    // Enable VC reflection to enable the paravisor to handle intercepts using
+    // trustworthy information.
     vmsa.sev_features_mut().set_reflect_vc(true);
-    vmsa.v_intr_cntrl_mut().set_guest_busy(true);
     vmsa.sev_features_mut().set_debug_swap(true);
 
+    // Configure the interrupt injection mode. Secure AVIC and alternate injection
+    // are mutually exclusive (AMD PPR 15.36.16, 15.36.21).
+    if vtl == GuestVtl::Vtl0 && sev_status.secure_avic() {
+        vmsa.sev_features_mut().set_secure_avic(true);
+        vmsa.sev_features_mut().set_guest_intercept_control(true);
+    } else {
+        vmsa.sev_features_mut().set_alternate_injection(true);
+    }
+    vmsa.v_intr_cntrl_mut().set_guest_busy(true);
     // Note: The VMSA pages for VTL0 and VTL1 are converted to a VMSA page
     // in the RMP by the kernel, in mshv_configure_vmsa_page. The VTL2 VMSA
     // page is converted via SNP_LAUNCH_UPDATE.
@@ -735,6 +872,7 @@ fn init_vmsa(
 struct SnpApicClient<'a, T> {
     partition: &'a UhPartitionInner,
     vmsa: VmsaWrapper<'a, &'a mut SevVmsa>,
+    avic_page: &'a mut SevAvicPage,
     dev: &'a T,
     vmtime: &'a VmTimeAccess,
     vtl: GuestVtl,
@@ -767,8 +905,24 @@ impl<T: CpuIo> ApicClient for SnpApicClient<'_, T> {
     }
 
     fn pull_offload(&mut self) -> ([u32; 8], [u32; 8]) {
-        unreachable!()
+        assert_eq!(self.vtl, GuestVtl::Vtl0);
+        pull_apic_offload(self.avic_page)
     }
+}
+
+fn pull_apic_offload(page: &mut SevAvicPage) -> ([u32; 8], [u32; 8]) {
+    let mut irr = [0; 8];
+    let mut isr = [0; 8];
+    for (((irr, page_irr), isr), page_isr) in irr
+        .iter_mut()
+        .zip(page.irr.iter_mut())
+        .zip(isr.iter_mut())
+        .zip(page.isr.iter_mut())
+    {
+        *irr = std::mem::take(&mut page_irr.value);
+        *isr = std::mem::take(&mut page_isr.value);
+    }
+    (irr, isr)
 }
 
 impl UhHypercallHandler<'_, '_, SnpBacked> {
@@ -1057,12 +1211,13 @@ impl UhProcessor<'_, SnpBacked> {
         entered_from_vtl: GuestVtl,
         msr: u32,
         is_write: bool,
+        is_fault: bool,
     ) {
         if is_write && self.cvm_try_protect_msr_write(entered_from_vtl, msr) {
             return;
         }
 
-        let vmsa = self.runner.vmsa_mut(entered_from_vtl);
+        let (avic_page, vmsa) = self.runner.secure_avic_page_vmsa_mut(entered_from_vtl);
         let gp = if is_write {
             let value = (vmsa.rax() as u32 as u64) | ((vmsa.rdx() as u32 as u64) << 32);
 
@@ -1071,6 +1226,7 @@ impl UhProcessor<'_, SnpBacked> {
                 .access(&mut SnpApicClient {
                     partition: self.partition,
                     vmsa,
+                    avic_page,
                     dev,
                     vmtime: &self.vmtime,
                     vtl: entered_from_vtl,
@@ -1093,6 +1249,7 @@ impl UhProcessor<'_, SnpBacked> {
                 .access(&mut SnpApicClient {
                     partition: self.partition,
                     vmsa,
+                    avic_page,
                     dev,
                     vmtime: &self.vmtime,
                     vtl: entered_from_vtl,
@@ -1130,7 +1287,9 @@ impl UhProcessor<'_, SnpBacked> {
                     .with_valid(true),
             );
         } else {
-            advance_to_next_instruction(&mut vmsa);
+            if is_fault {
+                advance_to_next_instruction(&mut vmsa);
+            }
         }
     }
 
@@ -1232,22 +1391,42 @@ impl UhProcessor<'_, SnpBacked> {
         let mut vmsa = self.runner.vmsa_mut(next_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
 
-        if vmsa.sev_features().alternate_injection() {
-            vmsa.v_intr_cntrl_mut().set_guest_busy(false);
-        }
+        // OpenHCL runs with:
+        // * the alternate interrupt injection, and the busy bit is used by the software to
+        //   disallow running the VMSA, OR
+        // * the secure AVIC, where the hardware might set the busy bit on exits
+        //   ("15.36.16 Interrupt Injection Restrictions", "15.36.21.5 Guest APIC Accesses")
+        // Clear the guest busy bit unconditionally as the prerequisites are met in either case.
+        vmsa.v_intr_cntrl_mut().set_guest_busy(false);
 
         self.unlock_tlb_lock(Vtl::Vtl2);
         let tlb_halt = self.should_halt_for_tlb_unlock(next_vtl);
-
         let halt = self.backing.cvm.lapics[next_vtl].activity != MpState::Running || tlb_halt;
+
+        // If we are halted in the kernel due to hlt or idle, and we receive an interrupt
+        // we'd like to unhalt, inject the interrupt, and resume vtl0 without returning to
+        // user-mode.
+        let activity = self.backing.cvm.lapics[next_vtl].activity;
+        let kernel_known_state =
+            matches!(activity, MpState::Running | MpState::Halted | MpState::Idle);
+        let halted_other = tlb_halt || !kernel_known_state;
+
+        self.runner.set_halted(halt);
+        self.runner.set_exit_vtl(next_vtl);
 
         if halt && next_vtl == GuestVtl::Vtl1 && !tlb_halt {
             tracelimit::warn_ratelimited!(CVM_ALLOWED, "halting VTL 1, which might halt the guest");
         }
 
-        self.runner.set_halted(halt);
-
-        self.runner.set_exit_vtl(next_vtl);
+        let x2apic_enabled = self.backing.cvm.lapics[next_vtl].lapic.x2apic_enabled();
+        let offload_enabled = self.backing.cvm.lapics[next_vtl].lapic.can_offload_irr();
+        let offload_flags = hcl_intr_offload_flags::new()
+            .with_offload_intr_inject(offload_enabled)
+            .with_offload_x2apic(offload_enabled && x2apic_enabled)
+            .with_halted_other(halted_other)
+            .with_halted_hlt(activity == MpState::Halted)
+            .with_halted_idle(activity == MpState::Idle);
+        *self.runner.offload_flags_mut() = offload_flags;
 
         // Set the lazy EOI bit just before running.
         let lazy_eoi = self.sync_lazy_eoi(next_vtl);
@@ -1258,7 +1437,7 @@ impl UhProcessor<'_, SnpBacked> {
             .map_err(|e| dev.fatal_error(SnpRunVpError(e).into()))?;
 
         let entered_from_vtl = next_vtl;
-        let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
+        let (avic_page, mut vmsa) = self.runner.secure_avic_page_vmsa_mut(entered_from_vtl);
 
         // TODO SNP: The guest busy bit needs to be tested and set atomically.
         let inject = if vmsa.sev_features().alternate_injection() {
@@ -1295,7 +1474,11 @@ impl UhProcessor<'_, SnpBacked> {
                 None
             }
         } else {
-            unimplemented!("Only alternate injection is supported for SNP")
+            assert!(
+                vmsa.sev_features().secure_avic(),
+                "secure AVIC must be enabled"
+            );
+            None
         };
 
         if let Some(inject) = inject {
@@ -1309,6 +1492,8 @@ impl UhProcessor<'_, SnpBacked> {
             self.backing.general_stats[entered_from_vtl]
                 .int_ack
                 .increment();
+            // TODO: Account for the offloaded state.
+
             // The guest has acknowledged the interrupt.
             self.backing.cvm.lapics[entered_from_vtl]
                 .lapic
@@ -1324,6 +1509,7 @@ impl UhProcessor<'_, SnpBacked> {
                 .access(&mut SnpApicClient {
                     partition: self.partition,
                     vmsa,
+                    avic_page,
                     dev,
                     vmtime: &self.vmtime,
                     vtl: entered_from_vtl,
@@ -1343,8 +1529,8 @@ impl UhProcessor<'_, SnpBacked> {
             SevExitCode::MSR => {
                 let is_write = vmsa.exit_info1() & 1 != 0;
                 let msr = vmsa.rcx() as u32;
-
-                self.handle_msr_access(dev, entered_from_vtl, msr, is_write);
+                let is_fault = true;
+                self.handle_msr_access(dev, entered_from_vtl, msr, is_write, is_fault);
 
                 if is_write {
                     &mut self.backing.exit_stats[entered_from_vtl].msr_write
@@ -1553,13 +1739,16 @@ impl UhProcessor<'_, SnpBacked> {
                 &mut self.backing.exit_stats[entered_from_vtl].vmgexit
             }
 
-            SevExitCode::NMI
-            | SevExitCode::PAUSE
-            | SevExitCode::SMI
-            | SevExitCode::VMGEXIT
-            | SevExitCode::BUSLOCK => {
+            SevExitCode::NMI | SevExitCode::PAUSE | SevExitCode::SMI | SevExitCode::VMGEXIT => {
                 // Ignore intercept processing if the guest exited due to an automatic exit.
                 &mut self.backing.exit_stats[entered_from_vtl].automatic_exit
+            }
+
+            SevExitCode::BUSLOCK => {
+                // The guest performs a misaligned atomic operation,
+                // or updating A/D bits in the PTEs. Might help in investigating
+                // performance issues.
+                &mut self.backing.exit_stats[entered_from_vtl].bus_lock
             }
 
             SevExitCode::VINTR => {
@@ -1616,6 +1805,130 @@ impl UhProcessor<'_, SnpBacked> {
                 }
 
                 &mut self.backing.exit_stats[entered_from_vtl].secure_reg_write
+            }
+
+            SevExitCode::AVIC_NOACCEL => {
+                let no_accel_info = SevAvicNoAccelInfo::from(vmsa.exit_info1());
+                tracing::debug!("AVIC no acceleration SEV exit: {no_accel_info:x?}");
+
+                if !matches!(
+                    no_accel_info.apic_register_number(),
+                    SevAvicRegisterNumber::APIC_ID
+                        | SevAvicRegisterNumber::VERSION
+                        | SevAvicRegisterNumber::TPR
+                        | SevAvicRegisterNumber::APR
+                        | SevAvicRegisterNumber::PPR
+                        | SevAvicRegisterNumber::EOI
+                        | SevAvicRegisterNumber::REMOTE_READ
+                        | SevAvicRegisterNumber::LDR
+                        | SevAvicRegisterNumber::DFR
+                        | SevAvicRegisterNumber::SPURIOUS
+                        | SevAvicRegisterNumber::ISR0
+                        | SevAvicRegisterNumber::ISR1
+                        | SevAvicRegisterNumber::ISR2
+                        | SevAvicRegisterNumber::ISR3
+                        | SevAvicRegisterNumber::ISR4
+                        | SevAvicRegisterNumber::ISR5
+                        | SevAvicRegisterNumber::ISR6
+                        | SevAvicRegisterNumber::ISR7
+                        | SevAvicRegisterNumber::TMR0
+                        | SevAvicRegisterNumber::TMR1
+                        | SevAvicRegisterNumber::TMR2
+                        | SevAvicRegisterNumber::TMR3
+                        | SevAvicRegisterNumber::TMR4
+                        | SevAvicRegisterNumber::TMR5
+                        | SevAvicRegisterNumber::TMR6
+                        | SevAvicRegisterNumber::TMR7
+                        | SevAvicRegisterNumber::IRR0
+                        | SevAvicRegisterNumber::IRR1
+                        | SevAvicRegisterNumber::IRR2
+                        | SevAvicRegisterNumber::IRR3
+                        | SevAvicRegisterNumber::IRR4
+                        | SevAvicRegisterNumber::IRR5
+                        | SevAvicRegisterNumber::IRR6
+                        | SevAvicRegisterNumber::IRR7
+                        | SevAvicRegisterNumber::ERROR
+                        | SevAvicRegisterNumber::ICR_LOW
+                        | SevAvicRegisterNumber::ICR_HIGH
+                        | SevAvicRegisterNumber::TIMER_LVT
+                        | SevAvicRegisterNumber::THERMAL_LVT
+                        | SevAvicRegisterNumber::PERFMON_LVT
+                        | SevAvicRegisterNumber::LINT0_LVT
+                        | SevAvicRegisterNumber::LINT1_LVT
+                        | SevAvicRegisterNumber::ERROR_LVT
+                        | SevAvicRegisterNumber::INITIAL_COUNT
+                        | SevAvicRegisterNumber::CURRENT_COUNT
+                        | SevAvicRegisterNumber::DIVIDER
+                        | SevAvicRegisterNumber::SELF_IPI
+                ) {
+                    tracelimit::error_ratelimited!(
+                        register_number = no_accel_info.apic_register_number().0,
+                        "unexpected AVIC register number"
+                    );
+                }
+
+                // Might be a fault (where the hardware doesn't advance the
+                // instruction pointer) or a trap (where the hardware
+                // advances the instruction pointer).
+                let is_write = no_accel_info.write_access();
+                let is_fault = matches!(
+                    no_accel_info.apic_register_number(),
+                    SevAvicRegisterNumber::VERSION
+                        | SevAvicRegisterNumber::APR
+                        | SevAvicRegisterNumber::PPR
+                        | SevAvicRegisterNumber::ISR0
+                        | SevAvicRegisterNumber::ISR1
+                        | SevAvicRegisterNumber::ISR2
+                        | SevAvicRegisterNumber::ISR3
+                        | SevAvicRegisterNumber::ISR4
+                        | SevAvicRegisterNumber::ISR5
+                        | SevAvicRegisterNumber::ISR6
+                        | SevAvicRegisterNumber::ISR7
+                        | SevAvicRegisterNumber::TMR0
+                        | SevAvicRegisterNumber::TMR1
+                        | SevAvicRegisterNumber::TMR2
+                        | SevAvicRegisterNumber::TMR3
+                        | SevAvicRegisterNumber::TMR4
+                        | SevAvicRegisterNumber::TMR5
+                        | SevAvicRegisterNumber::TMR6
+                        | SevAvicRegisterNumber::TMR7
+                        | SevAvicRegisterNumber::IRR0
+                        | SevAvicRegisterNumber::IRR1
+                        | SevAvicRegisterNumber::IRR2
+                        | SevAvicRegisterNumber::IRR3
+                        | SevAvicRegisterNumber::IRR4
+                        | SevAvicRegisterNumber::IRR5
+                        | SevAvicRegisterNumber::IRR6
+                        | SevAvicRegisterNumber::IRR7
+                        | SevAvicRegisterNumber::CURRENT_COUNT
+                );
+                let msr = X2APIC_MSR_BASE + no_accel_info.apic_register_number().0;
+                self.handle_msr_access(dev, entered_from_vtl, msr, is_write, is_fault);
+
+                &mut self.backing.exit_stats[entered_from_vtl].avic_no_accel
+            }
+
+            SevExitCode::AVIC_INCOMPLETE_IPI => {
+                let ipi_info1 = SevAvicIncompleteIpiInfo1::from(vmsa.exit_info1());
+                let ipi_info2 = SevAvicIncompleteIpiInfo2::from(vmsa.exit_info2());
+                let icr = x86defs::apic::Icr::from_bits(vmsa.exit_info1());
+
+                tracing::debug!(
+                    "AVIC incomplete IPI SEV exit: {ipi_info1:x?} {ipi_info2:x?}, {icr:x?}"
+                );
+
+                // This a trap, and the hardware has already advanced the instruction pointer:
+                // "15.36.21.5 Guest APIC Accesses".
+                let is_fault = false;
+                let is_write = true;
+                let msr = X2APIC_MSR_BASE + x86defs::apic::ApicRegister::ICR0.0 as u32;
+
+                // As the ICR is accessed through the `wrmsr` instruction (secure AVIC allows only
+                // the x2 APIC access), we already have `rax` and `rdx` set to the desired value by
+                // the guest.
+                self.handle_msr_access(dev, entered_from_vtl, msr, is_write, is_fault);
+
+                &mut self.backing.exit_stats[entered_from_vtl].avic_incomplete_ipi
             }
 
             _ => {
@@ -1941,11 +2254,13 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
 
     fn lapic_read(&mut self, address: u64, data: &mut [u8]) {
         let vtl = self.vtl;
+        let (avic_page, vmsa) = self.vp.runner.secure_avic_page_vmsa_mut(vtl);
         self.vp.backing.cvm.lapics[vtl]
             .lapic
             .access(&mut SnpApicClient {
                 partition: self.vp.partition,
-                vmsa: self.vp.runner.vmsa_mut(vtl),
+                vmsa,
+                avic_page,
                 dev: self.devices,
                 vmtime: &self.vp.vmtime,
                 vtl,
@@ -1955,11 +2270,13 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
 
     fn lapic_write(&mut self, address: u64, data: &[u8]) {
         let vtl = self.vtl;
+        let (avic_page, vmsa) = self.vp.runner.secure_avic_page_vmsa_mut(vtl);
         self.vp.backing.cvm.lapics[vtl]
             .lapic
             .access(&mut SnpApicClient {
                 partition: self.vp.partition,
-                vmsa: self.vp.runner.vmsa_mut(vtl),
+                vmsa,
+                avic_page,
                 dev: self.devices,
                 vmtime: &self.vp.vmtime,
                 vtl,
@@ -2185,15 +2502,20 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
     }
 
     fn apic(&mut self) -> Result<vp::Apic, Self::Error> {
-        Ok(self.vp.backing.cvm.lapics[self.vtl].lapic.save())
+        self.vp.access_apic_without_offload(self.vtl, |vp| {
+            Ok(vp.backing.cvm.lapics[self.vtl].lapic.save())
+        })
     }
 
     fn set_apic(&mut self, value: &vp::Apic) -> Result<(), Self::Error> {
-        self.vp.backing.cvm.lapics[self.vtl]
-            .lapic
-            .restore(value)
-            .map_err(vp_state::Error::InvalidApicBase)?;
-        Ok(())
+        self.vp.access_apic_without_offload(self.vtl, |vp| {
+            vp.backing.cvm.lapics[self.vtl]
+                .lapic
+                .restore(value)
+                .map_err(vp_state::Error::InvalidApicBase)?;
+
+            Ok(())
+        })
     }
 
     fn xcr(&mut self) -> Result<vp::Xcr0, Self::Error> {
@@ -2409,9 +2731,38 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
     }
 }
 
-/// Advances rip to be the same as next_rip.
+/// Advances the instruction pointer.
+///
+/// The hardware may have provided the next instruction pointer in the VMSA, so we
+/// use that if available. That is always the case for the automatic exits (exit on #VC
+/// when ReflectVC is set in VMSA SEV features). If the hypervisor interaction is not
+/// required, there would be no #VC exit, and the next instruction pointer would not be
+/// populated by the hardware. See these AMD PPR sections for details:
+/// * 15.35.4 Types of Exits
+/// * 15.35.5 #VC Exception
 fn advance_to_next_instruction(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>) {
-    vmsa.set_rip(vmsa.next_rip());
+    match SevExitCode(vmsa.guest_error_code()) {
+        SevExitCode::AVIC_NOACCEL => {
+            // With Secure AVIC, x2APIC MSR accesses that are not accelerated
+            // cause AVIC_NOACCEL exits. These accesses are via WRMSR/RDMSR
+            // (2-byte opcodes: 0x0F 0x30 / 0x0F 0x32), and the hardware does
+            // not provide next_rip for this exit type.
+            // See AMD PPR: 15.36.21.5 "Guest APIC Accesses".
+            vmsa.set_rip(vmsa.rip() + 2);
+        }
+        _ => vmsa.set_rip(vmsa.next_rip()),
+    }
+
+    // TODO SNP: provide the precise implementation for
+    // the next instruction pointer. For now, as a heuristic, we
+    // report on `0`'s in the rip field. The guest would need to
+    // execute an instruction at the top of the VA space to make the
+    // instruction pointer wrap around to `0` or fault at `0` --
+    // seems unlikely.
+    if vmsa.rip() == 0 {
+        tracing::warn!("rip is zero, might need to parse the instruction stream");
+    }
+
     vmsa.v_intr_cntrl_mut().set_intr_shadow(false);
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -81,6 +81,7 @@ use virt_support_x86emu::emulate::emulate_io;
 use virt_support_x86emu::emulate::emulate_translate_gva;
 use virt_support_x86emu::translate::TranslationRegisters;
 use vmcore::vmtime::VmTimeAccess;
+use x86defs::ApicRegisterValue;
 use x86defs::RFlags;
 use x86defs::X64_CR0_ET;
 use x86defs::X64_CR0_NE;
@@ -102,8 +103,6 @@ use x86defs::tdx::TdxGp;
 use x86defs::tdx::TdxInstructionInfo;
 use x86defs::tdx::TdxL2Ctls;
 use x86defs::tdx::TdxVpEnterRaxResult;
-use x86defs::vmx::ApicPage;
-use x86defs::vmx::ApicRegister;
 use x86defs::vmx::CR_ACCESS_TYPE_LMSW;
 use x86defs::vmx::CR_ACCESS_TYPE_MOV_TO_CR;
 use x86defs::vmx::CrAccessQualification;
@@ -125,6 +124,7 @@ use x86defs::vmx::SecondaryProcessorControls;
 use x86defs::vmx::VMX_ENTRY_CONTROL_LONG_MODE_GUEST;
 use x86defs::vmx::VMX_FEATURE_CONTROL_LOCKED;
 use x86defs::vmx::VmcsField;
+use x86defs::vmx::VmxApicPage;
 use x86defs::vmx::VmxEptExitQualification;
 use x86defs::vmx::VmxExit;
 use x86defs::vmx::VmxExitBasic;
@@ -3626,7 +3626,7 @@ impl UhProcessor<'_, TdxBacked> {
 
 struct TdxApicClient<'a, T> {
     partition: &'a UhPartitionInner,
-    apic_page: &'a mut ApicPage,
+    apic_page: &'a mut VmxApicPage,
     dev: &'a T,
     vmtime: &'a VmTimeAccess,
     vtl: GuestVtl,
@@ -3662,7 +3662,7 @@ impl<T: CpuIo> ApicClient for TdxApicClient<'_, T> {
     }
 }
 
-fn pull_apic_offload(page: &mut ApicPage) -> ([u32; 8], [u32; 8]) {
+fn pull_apic_offload(page: &mut VmxApicPage) -> ([u32; 8], [u32; 8]) {
     let mut irr = [0; 8];
     let mut isr = [0; 8];
     for (((irr, page_irr), isr), page_isr) in irr
@@ -4259,7 +4259,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
 /// Compute the index of the highest vector set in IRR/ISR, or 0
 /// if no vector is set. (Vectors 0-15 are invalid so this is not
 /// ambiguous.)
-fn top_vector(reg: &[ApicRegister; 8]) -> u8 {
+fn top_vector(reg: &[ApicRegisterValue; 8]) -> u8 {
     reg.iter()
         .enumerate()
         .rev()

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -2684,6 +2684,8 @@ registers! {
 
         // AMD SEV configuration MSRs
         SevControl = 0x00090040,
+        SevGhcbGpa = 0x00090041,
+        SevAvicGpa = 0x00090043,
 
         CrInterceptControl = 0x000E0000,
         CrInterceptCr0Mask = 0x000E0001,
@@ -3538,11 +3540,37 @@ pub struct HvRegisterVsmPartitionStatus {
     pub reserved: u64,
 }
 
+open_enum! {
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum HvSnpInterruptInjection : u8  {
+        #![allow(non_upper_case_globals)]
+        HvSnpRestricted = 0x0,
+        HvSnpNormal = 0x1,
+        HvSnpAlternate = 0x2,
+        HvSnpSecureAvic = 0x3,
+    }
+}
+
+// Support for bitfield structures.
+impl HvSnpInterruptInjection {
+    const fn from_bits(val: u8) -> Self {
+        HvSnpInterruptInjection(val)
+    }
+
+    const fn into_bits(self) -> u8 {
+        self.0
+    }
+}
+
 #[bitfield(u64)]
 pub struct HvRegisterGuestVsmPartitionConfig {
     #[bits(4)]
     pub maximum_vtl: u8,
-    #[bits(60)]
+    #[bits(2)]
+    pub vtl0_interrupt_injection: HvSnpInterruptInjection,
+    #[bits(2)]
+    pub vtl1_interrupt_injection: HvSnpInterruptInjection,
+    #[bits(56)]
     pub reserved: u64,
 }
 
@@ -4003,6 +4031,16 @@ pub struct HvX64RegisterSevControl {
     _rsvd1: u64,
     #[bits(52)]
     pub vmsa_gpa_page_number: u64,
+}
+
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct HvX64RegisterSevAvic {
+    pub enable_secure_apic: bool,
+    #[bits(11)]
+    _rsvd1: u64,
+    #[bits(52)]
+    pub avic_gpa_page_number: u64,
 }
 
 #[bitfield(u64)]

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -14,6 +14,7 @@ use crate::vp_context_builder::VpContextBuilder;
 use crate::vp_context_builder::VpContextPageState;
 use crate::vp_context_builder::VpContextState;
 use crate::vp_context_builder::snp::InjectionType;
+use crate::vp_context_builder::snp::SecureAvic;
 use crate::vp_context_builder::snp::SnpHardwareContext;
 use crate::vp_context_builder::tdx::TdxHardwareContext;
 use crate::vp_context_builder::vbs::VbsRegister;
@@ -149,6 +150,7 @@ pub enum LoaderIsolationType {
         shared_gpa_boundary_bits: Option<u8>,
         policy: SnpPolicy,
         injection_type: InjectionType,
+        secure_avic: SecureAvic,
         // TODO SNP: SNP Keys? Other data?
     },
     Tdx {
@@ -201,6 +203,7 @@ impl IgvmLoaderRegister for X86Register {
                 shared_gpa_boundary_bits,
                 policy,
                 injection_type,
+                secure_avic,
             } => {
                 // TODO SNP: assumed that shared_gpa_boundary is always available.
                 let shared_gpa_boundary =
@@ -227,6 +230,7 @@ impl IgvmLoaderRegister for X86Register {
                     !with_paravisor,
                     shared_gpa_boundary,
                     injection_type,
+                    secure_avic,
                 ));
 
                 (platform_header, vec![init_header], vp_context_builder)
@@ -906,6 +910,7 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
                 shared_gpa_boundary_bits,
                 policy: _,
                 injection_type: _,
+                secure_avic: _,
             } => IsolationConfig {
                 paravisor_present: self.loader.paravisor_present,
                 isolation_type: IsolationType::Snp,
@@ -1266,6 +1271,7 @@ mod tests {
                 shared_gpa_boundary_bits: Some(39),
                 policy: SnpPolicy::from((0x1 << 17) | (0x1 << 16) | (0x1f)),
                 injection_type: InjectionType::Restricted,
+                secure_avic: SecureAvic::Enabled,
             },
         );
         let data = vec![0, 5];

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -27,6 +27,7 @@ use igvmfilegen_config::Image;
 use igvmfilegen_config::LinuxImage;
 use igvmfilegen_config::ResourceType;
 use igvmfilegen_config::Resources;
+use igvmfilegen_config::SecureAvicType;
 use igvmfilegen_config::SnpInjectionType;
 use igvmfilegen_config::UefiConfigType;
 use loader::importer::Aarch64Register;
@@ -184,6 +185,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                 policy,
                 enable_debug,
                 injection_type,
+                secure_avic,
             } => LoaderIsolationType::Snp {
                 shared_gpa_boundary_bits,
                 policy: SnpPolicy::from(policy).with_debug(enable_debug as u8),
@@ -192,6 +194,10 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                     SnpInjectionType::Restricted => {
                         vp_context_builder::snp::InjectionType::Restricted
                     }
+                },
+                secure_avic: match secure_avic {
+                    SecureAvicType::Enabled => vp_context_builder::snp::SecureAvic::Enabled,
+                    SecureAvicType::Disabled => vp_context_builder::snp::SecureAvic::Disabled,
                 },
             },
             ConfigIsolationType::Tdx {

--- a/vm/loader/igvmfilegen/src/vp_context_builder/snp.rs
+++ b/vm/loader/igvmfilegen/src/vp_context_builder/snp.rs
@@ -29,6 +29,15 @@ pub enum InjectionType {
     Restricted,
 }
 
+/// The secure AVIC.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum SecureAvic {
+    /// Offload AVIC to the hardware.
+    Enabled,
+    /// The paravisor emulates APIC.
+    Disabled,
+}
+
 /// A hardware SNP VP context, that is imported as a VMSA.
 #[derive(Debug)]
 pub struct SnpHardwareContext {
@@ -59,6 +68,7 @@ impl SnpHardwareContext {
         enlightened_uefi: bool,
         shared_gpa_boundary: u64,
         injection_type: InjectionType,
+        secure_avic: SecureAvic,
     ) -> Self {
         let mut vmsa: SevVmsa = FromZeros::new_zeroed();
 
@@ -85,6 +95,12 @@ impl SnpHardwareContext {
             if vtl < HCL_SECURE_VTL {
                 vmsa.sev_features
                     .set_alternate_injection(injection_type == InjectionType::Restricted);
+                if injection_type == InjectionType::Normal {
+                    vmsa.sev_features
+                        .set_secure_avic(secure_avic == SecureAvic::Enabled);
+                    vmsa.sev_features
+                        .set_guest_intercept_control(secure_avic == SecureAvic::Enabled);
+                }
             } else {
                 vmsa.sev_features
                     .set_restrict_injection(injection_type == InjectionType::Restricted);
@@ -93,6 +109,8 @@ impl SnpHardwareContext {
                 vmsa.sev_features.set_prevent_host_ibs(true);
                 vmsa.sev_features.set_vmsa_reg_prot(true);
                 vmsa.sev_features.set_vtom(false);
+                vmsa.sev_features
+                    .set_secure_avic(secure_avic == SecureAvic::Enabled);
                 vmsa.virtual_tom = 0;
             }
         }

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -33,6 +33,17 @@ pub enum SnpInjectionType {
     Restricted,
 }
 
+/// Secure AVIC type.
+#[derive(Serialize, Default, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum SecureAvicType {
+    /// Offload AVIC to the hardware.
+    Enabled,
+    /// The paravisor emulates APIC.
+    #[default]
+    Disabled,
+}
+
 /// The isolation type that should be used for the loader.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -56,6 +67,9 @@ pub enum ConfigIsolationType {
         enable_debug: bool,
         /// The interrupt injection type to use for the highest vmpl.
         injection_type: SnpInjectionType,
+        /// Secure AVIC
+        #[serde(default)]
+        secure_avic: SecureAvicType,
     },
     /// Intel TDX.
     Tdx {

--- a/vm/loader/manifests/openhcl-x64-cvm-dev.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-dev.json
@@ -9,7 +9,8 @@
                     "shared_gpa_boundary_bits": 46,
                     "policy": 196639,
                     "enable_debug": true,
-                    "injection_type": "normal"
+                    "injection_type": "normal",
+                    "secure_avic": "enabled"
                 }
             },
             "image": {

--- a/vm/loader/manifests/openhcl-x64-cvm-release.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-release.json
@@ -9,7 +9,8 @@
                     "shared_gpa_boundary_bits": 46,
                     "policy": 196639,
                     "enable_debug": false,
-                    "injection_type": "normal"
+                    "injection_type": "normal",
+                    "secure_avic": "enabled"
                 }
             },
             "image": {

--- a/vm/loader/manifests/uefi-x64.json
+++ b/vm/loader/manifests/uefi-x64.json
@@ -24,7 +24,8 @@
                     "shared_gpa_boundary_bits": 39,
                     "policy": 196639,
                     "enable_debug": true,
-                    "injection_type": "restricted"
+                    "injection_type": "restricted",
+                    "secure_avic": "enabled"
                 }
             },
             "image": {

--- a/vm/x86/x86defs/src/cpuid.rs
+++ b/vm/x86/x86defs/src/cpuid.rs
@@ -703,14 +703,18 @@ pub struct ExtendedSevFeaturesEax {
     pub vmgexit_parameter: bool,
     pub virtual_tom_msr: bool,
     pub ibs_virtualization: bool,
-    #[bits(4)]
+    #[bits(2)]
     _reserved1: u32,
+    pub guest_intercept_control: bool,
+    pub segmented_rmp: bool,
     pub vmsa_register_protection: bool,
-    #[bits(4)]
-    _reserved2: u32,
+    _reserved2: bool,
+    pub secure_avic: bool,
+    pub allowed_sev_features: bool,
+    _reserved3: bool,
     pub nested_virt_msr_snp: bool,
     #[bits(2)]
-    _reserved3: u32,
+    _reserved4: u32,
 }
 
 #[bitfield(u32)]

--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -275,6 +275,7 @@ pub const X86X_AMD_MSR_NB_CFG: u32 = 0xC001001F;
 pub const X86X_AMD_MSR_VM_CR: u32 = 0xC0010114;
 pub const X86X_AMD_MSR_GHCB: u32 = 0xC0010130;
 pub const X86X_AMD_MSR_SEV: u32 = 0xC0010131;
+pub const X86X_AMD_MSR_SECURE_AVIC_CONTROL: u32 = 0xc0010138;
 pub const X86X_AMD_MSR_OSVW_ID_LENGTH: u32 = 0xc0010140;
 pub const X86X_AMD_MSR_OSVW_ID_STATUS: u32 = 0xc0010141;
 pub const X86X_AMD_MSR_DE_CFG: u32 = 0xc0011029;
@@ -517,4 +518,11 @@ pub struct X86xMcgStatusRegister {
     pub mcip: bool, // Machine check is in progress
     #[bits(61)]
     pub reserved0: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct ApicRegisterValue {
+    pub value: u32,
+    _reserved: [u32; 3],
 }

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -3,7 +3,9 @@
 
 //! AMD SEV-SNP specific definitions.
 
+use crate::ApicRegisterValue;
 use bitfield_struct::bitfield;
+use static_assertions::const_assert_eq;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -120,15 +122,16 @@ pub struct SevFeatures {
     pub vmgexit_param: bool,
     pub pmc_virt: bool,
     pub ibs_virt: bool,
-    rsvd: bool,
+    pub guest_intercept_control: bool,
     pub vmsa_reg_prot: bool,
     pub smt_prot: bool,
     pub secure_avic: bool,
     #[bits(4)]
-    _reserved: u64,
+    _reserved0: u64,
     pub ibpb_on_entry: bool,
-    #[bits(42)]
-    _unused: u64,
+    #[bits(41)]
+    _reserved1: u64,
+    pub allowed_sev_features_enable: bool,
 }
 
 #[bitfield(u64)]
@@ -138,16 +141,21 @@ pub struct SevVirtualInterruptControl {
     pub irq: bool,
     pub gif: bool,
     pub intr_shadow: bool,
-    #[bits(5)]
+    pub nmi: bool,
+    pub nmi_mask: bool,
+    #[bits(3)]
     _rsvd1: u64,
     #[bits(4)]
     pub priority: u64,
     pub ignore_tpr: bool,
-    #[bits(11)]
+    #[bits(5)]
     _rsvd2: u64,
+    pub nmi_enable: bool,
+    #[bits(5)]
+    _rsvd3: u64,
     pub vector: u8,
     #[bits(23)]
-    _rsvd3: u64,
+    _rsvd4: u64,
     pub guest_busy: bool,
 }
 
@@ -209,6 +217,160 @@ pub struct SevNpfInfo {
     pub npt_supervisor_shadow_stack: bool,
     #[bits(26)]
     rsvd38_63: u64,
+}
+
+/// SEV secure AVIC control register
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq)]
+pub struct SecureAvicControl {
+    pub secure_avic_en: bool,
+    pub allowed_nmi: bool,
+    #[bits(10)]
+    _rsvd: u64,
+    #[bits(52)]
+    pub guest_apic_backing_page_ptr: u64,
+}
+
+/// AVIC exit info1 for the incomplete IPI exit
+#[bitfield(u64)]
+pub struct SevAvicIncompleteIpiInfo1 {
+    pub icr_low: u32,
+    pub icr_high: u32,
+}
+
+open_enum::open_enum! {
+    pub enum SevAvicIpiFailure: u32 {
+        INVALID_TYPE = 0,
+        NOT_RUNNING = 1,
+        INVALID_TARGET = 2,
+        INVALID_BACKING_PAGE = 3,
+        INVALID_VECTOR = 4,
+        UNACCELERATED_IPI = 5,
+    }
+}
+
+impl SevAvicIpiFailure {
+    const fn into_bits(self) -> u32 {
+        self.0
+    }
+
+    const fn from_bits(bits: u32) -> Self {
+        Self(bits)
+    }
+}
+
+/// AVIC exit info2 for the incomplete IPI exit
+#[bitfield(u64)]
+pub struct SevAvicIncompleteIpiInfo2 {
+    #[bits(8)]
+    pub index: u32,
+    #[bits(24)]
+    _mbz: u32,
+    #[bits(32)]
+    pub failure: SevAvicIpiFailure,
+}
+
+open_enum::open_enum! {
+    pub enum SevAvicRegisterNumber: u32 {
+        /// APIC ID Register.
+        APIC_ID = 0x2,
+        /// APIC Version Register.
+        VERSION = 0x3,
+        /// Task Priority Register
+        TPR = 0x8,
+        /// Arbitration Priority Register.
+        APR = 0x9,
+        /// Processor Priority Register.
+        PPR = 0xA,
+        /// End Of Interrupt Register.
+        EOI = 0xB,
+        /// Remote Read Register
+        REMOTE_READ = 0xC,
+        /// Logical Destination Register.
+        LDR = 0xD,
+        /// Destination Format Register.
+        DFR = 0xE,
+        /// Spurious Interrupt Vector.
+        SPURIOUS = 0xF,
+        /// In-Service Registers.
+        ISR0 = 0x10,
+        ISR1 = 0x11,
+        ISR2 = 0x12,
+        ISR3 = 0x13,
+        ISR4 = 0x14,
+        ISR5 = 0x15,
+        ISR6 = 0x16,
+        ISR7 = 0x17,
+        /// Trigger Mode Registers.
+        TMR0 = 0x18,
+        TMR1 = 0x19,
+        TMR2 = 0x1A,
+        TMR3 = 0x1B,
+        TMR4 = 0x1C,
+        TMR5 = 0x1D,
+        TMR6 = 0x1E,
+        TMR7 = 0x1F,
+        /// Interrupt Request Registers.
+        IRR0 = 0x20,
+        IRR1 = 0x21,
+        IRR2 = 0x22,
+        IRR3 = 0x23,
+        IRR4 = 0x24,
+        IRR5 = 0x25,
+        IRR6 = 0x26,
+        IRR7 = 0x27,
+        /// Error Status Register.
+        ERROR = 0x28,
+        /// ICR Low.
+        ICR_LOW = 0x30,
+        /// ICR High.
+        ICR_HIGH = 0x31,
+        /// LVT Timer Register.
+        TIMER_LVT = 0x32,
+        /// LVT Thermal Register.
+        THERMAL_LVT = 0x33,
+        /// LVT Performance Monitor Register.
+        PERFMON_LVT = 0x34,
+        /// LVT Local Int0 Register.
+        LINT0_LVT = 0x35,
+        /// LVT Local Int1 Register.
+        LINT1_LVT = 0x36,
+        /// LVT Error Register.
+        ERROR_LVT = 0x37,
+        /// Initial count Register.
+        INITIAL_COUNT = 0x38,
+        /// R/O Current count Register.
+        CURRENT_COUNT = 0x39,
+        /// Divide configuration Register.
+        DIVIDER = 0x3e,
+        /// Self IPI register, only present in x2APIC.
+        SELF_IPI = 0x3f,
+    }
+}
+
+impl SevAvicRegisterNumber {
+    const fn into_bits(self) -> u32 {
+        self.0
+    }
+
+    const fn from_bits(bits: u32) -> Self {
+        Self(bits)
+    }
+}
+
+/// AVIC SEV exit info1 for the no acceleration exit
+#[bitfield(u64)]
+pub struct SevAvicNoAccelInfo {
+    #[bits(4)]
+    _rsvd1: u64,
+    #[bits(8)]
+    pub apic_register_number: SevAvicRegisterNumber,
+    #[bits(20)]
+    _rsvd2: u64,
+    #[bits(1)]
+    pub write_access: bool,
+    #[bits(31)]
+    _rsvd3: u64,
 }
 
 /// SEV VMSA structure representing CPU state
@@ -349,7 +511,7 @@ pub struct SevVmsa {
     pub rcx: u64,
     pub rdx: u64,
     pub rbx: u64,
-    pub vmsa_reserved8: u64, // MBZ
+    pub secure_avic_control: SecureAvicControl,
     pub rbp: u64,
     pub rsi: u64,
     pub rdi: u64,
@@ -420,6 +582,65 @@ pub struct SevVmsa {
     // YMM high registers
     pub ymm_registers: [SevXmmRegister; 16],
 }
+
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+/// Structure representing the SEV-ES AVIC IRR register.
+///
+/// If the UpdateIRR bit is set in the VMCB, the guest-controlled AllowedIRR mask
+/// is logically AND-ed with the host-controlled RequestedIRR and then is logically
+/// OR-ed into the IRR field in the Guest APIC Backing page.
+pub struct SevAvicIrrRegister {
+    pub value: u32,
+    pub allowed: u32,
+    _reserved: [u32; 2],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+/// Structure representing the SEV-ES AVIC backing page.
+/// Specification: "AMD64 PPR Vol3 System Programming", 15.29.3  AVIC Backing Page.
+pub struct SevAvicPage {
+    pub reserved_0: [ApicRegisterValue; 2],
+    pub id: ApicRegisterValue,
+    pub version: ApicRegisterValue,
+    pub reserved_4: [ApicRegisterValue; 4],
+    pub tpr: ApicRegisterValue,
+    pub apr: ApicRegisterValue,
+    pub ppr: ApicRegisterValue,
+    pub eoi: ApicRegisterValue,
+    pub rrd: ApicRegisterValue,
+    pub ldr: ApicRegisterValue,
+    pub dfr: ApicRegisterValue,
+    pub svr: ApicRegisterValue,
+    pub isr: [ApicRegisterValue; 8],
+    pub tmr: [ApicRegisterValue; 8],
+    pub irr: [SevAvicIrrRegister; 8],
+    pub esr: ApicRegisterValue,
+    pub reserved_29: [ApicRegisterValue; 6],
+    pub lvt_cmci: ApicRegisterValue,
+    pub icr: [ApicRegisterValue; 2],
+    pub lvt_timer: ApicRegisterValue,
+    pub lvt_thermal: ApicRegisterValue,
+    pub lvt_pmc: ApicRegisterValue,
+    pub lvt_lint0: ApicRegisterValue,
+    pub lvt_lint1: ApicRegisterValue,
+    pub lvt_error: ApicRegisterValue,
+    pub timer_icr: ApicRegisterValue,
+    pub timer_ccr: ApicRegisterValue,
+    pub reserved_3a: [ApicRegisterValue; 4],
+    pub timer_dcr: ApicRegisterValue,
+    pub self_ipi: ApicRegisterValue,
+    pub eafr: ApicRegisterValue,
+    pub eacr: ApicRegisterValue,
+    pub seoi: ApicRegisterValue,
+    pub reserved_44: [ApicRegisterValue; 0x5],
+    pub ier: [ApicRegisterValue; 8],
+    pub ei_lv_tr: [ApicRegisterValue; 3],
+    pub reserved_54: [ApicRegisterValue; 0xad],
+}
+
+const_assert_eq!(size_of::<SevAvicPage>(), 4096);
 
 // Info codes for the GHCB MSR protocol.
 open_enum::open_enum! {
@@ -775,14 +996,16 @@ pub struct SevStatusMsr {
     pub debug_swap: bool,
     pub prevent_host_ibs: bool,
     pub snp_btb_isolation: bool,
-    pub _rsvd1: bool,
+    pub vmpl_sss: bool,
     pub secure_tsc: bool,
-    pub _rsvd2: bool,
-    pub _rsvd3: bool,
-    pub _rsvd4: bool,
-    pub _rsvd5: bool,
+    pub vmgexit_param: bool,
+    _rsvd3: bool,
+    pub ibs_virt: bool,
+    _rsvd5: bool,
     pub vmsa_reg_prot: bool,
-    #[bits(6)]
+    pub smt_prot: bool,
+    pub secure_avic: bool,
+    #[bits(4)]
     _reserved: u64,
     pub ibpb_on_entry: bool,
     #[bits(40)]
@@ -1036,3 +1259,374 @@ static_assertions::const_assert_eq!(
     64,
     size_of::<SnpDerivedKeyResp>()
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zerocopy::FromZeros;
+
+    // ---- SecureAvicControl bitfield tests ----
+
+    #[test]
+    fn secure_avic_control_default_is_zero() {
+        let ctrl = SecureAvicControl::new();
+        assert_eq!(ctrl.into_bits(), 0);
+        assert_eq!(ctrl.secure_avic_en(), false);
+        assert_eq!(ctrl.allowed_nmi(), false);
+        assert_eq!(ctrl.guest_apic_backing_page_ptr(), 0);
+    }
+
+    #[test]
+    fn secure_avic_control_enable_bit() {
+        let ctrl = SecureAvicControl::new().with_secure_avic_en(true);
+        assert_eq!(ctrl.secure_avic_en(), true);
+        assert_eq!(ctrl.into_bits() & 1, 1);
+    }
+
+    #[test]
+    fn secure_avic_control_allowed_nmi_bit() {
+        let ctrl = SecureAvicControl::new().with_allowed_nmi(true);
+        assert_eq!(ctrl.allowed_nmi(), true);
+        assert_eq!(ctrl.into_bits() & 0b10, 0b10);
+    }
+
+    #[test]
+    fn secure_avic_control_page_ptr() {
+        // The page pointer is in bits [63:12], representing a PFN.
+        let pfn = 0xDEAD_BEEF_u64;
+        let ctrl = SecureAvicControl::new()
+            .with_secure_avic_en(true)
+            .with_guest_apic_backing_page_ptr(pfn);
+        assert_eq!(ctrl.guest_apic_backing_page_ptr(), pfn);
+        assert_eq!(ctrl.secure_avic_en(), true);
+        // The PFN should be in bits [63:12]
+        assert_eq!(ctrl.into_bits() >> 12, pfn);
+    }
+
+    #[test]
+    fn secure_avic_control_roundtrip() {
+        let raw = 0xABCD_1234_5678_9001_u64;
+        let ctrl = SecureAvicControl::from(raw);
+        assert_eq!(ctrl.into_bits(), raw);
+    }
+
+    // ---- SevAvicNoAccelInfo bitfield tests ----
+
+    #[test]
+    fn no_accel_info_register_number_extraction() {
+        // Register number is in bits [11:4].
+        let info = SevAvicNoAccelInfo::new().with_apic_register_number(SevAvicRegisterNumber::EOI);
+        assert_eq!(info.apic_register_number(), SevAvicRegisterNumber::EOI);
+        // EOI = 0xB, stored in bits [11:4]
+        assert_eq!((info.into_bits() >> 4) & 0xFF, 0xB);
+    }
+
+    #[test]
+    fn no_accel_info_write_access_bit() {
+        // Write access is bit 32.
+        let info = SevAvicNoAccelInfo::new().with_write_access(true);
+        assert!(info.write_access());
+        assert_eq!(info.into_bits() & (1 << 32), 1 << 32);
+
+        let info_read = SevAvicNoAccelInfo::new().with_write_access(false);
+        assert!(!info_read.write_access());
+    }
+
+    #[test]
+    fn no_accel_info_combined() {
+        let info = SevAvicNoAccelInfo::new()
+            .with_apic_register_number(SevAvicRegisterNumber::ICR_LOW)
+            .with_write_access(true);
+        assert_eq!(info.apic_register_number(), SevAvicRegisterNumber::ICR_LOW);
+        assert!(info.write_access());
+    }
+
+    #[test]
+    fn no_accel_info_all_register_numbers_roundtrip() {
+        let registers = [
+            SevAvicRegisterNumber::APIC_ID,
+            SevAvicRegisterNumber::VERSION,
+            SevAvicRegisterNumber::TPR,
+            SevAvicRegisterNumber::APR,
+            SevAvicRegisterNumber::PPR,
+            SevAvicRegisterNumber::EOI,
+            SevAvicRegisterNumber::LDR,
+            SevAvicRegisterNumber::DFR,
+            SevAvicRegisterNumber::SPURIOUS,
+            SevAvicRegisterNumber::ISR0,
+            SevAvicRegisterNumber::ISR7,
+            SevAvicRegisterNumber::TMR0,
+            SevAvicRegisterNumber::TMR7,
+            SevAvicRegisterNumber::IRR0,
+            SevAvicRegisterNumber::IRR7,
+            SevAvicRegisterNumber::ERROR,
+            SevAvicRegisterNumber::ICR_LOW,
+            SevAvicRegisterNumber::ICR_HIGH,
+            SevAvicRegisterNumber::TIMER_LVT,
+            SevAvicRegisterNumber::INITIAL_COUNT,
+            SevAvicRegisterNumber::CURRENT_COUNT,
+            SevAvicRegisterNumber::DIVIDER,
+            SevAvicRegisterNumber::SELF_IPI,
+        ];
+        for reg in registers {
+            let info = SevAvicNoAccelInfo::new().with_apic_register_number(reg);
+            assert_eq!(
+                info.apic_register_number(),
+                reg,
+                "register number roundtrip failed for {reg:#x?}"
+            );
+        }
+    }
+
+    // ---- SevAvicIncompleteIpiInfo1/2 bitfield tests ----
+
+    #[test]
+    fn incomplete_ipi_info1_icr_fields() {
+        let icr_low = 0x0004_10FFu32;
+        let icr_high = 0x0200_0000u32;
+        let info = SevAvicIncompleteIpiInfo1::new()
+            .with_icr_low(icr_low)
+            .with_icr_high(icr_high);
+        assert_eq!(info.icr_low(), icr_low);
+        assert_eq!(info.icr_high(), icr_high);
+        assert_eq!(info.into_bits(), icr_low as u64 | ((icr_high as u64) << 32));
+    }
+
+    #[test]
+    fn incomplete_ipi_info2_fields() {
+        let info = SevAvicIncompleteIpiInfo2::new()
+            .with_index(42)
+            .with_failure(SevAvicIpiFailure::NOT_RUNNING);
+        assert_eq!(info.index(), 42);
+        assert_eq!(info.failure(), SevAvicIpiFailure::NOT_RUNNING);
+    }
+
+    #[test]
+    fn incomplete_ipi_info2_all_failure_codes() {
+        let failures = [
+            SevAvicIpiFailure::INVALID_TYPE,
+            SevAvicIpiFailure::NOT_RUNNING,
+            SevAvicIpiFailure::INVALID_TARGET,
+            SevAvicIpiFailure::INVALID_BACKING_PAGE,
+            SevAvicIpiFailure::INVALID_VECTOR,
+            SevAvicIpiFailure::UNACCELERATED_IPI,
+        ];
+        for failure in failures {
+            let info = SevAvicIncompleteIpiInfo2::new().with_failure(failure);
+            assert_eq!(
+                info.failure(),
+                failure,
+                "failure code roundtrip failed for {failure:#x?}"
+            );
+        }
+    }
+
+    // ---- SevFeatures secure AVIC fields ----
+
+    #[test]
+    fn sev_features_secure_avic_bit() {
+        let features = SevFeatures::new().with_secure_avic(true);
+        assert!(features.secure_avic());
+        // secure_avic is bit 16 (0-indexed).
+        assert_ne!(features.into_bits() & (1 << 16), 0);
+    }
+
+    #[test]
+    fn sev_features_guest_intercept_control_bit() {
+        let features = SevFeatures::new().with_guest_intercept_control(true);
+        assert!(features.guest_intercept_control());
+        // guest_intercept_control is bit 13.
+        assert_ne!(features.into_bits() & (1 << 13), 0);
+    }
+
+    #[test]
+    fn sev_features_secure_avic_with_no_alternate_injection() {
+        // Secure AVIC and alternate injection are mutually exclusive per the
+        // init_vmsa logic.
+        let features = SevFeatures::new()
+            .with_secure_avic(true)
+            .with_guest_intercept_control(true)
+            .with_alternate_injection(false);
+        assert!(features.secure_avic());
+        assert!(features.guest_intercept_control());
+        assert!(!features.alternate_injection());
+    }
+
+    #[test]
+    fn sev_features_alternate_injection_without_secure_avic() {
+        let features = SevFeatures::new()
+            .with_alternate_injection(true)
+            .with_secure_avic(false);
+        assert!(features.alternate_injection());
+        assert!(!features.secure_avic());
+    }
+
+    // ---- SevStatusMsr secure AVIC field ----
+
+    #[test]
+    fn sev_status_msr_secure_avic_bit() {
+        let status = SevStatusMsr::new().with_secure_avic(true);
+        assert!(status.secure_avic());
+        // secure_avic is bit 18 in SevStatusMsr (after sev_enabled, es_enabled,
+        // snp_enabled, vtom, reflect_vc, restrict_injection, alternate_injection,
+        // debug_swap, prevent_host_ibs, snp_btb_isolation, vmpl_sss, secure_tsc,
+        // vmgexit_param, _rsvd3, ibs_virt, _rsvd5, vmsa_reg_prot, smt_prot).
+        assert_ne!(status.into_bits() & (1 << 18), 0);
+    }
+
+    // ---- SevVirtualInterruptControl NMI fields ----
+
+    #[test]
+    fn v_intr_cntrl_nmi_fields() {
+        let ctrl = SevVirtualInterruptControl::new()
+            .with_nmi(true)
+            .with_nmi_mask(true)
+            .with_nmi_enable(true);
+        assert!(ctrl.nmi());
+        assert!(ctrl.nmi_mask());
+        assert!(ctrl.nmi_enable());
+    }
+
+    // ---- SevAvicPage layout tests ----
+
+    #[test]
+    fn sev_avic_page_size_is_4096() {
+        // Already asserted at compile time, but verify at runtime too.
+        assert_eq!(size_of::<SevAvicPage>(), 4096);
+    }
+
+    #[test]
+    fn sev_avic_irr_register_size() {
+        // Each IRR register has value + allowed + reserved = 16 bytes,
+        // same as a standard ApicRegisterValue.
+        assert_eq!(
+            size_of::<SevAvicIrrRegister>(),
+            size_of::<ApicRegisterValue>()
+        );
+    }
+
+    #[test]
+    fn sev_avic_page_field_offsets() {
+        // Verify key field offsets match the APIC register map.
+        // Each "register" is 16 bytes (128 bits per the AMD spec).
+        let page = SevAvicPage::new_zeroed();
+        let base = core::ptr::from_ref(&page) as usize;
+
+        // id is at register index 2 (offset 0x20)
+        let id_offset = core::ptr::from_ref(&page.id) as usize - base;
+        assert_eq!(id_offset, 2 * 16, "APIC ID offset");
+
+        // version is at register index 3 (offset 0x30)
+        let version_offset = core::ptr::from_ref(&page.version) as usize - base;
+        assert_eq!(version_offset, 3 * 16, "version offset");
+
+        // TPR is at register index 8 (offset 0x80)
+        let tpr_offset = core::ptr::from_ref(&page.tpr) as usize - base;
+        assert_eq!(tpr_offset, 8 * 16, "TPR offset");
+
+        // ISR starts at register index 0x10 (offset 0x100)
+        let isr_offset = core::ptr::from_ref(&page.isr) as usize - base;
+        assert_eq!(isr_offset, 0x10 * 16, "ISR offset");
+
+        // TMR starts at register index 0x18 (offset 0x180)
+        let tmr_offset = core::ptr::from_ref(&page.tmr) as usize - base;
+        assert_eq!(tmr_offset, 0x18 * 16, "TMR offset");
+
+        // IRR starts at register index 0x20 (offset 0x200)
+        let irr_offset = core::ptr::from_ref(&page.irr) as usize - base;
+        assert_eq!(irr_offset, 0x20 * 16, "IRR offset");
+
+        // ICR is at register index 0x30 (offset 0x300)
+        let icr_offset = core::ptr::from_ref(&page.icr) as usize - base;
+        assert_eq!(icr_offset, 0x30 * 16, "ICR offset");
+    }
+
+    // ---- VMSA SecureAvicControl field offset test ----
+
+    #[test]
+    fn vmsa_secure_avic_control_at_rsp_offset() {
+        // In the VMSA, secure_avic_control occupies the RSP slot (between RBX and RBP).
+        // Verify it's at the expected offset by checking it doesn't overlap GPRs.
+        let vmsa = SevVmsa::new_zeroed();
+        let base = core::ptr::from_ref(&vmsa) as usize;
+        let rbx_offset = core::ptr::from_ref(&vmsa.rbx) as usize - base;
+        let savic_offset = core::ptr::from_ref(&vmsa.secure_avic_control) as usize - base;
+        let rbp_offset = core::ptr::from_ref(&vmsa.rbp) as usize - base;
+
+        // secure_avic_control should be right after rbx and before rbp.
+        assert_eq!(savic_offset, rbx_offset + 8);
+        assert_eq!(rbp_offset, savic_offset + 8);
+    }
+
+    // ---- SevAvicRegisterNumber to x2APIC MSR mapping ----
+
+    #[test]
+    fn avic_register_number_matches_apic_register_enum() {
+        // The SevAvicRegisterNumber values should match the corresponding
+        // x86defs::apic::ApicRegisterValue values, ensuring correct MSR computation.
+        use crate::apic::ApicRegister;
+        assert_eq!(SevAvicRegisterNumber::APIC_ID.0, ApicRegister::ID.0 as u32);
+        assert_eq!(
+            SevAvicRegisterNumber::VERSION.0,
+            ApicRegister::VERSION.0 as u32
+        );
+        assert_eq!(SevAvicRegisterNumber::TPR.0, ApicRegister::TPR.0 as u32);
+        assert_eq!(SevAvicRegisterNumber::EOI.0, ApicRegister::EOI.0 as u32);
+        assert_eq!(SevAvicRegisterNumber::LDR.0, ApicRegister::LDR.0 as u32);
+        assert_eq!(
+            SevAvicRegisterNumber::SPURIOUS.0,
+            ApicRegister::SVR.0 as u32
+        );
+        assert_eq!(SevAvicRegisterNumber::ISR0.0, ApicRegister::ISR0.0 as u32);
+        assert_eq!(SevAvicRegisterNumber::TMR0.0, ApicRegister::TMR0.0 as u32);
+        assert_eq!(SevAvicRegisterNumber::IRR0.0, ApicRegister::IRR0.0 as u32);
+        assert_eq!(SevAvicRegisterNumber::ERROR.0, ApicRegister::ESR.0 as u32);
+        assert_eq!(
+            SevAvicRegisterNumber::ICR_LOW.0,
+            ApicRegister::ICR0.0 as u32
+        );
+        assert_eq!(
+            SevAvicRegisterNumber::ICR_HIGH.0,
+            ApicRegister::ICR1.0 as u32
+        );
+        assert_eq!(
+            SevAvicRegisterNumber::TIMER_LVT.0,
+            ApicRegister::LVT_TIMER.0 as u32
+        );
+        assert_eq!(
+            SevAvicRegisterNumber::INITIAL_COUNT.0,
+            ApicRegister::TIMER_ICR.0 as u32
+        );
+        assert_eq!(
+            SevAvicRegisterNumber::CURRENT_COUNT.0,
+            ApicRegister::TIMER_CCR.0 as u32
+        );
+        assert_eq!(
+            SevAvicRegisterNumber::DIVIDER.0,
+            ApicRegister::TIMER_DCR.0 as u32
+        );
+        assert_eq!(
+            SevAvicRegisterNumber::SELF_IPI.0,
+            ApicRegister::SELF_IPI.0 as u32
+        );
+    }
+
+    #[test]
+    fn avic_register_to_x2apic_msr() {
+        // Verify the MSR computation: X2APIC_MSR_BASE + register_number.
+        use crate::apic::X2APIC_MSR_BASE;
+        let msr = X2APIC_MSR_BASE + SevAvicRegisterNumber::EOI.0;
+        assert_eq!(msr, 0x80B); // EOI is register 0xB
+
+        let msr = X2APIC_MSR_BASE + SevAvicRegisterNumber::ICR_LOW.0;
+        assert_eq!(msr, 0x830); // ICR_LOW is register 0x30
+    }
+
+    // ---- SevExitCode AVIC constants ----
+
+    #[test]
+    fn sev_exit_code_avic_values() {
+        assert_eq!(SevExitCode::AVIC_INCOMPLETE_IPI.0, 0x401);
+        assert_eq!(SevExitCode::AVIC_NOACCEL.0, 0x402);
+    }
+}

--- a/vm/x86/x86defs/src/vmx.rs
+++ b/vm/x86/x86defs/src/vmx.rs
@@ -5,8 +5,10 @@
 
 // TODO: move VMX defs somewhere?
 
+use crate::ApicRegisterValue;
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
+use static_assertions::const_assert_eq;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -498,44 +500,39 @@ pub struct SecondaryProcessorControls {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
-pub struct ApicRegister {
-    pub value: u32,
-    _reserved: [u32; 3],
+#[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct VmxApicPage {
+    pub reserved_0: [ApicRegisterValue; 2],
+    pub id: ApicRegisterValue,
+    pub version: ApicRegisterValue,
+    pub reserved_4: [ApicRegisterValue; 4],
+    pub tpr: ApicRegisterValue,
+    pub apr: ApicRegisterValue,
+    pub ppr: ApicRegisterValue,
+    pub eoi: ApicRegisterValue,
+    pub rrd: ApicRegisterValue,
+    pub ldr: ApicRegisterValue,
+    pub dfr: ApicRegisterValue,
+    pub svr: ApicRegisterValue,
+    pub isr: [ApicRegisterValue; 8],
+    pub tmr: [ApicRegisterValue; 8],
+    pub irr: [ApicRegisterValue; 8],
+    pub esr: ApicRegisterValue,
+    pub reserved_29: [ApicRegisterValue; 6],
+    pub lvt_cmci: ApicRegisterValue,
+    pub icr: [ApicRegisterValue; 2],
+    pub lvt_timer: ApicRegisterValue,
+    pub lvt_thermal: ApicRegisterValue,
+    pub lvt_pmc: ApicRegisterValue,
+    pub lvt_lint0: ApicRegisterValue,
+    pub lvt_lint1: ApicRegisterValue,
+    pub lvt_error: ApicRegisterValue,
+    pub timer_icr: ApicRegisterValue,
+    pub timer_ccr: ApicRegisterValue,
+    pub reserved_3a: [ApicRegisterValue; 4],
+    pub timer_dcr: ApicRegisterValue,
+    pub reserved_3f: ApicRegisterValue,
+    pub reserved_40: [ApicRegisterValue; 0xc0],
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
-pub struct ApicPage {
-    pub reserved_0: [ApicRegister; 2],
-    pub id: ApicRegister,
-    pub version: ApicRegister,
-    pub reserved_4: [ApicRegister; 4],
-    pub tpr: ApicRegister,
-    pub apr: ApicRegister,
-    pub ppr: ApicRegister,
-    pub eoi: ApicRegister,
-    pub rrd: ApicRegister,
-    pub ldr: ApicRegister,
-    pub dfr: ApicRegister,
-    pub svr: ApicRegister,
-    pub isr: [ApicRegister; 8],
-    pub tmr: [ApicRegister; 8],
-    pub irr: [ApicRegister; 8],
-    pub esr: ApicRegister,
-    pub reserved_29: [ApicRegister; 6],
-    pub lvt_cmci: ApicRegister,
-    pub icr: [ApicRegister; 2],
-    pub lvt_timer: ApicRegister,
-    pub lvt_thermal: ApicRegister,
-    pub lvt_pmc: ApicRegister,
-    pub lvt_lint0: ApicRegister,
-    pub lvt_lint1: ApicRegister,
-    pub lvt_error: ApicRegister,
-    pub timer_icr: ApicRegister,
-    pub timer_ccr: ApicRegister,
-    pub reserved_3a: [ApicRegister; 4],
-    pub timer_dcr: ApicRegister,
-    pub reserved_3f: ApicRegister,
-    pub reserved_40: [ApicRegister; 0xc0],
-}
+const_assert_eq!(size_of::<VmxApicPage>(), 4096);

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -229,7 +229,7 @@ async fn openhcl_linux_vtl2_ram_self_allocate(
     // tree and parse it ourselves again, but this requires refactoring some
     // crates to make `bootloader_fdt_parser` available outside the underhill
     // tree.
-    let vtl2_allowable_difference_kb = 29000;
+    let vtl2_allowable_difference_kb = 32000;
     let vtl2_expected_mem_kb = vtl2_ram_size / 1024;
     let vtl2_diff = (vtl2_mem_kb as i64 - vtl2_expected_mem_kb as i64).unsigned_abs();
     tracing::info!(


### PR DESCRIPTION
Add initial support for SNP secure AVIC.
Update kernel to a temporary 6.12 version that supports secure AVIC. A new 6.18 version is in progress.