### PR TITLE
netvsp: gdma driver advertises eqe 135 capabilities to the soc (#2933)

### DIFF
--- a/vm/devices/net/gdma_defs/src/lib.rs
+++ b/vm/devices/net/gdma_defs/src/lib.rs
@@ -454,6 +454,8 @@ pub struct HwcRxOobFlags {
 pub const DRIVER_CAP_FLAG_1_HWC_TIMEOUT_RECONFIG: u64 = 0x08;
 pub const DRIVER_CAP_FLAG_1_VARIABLE_INDIRECTION_TABLE_SUPPORT: u64 = 0x20;
 pub const DRIVER_CAP_FLAG_1_HW_VPORT_LINK_AWARE: u64 = 0x40;
+pub const DRIVER_CAP_FLAG_1_SELF_RESET_ON_EQE_NOTIFICATION: u64 = 0x4000;
+pub const DRIVER_CAP_FLAG_1_VTL2_REVOKE_SUB_ON_RESET_EQE: u64 = 0x10000;
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -477,6 +479,9 @@ pub struct GdmaVerifyVerReq {
     pub os_ver_str3: [u8; 128],
     pub os_ver_str4: [u8; 128],
 }
+
+pub const GDMA_PF_CAP_FLAG_1_QUERY_HWC_TIMEOUT: u64 = 0x08;
+pub const GDMA_PF_CAP_FLAG_1_EQE_REQUEST_VF_SELF_RESET: u64 = 0x80;
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -17,7 +17,9 @@ use futures::FutureExt;
 use gdma_defs::Cqe;
 use gdma_defs::DRIVER_CAP_FLAG_1_HW_VPORT_LINK_AWARE;
 use gdma_defs::DRIVER_CAP_FLAG_1_HWC_TIMEOUT_RECONFIG;
+use gdma_defs::DRIVER_CAP_FLAG_1_SELF_RESET_ON_EQE_NOTIFICATION;
 use gdma_defs::DRIVER_CAP_FLAG_1_VARIABLE_INDIRECTION_TABLE_SUPPORT;
+use gdma_defs::DRIVER_CAP_FLAG_1_VTL2_REVOKE_SUB_ON_RESET_EQE;
 use gdma_defs::EqeDataReconfig;
 use gdma_defs::EstablishHwc;
 use gdma_defs::GDMA_EQE_COMPLETION;
@@ -1079,7 +1081,10 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             let ms_wait = (HWC_INTERRUPT_POLL_WAIT_MIN_MS
                 * 2u32.pow(eqe_wait_result.interrupt_wait_count - 1))
             .min(HWC_INTERRUPT_POLL_WAIT_MAX_MS)
-            .min(self.hwc_timeout_in_ms - eqe_wait_result.elapsed as u32);
+            .min(
+                self.hwc_timeout_in_ms
+                    .saturating_sub(eqe_wait_result.elapsed as u32),
+            );
             let before_wait = std::time::Instant::now();
             eqe_wait_result.last_wait_result = Self::wait_for_hwc_interrupt(
                 self.interrupts[0].as_mut().unwrap(),
@@ -1232,7 +1237,9 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                     protocol_ver_max: 1,
                     gd_drv_cap_flags1: DRIVER_CAP_FLAG_1_VARIABLE_INDIRECTION_TABLE_SUPPORT
                         | DRIVER_CAP_FLAG_1_HW_VPORT_LINK_AWARE
-                        | DRIVER_CAP_FLAG_1_HWC_TIMEOUT_RECONFIG,
+                        | DRIVER_CAP_FLAG_1_HWC_TIMEOUT_RECONFIG
+                        | DRIVER_CAP_FLAG_1_SELF_RESET_ON_EQE_NOTIFICATION
+                        | DRIVER_CAP_FLAG_1_VTL2_REVOKE_SUB_ON_RESET_EQE,
                     ..FromZeros::new_zeroed()
                 },
             )
@@ -1241,6 +1248,16 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         if resp.gdma_protocol_ver != 1 {
             anyhow::bail!("invalid protocol version");
         }
+
+        tracing::info!(
+            gdma_protocol_ver = resp.gdma_protocol_ver,
+            pf_cap_flags1 = format_args!("{:#x}", resp.pf_cap_flags1),
+            pf_cap_flags2 = format_args!("{:#x}", resp.pf_cap_flags2),
+            pf_cap_flags3 = format_args!("{:#x}", resp.pf_cap_flags3),
+            pf_cap_flags4 = format_args!("{:#x}", resp.pf_cap_flags4),
+            "GDMA PF capability flags",
+        );
+
         Ok(())
     }
 

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -232,7 +232,7 @@ async fn test_gdma_reconfig_vf(driver: DefaultDriver) {
         "vf_reconfiguration_pending should be false"
     );
 
-    // Trigger the reconfig event
+    // Trigger the reconfig event (EQE 135).
     gdma.generate_reconfig_vf_event().await.unwrap();
     gdma.process_all_eqs();
     assert!(


### PR DESCRIPTION
Clean cherry pick of #2933

Now that OpenHCL handles the EQE 135, the Gdma driver should let the SoC know that it has that capability.

- Adding consts for the flags, matching those in Gdma Driver.
- Gdma driver now advertises support for SELF_RESET_ON_EQE_NOTIFICATION (EQE 135 handler)
- Gdma driver now advertises support for VTL2_REVOKE_SUB_ON_RESET_EQE (default behavior of EQE 135)
- In a follow-up PR, the EQE 135 handler may decide whether to revoke VTL0 VF based on additional context.
- GDMA PF Capabilities are logged for a possible benefit to future investigations.