### PR TITLE
flowey: persist job platform/arch in pipeline static DB

### DIFF
--- a/flowey/flowey_cli/src/cli/exec_snippet.rs
+++ b/flowey/flowey_cli/src/cli/exec_snippet.rs
@@ -14,8 +14,6 @@ use flowey_core::node::steps::rust::RustRuntimeServices;
 use flowey_core::node::user_facing::ClaimedGhParam;
 use flowey_core::node::user_facing::GhPermission;
 use flowey_core::node::user_facing::GhPermissionValue;
-use flowey_core::pipeline::HostExt;
-use flowey_core::pipeline::PipelineBackendHint;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -54,9 +52,6 @@ impl ExecSnippet {
             dry_run,
         } = self;
 
-        let flow_platform = FlowPlatform::host(PipelineBackendHint::Local);
-        let flow_arch = FlowArch::host(PipelineBackendHint::Local);
-
         let mut runtime_var_db = super::var_db::open_var_db(job_idx)?;
 
         let working_dir: PathBuf = {
@@ -77,6 +72,8 @@ impl ExecSnippet {
             var_db_backend_kind: _,
             job_reqs,
             job_command_wrappers,
+            job_platforms,
+            job_archs,
         } = {
             let current_exe = std::env::current_exe()
                 .context("failed to get path to current flowey executable")?;
@@ -84,6 +81,13 @@ impl ExecSnippet {
                 fs_err::File::open(current_exe.with_file_name("pipeline.json"))?;
             serde_json::from_reader(pipeline_static_db)?
         };
+
+        let flow_platform = *job_platforms
+            .get(&job_idx)
+            .context("invalid job_idx: missing platform")?;
+        let flow_arch = *job_archs
+            .get(&job_idx)
+            .context("invalid job_idx: missing arch")?;
 
         let command_wrapper = job_command_wrappers.get(&job_idx).cloned();
 
@@ -351,6 +355,8 @@ pub(crate) struct FloweyPipelineStaticDb {
     pub var_db_backend_kind: VarDbBackendKind,
     pub job_reqs: BTreeMap<usize, BTreeMap<String, Vec<SerializedRequest>>>,
     pub job_command_wrappers: BTreeMap<usize, flowey_core::shell::CommandWrapperKind>,
+    pub job_platforms: BTreeMap<usize, FlowPlatform>,
+    pub job_archs: BTreeMap<usize, FlowArch>,
 }
 
 // encode requests as JSON stored in a JSON string (to make human inspection

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -78,6 +78,8 @@ pub fn ado_yaml(
         var_db_backend_kind: crate::cli::exec_snippet::VarDbBackendKind::Json,
         job_reqs: BTreeMap::new(),
         job_command_wrappers: BTreeMap::new(),
+        job_platforms: BTreeMap::new(),
+        job_archs: BTreeMap::new(),
     };
 
     let mut ado_jobs = Vec::new();
@@ -130,6 +132,11 @@ pub fn ado_yaml(
                 .job_command_wrappers
                 .insert(job_idx.index(), wrapper_kind.clone());
         }
+
+        pipeline_static_db
+            .job_platforms
+            .insert(job_idx.index(), platform);
+        pipeline_static_db.job_archs.insert(job_idx.index(), arch);
 
         let mut ado_steps = Vec::new();
 

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -77,6 +77,8 @@ pub fn github_yaml(
         var_db_backend_kind: crate::cli::exec_snippet::VarDbBackendKind::Json,
         job_reqs: BTreeMap::new(),
         job_command_wrappers: BTreeMap::new(),
+        job_platforms: BTreeMap::new(),
+        job_archs: BTreeMap::new(),
     };
 
     let mut github_jobs = BTreeMap::new();
@@ -136,6 +138,11 @@ pub fn github_yaml(
                 .job_command_wrappers
                 .insert(job_idx.index(), wrapper_kind.clone());
         }
+
+        pipeline_static_db
+            .job_platforms
+            .insert(job_idx.index(), platform);
+        pipeline_static_db.job_archs.insert(job_idx.index(), arch);
 
         let mut gh_steps = Vec::new();
 

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -945,7 +945,7 @@ pub enum FlowPlatformKind {
 }
 
 /// The kind platform the flow is being running on, Windows or Unix.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum FlowPlatformLinuxDistro {
     /// Fedora (including WSL2)
     Fedora,
@@ -962,7 +962,7 @@ pub enum FlowPlatformLinuxDistro {
 }
 
 /// What platform the flow is being running on.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum FlowPlatform {
     /// Windows
@@ -1007,7 +1007,7 @@ impl std::fmt::Display for FlowPlatform {
 }
 
 /// What architecture the flow is being running on.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum FlowArch {
     X86_64,


### PR DESCRIPTION
Right now flowey gets its platform and arch at runtime, but since Nix has been introduced as a flavor of Linux distro that we want to be set at job level, there needs to be a way to set this per-job and have it persist. This change encodes the platform and arch as part of the generated JSON when flowey executes a pipeline and enables us to correctly select the platform if Nix has been set to be used in a job. 

This is part of a series of changes needed to get to a reproducible build that runs all of our build command and dependencies through Nix.