### PR TITLE
Add PIT (Programmable Interval Timer) support to the chipset

### DIFF
--- a/openhcl/openvmm_hcl_resources/src/lib.rs
+++ b/openhcl/openvmm_hcl_resources/src/lib.rs
@@ -14,6 +14,8 @@ vm_resource::register_static_resolvers! {
     // Chipset devices
     #[cfg(guest_arch = "x86_64")]
     chipset::i8042::resolver::I8042Resolver,
+    #[cfg(guest_arch = "x86_64")]
+    chipset::pit::resolver::PitResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]
     tpm_device::resolver::TpmDeviceResolver,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2778,7 +2778,6 @@ async fn new_underhill_vm(
     let deps_generic_isa_dma = chipset
         .with_generic_isa_dma
         .then_some(dev::GenericIsaDmaDeps);
-    let deps_generic_pit = chipset.with_generic_pit.then_some(dev::GenericPitDeps {});
     let deps_piix4_pci_isa_bridge =
         chipset
             .with_piix4_pci_isa_bridge
@@ -2983,7 +2982,6 @@ async fn new_underhill_vm(
         deps_generic_isa_floppy: None,
         deps_generic_pci_bus: None,
         deps_generic_pic,
-        deps_generic_pit,
         deps_hyperv_firmware_pcat,
         deps_hyperv_framebuffer: None,
         deps_hyperv_ide,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -162,6 +162,7 @@ pub fn new_device_thread() -> (JoinHandle<()>, DefaultDriver) {
 
 impl Manifest {
     fn from_config(config: Config) -> Self {
+        let with_pit = config.chipset_devices.iter().any(|d| d.name == "pit");
         Self {
             load_mode: config.load_mode,
             floppy_disks: config.floppy_disks,
@@ -174,6 +175,7 @@ impl Manifest {
             memory: config.memory,
             processor_topology: config.processor_topology,
             chipset: config.chipset,
+            with_pit,
             #[cfg(windows)]
             kernel_vmnics: config.kernel_vmnics,
             input: config.input,
@@ -221,6 +223,8 @@ pub struct Manifest {
     processor_topology: ProcessorTopologyConfig,
     hypervisor: HypervisorConfig,
     chipset: BaseChipsetManifest,
+    /// Whether a PIT device is present (used for ACPI table generation).
+    with_pit: bool,
     #[cfg(windows)]
     kernel_vmnics: Vec<openvmm_defs::config::KernelVmNicConfig>,
     input: mesh::Receiver<InputData>,
@@ -560,6 +564,7 @@ struct LoadedVmInner {
     vtl2_framebuffer_gpa_base: Option<u64>,
 
     chipset_cfg: BaseChipsetManifest,
+    with_pit: bool,
     #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
     virtio_mmio_count: usize,
     #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
@@ -1224,7 +1229,7 @@ impl InitializedVm {
                             pcie_host_bridges: &Vec::new(),
                             with_ioapic: cfg.chipset.with_generic_ioapic,
                             with_pic: cfg.chipset.with_generic_pic,
-                            with_pit: cfg.chipset.with_generic_pit,
+                            with_pit: cfg.with_pit,
                             with_psp: cfg.chipset.with_generic_psp,
                             pm_base: PM_BASE,
                             acpi_irq: SYSTEM_IRQ_ACPI,
@@ -1544,7 +1549,6 @@ impl InitializedVm {
 
         let deps_generic_pic = (cfg.chipset.with_generic_pic).then_some(dev::GenericPicDeps {});
 
-        let deps_generic_pit = (cfg.chipset.with_generic_pit).then_some(dev::GenericPitDeps {});
         let deps_generic_psp = (cfg.chipset.with_generic_psp).then_some(dev::GenericPspDeps {});
 
         let deps_hyperv_framebuffer =
@@ -1630,7 +1634,6 @@ impl InitializedVm {
                 deps_generic_isa_floppy,
                 deps_generic_pci_bus,
                 deps_generic_pic,
-                deps_generic_pit,
                 deps_generic_psp,
                 deps_hyperv_firmware_pcat,
                 deps_hyperv_firmware_uefi,
@@ -2297,6 +2300,7 @@ impl InitializedVm {
                 _kernel_vmnics: kernel_vmnics,
                 vmbus_devices,
                 chipset_cfg: cfg.chipset,
+                with_pit: cfg.with_pit,
                 firmware_event_send: cfg.firmware_event_send,
                 load_mode: cfg.load_mode,
                 virtio_mmio_count,
@@ -2343,7 +2347,7 @@ impl LoadedVmInner {
             with_ioapic: self.chipset_cfg.with_generic_ioapic,
             with_psp: self.chipset_cfg.with_generic_psp,
             with_pic: self.chipset_cfg.with_generic_pic,
-            with_pit: self.chipset_cfg.with_generic_pit,
+            with_pit: self.with_pit,
             pm_base: PM_BASE,
             acpi_irq: SYSTEM_IRQ_ACPI,
         };
@@ -2925,6 +2929,7 @@ impl LoadedVm {
             memory: self.inner.memory_cfg,
             processor_topology: self.inner.processor_topology.to_config(),
             chipset: self.inner.chipset_cfg,
+            with_pit: self.inner.with_pit,
             vmbus: None,      // TODO
             vtl2_vmbus: None, // TODO
             hypervisor: self.inner.hypervisor_cfg,

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -11,6 +11,8 @@ vm_resource::register_static_resolvers! {
     // Chipset devices
     #[cfg(guest_arch = "x86_64")]
     chipset::i8042::resolver::I8042Resolver,
+    #[cfg(guest_arch = "x86_64")]
+    chipset::pit::resolver::PitResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]
     tpm_device::resolver::TpmDeviceResolver,

--- a/vm/devices/chipset/src/pit/mod.rs
+++ b/vm/devices/chipset/src/pit/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+pub mod resolver;
+
 use bitfield_struct::bitfield;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;

--- a/vm/devices/chipset/src/pit/resolver.rs
+++ b/vm/devices/chipset/src/pit/resolver.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resource resolver for the PIT (Programmable Interval Timer) chipset device.
+
+use super::PitDevice;
+use async_trait::async_trait;
+use chipset_device_resources::IRQ_LINE_SET;
+use chipset_device_resources::ResolveChipsetDeviceHandleParams;
+use chipset_device_resources::ResolvedChipsetDevice;
+use chipset_resources::pit::PitDeviceHandle;
+use vm_resource::AsyncResolveResource;
+use vm_resource::ResourceResolver;
+use vm_resource::declare_static_async_resolver;
+use vm_resource::kind::ChipsetDeviceHandleKind;
+
+/// A resolver for PIT devices.
+pub struct PitResolver;
+
+declare_static_async_resolver! {
+    PitResolver,
+    (ChipsetDeviceHandleKind, PitDeviceHandle),
+}
+
+#[async_trait]
+impl AsyncResolveResource<ChipsetDeviceHandleKind, PitDeviceHandle> for PitResolver {
+    type Output = ResolvedChipsetDevice;
+    type Error = std::convert::Infallible;
+
+    async fn resolve(
+        &self,
+        _resolver: &ResourceResolver,
+        _resource: PitDeviceHandle,
+        input: ResolveChipsetDeviceHandleParams<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        // Hard-coded to IRQ line 2, as per x86 spec
+        let interrupt = input.configure.new_line(IRQ_LINE_SET, "timer0", 2);
+        let vmtime = input.vmtime.access("pit");
+        Ok(PitDevice::new(interrupt, vmtime).into())
+    }
+}

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -26,6 +26,22 @@ pub mod i8042 {
     }
 }
 
+pub mod pit {
+    //! Resource definitions for the PIT (Programmable Interval Timer).
+
+    use mesh::MeshPayload;
+    use vm_resource::ResourceId;
+    use vm_resource::kind::ChipsetDeviceHandleKind;
+
+    /// A handle to a PIT (Intel 8253/8254 Programmable Interval Timer) device.
+    #[derive(MeshPayload)]
+    pub struct PitDeviceHandle;
+
+    impl ResourceId<ChipsetDeviceHandleKind> for PitDeviceHandle {
+        const ID: &'static str = "pit";
+    }
+}
+
 pub mod battery {
     //! Resource definitions for the battery device
 

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -20,6 +20,7 @@ use chipset_resources::battery::BatteryDeviceHandleAArch64;
 use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
 use chipset_resources::i8042::I8042DeviceHandle;
+use chipset_resources::pit::PitDeviceHandle;
 use input_core::MultiplexedInputHandle;
 use missing_dev_resources::MissingDevHandle;
 use serial_16550_resources::Serial16550DeviceHandle;
@@ -238,7 +239,6 @@ impl VmManifestBuilder {
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
                     with_generic_pic: true,
-                    with_generic_pit: true,
                     with_generic_psp: false,
                     with_hyperv_firmware_pcat: true,
                     with_hyperv_firmware_uefi: false,
@@ -257,6 +257,7 @@ impl VmManifestBuilder {
                     with_winbond_super_io_and_floppy_stub: self.stub_floppy,
                     with_winbond_super_io_and_floppy_full: !self.stub_floppy,
                 };
+                result.attach_pit();
                 result.attach_missing_arch_ports(self.arch, false);
                 if let Some(recv) = self.battery_status_recv {
                     result.attach_battery(self.arch, recv);
@@ -271,7 +272,6 @@ impl VmManifestBuilder {
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
                     with_generic_pic: is_x86,
-                    with_generic_pit: is_x86,
                     with_generic_psp: self.psp,
                     with_hyperv_firmware_pcat: false,
                     with_hyperv_firmware_uefi: false,
@@ -290,6 +290,9 @@ impl VmManifestBuilder {
                     with_winbond_super_io_and_floppy_stub: false,
                     with_winbond_super_io_and_floppy_full: false,
                 };
+                if is_x86 {
+                    result.attach_pit();
+                }
                 result
                     .maybe_attach_arch_serial(
                         self.arch,
@@ -311,7 +314,6 @@ impl VmManifestBuilder {
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
                     with_generic_pic: false,
-                    with_generic_pit: false,
                     with_generic_psp: self.psp,
                     with_hyperv_firmware_pcat: false,
                     with_hyperv_firmware_uefi: matches!(self.ty, BaseChipsetType::HypervGen2Uefi),
@@ -370,6 +372,14 @@ impl VmChipsetResult {
                 keyboard_input: MultiplexedInputHandle { elevation: 0 }.into_resource(),
             }
             .into_resource(),
+        });
+        self
+    }
+
+    fn attach_pit(&mut self) -> &mut Self {
+        self.chipset_devices.push(ChipsetDeviceHandle {
+            name: "pit".to_owned(),
+            resource: PitDeviceHandle.into_resource(),
         });
         self
     }

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -208,7 +208,6 @@ impl<'a> BaseChipsetBuilder<'a> {
             deps_generic_isa_floppy,
             deps_generic_pci_bus,
             deps_generic_pic,
-            deps_generic_pit,
             deps_generic_psp: _, // not actually a device... yet
             deps_hyperv_firmware_pcat,
             deps_hyperv_firmware_uefi,
@@ -343,16 +342,6 @@ impl<'a> BaseChipsetBuilder<'a> {
                 .arc_mutex_device("piix4-usb-uhci-stub")
                 .on_pci_bus(attached_to)
                 .add(|_| chipset_legacy::piix4_uhci::Piix4UsbUhciStub::new())?;
-        }
-
-        if let Some(options::dev::GenericPitDeps {}) = deps_generic_pit {
-            // hard-coded IRQ lines, as per x86 spec
-            builder.arc_mutex_device("pit").add(|services| {
-                pit::PitDevice::new(
-                    services.new_line(IRQ_LINE_SET, "timer0", 2),
-                    services.register_vmtime().access("pit"),
-                )
-            })?;
         }
 
         let _ = dma;
@@ -1125,7 +1114,6 @@ pub mod options {
             generic_isa_floppy:          dev::GenericIsaFloppyDeps,
             generic_pci_bus:             dev::GenericPciBusDeps,
             generic_pic:                 dev::GenericPicDeps,
-            generic_pit:                 dev::GenericPitDeps,
             generic_psp:                 dev::GenericPspDeps,
 
             hyperv_firmware_pcat:        dev::HyperVFirmwarePcat,
@@ -1298,9 +1286,6 @@ pub mod options {
             /// Interface to create GPA alias ranges.
             pub adjust_gpa_range: Box<dyn chipset_legacy::i440bx_host_pci_bridge::AdjustGpaRange>,
         }
-
-        /// Generic Intel 8253/8254 Programmable Interval Timer (PIT)
-        pub struct GenericPitDeps;
 
         feature_gated! {
             feature = "dev_hyperv_vga";


### PR DESCRIPTION
- Introduced a new `PitDeviceHandle` struct in `chipset_resources` for resource identification.
- Updated `vm_manifest_builder` to attach the PIT device during VM build.
- Removed deprecated generic PIT dependencies from `base_chipset`.
- Implemented the PIT device functionality in `pit/mod.rs`, including timer management and I/O operations.
- Created a resource resolver for the PIT device in `pit/resolver.rs` to handle IRQ configuration and instantiation.
- Added tests for the PIT device to ensure correct behavior in both binary and BCD modes.