### PR TITLE
ci: fix dep-review checkout to use default ref

### DIFF
--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Checkout base branch (safe — our own code)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: |
             .github/scripts
             .github/dep-policy.json


### PR DESCRIPTION
The dep-review workflow was checking out the base SHA, which can predate the commit that added the dep-review script itself. This causes a MODULE_NOT_FOUND error for PRs whose base SHA is older than the script.

Drop the explicit ref so the checkout uses the default for pull_request_target, which is the current tip of the base branch.