### PR TITLE
flowey: add explicit no_incremental flag for cargo builds

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
@@ -414,6 +414,7 @@ impl IntoPipeline for BuildIgvmCli {
             verbose: ReadVar::from_static(verbose),
             locked,
             deny_warnings: false,
+            no_incremental: false,
         })
         .dep_on(|ctx| flowey_lib_hvlite::_jobs::local_build_igvm::Params {
             artifact_dir: ctx.publish_artifact(pub_out_dir),

--- a/flowey/flowey_hvlite/src/pipelines/build_reproducible.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_reproducible.rs
@@ -58,10 +58,16 @@ impl IntoPipeline for BuildReproducibleCli {
         let (pub_openhcl_igvm_extras, _use_openhcl_igvm_extras) =
             pipeline.new_artifact("x64-cvm-openhcl-igvm-extras");
 
+        let local_run_args = {
+            let mut args = crate::pipelines_shared::cfg_common_params::LocalRunArgs::default();
+            args.locked = true;
+            args.no_incremental = true;
+            args
+        };
         let cfg_common_params = crate::pipelines_shared::cfg_common_params::get_cfg_common_params(
             &mut pipeline,
             backend_hint,
-            None,
+            Some(local_run_args),
         )?;
 
         let openvmm_repo_source =

--- a/flowey/flowey_hvlite/src/pipelines/custom_vmfirmwareigvm_dll.rs
+++ b/flowey/flowey_hvlite/src/pipelines/custom_vmfirmwareigvm_dll.rs
@@ -83,6 +83,7 @@ impl IntoPipeline for CustomVmfirmwareigvmDllCli {
                 verbose: ReadVar::from_static(false),
                 locked: false,
                 deny_warnings: false,
+                no_incremental: false,
             })
             .dep_on(
                 |ctx| flowey_lib_hvlite::_jobs::local_custom_vmfirmwareigvm_dll::Params {

--- a/flowey/flowey_hvlite/src/pipelines/restore_packages.rs
+++ b/flowey/flowey_hvlite/src/pipelines/restore_packages.rs
@@ -53,6 +53,7 @@ impl IntoPipeline for RestorePackagesCli {
                 verbose: ReadVar::from_static(true),
                 locked: false,
                 deny_warnings: false,
+                no_incremental: false,
             });
 
         let arches = {

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests.rs
@@ -188,6 +188,7 @@ impl IntoPipeline for VmmTestsCli {
                 verbose: ReadVar::from_static(verbose),
                 locked: false,
                 deny_warnings: false,
+                no_incremental: false,
             })
             .dep_on(|ctx| {
                 flowey_lib_hvlite::_jobs::local_build_and_run_nextest_vmm_tests::Params {

--- a/flowey/flowey_hvlite/src/pipelines_shared/cfg_common_params.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/cfg_common_params.rs
@@ -16,7 +16,11 @@ pub struct LocalRunArgs {
 
     /// Run builds with --locked
     #[clap(long)]
-    locked: bool,
+    pub locked: bool,
+
+    /// Disable incremental compilation (sets CARGO_INCREMENTAL=0)
+    #[clap(long)]
+    pub no_incremental: bool,
 
     /// Automatically install all required dependencies
     #[clap(long)]
@@ -37,6 +41,7 @@ fn get_params_local(
         let LocalRunArgs {
             verbose,
             locked,
+            no_incremental,
             auto_install_deps,
             non_interactive,
         } = local_run_args.clone().unwrap_or_default();
@@ -50,6 +55,7 @@ fn get_params_local(
             verbose: ReadVar::from_static(verbose),
             locked,
             deny_warnings: false,
+            no_incremental,
         }
     }))
 }
@@ -70,6 +76,7 @@ fn get_params_cloud(
             verbose: ctx.use_parameter(param_verbose.clone()),
             locked: true,
             deny_warnings: true,
+            no_incremental: true,
         }
     }))
 }

--- a/flowey/flowey_lib_common/src/cfg_cargo_common_flags.rs
+++ b/flowey/flowey_lib_common/src/cfg_cargo_common_flags.rs
@@ -14,12 +14,14 @@ use flowey::node::prelude::*;
 pub struct Flags {
     pub locked: bool,
     pub verbose: bool,
+    pub no_incremental: bool,
 }
 
 flowey_request! {
     pub enum Request {
         SetLocked(bool),
         SetVerbose(ReadVar<bool>),
+        SetNoIncremental(bool),
         GetFlags(WriteVar<Flags>),
     }
 }
@@ -37,12 +39,16 @@ impl FlowNode for Node {
         let mut set_locked = None;
         let mut set_verbose = None;
         let mut get_flags = Vec::new();
+        let mut set_no_incremental = None;
 
         for req in requests {
             match req {
                 Request::SetLocked(v) => same_across_all_reqs("SetLocked", &mut set_locked, v)?,
                 Request::SetVerbose(v) => {
                     same_across_all_reqs_backing_var("SetVerbose", &mut set_verbose, v)?
+                }
+                Request::SetNoIncremental(v) => {
+                    same_across_all_reqs("SetNoIncremental", &mut set_no_incremental, v)?
                 }
                 Request::GetFlags(v) => get_flags.push(v),
             }
@@ -52,6 +58,7 @@ impl FlowNode for Node {
             set_locked.ok_or(anyhow::anyhow!("Missing essential request: SetLocked"))?;
         let set_verbose =
             set_verbose.ok_or(anyhow::anyhow!("Missing essential request: SetVerbose"))?;
+        let set_no_incremental = set_no_incremental.unwrap_or(false);
         let get_flags = get_flags;
 
         // -- end of req processing -- //
@@ -72,6 +79,7 @@ impl FlowNode for Node {
                         &Flags {
                             locked: set_locked,
                             verbose: set_verbose,
+                            no_incremental: set_no_incremental,
                         },
                     );
                 }

--- a/flowey/flowey_lib_common/src/gen_cargo_nextest_run_cmd.rs
+++ b/flowey/flowey_lib_common/src/gen_cargo_nextest_run_cmd.rs
@@ -342,12 +342,6 @@ impl FlowNode for Node {
                         with_env.insert("RUST_BACKTRACE".into(), "1".into());
                     }
 
-                    // if running in CI, no need to waste time with incremental
-                    // build artifacts
-                    if !matches!(rt.backend(), FlowBackend::Local) {
-                        with_env.insert("CARGO_INCREMENTAL".into(), "0".into());
-                    }
-
                     // also update WSLENV in cases where we're running windows tests via WSL2
                     if !portable && crate::_util::running_in_wsl(rt) {
                         let old_wslenv = std::env::var("WSLENV");
@@ -405,6 +399,7 @@ pub(crate) fn cargo_nextest_build_args_and_env(
     no_default_features: bool,
     mut extra_env: BTreeMap<String, String>,
 ) -> (Vec<String>, BTreeMap<String, String>) {
+    let no_incremental = cargo_flags.no_incremental;
     let locked = cargo_flags.locked.then_some("--locked");
     let verbose = cargo_flags.verbose.then_some("--verbose");
     let cargo_profile = match &cargo_profile {
@@ -451,6 +446,10 @@ pub(crate) fn cargo_nextest_build_args_and_env(
     args.extend(features.to_cargo_arg_strings());
 
     let mut env = BTreeMap::new();
+
+    if no_incremental {
+        env.insert("CARGO_INCREMENTAL".into(), "0".into());
+    }
 
     env.append(&mut extra_env);
 

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -187,7 +187,11 @@ impl FlowNode for Node {
                     let in_folder = rt.read(in_folder);
                     let with_env = rt.read(extra_env).unwrap_or_default();
 
-                    let crate::cfg_cargo_common_flags::Flags { locked, verbose } = flags;
+                    let crate::cfg_cargo_common_flags::Flags {
+                        locked,
+                        verbose,
+                        no_incremental,
+                    } = flags;
 
                     let cargo_profile = match &profile {
                         CargoBuildProfile::Debug => "dev",
@@ -265,12 +269,10 @@ impl FlowNode for Node {
 
                     rt.sh.change_dir(cargo_work_dir);
                     let mut cmd = flowey::shell_cmd!(rt, "{argv0} {params...}");
-                    if !matches!(rt.backend(), FlowBackend::Local) {
-                        // if running in CI, no need to waste time with incremental
-                        // build artifacts
+                    if no_incremental {
                         with_env.insert("CARGO_INCREMENTAL".to_owned(), "0".to_owned());
-                    } else {
-                        // if build locally, use per-package target dirs
+                    } else if matches!(rt.backend(), FlowBackend::Local) {
+                        // if building locally, use per-package target dirs
                         // to avoid rebuilding
                         // TODO: remove this once cargo's caching improves
                         cmd = cmd

--- a/flowey/flowey_lib_common/src/run_cargo_clippy.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_clippy.rs
@@ -81,7 +81,11 @@ impl FlowNode for Node {
                     let in_folder = rt.read(in_folder);
                     let exclude = rt.read(exclude);
 
-                    let crate::cfg_cargo_common_flags::Flags { locked, verbose } = flags;
+                    let crate::cfg_cargo_common_flags::Flags {
+                        locked,
+                        verbose,
+                        no_incremental,
+                    } = flags;
 
                     let target = target.to_string();
 
@@ -134,9 +138,7 @@ impl FlowNode for Node {
                         flowey::shell_cmd!(rt, "cargo")
                     };
 
-                    // if running in CI, no need to waste time with incremental
-                    // build artifacts
-                    if !matches!(rt.backend(), FlowBackend::Local) {
+                    if no_incremental {
                         cmd = cmd.env("CARGO_INCREMENTAL", "0");
                     }
                     if let Some(env) = extra_env {

--- a/flowey/flowey_lib_common/src/run_cargo_doc.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_doc.rs
@@ -10,11 +10,11 @@ use crate::_util::cargo_output;
 use flowey::node::prelude::*;
 use flowey::shell::FloweyCmd;
 use std::collections::BTreeMap;
-
 #[derive(Serialize, Deserialize)]
 pub struct CargoDocCommands {
     cmds: Vec<Vec<String>>,
     cargo_work_dir: PathBuf,
+    no_incremental: bool,
 }
 
 impl CargoDocCommands {
@@ -37,6 +37,7 @@ impl CargoDocCommands {
         let Self {
             cmds,
             cargo_work_dir,
+            no_incremental,
         } = self;
 
         let out_dir = rt.sh.current_dir();
@@ -46,6 +47,11 @@ impl CargoDocCommands {
         for mut cmd in cmds {
             let argv0 = cmd.remove(0);
             let cmd = flowey::shell_cmd!(rt, "{argv0} {cmd...}");
+            let cmd = if no_incremental {
+                cmd.env("CARGO_INCREMENTAL", "0")
+            } else {
+                cmd
+            };
             let cmd = f(cmd);
             json.push_str(&cmd.read()?);
         }
@@ -189,7 +195,11 @@ impl FlowNode for Node {
                     let flags = rt.read(flags);
                     let in_folder = rt.read(in_folder);
 
-                    let crate::cfg_cargo_common_flags::Flags { locked, verbose } = flags;
+                    let crate::cfg_cargo_common_flags::Flags {
+                        locked,
+                        verbose,
+                        no_incremental,
+                    } = flags;
 
                     let mut cmds = Vec::new();
                     let ResolvedDocPackages {
@@ -271,6 +281,7 @@ impl FlowNode for Node {
                     let cmd = CargoDocCommands {
                         cmds,
                         cargo_work_dir: in_folder.clone(),
+                        no_incremental,
                     };
 
                     rt.write(write_doc_cmd, &cmd);

--- a/flowey/flowey_lib_common/src/run_cargo_nextest_archive.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_archive.rs
@@ -105,12 +105,6 @@ impl FlowNode for Node {
                             "
                         );
 
-                        // if running in CI, no need to waste time with incremental
-                        // build artifacts
-                        if !matches!(rt.backend(), FlowBackend::Local) {
-                            cmd = cmd.env("CARGO_INCREMENTAL", "0");
-                        }
-
                         for (k, v) in build_env {
                             cmd = cmd.env(k, v);
                         }

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_common.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_common.rs
@@ -26,6 +26,7 @@ flowey_request! {
         pub verbose: ReadVar<bool>,
         pub locked: bool,
         pub deny_warnings: bool,
+        pub no_incremental: bool,
     }
 }
 
@@ -64,6 +65,7 @@ impl SimpleFlowNode for Node {
             verbose,
             locked,
             deny_warnings,
+            no_incremental,
         } = request;
 
         if matches!(ctx.backend(), FlowBackend::Github) {
@@ -152,6 +154,7 @@ impl SimpleFlowNode for Node {
         ctx.requests::<flowey_lib_common::cfg_cargo_common_flags::Node>([
             flowey_lib_common::cfg_cargo_common_flags::Request::SetVerbose(verbose),
             flowey_lib_common::cfg_cargo_common_flags::Request::SetLocked(locked),
+            flowey_lib_common::cfg_cargo_common_flags::Request::SetNoIncremental(no_incremental),
         ]);
 
         ctx.req(


### PR DESCRIPTION
Flowey needs the ability to set if the build is incremental or not so that the build-reproducible pipeline can set it and not have machine-dependent paths as part of its target directory outputs. This change makes that configuration explicit rather than just plumbing in the environment variable based on CI or not. 

This change is part of a few remaining changes needed to get OpenHCL building reproducibly across machines.