### PR TITLE
virtiofs: migrate from VirtioQueueWorkerContext to direct VirtioQueue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9085,15 +9085,15 @@ name = "virtiofs"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
- "event-listener",
  "fuse",
+ "futures",
  "guestmem",
  "inspect",
  "lx",
  "lxutil",
  "ntapi",
  "pal",
+ "pal_async",
  "parking_lot",
  "task_control",
  "tracing",

--- a/vm/devices/virtio/virtiofs/Cargo.toml
+++ b/vm/devices/virtio/virtiofs/Cargo.toml
@@ -22,8 +22,8 @@ pal.workspace = true
 task_control.workspace = true
 
 anyhow.workspace = true
-async-trait.workspace = true
-event-listener.workspace = true
+futures.workspace = true
+pal_async.workspace = true
 parking_lot.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -3,25 +3,27 @@
 
 use crate::virtio_util::VirtioPayloadReader;
 use crate::virtio_util::VirtioPayloadWriter;
-use async_trait::async_trait;
+use futures::StreamExt;
 use guestmem::GuestMemory;
 use guestmem::MappedMemoryRegion;
 use inspect::InspectMut;
+use pal_async::wait::PolledWait;
 use std::io;
 use std::io::Write;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::task::ready;
+use task_control::AsyncRun;
+use task_control::Cancelled;
+use task_control::StopTask;
 use task_control::TaskControl;
 use virtio::DeviceTraits;
 use virtio::DeviceTraitsSharedMemory;
 use virtio::Resources;
 use virtio::VirtioDevice;
+use virtio::VirtioQueue;
 use virtio::VirtioQueueCallbackWork;
-use virtio::VirtioQueueState;
-use virtio::VirtioQueueWorker;
-use virtio::VirtioQueueWorkerContext;
 use virtio::spec::VirtioDeviceFeatures;
 use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
@@ -42,18 +44,15 @@ struct VirtioFsDeviceConfig {
 /// A virtio-fs PCI device.
 #[derive(InspectMut)]
 pub struct VirtioFsDevice {
-    name: Box<str>,
-
+    task_name: Box<str>,
     driver: VmTaskDriver,
     #[inspect(skip)]
     config: VirtioFsDeviceConfig,
-    memory: GuestMemory,
+    mem: GuestMemory,
     #[inspect(skip)]
     fs: Arc<fuse::Session>,
     #[inspect(skip)]
-    workers: Vec<TaskControl<VirtioQueueWorker, VirtioQueueState>>,
-    #[inspect(skip)]
-    exit_event: event_listener::Event,
+    workers: Vec<TaskControl<VirtioFsWorker, VirtioFsQueue>>,
     shmem_size: u64,
     #[inspect(skip)]
     notify_corruption: Arc<dyn Fn() + Sync + Send>,
@@ -88,13 +87,12 @@ impl VirtioFsDevice {
         config.tag[..length].copy_from_slice(&tag.as_bytes()[..length]);
 
         Self {
-            name: format!("virtio-fs-{}", tag).into(),
+            task_name: format!("virtiofs-{}", tag).into(),
             driver: driver_source.simple(),
             config,
-            memory,
+            mem: memory,
             fs: Arc::new(fuse::Session::new(fs)),
             workers: Vec::new(),
-            exit_event: event_listener::Event::new(),
             shmem_size,
             notify_corruption,
         }
@@ -141,28 +139,38 @@ impl VirtioDevice for VirtioFsDevice {
                 if !queue_resources.params.enable {
                     return None;
                 }
-                let worker = VirtioFsWorker {
+
+                let mut tc = TaskControl::new(VirtioFsWorker {
                     fs: self.fs.clone(),
-                    mem: self.memory.clone(),
+                    mem: self.mem.clone(),
                     shared_memory_region: resources.shared_memory_region.clone(),
                     shared_memory_size: resources.shared_memory_size,
                     notify_corruption: self.notify_corruption.clone(),
-                };
-                let worker = VirtioQueueWorker::new(self.driver.clone(), Box::new(worker));
-                Some(worker.into_running_task(
-                    "virtiofs-virtio-queue".to_string(),
-                    self.memory.clone(),
+                });
+
+                let queue_event = PolledWait::new(&self.driver, queue_resources.event).unwrap();
+                let queue = VirtioQueue::new(
                     resources.features.clone(),
-                    queue_resources,
-                    self.exit_event.listen(),
-                ))
+                    queue_resources.params,
+                    self.mem.clone(),
+                    queue_resources.notify,
+                    queue_event,
+                )
+                .expect("failed to create virtio queue");
+
+                tc.insert(
+                    self.driver.clone(),
+                    &*self.task_name,
+                    VirtioFsQueue { queue },
+                );
+                tc.start();
+                Some(tc)
             })
             .collect();
         Ok(())
     }
 
     fn poll_disable(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        self.exit_event.notify(usize::MAX);
         for worker in &mut self.workers {
             ready!(worker.poll_stop(cx));
         }
@@ -179,55 +187,72 @@ struct VirtioFsWorker {
     notify_corruption: Arc<dyn Fn() + Sync + Send>,
 }
 
-#[async_trait]
-impl VirtioQueueWorkerContext for VirtioFsWorker {
-    async fn process_work(&mut self, work: anyhow::Result<VirtioQueueCallbackWork>) -> bool {
-        if let Err(err) = work {
-            tracing::error!(
-                error = err.as_ref() as &dyn std::error::Error,
-                "Failed processing queue"
-            );
-            return false;
-        }
+struct VirtioFsQueue {
+    queue: VirtioQueue,
+}
 
-        let mut work = work.unwrap();
-        // Parse the request.
-        let reader = VirtioPayloadReader::new(&self.mem, &work);
-        let request = match fuse::Request::new(reader) {
-            Ok(request) => request,
-            Err(e) => {
-                tracing::error!(
-                    error = &e as &dyn std::error::Error,
-                    "[virtiofs] Invalid FUSE message, error"
-                );
-                // Often this will result in the guest failing the device as there is no response to a request.
-                (self.notify_corruption)();
-                // This only happens if even the header couldn't be parsed, so there's no way
-                // to send an error reply since the request's unique ID isn't known.
-                work.complete(0);
-                return true;
+impl AsyncRun<VirtioFsQueue> for VirtioFsWorker {
+    async fn run(
+        &mut self,
+        stop: &mut StopTask<'_>,
+        state: &mut VirtioFsQueue,
+    ) -> Result<(), Cancelled> {
+        loop {
+            let work = stop.until_stopped(state.queue.next()).await?;
+            let Some(work) = work else { break };
+            match work {
+                Ok(work) => {
+                    process_virtiofs_request(self, work);
+                }
+                Err(err) => {
+                    tracing::error!(
+                        error = &err as &dyn std::error::Error,
+                        "Failed processing queue"
+                    );
+                    break;
+                }
             }
-        };
-
-        // Dispatch to the file system.
-        let mut sender = VirtioReplySender {
-            work,
-            mem: &self.mem,
-        };
-        let mapper = self
-            .shared_memory_region
-            .as_ref()
-            .map(|shared_memory_region| VirtioMapper {
-                region: shared_memory_region.as_ref(),
-                size: self.shared_memory_size,
-            });
-        self.fs.dispatch(
-            request,
-            &mut sender,
-            mapper.as_ref().map(|x| x as &dyn fuse::Mapper),
-        );
-        true
+        }
+        Ok(())
     }
+}
+
+fn process_virtiofs_request(worker: &VirtioFsWorker, mut work: VirtioQueueCallbackWork) {
+    // Parse the request.
+    let reader = VirtioPayloadReader::new(&worker.mem, &work);
+    let request = match fuse::Request::new(reader) {
+        Ok(request) => request,
+        Err(e) => {
+            tracing::error!(
+                error = &e as &dyn std::error::Error,
+                "[virtiofs] Invalid FUSE message, error"
+            );
+            // Often this will result in the guest failing the device as there is no response to a request.
+            (worker.notify_corruption)();
+            // This only happens if even the header couldn't be parsed, so there's no way
+            // to send an error reply since the request's unique ID isn't known.
+            work.complete(0);
+            return;
+        }
+    };
+
+    // Dispatch to the file system.
+    let mut sender = VirtioReplySender {
+        work,
+        mem: &worker.mem,
+    };
+    let mapper = worker
+        .shared_memory_region
+        .as_ref()
+        .map(|shared_memory_region| VirtioMapper {
+            region: shared_memory_region.as_ref(),
+            size: worker.shared_memory_size,
+        });
+    worker.fs.dispatch(
+        request,
+        &mut sender,
+        mapper.as_ref().map(|x| x as &dyn fuse::Mapper),
+    );
 }
 /// An implementation of `ReplySender` for virtio payload.
 struct VirtioReplySender<'a> {


### PR DESCRIPTION
Replace VirtioQueueWorkerContext callback pattern with direct VirtioQueue + AsyncRun task. Each queue gets its own TaskControl<VirtioFsWorker, VirtioFsQueue> created per-enable (multi-queue device with max_queues=2).

- VirtioFsWorker (T): owns fs, mem, shared_memory_region, notify_corruption
- VirtioFsQueue (S): owns VirtioQueue
- StopTask replaces exit_event for cancellation
- Remove async-trait and event-listener deps; add futures and pal_async