### PR TITLE
fix: resolve deprecated API usage in disk_blockdevice and storvsp

### DIFF
--- a/vm/devices/storage/disk_blockdevice/src/lib.rs
+++ b/vm/devices/storage/disk_blockdevice/src/lib.rs
@@ -31,7 +31,6 @@ use guestmem::MemoryWrite;
 use inspect::Inspect;
 use io_uring::opcode;
 use io_uring::types;
-use io_uring::types::RwFlags;
 use mesh::MeshPayload;
 use nvme::check_nvme_status;
 use nvme_spec::nvm;
@@ -635,7 +634,7 @@ impl DiskIo for BlockDevice {
 
         // Documented in Linux manual page: https://man7.org/linux/man-pages/man2/readv.2.html
         // It's only defined in linux_gnu but not in linux_musl. So we have to define it.
-        const RWF_DSYNC: RwFlags = 0x00000002;
+        const RWF_DSYNC: i32 = 0x00000002;
 
         // SAFETY: the buffers for the IO are this stack, and they will be
         // kept alive for the duration of the IO since we immediately call

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -1108,7 +1108,7 @@ impl<T: RingMem> Worker<T> {
                                     )?;
                                     // Reset the rescan notification event now, before the guest has a
                                     // chance to send any SCSI requests to scan the bus.
-                                    self.rescan_notification.try_next().ok();
+                                    self.rescan_notification.try_recv().ok();
                                     *self.inner.protocol.state.write() = ProtocolState::Ready {
                                         version,
                                         subchannel_count: subchannel_count.unwrap_or(0),


### PR DESCRIPTION
- disk_blockdevice: Replace deprecated io_uring::types::RwFlags with i32 to match updated rw_flags() method signature
- storvsp: Replace deprecated try_next() with try_recv() on mpsc::Receiver