### PR TITLE
vmm_tests: Add a test to verify availability when admin commands are slow

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -998,7 +998,7 @@ async fn servicing_keepalive_slow_create_io_queue(
 
     assert!(
         io_result.is_err(),
-        "IO command should have timed out while waiting for create_io_queue to complete, but it succeeded. This likely means the create_io_queue command did not get injected correctly."
+        "IO command should have timed out. This likely means the create_io_queue command did not get injected correctly."
     );
 
     CancelContext::new()


### PR DESCRIPTION
When creating an io_queue for a cpu, the run loop of the `DriverWorkerTask` issues a blocking call to `create_io_issuers`. This same loop also processes `Save` commands.
Adding a test that verifies that `save()` eventually gets processed correctly after `create_io_issuers` completes, even when this completion happens after `save()` has been issued.