### PR TITLE
Fix issue with hyperv_secure_boot_templates build script

### DIFF
--- a/vm/devices/firmware/hyperv_secure_boot_templates/build.rs
+++ b/vm/devices/firmware/hyperv_secure_boot_templates/build.rs
@@ -8,7 +8,9 @@ use std::path::PathBuf;
 
 pub fn main() {
     println!("cargo::rerun-if-changed=build.rs");
-    println!("cargo::rerun-if-changed=./templates/");
+    println!("cargo::rerun-if-changed=./templates/aarch64");
+    println!("cargo::rerun-if-changed=./templates/x64");
+
     let out_dir: PathBuf = std::env::var_os("OUT_DIR").unwrap().into();
 
     minify_json_in_folder(Path::new("./templates/aarch64"), &out_dir.join("aarch64"));


### PR DESCRIPTION
#2896 added a couple of new json files to the hyperv_secure_boot_templates/templates directory and added code to reference them in the OUT_DIR, where they're copied by the build script. Previously, the build script was only re-run if it itself is modified, which is incorrect as it needs to copy any changes to the json files to the OUT_DIR.

This change ensures the build script is re-run if there are any changes to the json files in templates/*.