### PR TITLE
ide: include WRITE_DMA_FUA_EXT in enlightened 48-bit LBA setup

### DIFF
--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -423,7 +423,10 @@ impl Channel {
         // Now that we know what the IDE command is, disambiguate between
         // 28-bit LBA and 48-bit LBA
         let cmd = eint13_cmd.command;
-        if cmd == IdeCommand::READ_DMA_EXT || cmd == IdeCommand::WRITE_DMA_EXT {
+        if cmd == IdeCommand::READ_DMA_EXT
+            || cmd == IdeCommand::WRITE_DMA_EXT
+            || cmd == IdeCommand::WRITE_DMA_FUA_EXT
+        {
             // 48-bit LBA, high 24 bits of logical block address
             self.write_drive_register(
                 DriveRegister::LbaLow,


### PR DESCRIPTION
The enlightened HDD path in `enlightened_hdd_command()` programs high LBA/sector-count registers only for `READ_DMA_EXT` and `WRITE_DMA_EXT`. `WRITE_DMA_FUA_EXT` (0x3D) is also a 48-bit command but was missing from the check, so its high LBA bytes would not be written to the drive registers -- the drive would use stale values.

Add `WRITE_DMA_FUA_EXT` to the 48-bit LBA branch condition.

Fixes #3061
