### PR TITLE
netvsp: gdma driver returns valid os_type for openhcl

### DIFF
--- a/vm/devices/net/gdma_defs/src/lib.rs
+++ b/vm/devices/net/gdma_defs/src/lib.rs
@@ -457,6 +457,8 @@ pub const DRIVER_CAP_FLAG_1_HW_VPORT_LINK_AWARE: u64 = 0x40;
 pub const DRIVER_CAP_FLAG_1_SELF_RESET_ON_EQE_NOTIFICATION: u64 = 0x4000;
 pub const DRIVER_CAP_FLAG_1_VTL2_REVOKE_SUB_ON_RESET_EQE: u64 = 0x10000;
 
+pub const OS_TYPE_OHCL: u32 = 0x60;
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct GdmaVerifyVerReq {

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -1240,6 +1240,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                         | DRIVER_CAP_FLAG_1_HWC_TIMEOUT_RECONFIG
                         | DRIVER_CAP_FLAG_1_SELF_RESET_ON_EQE_NOTIFICATION
                         | DRIVER_CAP_FLAG_1_VTL2_REVOKE_SUB_ON_RESET_EQE,
+                    os_type: gdma_defs::OS_TYPE_OHCL,
                     ..FromZeros::new_zeroed()
                 },
             )


### PR DESCRIPTION
During the initial handshake with the MANA NIC, GDMA driver supplies a 0 for os_type. `verify_vf_driver_version()` should send a valid value for the os_type to the NIC. The SOC has been updated to expect 0x60 from UH. The soc will be able distinguish that the driver is OpenHCL.