### PR TITLE
deps: update openvmm_deps to 0.1.0-20260319.1

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -31,7 +31,7 @@ pub const NODEJS: &str = "24.x";
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.5";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.5";
-pub const OPENVMM_DEPS: &str = "0.1.0-20260312.3";
+pub const OPENVMM_DEPS: &str = "0.1.0-20260319.1";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {


### PR DESCRIPTION
Linux: Add NVMe drivers to test kernels (https://github.com/microsoft/openvmm-deps/pull/38)

Turn on `CONFIG_BLK_DEV_NVME`, and pickup the resulting automatic config
updates
