### PR TITLE
sidecar: vp offline diagnostic logging

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1864,6 +1864,11 @@ impl Hcl {
         Some(self.sidecar.as_ref()?.base_cpu(vp_index))
     }
 
+    /// Returns whether sidecar support is enabled for this partition.
+    pub fn sidecar_enabled(&self) -> bool {
+        self.sidecar.is_some()
+    }
+
     /// Create a VP runner for the given partition.
     pub fn runner<'a, T: Backing<'a>>(
         &'a self,

--- a/openhcl/underhill_core/src/vp.rs
+++ b/openhcl/underhill_core/src/vp.rs
@@ -54,7 +54,12 @@ impl VpSpawner {
         if underhill_threadpool::is_cpu_online(self.cpu)? {
             self.spawn_main_vp().await
         } else {
-            // The CPU is not online, so this should be a sidecar VP. Run the VP
+            // No sidecar and the CPU is offline; this VP cannot run.
+            if !self.vp.sidecar_enabled() {
+                anyhow::bail!("cpu {} is offline", self.cpu);
+            }
+
+            // The CPU is not online and it's a sidecar managed CPU. Run the VP
             // remotely via the sidecar kernel.
             if self.isolation.is_isolated() {
                 anyhow::bail!(

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -649,6 +649,11 @@ impl UhProcessorBox {
         self.vp_info.base.vp_index
     }
 
+    /// Returns whether sidecar support is enabled.
+    pub fn sidecar_enabled(&self) -> bool {
+        self.partition.hcl.sidecar_enabled()
+    }
+
     /// Returns the base CPU that manages this processor, when it is a sidecar
     /// VP.
     pub fn sidecar_base_cpu(&self) -> Option<u32> {


### PR DESCRIPTION
When sidecar is not enabled, VP startup should indicate proper logging to as not confuse with sidecar.