### PR TITLE
nix: trim paths in nix build

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -157,6 +157,15 @@ in pkgs.mkShell {
 
   RUST_BACKTRACE = 1;
   SOURCE_DATE_EPOCH = 12345;
+  # Need the unstable trim-paths feature on the stable toolchain to strip paths from the output binary
+  RUSTC_BOOTSTRAP = 1;
+  # Enable path trimming
+  CARGO_UNSTABLE_TRIM_PATHS = "true";
+  CARGO_PROFILE_DEV_TRIM_PATHS = "object";
+  CARGO_PROFILE_RELEASE_TRIM_PATHS = "object";
+  CARGO_PROFILE_UNDERHILL_SHIP_TRIM_PATHS = "object";
+  CARGO_PROFILE_BOOT_DEV_TRIM_PATHS = "object";
+  CARGO_PROFILE_BOOT_RELEASE_TRIM_PATHS = "object";
 
   shellHook = ''
     # Create a temp bin directory with symlinks using the expected gcc names.


### PR DESCRIPTION
Our binary currently has machine-dependent paths in its output - to fix this rustc has a flag `--remap-path-prefix`, but unfortunately it requires a key-value mapping so we have to figure out the path at runtime to be replaced. A future rust version will have better support for trimming paths that should make this unnecessary (RFC [here](https://rust-lang.github.io/rfcs/3127-trim-paths.html))

The RUSTFLAGS in our config.toml are duplicated here instead of trying to do some sort of merge/reading of the .toml file at runtime. 