### PR TITLE
chipset_device: Allow most devices to avoid tdisp dependencies

### DIFF
--- a/vm/chipset_device/Cargo.toml
+++ b/vm/chipset_device/Cargo.toml
@@ -6,10 +6,13 @@ name = "chipset_device"
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+tdisp = ["dep:tdisp"]
+
 [dependencies]
 mesh.workspace = true
 inspect.workspace = true
-tdisp.workspace = true
+tdisp = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/vm/chipset_device/src/lib.rs
+++ b/vm/chipset_device/src/lib.rs
@@ -62,6 +62,7 @@ pub trait ChipsetDevice: 'static + Send /* see DEVNOTE before adding bounds */ {
         None
     }
 
+    #[cfg(feature = "tdisp")]
     /// Optionally returns a trait object which implements TDISP host
     /// communication.
     #[inline(always)]

--- a/vm/chipset_device_resources/Cargo.toml
+++ b/vm/chipset_device_resources/Cargo.toml
@@ -6,10 +6,13 @@ name = "chipset_device_resources"
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+tdisp = ["dep:tdisp", "chipset_device/tdisp"]
+
 [dependencies]
 chipset_device.workspace = true
 guestmem.workspace = true
-tdisp.workspace = true
+tdisp = { workspace = true, optional = true }
 vmcore.workspace = true
 vm_resource.workspace = true
 

--- a/vm/chipset_device_resources/src/lib.rs
+++ b/vm/chipset_device_resources/src/lib.rs
@@ -174,6 +174,7 @@ impl ChipsetDevice for ErasedChipsetDevice {
         self.0.supports_acknowledge_pic_interrupt()
     }
 
+    #[cfg(feature = "tdisp")]
     fn supports_tdisp(&mut self) -> Option<&mut dyn tdisp::TdispHostDeviceTarget> {
         self.0.supports_tdisp()
     }

--- a/vm/devices/pci/vpci/Cargo.toml
+++ b/vm/devices/pci/vpci/Cargo.toml
@@ -18,7 +18,7 @@ vmbus_async.workspace = true
 vmbus_ring.workspace = true
 
 chipset_arc_mutex_device.workspace = true
-chipset_device.workspace = true
+chipset_device = { workspace = true, features = ["tdisp"] }
 guestmem.workspace = true
 vmcore.workspace = true
 hvdef.workspace = true

--- a/vm/devices/tdisp/src/lib.rs
+++ b/vm/devices/tdisp/src/lib.rs
@@ -97,6 +97,10 @@ pub trait TdispHostDeviceInterface: Send + Sync {
 /// Trait added to host virtual devices to dispatch TDISP commands from guests.
 pub trait TdispHostDeviceTarget: Send + Sync {
     /// Dispatch a TDISP command from a guest.
+    // TODO: We shouldn't take raw protobuf-generated types here.
+    // We should probably have a method per-command with strongly typed arguments,
+    // and do the protobuf translation only when needed. Then this trait can move
+    // into chipset_device, and that crate can continue to avoid depending on prost.
     fn tdisp_handle_guest_command(
         &mut self,
         _command: GuestToHostCommand,


### PR DESCRIPTION
Break the dependency chain by putting tdisp types behind a feature, and leave a TODO for the better solution for the future.