### PR TITLE
virtio_blk: fix DEFAULT_SEG_MAX to match queue size

### DIFF
--- a/vm/devices/virtio/virtio/src/lib.rs
+++ b/vm/devices/virtio/virtio/src/lib.rs
@@ -16,4 +16,4 @@ pub mod transport;
 pub use common::*;
 pub use transport::*;
 
-const QUEUE_MAX_SIZE: u16 = 0x40; // TODO: make queue size configurable
+pub const QUEUE_MAX_SIZE: u16 = 0x40; // TODO: make queue size configurable

--- a/vm/devices/virtio/virtio_blk/src/integration_tests.rs
+++ b/vm/devices/virtio/virtio_blk/src/integration_tests.rs
@@ -49,7 +49,7 @@ use zerocopy::IntoBytes;
 
 // --- Constants ---
 
-const QUEUE_SIZE: u16 = 16;
+const QUEUE_SIZE: u16 = 32;
 
 // Memory layout for the single requestq
 const DESC_ADDR: u64 = 0x0000;

--- a/vm/devices/virtio/virtio_blk/src/spec.rs
+++ b/vm/devices/virtio/virtio_blk/src/spec.rs
@@ -57,10 +57,11 @@ pub const VIRTIO_BLK_ID_BYTES: usize = 20;
 /// Maximum number of segments per request advertised via `seg_max` (spec §5.2.4).
 ///
 /// This is the maximum number of data descriptors (excluding header and
-/// status) in a single request. 128 segments is generous for typical
-/// I/O; combined with `size_max` it allows up to 512 MiB per request.
-/// This matches common virtio-blk implementations (QEMU uses 128).
-pub const DEFAULT_SEG_MAX: u32 = 128;
+/// status) in a single request. The virtio spec requires that a
+/// descriptor chain is no longer than the queue size, and each block
+/// request uses one descriptor for the header and one for the status
+/// byte, so the data segment limit is `QUEUE_MAX_SIZE - 2`.
+pub const DEFAULT_SEG_MAX: u32 = virtio::QUEUE_MAX_SIZE as u32 - 2;
 
 /// Flag bit in `VirtioBlkDiscardWriteZeroes::flags` (spec §5.2.6).
 /// When set in a write zeroes command, allows the device to deallocate


### PR DESCRIPTION
DEFAULT_SEG_MAX was 128 but QUEUE_MAX_SIZE is 64, so only 62 data segments can fit in a descriptor chain (64 minus header and status descriptors). A guest building 128-segment chains would exceed the queue capacity.

Set DEFAULT_SEG_MAX = QUEUE_MAX_SIZE - 2 and make QUEUE_MAX_SIZE pub so virtio_blk can reference it. Bump integration test QUEUE_SIZE from 16 to 32 to accommodate test chains that previously relied on modulo wrapping to stay in bounds.