### PR TITLE
investigate_ci: add JUnit XML parsing and fix artifact pagination

### DIFF
--- a/.github/skills/openvmm-ci-investigation/SKILL.md
+++ b/.github/skills/openvmm-ci-investigation/SKILL.md
@@ -5,13 +5,14 @@ description: Investigate CI failures on OpenVMM PRs. Load when a PR has failing 
 
 # Investigating CI Failures
 
-When a PR has failing CI checks, use this workflow to diagnose the root cause.
-A helper script is available at `repo_support/investigate_ci.py`.
+When a PR has failing CI checks, **always start by running the investigation
+script**. Do not manually query the GitHub API or download artifacts by hand
+— the script handles all of that automatically.
 
-## Quick Start
+## Step 1: Run the Script
 
 ```bash
-# Investigate a PR by number
+# Investigate a PR by number (ALWAYS use this first)
 python3 repo_support/investigate_ci.py 2946
 
 # Or by run ID directly
@@ -29,7 +30,19 @@ The script automatically:
 6. If no test or JUnit artifacts exist (build/fmt/clippy failure), shows the
    tail of the failed job's log
 
-## Manual Investigation Steps
+## Step 2: Analyze the Script Output
+
+Read the script's output to identify:
+- Which tests failed (unit tests and/or VMM tests)
+- Error messages and root causes
+- Whether it's a build/fmt/clippy failure vs. a test failure
+
+Then use the information to diagnose the issue and suggest fixes.
+
+## Reference: Manual Commands
+
+> **Only use these if the script fails or you need to dig deeper into a
+> specific artifact.** In normal usage, the script above is sufficient.
 
 If the script isn't available or you need more control, follow these steps:
 
@@ -66,7 +79,9 @@ python3 -c "
 import xml.etree.ElementTree as ET, sys
 for f in __import__('pathlib').Path(sys.argv[1]).rglob('*.xml'):
     for tc in ET.parse(f).iter('testcase'):
-        fail = tc.find('failure') or tc.find('error')
+        fail = tc.find('failure')
+        if fail is None:
+            fail = tc.find('error')
         if fail is not None:
             print(f'FAIL: {tc.get(\"classname\",\"\")}::{tc.get(\"name\",\"\")}')
             print(f'  {fail.get(\"message\",\"\")[:200]}')

--- a/repo_support/investigate_ci.py
+++ b/repo_support/investigate_ci.py
@@ -197,7 +197,9 @@ def list_artifacts(run_id: str) -> list[str]:
             obj, end = decoder.raw_decode(text, pos)
             names.extend(a["name"] for a in obj.get("artifacts", []))
             pos = end
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            print(f"WARNING: Failed to parse artifact JSON at position {pos}: {e}", file=sys.stderr)
+            print(f"  Context: ...{text[max(0, pos-20):pos+40]}...", file=sys.stderr)
             break
         # skip whitespace between objects
         while pos < len(text) and text[pos] in " \t\n\r":
@@ -205,7 +207,7 @@ def list_artifacts(run_id: str) -> list[str]:
     return names
 
 
-def list_test_log_artifacts(run_id: str, all_artifacts: list[str]) -> list[str]:
+def list_test_log_artifacts(all_artifacts: list[str]) -> list[str]:
     """List available *-vmm-tests-logs artifact names for a run."""
     print()
     print("==> Listing available test log artifacts...")
@@ -282,7 +284,15 @@ def parse_junit_failures(xml_path: Path) -> list[dict]:
     """
     failures: list[dict] = []
     try:
-        tree = ET.parse(xml_path)  # noqa: S314 - trusted CI artifact
+        # CI artifacts come from potentially-untrusted PR code.
+        # Python's expat-based parser does not resolve external entities and
+        # has built-in entity expansion limits, but use defusedxml when
+        # available for belt-and-suspenders protection against XML DoS.
+        try:
+            import defusedxml.ElementTree as SafeET
+            tree = SafeET.parse(xml_path)
+        except ImportError:
+            tree = ET.parse(xml_path)
     except (ET.ParseError, OSError) as e:
         failures.append({"suite": "?", "test": "?", "message": f"(failed to parse JUnit XML: {e})", "output": ""})
         return failures
@@ -429,7 +439,7 @@ def main() -> None:
         sys.exit(0)
 
     all_artifacts = list_artifacts(run_id)
-    vmm_artifact_names = list_test_log_artifacts(run_id, all_artifacts)
+    vmm_artifact_names = list_test_log_artifacts(all_artifacts)
     junit_artifact_names = list_junit_artifacts(all_artifacts)
 
     if not vmm_artifact_names and not junit_artifact_names:
@@ -456,24 +466,25 @@ def main() -> None:
             print(f"  Total unit test failures: {junit_failure_count}")
 
     # --- VMM test failures (petri) ---
+    failed_markers: list[Path] = []
     if vmm_artifact_names:
         download_artifacts(run_id, vmm_artifact_names, workdir)
 
-    print()
-    print("==========================================")
-    print("  VMM TEST FAILURES (petri)")
-    print("==========================================")
+        print()
+        print("==========================================")
+        print("  VMM TEST FAILURES (petri)")
+        print("==========================================")
 
-    failed_markers = find_failed_tests(workdir)
+        failed_markers = find_failed_tests(workdir)
 
-    if not failed_markers:
-        print("  No petri.failed markers found.")
-        if junit_failure_count == 0:
-            print("  Tests may have passed, or failure occurred before test execution.")
-            sys.exit(0)
-
-    print(f"  Found {len(failed_markers)} failed test(s):")
-    print()
+        if not failed_markers:
+            print("  No petri.failed markers found.")
+            if junit_failure_count == 0:
+                print("  Tests may have passed, or failure occurred before test execution.")
+                sys.exit(0)
+        else:
+            print(f"  Found {len(failed_markers)} failed test(s):")
+            print()
 
     for marker in failed_markers:
         test_dir = marker.parent
@@ -505,7 +516,12 @@ def main() -> None:
     print("==========================================")
     print(f"  Run ID:       {run_id}")
     print(f"  Logview URL:  https://openvmm.dev/test-results/#/runs/{run_id}")
-    print(f"  Failed tests: {len(failed_markers)}")
+    if junit_failure_count > 0:
+        print(f"  Unit test failures: {junit_failure_count}")
+    if failed_markers:
+        print(f"  VMM test failures:  {len(failed_markers)}")
+    if junit_failure_count == 0 and not failed_markers:
+        print("  No test failures found.")
     print()
     print(f"  For full logs, examine files in: {workdir}")
     print("  Each test directory may contain:")


### PR DESCRIPTION
Add support for downloading and parsing *-unit-tests-junit-xml artifacts to surface unit test failures alongside VMM test failures. The script now shows a UNIT TEST FAILURES section before the VMM TEST FAILURES section.

Extract failure details from nextest's <system-out> elements, since nextest puts error messages there rather than in the <failure> element body. The output is parsed to find the 'failures:' section and display the root cause (e.g., 'PermissionDenied') rather than just test names.

Fix a pagination bug where list_artifacts() only returned the first page (30 items) from the GitHub API, missing artifacts when runs produce more than 30 (e.g., 71 for a full PR run). Now uses --paginate to fetch all pages.

Update SKILL.md with documentation for JUnit XML artifacts and unit test failure investigation.