### PR TITLE
flowey: strip debug info when running in Nix

### DIFF
--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -537,6 +537,10 @@ impl SimpleFlowNode for Node {
                 in_bin,
                 out_bin: write,
                 out_dbg_info: write_dbg,
+                reproducible_without_debuglink: matches!(
+                    ctx.platform(),
+                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Nix)
+                ),
             });
 
             read.zip(ctx, read_dbg).map(ctx, |(bin, dbg)| {

--- a/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
@@ -452,6 +452,10 @@ impl FlowNode for Node {
                     in_bin: elf_bin,
                     out_bin: write_out_bin,
                     out_dbg_info: write_out_dbg,
+                    reproducible_without_debuglink: matches!(
+                        ctx.platform(),
+                        FlowPlatform::Linux(FlowPlatformLinuxDistro::Nix)
+                    ),
                 });
 
                 ctx.emit_minor_rust_step("reporting split debug info", |ctx| {

--- a/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
+++ b/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
@@ -12,6 +12,14 @@ flowey_request! {
         pub in_bin: ReadVar<PathBuf>,
         pub out_bin: WriteVar<PathBuf>,
         pub out_dbg_info: WriteVar<PathBuf>,
+        // TODO: This is only necessary because our .dbg file is not reproducible and the build-id
+        // is a hash over the binary + the .dbg file, rendering the whole build non-reproducible.
+        // We don't want to do this for all builds because we would lose the ability for the debugger
+        // to auto-discover the .dbg file when debugging. For now, this is only used for Nix builds
+        // where reproducibility is the main concern and will be removed when the debug file is reproducible.
+        /// When true, remove `.note.gnu.build-id` and omit `--add-gnu-debuglink`
+        /// to produce byte-for-byte reproducible stripped binaries.
+        pub reproducible_without_debuglink: bool,
     }
 }
 
@@ -30,6 +38,7 @@ impl SimpleFlowNode for Node {
             in_bin,
             out_bin,
             out_dbg_info,
+            reproducible_without_debuglink,
         } = request;
 
         let host_arch = ctx.arch();
@@ -108,12 +117,21 @@ impl SimpleFlowNode for Node {
                 let in_bin = rt.read(in_bin);
 
                 let output = rt.sh.current_dir().join(in_bin.file_name().unwrap());
-                flowey::shell_cmd!(rt, "{objcopy_bin} --only-keep-debug {in_bin} {output}.dbg").run()?;
-                flowey::shell_cmd!(
-                    rt,
-                    "{objcopy_bin} --strip-all --keep-section=.build_info --add-gnu-debuglink={output}.dbg {in_bin} {output}"
-                )
-                .run()?;
+                flowey::shell_cmd!(rt, "{objcopy_bin} --only-keep-debug {in_bin} {output}.dbg")
+                    .run()?;
+                if reproducible_without_debuglink {
+                    flowey::shell_cmd!(
+                        rt,
+                        "{objcopy_bin} --strip-all --keep-section=.build_info --remove-section=.note.gnu.build-id {in_bin} {output}"
+                    )
+                    .run()?;
+                } else {
+                    flowey::shell_cmd!(
+                        rt,
+                        "{objcopy_bin} --strip-all --keep-section=.build_info --add-gnu-debuglink={output}.dbg {in_bin} {output}"
+                    )
+                    .run()?;
+                }
 
                 let output = output.absolute()?;
 


### PR DESCRIPTION
Right now our debug info isn't reproducible and the gnu build-id is a hash over the binary + the debug info. This means that not stripping the debuglink results in a binary that isn't reproducible. The main thing we lose here is the debugger automatically finding the right debug file (which is definitely not great). I'm looking into ways to fix this, but for now make it configurable and have the Nix builds strip it out.