### PR TITLE
nix: simplify logic for selecting rust overlay and rustc version

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,10 +4,9 @@ let
     url = "https://github.com/NixOS/nixpkgs/archive/50ab793786d9de88ee30ec4e4c24fb4236fc2674.tar.gz";
     sha256 = "1s2gr5rcyqvpr58vxdcb095mdhblij9bfzaximrva2243aal3dgx";
   };
-  # Pinned rust-overlay from stable branch which has our current rust version (1.93)
+  # Latest rust overlay from master - we should pin this to a specific commit and hash when we fork release branches
   rust_overlay = import (builtins.fetchTarball {
-    url = "https://github.com/oxalica/rust-overlay/archive/ec6a3d5cdf14bb5a1dd03652bd3f6351004d2188.tar.gz";
-    sha256 = "0pik603mmxsgs2gndk681j9rkxjlrx3lxbpwd9linn2rn8vacg0a";
+    url = "https://github.com/oxalica/rust-overlay/archive/master.tar.gz";
   });
   pkgs = import nixpkgs { overlays = [ rust_overlay ]; };
 
@@ -59,19 +58,8 @@ let
     if hostArch == "x86_64" then [ aarch64CrossGcc ]
     else [ x64CrossGcc ];
 
-  # Rust configuration
-  overrides = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
-  rustVersionFromCargo = overrides.workspace.package.rust-version;
-  # Cargo.toml uses "X.Y", rust-overlay uses "X.Y.Z"
-  # Find the latest patch version available for the given MAJOR.MINOR
-  availableVersions = builtins.attrNames pkgs.rust-bin.stable;
-  matchingVersions = builtins.filter
-    (v: pkgs.lib.hasPrefix "${rustVersionFromCargo}." v)
-    availableVersions;
-  rustVersion =
-    if builtins.length matchingVersions == 0
-    then throw "No rust version matching ${rustVersionFromCargo}.* found in rust-overlay"
-    else builtins.head (builtins.sort (a: b: builtins.compareVersions a b > 0) matchingVersions);
+  # Rust configuration — update this version manually when upgrading rustc
+  rustVersion = "1.94.0";
 
   rust = pkgs.rust-bin.stable.${rustVersion}.default.override {
     extensions = [


### PR DESCRIPTION
Whenever we update our rust version it's a bit of a pain to update the oxalica overlay to a pinned hash that has the new version. It seems unproblematic to use their main branch and pin the compiler version. I also removed a bunch of code that uses the Cargo.toml to select the rust version and just directly set it in the Nix file, which will make updating the version with find and replace easier in the future.