### PR TITLE
WIP: Add ASAN-enabled OpenHCL IGVM build and test pipeline

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -11,10 +11,8 @@ use flowey::node::prelude::ReadVar;
 use flowey::pipeline::prelude::*;
 use flowey_lib_common::git_checkout::RepoSource;
 use flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe::OpenhclIgvmBuildParams;
-use flowey_lib_hvlite::build_openhcl_igvm_from_recipe::IgvmManifestPath;
 use flowey_lib_hvlite::build_openhcl_igvm_from_recipe::OpenhclIgvmRecipe;
 use flowey_lib_hvlite::build_openvmm_hcl::OpenvmmHclBuildProfile;
-use flowey_lib_hvlite::build_openvmm_hcl::OpenvmmHclFeature;
 use flowey_lib_hvlite::run_cargo_build::common::CommonArch;
 use flowey_lib_hvlite::run_cargo_build::common::CommonPlatform;
 use flowey_lib_hvlite::run_cargo_build::common::CommonProfile;
@@ -744,14 +742,7 @@ impl IntoPipeline for CheckinGatesCli {
                 CommonArch::X86_64 => {
                     // Build an ASAN variant of X64 alongside the standard recipes.
                     let mut asan_details = OpenhclIgvmRecipe::X64.recipe_details(release);
-                    asan_details
-                        .openvmm_hcl_features
-                        .insert(OpenvmmHclFeature::Sanitizer);
-                    asan_details.igvm_manifest =
-                        IgvmManifestPath::InTree("openhcl-x64-asan.json".into());
-                    asan_details
-                        .extra_rootfs_configs
-                        .push("rootfs.asan.config".into());
+                    asan_details.apply_asan_overrides();
 
                     vec![
                         OpenhclIgvmRecipe::X64,

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
@@ -118,13 +118,7 @@ impl SimpleFlowNode for Node {
             if recipe_details.target != CommonTriple::X86_64_LINUX_MUSL {
                 anyhow::bail!("--with-asan is currently only supported for x86_64 recipes");
             }
-            recipe_details
-                .openvmm_hcl_features
-                .insert(OpenvmmHclFeature::Sanitizer);
-            recipe_details.igvm_manifest = IgvmManifestPath::InTree("openhcl-x64-asan.json".into());
-            recipe_details
-                .extra_rootfs_configs
-                .push("rootfs.asan.config".into());
+            recipe_details.apply_asan_overrides();
         }
 
         {

--- a/flowey/flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs
+++ b/flowey/flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs
@@ -80,7 +80,6 @@ impl SimpleFlowNode for Node {
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,
-            extra_cargo_config: vec![],
             pre_build_deps,
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_guest_test_uefi.rs
+++ b/flowey/flowey_lib_hvlite/src/build_guest_test_uefi.rs
@@ -72,7 +72,6 @@ impl FlowNode for Node {
                     },
                     no_split_dbg_info: false,
                     extra_env: None,
-                    extra_cargo_config: vec![],
                     pre_build_deps: Vec::new(),
                     output: v,
                 }

--- a/flowey/flowey_lib_hvlite/src/build_hypestv.rs
+++ b/flowey/flowey_lib_hvlite/src/build_hypestv.rs
@@ -50,7 +50,6 @@ impl SimpleFlowNode for Node {
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,
-            extra_cargo_config: vec![],
             pre_build_deps: Vec::new(),
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_igvmfilegen.rs
+++ b/flowey/flowey_lib_hvlite/src/build_igvmfilegen.rs
@@ -72,7 +72,6 @@ impl FlowNode for Node {
                 target: target.as_triple(),
                 no_split_dbg_info: false,
                 extra_env: None,
-                extra_cargo_config: vec![],
                 pre_build_deps: Vec::new(),
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_ohcldiag_dev.rs
+++ b/flowey/flowey_lib_hvlite/src/build_ohcldiag_dev.rs
@@ -59,7 +59,6 @@ impl SimpleFlowNode for Node {
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,
-            extra_cargo_config: vec![],
             pre_build_deps: Vec::new(),
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
@@ -101,7 +101,6 @@ impl FlowNode for Node {
                         .into_iter()
                         .collect(),
                 )),
-                extra_cargo_config: vec![],
                 pre_build_deps,
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -71,6 +71,19 @@ pub struct OpenhclIgvmRecipeDetails {
     pub extra_rootfs_configs: Vec<String>,
 }
 
+impl OpenhclIgvmRecipeDetails {
+    /// Apply ASAN build overrides to this recipe.
+    ///
+    /// Adds the `Sanitizer` feature, switches to the ASAN manifest (2 GB
+    /// VTL2 memory), and includes `rootfs.asan.config` for musl shared libs.
+    pub fn apply_asan_overrides(&mut self) {
+        self.openvmm_hcl_features
+            .insert(OpenvmmHclFeature::Sanitizer);
+        self.igvm_manifest = IgvmManifestPath::InTree("openhcl-x64-asan.json".into());
+        self.extra_rootfs_configs.push("rootfs.asan.config".into());
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct OpenhclIgvmRecipeDetailsLocalOnly {
     pub openvmm_hcl_no_strip: bool,

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -106,7 +106,6 @@ impl FlowNode for Node {
                 target: target.as_triple(),
                 no_split_dbg_info: false,
                 extra_env: None,
-                extra_cargo_config: vec![],
                 pre_build_deps: pre_build_deps.clone(),
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
@@ -151,6 +151,9 @@ impl FlowNode for Node {
             }
 
             let is_sanitizer = features.contains(&OpenvmmHclFeature::Sanitizer);
+            if is_sanitizer && !matches!(arch, CommonArch::X86_64) {
+                anyhow::bail!("ASAN is currently only supported for x86_64");
+            }
 
             let mut features = features
                 .into_iter()
@@ -200,8 +203,6 @@ impl FlowNode for Node {
                 None
             };
 
-            let extra_cargo_config = vec![];
-
             let output = ctx.reqv(|v| crate::run_cargo_build::Request {
                 crate_name: "openvmm_hcl".into(),
                 out_name: "openvmm_hcl".into(),
@@ -219,7 +220,6 @@ impl FlowNode for Node {
                 target,
                 no_split_dbg_info,
                 extra_env,
-                extra_cargo_config,
                 pre_build_deps,
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_pipette.rs
+++ b/flowey/flowey_lib_hvlite/src/build_pipette.rs
@@ -59,7 +59,6 @@ impl SimpleFlowNode for Node {
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,
-            extra_cargo_config: vec![],
             pre_build_deps: Vec::new(),
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_prep_steps.rs
+++ b/flowey/flowey_lib_hvlite/src/build_prep_steps.rs
@@ -59,7 +59,6 @@ impl SimpleFlowNode for Node {
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,
-            extra_cargo_config: vec![],
             pre_build_deps: Vec::new(),
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_sidecar.rs
+++ b/flowey/flowey_lib_hvlite/src/build_sidecar.rs
@@ -101,7 +101,6 @@ impl FlowNode for Node {
                         .into_iter()
                         .collect(),
                 )),
-                extra_cargo_config: vec![],
                 pre_build_deps,
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_test_igvm_agent_rpc_server.rs
+++ b/flowey/flowey_lib_hvlite/src/build_test_igvm_agent_rpc_server.rs
@@ -76,7 +76,6 @@ impl SimpleFlowNode for Node {
             target: target_triple,
             no_split_dbg_info: false,
             extra_env,
-            extra_cargo_config: vec![],
             pre_build_deps: Vec::new(),
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_tmk_vmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tmk_vmm.rs
@@ -78,7 +78,6 @@ impl FlowNode for Node {
                 target: target.as_triple(),
                 no_split_dbg_info: false,
                 extra_env: None,
-                extra_cargo_config: vec![],
                 pre_build_deps: Vec::new(),
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_tmks.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tmks.rs
@@ -73,7 +73,6 @@ impl FlowNode for Node {
                         .into_iter()
                         .collect(),
                 )),
-                extra_cargo_config: vec![],
                 pre_build_deps: Vec::new(),
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_tpm_guest_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tpm_guest_tests.rs
@@ -78,7 +78,6 @@ impl SimpleFlowNode for Node {
             target: target_triple,
             no_split_dbg_info: false,
             extra_env,
-            extra_cargo_config: vec![],
             pre_build_deps: Vec::new(),
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_vmfirmwareigvm_dll.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmfirmwareigvm_dll.rs
@@ -95,7 +95,6 @@ impl SimpleFlowNode for Node {
             .as_triple(),
             no_split_dbg_info: false,
             extra_env: Some(extra_env),
-            extra_cargo_config: vec![],
             pre_build_deps: Vec::new(),
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
@@ -91,7 +91,6 @@ impl SimpleFlowNode for Node {
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,
-            extra_cargo_config: vec![],
             pre_build_deps,
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/build_xtask.rs
+++ b/flowey/flowey_lib_hvlite/src/build_xtask.rs
@@ -42,7 +42,6 @@ impl SimpleFlowNode for Node {
             target: target.as_triple(),
             no_split_dbg_info: false,
             extra_env: None,
-            extra_cargo_config: vec![],
             pre_build_deps: Vec::new(),
             output: v,
         });

--- a/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
@@ -284,8 +284,6 @@ flowey_request! {
         /// If supported by the target, build without split debuginfo.
         pub no_split_dbg_info: bool,
         pub extra_env: Option<ReadVar<BTreeMap<String, String>>>,
-        /// Extra `--config` arguments to pass to `cargo build`.
-        pub extra_cargo_config: Vec<String>,
         /// Wait for specified side-effects to resolve before running cargo-run.
         ///
         /// (e.g: to allow for some ambient packages / dependencies to get
@@ -326,7 +324,6 @@ impl FlowNode for Node {
             mut target,
             no_split_dbg_info,
             extra_env,
-            extra_cargo_config,
             pre_build_deps: user_pre_build_deps,
             output,
         } in requests
@@ -377,7 +374,6 @@ impl FlowNode for Node {
             };
 
             let mut config = Vec::new();
-            config.extend(extra_cargo_config);
 
             // If the target vendor is specified as `minimal_rt`, then this is
             // our custom target triple for the minimal_rt toolchain. Include the appropriate


### PR DESCRIPTION
Add AddressSanitizer (ASAN) support to the OpenHCL build pipeline and CI.

## Changes

- **`Sanitizer` feature**: New `OpenvmmHclFeature::Sanitizer` variant that injects ASAN RUSTFLAGS and `RUSTC_BOOTSTRAP=1`
- **`X64Asan` recipe**: Dedicated IGVM recipe with 2GB VTL2 memory manifest, `rootfs.asan.config` (musl shared libs for dynamic linking), and the `sanitizer` cargo feature
- **`extra_rootfs_configs` field**: New field on `OpenhclIgvmRecipeDetails` for per-recipe rootfs additions
- **Petri artifact**: `LATEST_ASAN_X64` artifact and resolver for ASAN IGVM
- **ASAN tests**: Boot tests (UEFI + Linux-direct) using `with_custom_openhcl` to swap in the ASAN IGVM
- **CI**: `X64Asan` added to checkin gates IGVM recipe list
- **CLI**: `cargo xflowey build-igvm x64-asan` support
- **Guide**: ASAN documentation under reference/openhcl/debugging/