### PR TITLE
flowey: resolve several issues in that prevent using Azure Linux on ARM64 hosts

### DIFF
--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -152,10 +152,14 @@ pub fn ado_yaml(
                 )
                 .replace(
                     "{{FLOWEY_TARGET}}",
-                    match platform {
-                        FlowPlatform::Windows => "x86_64-pc-windows-msvc",
-                        FlowPlatform::Linux(_) => "x86_64-unknown-linux-gnu",
-                        platform => anyhow::bail!("unsupported ADO platform {platform:?}"),
+                    match (platform, arch) {
+                        (FlowPlatform::Windows, FlowArch::X86_64) => "x86_64-pc-windows-msvc",
+                        (FlowPlatform::Windows, FlowArch::Aarch64) => "aarch64-pc-windows-msvc",
+                        (FlowPlatform::Linux(_), FlowArch::X86_64) => "x86_64-unknown-linux-gnu",
+                        (FlowPlatform::Linux(_), FlowArch::Aarch64) => "aarch64-unknown-linux-gnu",
+                        (platform, arch) => anyhow::bail!(
+                            "unsupported ADO platform/arch combo {platform:?}/{arch:?}"
+                        ),
                     },
                 )
                 .replace(

--- a/flowey/flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs
+++ b/flowey/flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs
@@ -56,10 +56,16 @@ impl SimpleFlowNode for Node {
             vmgs_lib,
         } = request;
 
+        let ssl_pkg = match ctx.platform() {
+            FlowPlatform::Linux(
+                FlowPlatformLinuxDistro::Fedora | FlowPlatformLinuxDistro::AzureLinux,
+            ) => "openssl-devel",
+            _ => "libssl-dev",
+        };
         let pre_build_deps =
             [
                 ctx.reqv(|v| flowey_lib_common::install_dist_pkg::Request::Install {
-                    package_names: vec!["libssl-dev".into()],
+                    package_names: vec![ssl_pkg.into()],
                     done: v,
                 }),
             ]

--- a/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
@@ -60,9 +60,15 @@ impl SimpleFlowNode for Node {
         let mut pre_build_deps = Vec::new();
 
         if with_crypto {
+            let ssl_pkgs = match ctx.platform() {
+                FlowPlatform::Linux(
+                    FlowPlatformLinuxDistro::Fedora | FlowPlatformLinuxDistro::AzureLinux,
+                ) => vec!["openssl-devel".into(), "perl".into()],
+                _ => vec!["libssl-dev".into()],
+            };
             pre_build_deps.push(ctx.reqv(|v| {
                 flowey_lib_common::install_dist_pkg::Request::Install {
-                    package_names: vec!["libssl-dev".into()],
+                    package_names: ssl_pkgs,
                     done: v,
                 }
             }));

--- a/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
+++ b/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
@@ -57,28 +57,37 @@ impl SimpleFlowNode for Node {
                 },
                 _ => anyhow::bail!("Unsupported platform"),
             },
-            CommonArch::Aarch64 => {
-                let pkg = match platform {
-                    FlowPlatform::Linux(linux_distribution) => match linux_distribution {
-                        FlowPlatformLinuxDistro::Fedora
-                        | FlowPlatformLinuxDistro::Ubuntu
-                        | FlowPlatformLinuxDistro::AzureLinux => Some("binutils-aarch64-linux-gnu"),
-                        FlowPlatformLinuxDistro::Arch => {
-                            match_arch!(
-                                host_arch,
-                                FlowArch::X86_64,
-                                Some("aarch64-linux-gnu-binutils")
-                            )
-                        }
-                        FlowPlatformLinuxDistro::Nix => None,
-                        FlowPlatformLinuxDistro::Unknown => {
-                            anyhow::bail!("Unknown Linux distribution")
-                        }
+            CommonArch::Aarch64 => match platform {
+                FlowPlatform::Linux(linux_distribution) => match linux_distribution {
+                    FlowPlatformLinuxDistro::Fedora | FlowPlatformLinuxDistro::Ubuntu => (
+                        Some("binutils-aarch64-linux-gnu"),
+                        "aarch64-linux-gnu-objcopy",
+                    ),
+                    FlowPlatformLinuxDistro::AzureLinux => match host_arch {
+                        FlowArch::Aarch64 => (Some("binutils"), "objcopy"),
+                        FlowArch::X86_64 => (
+                            Some("binutils-aarch64-linux-gnu"),
+                            "aarch64-linux-gnu-objcopy",
+                        ),
+                        _ => anyhow::bail!("unsupported host arch {host_arch:?}"),
                     },
-                    _ => anyhow::bail!("Unsupported platform"),
-                };
-                (pkg, "aarch64-linux-gnu-objcopy")
-            }
+                    FlowPlatformLinuxDistro::Arch => {
+                        match_arch!(
+                            host_arch,
+                            FlowArch::X86_64,
+                            (
+                                Some("aarch64-linux-gnu-binutils"),
+                                "aarch64-linux-gnu-objcopy"
+                            )
+                        )
+                    }
+                    FlowPlatformLinuxDistro::Nix => (None, "aarch64-linux-gnu-objcopy"),
+                    FlowPlatformLinuxDistro::Unknown => {
+                        anyhow::bail!("Unknown Linux distribution")
+                    }
+                },
+                _ => anyhow::bail!("Unsupported platform"),
+            },
         };
 
         let installed_objcopy = objcopy_pkg.map(|objcopy_pkg| {


### PR DESCRIPTION
- Use distro-appropriate OpenSSL package names (openssl-devel on Fedora/Azure Linux, libssl-dev on Debian/Ubuntu) in build_vmgstool and build_and_test_vmgs_lib. Also add perl as a build dependency on Fedora/Azure Linux for OpenSSL.
- Fix aarch64 split-debug-info objcopy resolution: on Azure Linux aarch64 hosts use native binutils/objcopy, on x86_64 hosts cross-compile with binutils-aarch64-linux-gnu. Also set the correct objcopy binary name per distro instead of always using aarch64-linux-gnu-objcopy.
- Resolve FLOWEY_TARGET based on both platform and arch in the ADO YAML pipeline resolver, adding support for aarch64-pc-windows-msvc and aarch64-unknown-linux-gnu targets.