### PR TITLE
copilot-instructions: prune generic advice, add actionable project-specific guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,13 +31,6 @@ headers, naming conventions) and applies auto-fixes where supported. If it
 still fails, fix the remaining reported issues manually and re-run until it
 succeeds. Do not run individual `--pass` commands afterward.
 
-The project also enforces clippy rules via `clippy.toml`. Key disallowed types:
-- Use `parking_lot::Mutex`, `Condvar`, `RwLock` — **not** `std::sync` equivalents
-- Use `unicycle::FuturesUnordered` — **not** `futures::FuturesUnordered`
-- Use `mesh` or `async-channel` for channels — **not** `futures::channel`
-- Use `std::future::ready`, `std::future::pending`, `std::task::ready`,
-  `std::pin::pin` — **not** the `futures` crate equivalents
-
 ## Trust Boundaries & Safety
 
 Both OpenVMM and OpenHCL process data from untrusted sources. Code must
@@ -89,7 +82,6 @@ cargo nextest run -p <package-name>
   is initialized and traces appear in test output.
 - **VMM tests** — integration tests in `vmm_tests/` using the petri
   framework (requires additional setup).
-- **Fuzz tests** — nondeterministic tests that identify edge cases and security issues.
 - Mark tests requiring special setup with `#[ignore]`.
 - Update `Guide/` docs when adding features or changing behavior
   (see `.github/instructions/doc-code-sync.instructions.md` for the mapping)


### PR DESCRIPTION
Builds on the scoped-instructions refactor in PR #2948, which moved documentation style rules to guide-docs.instructions.md and added doc-code-sync.instructions.md and the guide-maintenance skill.

This commit further refines copilot-instructions.md by removing content that wastes agent context and adding domain-specific rules that prevent common CI failures and incorrect code patterns.

Removed:
- Technology Stack section: agents infer Rust/Cargo from the workspace; other sections already mention nextest, mdBook, and flowey.
- Project Structure section: duplicates the workspace directory tree that agents already receive as context.
- Generic 'cargo build' / 'cargo build --release' commands: standard Rust knowledge. Only the non-obvious 'cargo xflowey restore-packages' step is worth documenting.
- Generic Code Standards (follow best practices, write tests, document APIs): dilutes domain-specific guidance. Moved doc-sync reference into the Testing section where it's actionable.

Added:
- Clippy disallowed-type rules from clippy.toml: parking_lot over std::sync, unicycle over futures, mesh/async-channel over futures::channel, std equivalents over futures crate utilities.
- Error handling across trust boundaries: thiserror at API boundaries, anyhow with .context() for plumbing, never .unwrap() on untrusted data.
- open_enum! macro for protocol/hardware enums that must round-trip unknown values without panicking.
- tracelimit::warn_ratelimited! (and variants) for trace events triggerable by guest interactions.
- test_with_tracing::test in test modules for tracing initialization.
- Prefer assert! over debug_assert! with fail-fast philosophy: crash immediately on broken invariants rather than continuing in an undefined state.
- no_std constraints for OpenHCL crates (minimal_rt, openhcl_boot, sidecar, host_fdt_parser).
- Common Pitfalls section: guest_arch not target_arch, workspace dependency conventions, auto-generated pipeline YAMLs, flowey node macros, and the .bat/.cmd CRLF exception.
- clippy --all-targets -p <package> and cargo doc -p <package> as required pre-commit steps.

Changed:
- Formatting section: prescriptive statement that 'cargo xtask fmt --fix' handles everything — do not re-run without --fix or run individual passes.
- Trust boundary: 'OpenVMM does not trust the VTL0 guest' corrected to 'OpenVMM does not trust the guest' (applies regardless of VTL).