### PR TITLE
virtio: make VirtioDevice trait async and add DynVirtioDevice

### DIFF
--- a/vm/devices/virtio/virtio/src/device.rs
+++ b/vm/devices/virtio/virtio/src/device.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Per-queue virtio device trait (`VirtioDevice`).
+//! Per-queue virtio device trait (`VirtioDevice`) and object-safe wrapper
+//! (`DynVirtioDevice`).
 
 use crate::DeviceTraits;
 use crate::QueueResources;
@@ -9,21 +10,23 @@ use crate::queue::QueueState;
 use crate::spec::VirtioDeviceFeatures;
 use guestmem::MappedMemoryRegion;
 use inspect::InspectMut;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Context;
-use std::task::Poll;
 
-/// Per-queue virtio device trait. Replaces the device-level
-/// `VirtioDevice::enable()` / `poll_disable()` with per-queue start/stop.
+/// Per-queue virtio device trait. Ergonomic async fn — not object-safe.
+///
+/// Devices implement this trait. The blanket impl converts any
+/// `VirtioDevice` into a `DynVirtioDevice` for use behind `Box<dyn>`.
 pub trait VirtioDevice: InspectMut + Send {
     /// Device identity and capabilities.
     fn traits(&self) -> DeviceTraits;
 
     /// Read device-specific config registers.
-    fn read_registers_u32(&mut self, offset: u16) -> u32;
+    fn read_registers_u32(&mut self, offset: u16) -> impl Future<Output = u32> + Send;
 
     /// Write device-specific config registers.
-    fn write_registers_u32(&mut self, offset: u16, val: u32);
+    fn write_registers_u32(&mut self, offset: u16, val: u32) -> impl Future<Output = ()> + Send;
 
     /// Provide the shared memory region to the device.
     ///
@@ -57,7 +60,7 @@ pub trait VirtioDevice: InspectMut + Send {
         resources: QueueResources,
         features: &VirtioDeviceFeatures,
         initial_state: Option<QueueState>,
-    ) -> anyhow::Result<()>;
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     /// Stop a single queue and return its state.
     ///
@@ -68,16 +71,18 @@ pub trait VirtioDevice: InspectMut + Send {
     /// queue was not active.
     ///
     /// This must be idempotent: calling it on a queue that was never
-    /// started (or has already been stopped) must return
-    /// `Poll::Ready(None)` immediately. Transports rely on this during
-    /// reset/disable by iterating all queue indices, not just active ones.
-    fn poll_stop_queue(&mut self, cx: &mut Context<'_>, idx: u16) -> Poll<Option<QueueState>>;
+    /// started (or has already been stopped) must return `None`
+    /// immediately. Transports rely on this during reset/disable by
+    /// iterating all queue indices, not just active ones.
+    fn stop_queue(&mut self, idx: u16) -> impl Future<Output = Option<QueueState>> + Send;
 
     /// Reset device-internal state to initial values.
     ///
     /// Called after all queues have been stopped on guest-initiated reset.
     /// Default: no-op.
-    fn reset(&mut self) {}
+    fn reset(&mut self) -> impl Future<Output = ()> + Send {
+        async {}
+    }
 
     /// Whether the device supports save/restore.
     ///
@@ -87,5 +92,113 @@ pub trait VirtioDevice: InspectMut + Send {
     /// leave this as `false`.
     fn supports_save_restore(&self) -> bool {
         false
+    }
+}
+
+/// Object-safe wrapper for [`VirtioDevice`].
+///
+/// Uses boxed futures instead of `async fn` for object safety. The blanket
+/// impl converts any `T: VirtioDevice` into a `DynVirtioDevice`.
+///
+/// The device task, backend server, and resolver hold `Box<dyn DynVirtioDevice>`.
+pub trait DynVirtioDevice: InspectMut + Send {
+    /// Device identity and capabilities.
+    fn traits(&self) -> DeviceTraits;
+
+    /// Read device-specific config registers.
+    fn read_registers_u32(&mut self, offset: u16)
+    -> Pin<Box<dyn Future<Output = u32> + Send + '_>>;
+
+    /// Write device-specific config registers.
+    fn write_registers_u32(
+        &mut self,
+        offset: u16,
+        val: u32,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
+    /// Provide the shared memory region to the device.
+    fn set_shared_memory_region(
+        &mut self,
+        region: &Arc<dyn MappedMemoryRegion>,
+    ) -> anyhow::Result<()>;
+
+    /// Start a single queue.
+    fn start_queue<'a>(
+        &'a mut self,
+        idx: u16,
+        resources: QueueResources,
+        features: &'a VirtioDeviceFeatures,
+        initial_state: Option<QueueState>,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+    /// Stop a single queue and return its state.
+    fn stop_queue(
+        &mut self,
+        idx: u16,
+    ) -> Pin<Box<dyn Future<Output = Option<QueueState>> + Send + '_>>;
+
+    /// Reset device-internal state.
+    fn reset(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
+    /// Whether the device supports save/restore.
+    fn supports_save_restore(&self) -> bool;
+}
+
+impl<T: VirtioDevice> DynVirtioDevice for T {
+    fn traits(&self) -> DeviceTraits {
+        VirtioDevice::traits(self)
+    }
+
+    fn read_registers_u32(
+        &mut self,
+        offset: u16,
+    ) -> Pin<Box<dyn Future<Output = u32> + Send + '_>> {
+        Box::pin(VirtioDevice::read_registers_u32(self, offset))
+    }
+
+    fn write_registers_u32(
+        &mut self,
+        offset: u16,
+        val: u32,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(VirtioDevice::write_registers_u32(self, offset, val))
+    }
+
+    fn set_shared_memory_region(
+        &mut self,
+        region: &Arc<dyn MappedMemoryRegion>,
+    ) -> anyhow::Result<()> {
+        VirtioDevice::set_shared_memory_region(self, region)
+    }
+
+    fn start_queue<'a>(
+        &'a mut self,
+        idx: u16,
+        resources: QueueResources,
+        features: &'a VirtioDeviceFeatures,
+        initial_state: Option<QueueState>,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
+        Box::pin(VirtioDevice::start_queue(
+            self,
+            idx,
+            resources,
+            features,
+            initial_state,
+        ))
+    }
+
+    fn stop_queue(
+        &mut self,
+        idx: u16,
+    ) -> Pin<Box<dyn Future<Output = Option<QueueState>> + Send + '_>> {
+        Box::pin(VirtioDevice::stop_queue(self, idx))
+    }
+
+    fn reset(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(VirtioDevice::reset(self))
+    }
+
+    fn supports_save_restore(&self) -> bool {
+        VirtioDevice::supports_save_restore(self)
     }
 }

--- a/vm/devices/virtio/virtio/src/lib.rs
+++ b/vm/devices/virtio/virtio/src/lib.rs
@@ -15,6 +15,7 @@ mod tests;
 pub mod transport;
 
 pub use common::*;
+pub use device::DynVirtioDevice;
 pub use device::VirtioDevice;
 pub use transport::*;
 

--- a/vm/devices/virtio/virtio/src/resolve.rs
+++ b/vm/devices/virtio/virtio/src/resolve.rs
@@ -3,6 +3,7 @@
 
 //! Resource resolver definitions for virtio devices.
 
+use crate::DynVirtioDevice;
 use crate::VirtioDevice;
 use guestmem::GuestMemory;
 use vm_resource::CanResolveTo;
@@ -14,7 +15,7 @@ impl CanResolveTo<ResolvedVirtioDevice> for VirtioDeviceHandle {
 }
 
 /// A resolved virtio device.
-pub struct ResolvedVirtioDevice(pub Box<dyn VirtioDevice>);
+pub struct ResolvedVirtioDevice(pub Box<dyn DynVirtioDevice>);
 
 impl<T: 'static + VirtioDevice> From<T> for ResolvedVirtioDevice {
     fn from(value: T) -> Self {

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -7,6 +7,7 @@
 #![cfg(test)]
 
 use crate::DeviceTraits;
+use crate::DynVirtioDevice;
 use crate::PciInterruptModel;
 use crate::QueueResources;
 use crate::VirtioDevice;
@@ -1228,13 +1229,13 @@ impl VirtioDevice for FailingTestDevice {
         self.traits.clone()
     }
 
-    fn read_registers_u32(&mut self, _offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, _offset: u16) -> u32 {
         0
     }
 
-    fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
+    async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         _idx: u16,
         _resources: QueueResources,
@@ -1244,12 +1245,8 @@ impl VirtioDevice for FailingTestDevice {
         anyhow::bail!("intentional enable failure for testing")
     }
 
-    fn poll_stop_queue(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-        _idx: u16,
-    ) -> std::task::Poll<Option<QueueState>> {
-        std::task::Poll::Ready(None)
+    async fn stop_queue(&mut self, _idx: u16) -> Option<QueueState> {
+        None
     }
 }
 
@@ -1285,13 +1282,13 @@ impl VirtioDevice for TestDevice {
         self.traits.clone()
     }
 
-    fn read_registers_u32(&mut self, _offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, _offset: u16) -> u32 {
         0
     }
 
-    fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
+    async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         idx: u16,
         resources: QueueResources,
@@ -1334,21 +1331,17 @@ impl VirtioDevice for TestDevice {
         Ok(())
     }
 
-    fn poll_stop_queue(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-        idx: u16,
-    ) -> std::task::Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         let idx = idx as usize;
         if idx >= self.workers.len() || !self.workers[idx].has_state() {
-            return std::task::Poll::Ready(None);
+            return None;
         }
-        std::task::ready!(self.workers[idx].poll_stop(cx));
+        self.workers[idx].stop().await;
         let state = self.workers[idx].remove().queue.queue_state();
-        std::task::Poll::Ready(Some(state))
+        Some(state)
     }
 
-    fn reset(&mut self) {
+    async fn reset(&mut self) {
         self.workers.clear();
     }
 
@@ -3549,11 +3542,11 @@ impl VirtioDevice for PartialFailTestDevice {
     fn traits(&self) -> DeviceTraits {
         self.traits.clone()
     }
-    fn read_registers_u32(&mut self, _offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, _offset: u16) -> u32 {
         0
     }
-    fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
-    fn start_queue(
+    async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
+    async fn start_queue(
         &mut self,
         idx: u16,
         _resources: QueueResources,
@@ -3566,15 +3559,11 @@ impl VirtioDevice for PartialFailTestDevice {
         self.started.push(idx);
         Ok(())
     }
-    fn poll_stop_queue(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-        idx: u16,
-    ) -> std::task::Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         self.stopped.push(idx);
-        std::task::Poll::Ready(None)
+        None
     }
-    fn reset(&mut self) {
+    async fn reset(&mut self) {
         self.reset_count += 1;
     }
 }
@@ -3611,7 +3600,7 @@ struct MmioTestTransport {
 }
 
 impl MmioTestTransport {
-    fn new(device: Box<dyn VirtioDevice>, driver: &DefaultDriver, num_queues: u16) -> Self {
+    fn new(device: Box<dyn DynVirtioDevice>, driver: &DefaultDriver, num_queues: u16) -> Self {
         let test_mem = VirtioTestMemoryAccess::new();
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem;
         let interrupt = LineInterrupt::detached();
@@ -3676,7 +3665,7 @@ struct PciTestTransport {
 }
 
 impl PciTestTransport {
-    fn new(device: Box<dyn VirtioDevice>, driver: &DefaultDriver, num_queues: u16) -> Self {
+    fn new(device: Box<dyn DynVirtioDevice>, driver: &DefaultDriver, num_queues: u16) -> Self {
         let test_mem = VirtioTestMemoryAccess::new();
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem;
         let msi_conn = MsiConnection::new();

--- a/vm/devices/virtio/virtio/src/transport/mmio.rs
+++ b/vm/devices/virtio/virtio/src/transport/mmio.rs
@@ -8,10 +8,9 @@ use super::task::TransportStateResult;
 use super::task::defer_config_read;
 use super::task::defer_config_write;
 use super::task::run_device_task;
-
+use crate::DynVirtioDevice;
 use crate::QUEUE_MAX_SIZE;
 use crate::QueueResources;
-use crate::VirtioDevice;
 use crate::VirtioDoorbells;
 use crate::queue::QueueParams;
 use crate::queue::QueueState;
@@ -108,7 +107,7 @@ impl fmt::Debug for VirtioMmioDevice {
 
 impl VirtioMmioDevice {
     pub fn new(
-        device: Box<dyn VirtioDevice>,
+        device: Box<dyn DynVirtioDevice>,
         driver: &impl Spawn,
         interrupt: LineInterrupt,
         doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -11,10 +11,9 @@ use super::task::TransportStateResult;
 use super::task::defer_config_read;
 use super::task::defer_config_write;
 use super::task::run_device_task;
-
+use crate::DynVirtioDevice;
 use crate::QUEUE_MAX_SIZE;
 use crate::QueueResources;
-use crate::VirtioDevice;
 use crate::VirtioDoorbells;
 use crate::queue::QueueParams;
 use crate::queue::QueueState;
@@ -127,7 +126,7 @@ pub struct VirtioPciDevice {
 
 impl VirtioPciDevice {
     pub fn new(
-        mut device: Box<dyn VirtioDevice>,
+        mut device: Box<dyn DynVirtioDevice>,
         driver: &impl Spawn,
         interrupt_model: PciInterruptModel<'_>,
         doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,

--- a/vm/devices/virtio/virtio/src/transport/task.rs
+++ b/vm/devices/virtio/virtio/src/transport/task.rs
@@ -4,12 +4,12 @@
 //! Device task and shared transport state machine for virtio transports.
 //!
 //! Both the PCI and MMIO transports spawn an async task that owns the
-//! `Box<dyn VirtioDevice>` and processes commands via a mesh channel.
+//! `Box<dyn DynVirtioDevice>` and processes commands via a mesh channel.
 //! The transports become thin MMIO/PCI forwarders that send RPCs to
 //! the task.
 
+use crate::DynVirtioDevice;
 use crate::QueueResources;
-use crate::VirtioDevice;
 use crate::queue::QueueState;
 use crate::spec::VirtioDeviceFeatures;
 use chipset_device::io::IoResult;
@@ -23,7 +23,6 @@ use mesh::rpc::FailableRpc;
 use mesh::rpc::PendingRpc;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
-use std::future::poll_fn;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -234,7 +233,7 @@ impl TransportState {
 
 /// Owns the virtio device and processes commands from the transport.
 struct DeviceTask {
-    device: Box<dyn VirtioDevice>,
+    device: Box<dyn DynVirtioDevice>,
     max_queues: u16,
 }
 
@@ -244,6 +243,7 @@ impl DeviceTask {
             if let Err(err) = self
                 .device
                 .start_queue(idx, resources, &params.features, None)
+                .await
             {
                 tracelimit::error_ratelimited!(
                     error = &*err as &dyn std::error::Error,
@@ -251,7 +251,7 @@ impl DeviceTask {
                     "virtio device start_queue failed"
                 );
                 self.stop_all_queues().await;
-                self.device.reset();
+                self.device.reset().await;
                 return false;
             }
         }
@@ -260,21 +260,22 @@ impl DeviceTask {
 
     async fn disable(&mut self) {
         self.stop_all_queues().await;
-        self.device.reset();
+        self.device.reset().await;
     }
 
     async fn stop(&mut self) -> Vec<Option<QueueState>> {
         let mut states = vec![None; self.max_queues as usize];
         for idx in 0..self.max_queues {
-            states[idx as usize] = poll_fn(|cx| self.device.poll_stop_queue(cx, idx)).await;
+            states[idx as usize] = self.device.stop_queue(idx).await;
         }
         states
     }
 
-    fn start(&mut self, params: StartParams) -> anyhow::Result<()> {
+    async fn start(&mut self, params: StartParams) -> anyhow::Result<()> {
         for (idx, resources, initial_state) in params.queues {
             self.device
                 .start_queue(idx, resources, &params.features, initial_state)
+                .await
                 .map_err(|err| {
                     tracelimit::error_ratelimited!(
                         error = &*err as &dyn std::error::Error,
@@ -289,19 +290,19 @@ impl DeviceTask {
 
     async fn reset(&mut self) {
         self.stop_all_queues().await;
-        self.device.reset();
+        self.device.reset().await;
     }
 
     async fn stop_all_queues(&mut self) {
         for idx in 0..self.max_queues {
-            poll_fn(|cx| self.device.poll_stop_queue(cx, idx)).await;
+            self.device.stop_queue(idx).await;
         }
     }
 }
 
 /// Runs the device task, processing commands from the transport.
 pub async fn run_device_task(
-    device: Box<dyn VirtioDevice>,
+    device: Box<dyn DynVirtioDevice>,
     mut recv: mesh::Receiver<DeviceCommand>,
 ) {
     let mut task = DeviceTask {
@@ -326,7 +327,8 @@ pub async fn run_device_task(
                 // but not propagated to the transport.
                 // TODO: update ChangeDeviceState to allow async start()
                 // so failures can be handled by the transport.
-                rpc.handle_failable_sync(|params| task.start(params));
+                rpc.handle_failable(async |params| task.start(params).await)
+                    .await;
             }
             DeviceCommand::Reset(rpc) => {
                 rpc.handle(async |()| task.reset().await).await;
@@ -340,7 +342,7 @@ pub async fn run_device_task(
                 let end = offset as usize + len as usize;
                 let mut buf = [0u8; 12];
                 for word_off in (start_word as usize..end).step_by(4) {
-                    let val = task.device.read_registers_u32(word_off as u16);
+                    let val = task.device.read_registers_u32(word_off as u16).await;
                     let i = word_off - start_word as usize;
                     buf[i..i + 4].copy_from_slice(&val.to_ne_bytes());
                 }
@@ -354,17 +356,19 @@ pub async fn run_device_task(
                 deferred,
             } => {
                 if len == 4 && offset & 3 == 0 {
-                    task.device.write_registers_u32(
-                        offset,
-                        u32::from_ne_bytes(data[..4].try_into().unwrap()),
-                    );
+                    task.device
+                        .write_registers_u32(
+                            offset,
+                            u32::from_ne_bytes(data[..4].try_into().unwrap()),
+                        )
+                        .await;
                 } else {
                     let start_word = offset & !3;
                     let end = offset as usize + len as usize;
                     let byte_off = (offset - start_word) as usize;
                     let mut buf = [0u8; 12];
                     for word_off in (start_word as usize..end).step_by(4) {
-                        let val = task.device.read_registers_u32(word_off as u16);
+                        let val = task.device.read_registers_u32(word_off as u16).await;
                         let i = word_off - start_word as usize;
                         buf[i..i + 4].copy_from_slice(&val.to_ne_bytes());
                     }
@@ -372,7 +376,7 @@ pub async fn run_device_task(
                     for word_off in (start_word as usize..end).step_by(4) {
                         let i = word_off - start_word as usize;
                         let val = u32::from_ne_bytes(buf[i..i + 4].try_into().unwrap());
-                        task.device.write_registers_u32(word_off as u16, val);
+                        task.device.write_registers_u32(word_off as u16, val).await;
                     }
                 }
                 deferred.complete();

--- a/vm/devices/virtio/virtio_blk/src/integration_tests.rs
+++ b/vm/devices/virtio/virtio_blk/src/integration_tests.rs
@@ -201,7 +201,7 @@ impl TestHarness {
     }
 
     /// Enable the device with one queue.
-    fn enable(&mut self) {
+    async fn enable(&mut self) {
         let interrupt = Interrupt::from_event(self.interrupt_event.clone());
 
         self.device
@@ -221,6 +221,7 @@ impl TestHarness {
                 &VirtioDeviceFeatures::new(),
                 None,
             )
+            .await
             .unwrap();
     }
 
@@ -588,7 +589,7 @@ fn ram_disk(size: u64, read_only: bool) -> Disk {
 async fn write_then_read_roundtrip(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false); // 64 KiB
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     // Write a recognizable pattern to sector 0.
     let data: Vec<u8> = (0..512).map(|i| (i % 251) as u8).collect();
@@ -620,7 +621,7 @@ async fn write_then_read_roundtrip(driver: DefaultDriver) {
 async fn read_unwritten_sector_returns_zeroes(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false);
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     let data_gpa = harness.post_read_request(0, 4, 512);
     let (used_id, used_len) = harness.wait_for_used().await;
@@ -637,7 +638,7 @@ async fn read_unwritten_sector_returns_zeroes(driver: DefaultDriver) {
 async fn write_to_read_only_disk_fails(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, true);
     let mut harness = TestHarness::new(&driver, disk, true);
-    harness.enable();
+    harness.enable().await;
 
     // Attempt to write — this should fail.
     // We need to find the status byte location: it's the writable descriptor
@@ -686,7 +687,7 @@ async fn write_to_read_only_disk_fails(driver: DefaultDriver) {
 async fn flush_succeeds(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false);
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     harness.post_flush_request(0);
     let (used_id, used_len) = harness.wait_for_used().await;
@@ -699,7 +700,7 @@ async fn flush_succeeds(driver: DefaultDriver) {
 async fn get_id_returns_identifier(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false);
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     let id_gpa = harness.post_get_id_request(0);
     let (used_id, used_len) = harness.wait_for_used().await;
@@ -718,7 +719,7 @@ async fn get_id_returns_identifier(driver: DefaultDriver) {
 async fn unsupported_request_type(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false);
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     let status_gpa = harness.post_raw_request(0, 0xFF, 0);
     let (used_id, used_len) = harness.wait_for_used().await;
@@ -734,7 +735,7 @@ async fn unsupported_request_type(driver: DefaultDriver) {
 async fn multi_sector_write_read(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false);
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     // Write 2 sectors (1024 bytes) starting at sector 2.
     let data: Vec<u8> = (0..1024).map(|i| ((i * 7 + 3) % 256) as u8).collect();
@@ -757,7 +758,7 @@ async fn multi_sector_write_read(driver: DefaultDriver) {
 async fn sequential_write_read_flush(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false);
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     // Write
     let pattern = [0xDE; 512];
@@ -795,7 +796,7 @@ async fn sequential_write_read_flush(driver: DefaultDriver) {
 async fn sector_offset_correctness(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false); // 128 × 512-byte sectors
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     // Write to sector 10.
     let data = [0xAA; 512];
@@ -955,7 +956,7 @@ async fn write_read_4k_sector_disk(driver: DefaultDriver) {
     // 64 KiB disk with 4096-byte sectors → 16 disk sectors.
     let disk = Disk::new(TestDisk4K::new(64 * 1024, 4096)).unwrap();
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     // Write to virtio sector 8 (= byte offset 4096 = disk sector 1).
     let data = [0xAA; 4096];
@@ -993,7 +994,7 @@ async fn sector_shift_multiple_offsets_4k(driver: DefaultDriver) {
     // 128 KiB disk with 4096-byte sectors → 32 disk sectors.
     let disk = Disk::new(TestDisk4K::new(128 * 1024, 4096)).unwrap();
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     // Write different patterns to virtio sectors 0, 16, and 24.
     // Virtio sector 0  → disk sector 0  (byte offset 0)
@@ -1046,7 +1047,7 @@ async fn check_discard(
     expected_status: u8,
 ) {
     let mut harness = TestHarness::new(driver, disk, read_only);
-    harness.enable();
+    harness.enable().await;
     let status_gpa = harness.post_discard_request(0, sector, num_sectors, flags);
     let (_id, used_len) = harness.wait_for_used().await;
     assert_eq!(used_len, 1);
@@ -1175,7 +1176,7 @@ async fn discard_512b_sector_any_count_succeeds(driver: DefaultDriver) {
 async fn bounce_buffer_write_read_roundtrip(driver: DefaultDriver) {
     let disk = ram_disk(64 * 1024, false);
     let mut harness = TestHarness::new(&driver, disk, false);
-    harness.enable();
+    harness.enable().await;
 
     let frag_size: u32 = 256;
 

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -23,10 +23,10 @@ use inspect_counters::Counter;
 use pal_async::wait::PolledWait;
 use scsi_buffers::RequestBuffers;
 use std::future::Future;
+use std::future::poll_fn;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
-use std::task::ready;
 use task_control::AsyncRun;
 use task_control::InspectTask;
 use task_control::StopTask;
@@ -166,7 +166,7 @@ impl AsyncRun<BlkQueueState> for BlkWorker {
                     Completed(IoCompletion),
                 }
 
-                let event = std::future::poll_fn(|cx| {
+                let event = poll_fn(|cx| {
                     // Poll for completed IOs first to free up slots.
                     if let Poll::Ready(Some(completion)) = self.ios.poll_next_unpin(cx) {
                         return Poll::Ready(Event::Completed(completion));
@@ -324,7 +324,7 @@ impl VirtioDevice for VirtioBlkDevice {
         }
     }
 
-    fn read_registers_u32(&mut self, offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, offset: u16) -> u32 {
         // The transport reads the device config space as a sequence of u32s.
         // We serialize VirtioBlkConfig to bytes and return the requested
         // 4-byte window. Three cases:
@@ -346,11 +346,11 @@ impl VirtioDevice for VirtioBlkDevice {
         }
     }
 
-    fn write_registers_u32(&mut self, _offset: u16, _val: u32) {
+    async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {
         // Config space is read-only for virtio-blk.
     }
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         idx: u16,
         resources: QueueResources,
@@ -381,20 +381,20 @@ impl VirtioDevice for VirtioBlkDevice {
         Ok(())
     }
 
-    fn poll_stop_queue(&mut self, cx: &mut Context<'_>, idx: u16) -> Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         assert_eq!(idx, 0);
         if !self.worker.has_state() {
-            return Poll::Ready(None);
+            return None;
         }
         // Stop the worker task (cancels the run loop via until_stopped).
-        ready!(self.worker.poll_stop(cx));
+        self.worker.stop().await;
         // Drain in-flight IOs to completion. The FuturesUnordered lives in
         // BlkWorker and survives the stop — its pending disk IO futures are
         // polled here until all descriptors are completed in the used ring.
-        ready!(self.worker.task_mut().poll_drain(cx));
+        poll_fn(|cx| self.worker.task_mut().poll_drain(cx)).await;
         // Remove the queue state (drops VirtioQueue).
         let state = self.worker.remove().queue.queue_state();
-        Poll::Ready(Some(state))
+        Some(state)
     }
 
     fn supports_save_restore(&self) -> bool {

--- a/vm/devices/virtio/virtio_console/src/lib.rs
+++ b/vm/devices/virtio/virtio_console/src/lib.rs
@@ -49,9 +49,6 @@ use spec::VirtioConsoleConfig;
 use std::future::poll_fn;
 use std::pin::Pin;
 use std::pin::pin;
-use std::task::Context;
-use std::task::Poll;
-use std::task::ready;
 use task_control::AsyncRun;
 use task_control::Cancelled;
 use task_control::InspectTaskMut;
@@ -105,15 +102,15 @@ impl VirtioDevice for VirtioConsoleDevice {
         }
     }
 
-    fn read_registers_u32(&mut self, offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, offset: u16) -> u32 {
         self.config.read_u32(offset)
     }
 
-    fn write_registers_u32(&mut self, _offset: u16, _val: u32) {
+    async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {
         // Console config is read-only from the guest perspective.
     }
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         idx: u16,
         resources: QueueResources,
@@ -166,14 +163,14 @@ impl VirtioDevice for VirtioConsoleDevice {
         Ok(())
     }
 
-    fn poll_stop_queue(&mut self, cx: &mut Context<'_>, idx: u16) -> Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         if !self.worker.has_state() {
-            return Poll::Ready(None);
+            return None;
         }
 
         // Stop the worker (shared by both queues). Once stopped, we can
         // reach into the state to take the requested queue.
-        ready!(self.worker.poll_stop(cx));
+        self.worker.stop().await;
 
         let state = self.worker.state_mut().unwrap();
         let queue = match idx {
@@ -190,10 +187,10 @@ impl VirtioDevice for VirtioConsoleDevice {
             self.worker.start();
         }
 
-        Poll::Ready(queue.map(|q| q.queue_state()))
+        queue.map(|q| q.queue_state())
     }
 
-    fn reset(&mut self) {}
+    async fn reset(&mut self) {}
 }
 
 #[derive(InspectMut)]

--- a/vm/devices/virtio/virtio_console/src/tests.rs
+++ b/vm/devices/virtio/virtio_console/src/tests.rs
@@ -387,7 +387,7 @@ impl TestHarness {
     }
 
     /// Enable the device with both queues.
-    fn enable(&mut self) {
+    async fn enable(&mut self) {
         let features = VirtioDeviceFeatures::new();
 
         // Queue 0: receiveq (host→guest)
@@ -408,6 +408,7 @@ impl TestHarness {
                 &features,
                 None,
             )
+            .await
             .unwrap();
 
         // Queue 1: transmitq (guest→host)
@@ -428,6 +429,7 @@ impl TestHarness {
                 &features,
                 None,
             )
+            .await
             .unwrap();
     }
 
@@ -523,9 +525,9 @@ impl TestHarness {
 
     /// Disable the device.
     async fn disable(&mut self) {
-        futures::future::poll_fn(|cx| self.device.poll_stop_queue(cx, 0)).await;
-        futures::future::poll_fn(|cx| self.device.poll_stop_queue(cx, 1)).await;
-        self.device.reset();
+        self.device.stop_queue(0).await;
+        self.device.stop_queue(1).await;
+        self.device.reset().await;
     }
 
     /// Reset memory layout tracking for a fresh enable cycle.
@@ -548,7 +550,7 @@ impl TestHarness {
 #[async_test]
 async fn guest_tx_basic(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     let payload = b"Hello from guest!";
     harness.post_tx_and_signal(0, payload);
@@ -565,7 +567,7 @@ async fn guest_tx_basic(driver: DefaultDriver) {
 #[async_test]
 async fn guest_rx_basic(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     let buffer_size: u32 = 256;
     let gpa = harness.post_rx_buffer_and_signal(0, buffer_size);
@@ -588,7 +590,7 @@ async fn guest_rx_basic(driver: DefaultDriver) {
 #[async_test]
 async fn guest_tx_multiple(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     let messages: [&[u8]; 3] = [b"one", b"two", b"three"];
 
@@ -607,7 +609,7 @@ async fn guest_tx_multiple(driver: DefaultDriver) {
 #[async_test]
 async fn guest_rx_multiple(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     let payloads: [&[u8]; 3] = [b"alpha", b"beta!", b"gamma"];
 
@@ -630,7 +632,7 @@ async fn guest_rx_multiple(driver: DefaultDriver) {
 #[async_test]
 async fn guest_rx_large_payload(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     let data_len: u32 = 4000;
     let gpa = harness.post_rx_buffer_and_signal(0, data_len);
@@ -652,7 +654,7 @@ async fn guest_rx_large_payload(driver: DefaultDriver) {
 #[async_test]
 async fn disconnect_drains_tx_then_reconnect(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     // Verify TX works while connected.
     harness.post_tx_and_signal(0, b"before-disconnect");
@@ -688,7 +690,7 @@ async fn disconnect_drains_tx_then_reconnect(driver: DefaultDriver) {
 #[async_test]
 async fn disable_and_reenable(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     // Send a TX message to verify the device is working.
     harness.post_tx_and_signal(0, b"first-cycle");
@@ -702,7 +704,7 @@ async fn disable_and_reenable(driver: DefaultDriver) {
 
     // Re-enable.
     harness.reset_rings();
-    harness.enable();
+    harness.enable().await;
 
     // Verify the device works after re-enable.
     harness.post_tx_and_signal(0, b"second-cycle");
@@ -729,7 +731,7 @@ async fn traits_are_correct(driver: DefaultDriver) {
 #[async_test]
 async fn guest_tx_used_len_is_zero(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     harness.post_tx_and_signal(0, b"test payload");
     let (used_id, used_len) = harness.wait_for_tx_used().await;
@@ -744,7 +746,7 @@ async fn guest_tx_used_len_is_zero(driver: DefaultDriver) {
 #[async_test]
 async fn guest_tx_large_payload(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     let payload: Vec<u8> = (0..8000u16).map(|i| (i % 256) as u8).collect();
     harness.post_tx_and_signal(0, &payload);
@@ -762,7 +764,7 @@ async fn guest_tx_large_payload(driver: DefaultDriver) {
 #[async_test]
 async fn guest_tx_large_payload_partial_writes(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     // Limit each poll_write to 100 bytes to force many iterations.
     harness.handle.set_max_write_size(100);
@@ -784,7 +786,7 @@ async fn guest_tx_large_payload_partial_writes(driver: DefaultDriver) {
 #[async_test]
 async fn tx_partial_write_disconnect_reconnect(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     // Arrange: the next write accepts 3 bytes then auto-disconnects.
     harness.handle.set_write_limit_then_disconnect(3);
@@ -820,7 +822,7 @@ async fn tx_partial_write_disconnect_reconnect(driver: DefaultDriver) {
 #[async_test]
 async fn rx_zero_length_buffer_no_disconnect(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
-    harness.enable();
+    harness.enable().await;
 
     // Post a zero-length writeable RX buffer.
     harness.post_rx_buffer_and_signal(0, 0);
@@ -851,7 +853,7 @@ async fn config_read(driver: DefaultDriver) {
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
     let mut device = VirtioConsoleDevice::new(&driver_source, mem, Box::new(io));
     // Default config: cols=0, rows=0
-    let val = device.read_registers_u32(0);
+    let val = device.read_registers_u32(0).await;
     assert_eq!(val, 0);
 }
 
@@ -880,6 +882,7 @@ async fn tx_only_single_queue(driver: DefaultDriver) {
             &features,
             None,
         )
+        .await
         .unwrap();
 
     harness.post_tx_and_signal(0, b"tx-only");
@@ -915,6 +918,7 @@ async fn rx_only_single_queue(driver: DefaultDriver) {
             &features,
             None,
         )
+        .await
         .unwrap();
 
     let gpa = harness.post_rx_buffer_and_signal(0, 64);

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -40,7 +40,6 @@ use pal_async::wait::PolledWait;
 use std::future::pending;
 use std::mem::offset_of;
 use std::sync::Arc;
-use std::task::Context;
 use std::task::Poll;
 use task_control::AsyncRun;
 use task_control::InspectTaskMut;
@@ -279,7 +278,7 @@ impl VirtioDevice for Device {
         }
     }
 
-    fn read_registers_u32(&mut self, offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, offset: u16) -> u32 {
         match offset {
             0 => u32::from_le_bytes(self.registers.mac[..4].try_into().unwrap()),
             4 => {
@@ -298,9 +297,9 @@ impl VirtioDevice for Device {
         }
     }
 
-    fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
+    async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         idx: u16,
         resources: QueueResources,
@@ -389,7 +388,7 @@ impl VirtioDevice for Device {
         Ok(())
     }
 
-    fn poll_stop_queue(&mut self, cx: &mut Context<'_>, idx: u16) -> Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         let pair_idx = (idx / 2) as usize;
 
         if pair_idx < self.pairs.len() {
@@ -398,16 +397,16 @@ impl VirtioDevice for Device {
                 if is_rx != stopping_rx {
                     // The caller is stopping the queue that wasn't started;
                     // leave the pending half intact.
-                    return Poll::Ready(None);
+                    return None;
                 }
                 // Drop the pending half-open queue.
                 self.pairs[pair_idx] = QueuePairState::Empty;
             } else if matches!(self.pairs[pair_idx], QueuePairState::Active) {
                 // Stop the coordinator (which stops all workers).
-                let _ = std::task::ready!(self.coordinator.poll_stop(cx));
+                self.coordinator.stop().await;
                 if let Some(coordinator) = self.coordinator.state_mut() {
                     for worker in &mut coordinator.workers {
-                        let _ = std::task::ready!(worker.poll_stop(cx));
+                        worker.stop().await;
                     }
                 }
                 let _ = self.coordinator.remove();
@@ -416,10 +415,10 @@ impl VirtioDevice for Device {
         }
 
         // We don't support save/restore of virtio-net queue state yet.
-        Poll::Ready(None)
+        None
     }
 
-    fn reset(&mut self) {
+    async fn reset(&mut self) {
         self.pairs.fill_with(|| QueuePairState::Empty);
     }
 

--- a/vm/devices/virtio/virtio_net/src/tests.rs
+++ b/vm/devices/virtio/virtio_net/src/tests.rs
@@ -586,6 +586,7 @@ impl TestHarness {
                 &features,
                 None,
             )
+            .await
             .unwrap();
 
         // Queue 1: TX
@@ -606,6 +607,7 @@ impl TestHarness {
                 &features,
                 None,
             )
+            .await
             .unwrap();
 
         // Wait for the mock endpoint to provide a queue handle
@@ -715,9 +717,9 @@ impl TestHarness {
 
     /// Disable the device (stops all queues).
     async fn disable(&mut self) {
-        futures::future::poll_fn(|cx| self.device.poll_stop_queue(cx, 1)).await;
-        futures::future::poll_fn(|cx| self.device.poll_stop_queue(cx, 0)).await;
-        self.device.reset();
+        self.device.stop_queue(1).await;
+        self.device.stop_queue(0).await;
+        self.device.reset().await;
     }
 
     /// Reset memory layout tracking for a fresh enable cycle.

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -13,9 +13,6 @@ use guestmem::GuestMemory;
 use inspect::InspectMut;
 use pal_async::wait::PolledWait;
 use plan9::Plan9FileSystem;
-use std::task::Context;
-use std::task::Poll;
-use std::task::ready;
 use task_control::AsyncRun;
 use task_control::Cancelled;
 use task_control::InspectTaskMut;
@@ -84,7 +81,7 @@ impl VirtioDevice for VirtioPlan9Device {
         }
     }
 
-    fn read_registers_u32(&mut self, offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, offset: u16) -> u32 {
         assert!(self.tag.len().is_multiple_of(4));
         assert!(offset.is_multiple_of(4));
 
@@ -100,11 +97,11 @@ impl VirtioDevice for VirtioPlan9Device {
         }
     }
 
-    fn write_registers_u32(&mut self, offset: u16, val: u32) {
+    async fn write_registers_u32(&mut self, offset: u16, val: u32) {
         tracing::warn!(offset, val, "[VIRTIO 9P] Unknown write",);
     }
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         idx: u16,
         resources: QueueResources,
@@ -131,17 +128,17 @@ impl VirtioDevice for VirtioPlan9Device {
         Ok(())
     }
 
-    fn poll_stop_queue(&mut self, cx: &mut Context<'_>, idx: u16) -> Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         assert_eq!(idx, 0);
         if !self.worker.has_state() {
-            return Poll::Ready(None);
+            return None;
         }
-        ready!(self.worker.poll_stop(cx));
+        self.worker.stop().await;
         let state = self.worker.remove().queue.queue_state();
-        Poll::Ready(Some(state))
+        Some(state)
     }
 
-    fn reset(&mut self) {
+    async fn reset(&mut self) {
         self.worker.task().fs.reset();
     }
 }

--- a/vm/devices/virtio/virtio_pmem/src/lib.rs
+++ b/vm/devices/virtio/virtio_pmem/src/lib.rs
@@ -12,8 +12,6 @@ use guestmem::GuestMemory;
 use inspect::InspectMut;
 use pal_async::wait::PolledWait;
 use std::fs;
-use std::task::Poll;
-use std::task::ready;
 use task_control::AsyncRun;
 use task_control::Cancelled;
 use task_control::InspectTaskMut;
@@ -86,13 +84,13 @@ impl VirtioDevice for Device {
         }
     }
 
-    fn read_registers_u32(&mut self, _offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, _offset: u16) -> u32 {
         // The PmemConfig type is not used--instead, the memory region is
         // reported via the shared memory capability.
         0
     }
 
-    fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
+    async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
 
     fn set_shared_memory_region(
         &mut self,
@@ -105,7 +103,7 @@ impl VirtioDevice for Device {
         Ok(())
     }
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         idx: u16,
         resources: QueueResources,
@@ -135,18 +133,14 @@ impl VirtioDevice for Device {
         Ok(())
     }
 
-    fn poll_stop_queue(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-        idx: u16,
-    ) -> Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         assert_eq!(idx, 0);
         if !self.worker.has_state() {
-            return Poll::Ready(None);
+            return None;
         }
-        ready!(self.worker.poll_stop(cx));
+        self.worker.stop().await;
         let state = self.worker.remove().queue.queue_state();
-        Poll::Ready(Some(state))
+        Some(state)
     }
 
     fn supports_save_restore(&self) -> bool {

--- a/vm/devices/virtio/virtio_rng/src/lib.rs
+++ b/vm/devices/virtio/virtio_rng/src/lib.rs
@@ -19,9 +19,6 @@ use futures::StreamExt;
 use guestmem::GuestMemory;
 use inspect::InspectMut;
 use pal_async::wait::PolledWait;
-use std::task::Context;
-use std::task::Poll;
-use std::task::ready;
 use task_control::AsyncRun;
 use task_control::Cancelled;
 use task_control::InspectTaskMut;
@@ -67,13 +64,13 @@ impl VirtioDevice for VirtioRngDevice {
         }
     }
 
-    fn read_registers_u32(&mut self, _offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, _offset: u16) -> u32 {
         0
     }
 
-    fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
+    async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         idx: u16,
         resources: QueueResources,
@@ -100,14 +97,14 @@ impl VirtioDevice for VirtioRngDevice {
         Ok(())
     }
 
-    fn poll_stop_queue(&mut self, cx: &mut Context<'_>, idx: u16) -> Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         assert_eq!(idx, 0);
         if !self.worker.has_state() {
-            return Poll::Ready(None);
+            return None;
         }
-        ready!(self.worker.poll_stop(cx));
+        self.worker.stop().await;
         let state = self.worker.remove().queue.queue_state();
-        Poll::Ready(Some(state))
+        Some(state)
     }
 
     fn supports_save_restore(&self) -> bool {
@@ -317,7 +314,7 @@ mod tests {
             }
         }
 
-        fn enable(&mut self) {
+        async fn enable(&mut self) {
             let interrupt = Interrupt::from_event(self.interrupt_event.clone());
 
             self.device
@@ -337,6 +334,7 @@ mod tests {
                     &VirtioDeviceFeatures::new(),
                     None,
                 )
+                .await
                 .unwrap();
         }
 
@@ -371,7 +369,7 @@ mod tests {
     #[async_test]
     async fn rng_fills_buffer_with_random_bytes(driver: DefaultDriver) {
         let mut harness = TestHarness::new(&driver);
-        harness.enable();
+        harness.enable().await;
 
         let buf_len = 64u32;
         let data_gpa = DATA_BASE;
@@ -393,7 +391,7 @@ mod tests {
     #[async_test]
     async fn rng_handles_zero_length_buffer(driver: DefaultDriver) {
         let mut harness = TestHarness::new(&driver);
-        harness.enable();
+        harness.enable().await;
 
         let (_id, written) = harness.submit_and_wait(DATA_BASE, 0).await;
         assert_eq!(

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -12,9 +12,6 @@ use pal_async::wait::PolledWait;
 use std::io;
 use std::io::Write;
 use std::sync::Arc;
-use std::task::Context;
-use std::task::Poll;
-use std::task::ready;
 use task_control::AsyncRun;
 use task_control::Cancelled;
 use task_control::StopTask;
@@ -118,7 +115,7 @@ impl VirtioDevice for VirtioFsDevice {
         }
     }
 
-    fn read_registers_u32(&mut self, offset: u16) -> u32 {
+    async fn read_registers_u32(&mut self, offset: u16) -> u32 {
         let offset = offset as usize;
         let config = self.config.as_bytes();
         if offset < config.len() {
@@ -132,7 +129,7 @@ impl VirtioDevice for VirtioFsDevice {
         }
     }
 
-    fn write_registers_u32(&mut self, offset: u16, val: u32) {
+    async fn write_registers_u32(&mut self, offset: u16, val: u32) {
         tracing::warn!(offset, val, "[virtiofs] Unknown write",);
     }
 
@@ -144,7 +141,7 @@ impl VirtioDevice for VirtioFsDevice {
         Ok(())
     }
 
-    fn start_queue(
+    async fn start_queue(
         &mut self,
         idx: u16,
         resources: QueueResources,
@@ -194,17 +191,17 @@ impl VirtioDevice for VirtioFsDevice {
         Ok(())
     }
 
-    fn poll_stop_queue(&mut self, cx: &mut Context<'_>, idx: u16) -> Poll<Option<QueueState>> {
+    async fn stop_queue(&mut self, idx: u16) -> Option<QueueState> {
         let idx = idx as usize;
         if idx >= self.workers.len() || !self.workers[idx].has_state() {
-            return Poll::Ready(None);
+            return None;
         }
-        ready!(self.workers[idx].poll_stop(cx));
+        self.workers[idx].stop().await;
         let state = self.workers[idx].remove().queue.queue_state();
-        Poll::Ready(Some(state))
+        Some(state)
     }
 
-    fn reset(&mut self) {
+    async fn reset(&mut self) {
         self.workers.clear();
         if let Some(region) = &self.shared_memory_region {
             if let Err(e) = region.unmap(0, self.shmem_size as usize) {


### PR DESCRIPTION
Make the VirtioDevice trait methods async to enable vhost-user frontend support, where protocol operations (SET_VRING_ENABLE, GET_VRING_BASE) are inherently asynchronous message exchanges over a Unix socket.

Introduce a two-trait pattern:
- VirtioDevice: ergonomic async fn trait (not object-safe) that devices implement directly
- DynVirtioDevice: object-safe wrapper using Pin<Box<dyn Future>> with a blanket impl from VirtioDevice, used behind Box<dyn> by transports, the device task, and resolvers

Async methods: read_registers_u32, write_registers_u32, start_queue, stop_queue (renamed from poll_stop_queue), reset.

All existing device implementations (virtio-blk, virtio-net, virtio-console, virtio-rng, virtio-pmem, virtio-p9, virtiofs) and their tests are updated mechanically—none of these devices actually need to await in their trait methods today, but the interface is now ready for vhost-user-frontend which will.