### PR TITLE
consomme: increase default TCP buffer sizes

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -109,8 +109,8 @@ impl Tcp {
             connections: HashMap::new(),
             listeners: HashMap::new(),
             connection_params: ConnectionParams {
-                rx_buffer_size: 16384,
-                tx_buffer_size: 16384,
+                rx_buffer_size: 256 * 1024,
+                tx_buffer_size: 256 * 1024,
             },
         }
     }


### PR DESCRIPTION
This significantly improves TCP performance, at the cost of some memory. Future changes can be smarter about not using memory for connections that don't need it.