### PR TITLE
flowey: skip copy when source and destination paths are identical

### DIFF
--- a/flowey/flowey_lib_hvlite/src/init_openvmm_magicpath_linux_test_kernel.rs
+++ b/flowey/flowey_lib_hvlite/src/init_openvmm_magicpath_linux_test_kernel.rs
@@ -76,14 +76,19 @@ impl FlowNode for Node {
                                 OpenvmmLinuxTestKernelArch::X64 => "x64",
                             });
                     fs_err::create_dir_all(&test_kernel_path)?;
-                    fs_err::copy(openvmm_linux_test_initrd, test_kernel_path.join("initrd"))?;
-                    fs_err::copy(
-                        openvmm_linux_test_kernel,
-                        test_kernel_path.join(match arch {
-                            OpenvmmLinuxTestKernelArch::Aarch64 => "Image",
-                            OpenvmmLinuxTestKernelArch::X64 => "vmlinux",
-                        }),
-                    )?;
+
+                    let initrd_dst = test_kernel_path.join("initrd");
+                    if openvmm_linux_test_initrd.absolute()? != initrd_dst.absolute()? {
+                        fs_err::copy(openvmm_linux_test_initrd, initrd_dst)?;
+                    }
+
+                    let kernel_dst = test_kernel_path.join(match arch {
+                        OpenvmmLinuxTestKernelArch::Aarch64 => "Image",
+                        OpenvmmLinuxTestKernelArch::X64 => "vmlinux",
+                    });
+                    if openvmm_linux_test_kernel.absolute()? != kernel_dst.absolute()? {
+                        fs_err::copy(openvmm_linux_test_kernel, kernel_dst)?;
+                    }
 
                     Ok(())
                 }


### PR DESCRIPTION
On Windows, the closed-source NuGet package installs files directly into the magic path (oss/.packages/underhill-deps-private/{arch}/), so the copy step was trying to copy files onto themselves, causing OS error 32.