### PR TITLE
flowey: don't use rustup in Nix environments

### DIFF
--- a/flowey/flowey_lib_common/src/install_rust.rs
+++ b/flowey/flowey_lib_common/src/install_rust.rs
@@ -120,21 +120,42 @@ impl FlowNode for Node {
                     anyhow::bail!("did not find `cargo` on $PATH");
                 }
 
-                let rust_toolchain = rust_toolchain.map(|s| format!("+{s}"));
-                let rust_toolchain = rust_toolchain.as_ref();
+                let has_rustup = which::which("rustup").is_ok();
 
-                // make sure the specific rust version was installed
-                flowey::shell_cmd!(rt, "rustc {rust_toolchain...} -vV").run()?;
+                // Check if the specified version is installed — use rustup when
+                // available, otherwise check via plain `rustc`.
+                if has_rustup {
+                    let rust_toolchain = rust_toolchain.as_ref().map(|s| format!("+{s}"));
+                    let rust_toolchain = rust_toolchain.as_ref();
+                    flowey::shell_cmd!(rt, "rustc {rust_toolchain...} -vV").run()?;
+                } else if let Some(ref version) = rust_toolchain {
+                    let output = flowey::shell_cmd!(rt, "rustc -vV").output()?;
+                    let stdout = String::from_utf8(output.stdout)?;
+                    let installed_version = stdout
+                        .lines()
+                        .find_map(|line| line.strip_prefix("release: "))
+                        .context("failed to parse rustc version output")?;
+                    if installed_version != version.as_str() {
+                        anyhow::bail!(
+                            "required Rust {version}, found {installed_version} \
+                             (rustup unavailable)"
+                        );
+                    }
+                } else {
+                    flowey::shell_cmd!(rt, "rustc -vV").run()?;
+                }
 
                 // make sure the additional target triples were installed
-                if let Ok(rustup) = which::which("rustup") {
+                if has_rustup {
+                    let rust_toolchain = rust_toolchain.as_ref().map(|s| format!("+{s}"));
+                    let rust_toolchain = rust_toolchain.as_ref();
                     for (thing, expected_things) in [
                         ("target", &additional_target_triples),
                         ("component", &additional_components),
                     ] {
                         let output = flowey::shell_cmd!(
                             rt,
-                            "{rustup} {rust_toolchain...} {thing} list --installed"
+                            "rustup {rust_toolchain...} {thing} list --installed"
                         )
                         .ignore_status()
                         .output()?;
@@ -222,9 +243,22 @@ impl FlowNode for Node {
                             if let Some(write_cargo_bin) = write_cargo_bin {
                                 rt.write(write_cargo_bin, &Some(crate::check_needs_relaunch::BinOrEnv::Bin("cargo".to_string())));
                             }
+
                             let rust_toolchain = rust_toolchain.clone();
                             if check_rust_install.clone()(rt).is_ok() {
                                 return Ok(());
+                            }
+
+                            // If cargo is already on PATH but rustup is not then assume
+                            // rust is being managed manually (Nix for example) and bail
+                            if which::which("cargo").is_ok()
+                                && which::which("rustup").is_err()
+                            {
+                                anyhow::bail!(
+                                    "Rust installation check failed and rustup is \
+                                     not available; Rust appears to be externally \
+                                     managed and cannot be installed by this node"
+                                );
                             }
 
                             match rt.platform() {
@@ -331,16 +365,17 @@ impl FlowNode for Node {
                 let get_rust_toolchain = get_rust_toolchain.claim(ctx);
 
                 move |rt| {
+                    let has_rustup = which::which("rustup").is_ok();
                     let rust_toolchain = match rust_toolchain {
-                        Some(toolchain) => Some(toolchain),
-                        None => {
-                            if matches!(
-                                rt.platform(),
-                                FlowPlatform::Linux(FlowPlatformLinuxDistro::Nix)
-                            ) {
-                                // Nix will provide the right cargo version, no need to use rustup
+                        Some(toolchain) => {
+                            if has_rustup {
+                                Some(toolchain)
+                            } else {
                                 None
-                            } else if let Ok(rustup) = which::which("rustup") {
+                            }
+                        }
+                        None => {
+                            if has_rustup {
                                 // Unfortunately, `rustup` still doesn't have any stable way to emit
                                 // machine-readable output. See https://github.com/rust-lang/rustup/issues/450
                                 //
@@ -355,12 +390,17 @@ impl FlowNode for Node {
                                 //   $ rustup show active-toolchain
                                 //   stable-x86_64-unknown-linux-gnu
                                 //   active because: it's the default toolchain
-                                let output =
-                                    flowey::shell_cmd!(rt, "{rustup} show active-toolchain")
-                                        .output()?;
+                                let output = flowey::shell_cmd!(rt, "rustup show active-toolchain")
+                                    .output()?;
                                 let stdout = String::from_utf8(output.stdout)?;
-                                let line = stdout.lines().next().unwrap();
-                                Some(line.split(' ').next().unwrap().into())
+                                let line = stdout
+                                    .lines()
+                                    .next()
+                                    .context("`rustup show active-toolchain` produced no output")?;
+                                let toolchain = line.split(' ').next().context(format!(
+                                    "unexpected `rustup show active-toolchain` output: `{line}`"
+                                ))?;
+                                Some(toolchain.into())
                             } else {
                                 None
                             }


### PR DESCRIPTION
In CI, the install_rust node tries to use rustup from within the Nix shell to validate that the right version of rustc is installed. Since Nix is managing the rustc install, rustup isn't present and this node will fail even if the right version of rustc is available. This node has been adjusted to still validate the presence of the requested rustc version in the absence of rustup for the nix case and only bails with a failure if the requested rustc version actually isn't present in any way.