### PR TITLE
virtio: pass GuestMemory to start_queue instead of device constructor

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2149,7 +2149,6 @@ impl InitializedVm {
                     device,
                     VirtioResolveInput {
                         driver_source: &driver_source,
-                        guest_memory: &gm,
                     },
                 )
                 .await?;
@@ -2158,10 +2157,12 @@ impl InitializedVm {
                     let mmio_start = virtio_mmio_start - 0x1000;
                     virtio_mmio_start -= 0x1000;
                     let id = format!("{id}-{mmio_start}");
+                    let gm = gm.clone();
                     chipset_builder.arc_mutex_device(id).add(|services| {
                         VirtioMmioDevice::new(
                             device.0,
                             &driver_source.simple(),
+                            gm,
                             services.new_line(IRQ_LINE_SET, "interrupt", virtio_mmio_irq),
                             partition.clone().into_doorbell_registration(Vtl::Vtl0),
                             mmio_start,
@@ -2191,6 +2192,7 @@ impl InitializedVm {
                             VirtioPciDevice::new(
                                 device.0,
                                 &driver_source.simple(),
+                                gm.clone(),
                                 PciInterruptModel::IntX(
                                     PciInterruptPin::IntA,
                                     services.new_line(IRQ_LINE_SET, "interrupt", pci_inta_line),

--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -459,4 +459,5 @@ pub struct QueueResources {
     pub params: QueueParams,
     pub notify: Interrupt,
     pub event: Event,
+    pub guest_memory: GuestMemory,
 }

--- a/vm/devices/virtio/virtio/src/resolve.rs
+++ b/vm/devices/virtio/virtio/src/resolve.rs
@@ -5,7 +5,6 @@
 
 use crate::DynVirtioDevice;
 use crate::VirtioDevice;
-use guestmem::GuestMemory;
 use vm_resource::CanResolveTo;
 use vm_resource::kind::VirtioDeviceHandle;
 use vmcore::vm_task::VmTaskDriverSource;
@@ -27,6 +26,4 @@ impl<T: 'static + VirtioDevice> From<T> for ResolvedVirtioDevice {
 pub struct VirtioResolveInput<'a> {
     /// The VM driver source.
     pub driver_source: &'a VmTaskDriverSource,
-    /// The guest memory for virtio device DMA.
-    pub guest_memory: &'a GuestMemory,
 }

--- a/vm/devices/virtio/virtio/src/resolver.rs
+++ b/vm/devices/virtio/virtio/src/resolver.rs
@@ -49,7 +49,6 @@ impl AsyncResolveResource<PciDeviceHandleKind, VirtioPciDeviceHandle> for Virtio
                 resource.0,
                 VirtioResolveInput {
                     driver_source: input.driver_source,
-                    guest_memory: input.guest_memory,
                 },
             )
             .await
@@ -58,6 +57,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VirtioPciDeviceHandle> for Virtio
         let device = VirtioPciDevice::new(
             inner.0,
             &input.driver_source.simple(),
+            input.guest_memory.clone(),
             PciInterruptModel::Msix(input.msi_target),
             input.doorbell_registration,
             input.register_mmio,

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -1256,7 +1256,6 @@ struct TestDevice {
     traits: DeviceTraits,
     queue_work: Option<TestDeviceQueueWorkFn>,
     driver: vmcore::vm_task::VmTaskDriver,
-    mem: GuestMemory,
     workers: Vec<TaskControl<TestDeviceTask, TestDeviceQueue>>,
 }
 
@@ -1265,13 +1264,11 @@ impl TestDevice {
         driver_source: &VmTaskDriverSource,
         traits: DeviceTraits,
         queue_work: Option<TestDeviceQueueWorkFn>,
-        mem: &GuestMemory,
     ) -> Self {
         Self {
             traits,
             queue_work,
             driver: driver_source.simple(),
-            mem: mem.clone(),
             workers: Vec::new(),
         }
     }
@@ -1304,7 +1301,7 @@ impl VirtioDevice for TestDevice {
         let queue = VirtioQueue::new(
             features.clone(),
             resources.params,
-            self.mem.clone(),
+            resources.guest_memory,
             resources.notify,
             queue_event,
             initial_state,
@@ -1409,9 +1406,9 @@ impl VirtioPciTestDevice {
                     ..Default::default()
                 },
                 queue_work,
-                &mem,
             )),
             driver,
+            mem.clone(),
             PciInterruptModel::Msix(msi_conn.target()),
             Some(doorbell_registration),
             &mut ExternallyManagedMmioIntercepts,
@@ -1460,9 +1457,9 @@ async fn verify_chipset_config(driver: DefaultDriver) {
                 ..Default::default()
             },
             None,
-            &mem,
         )),
         &driver_source.simple(),
+        mem.clone(),
         interrupt,
         Some(doorbell_registration),
         0,
@@ -2548,9 +2545,9 @@ async fn verify_device_queue_simple_inner(
                 ..Default::default()
             },
             Some(queue_work),
-            &mem,
         )),
         &driver_source.simple(),
+        mem.clone(),
         interrupt,
         Some(doorbell_registration),
         0,
@@ -2634,9 +2631,9 @@ async fn verify_device_multi_queue_inner(
                 ..Default::default()
             },
             Some(queue_work),
-            &mem,
         )),
         &driver_source.simple(),
+        mem.clone(),
         interrupt,
         Some(doorbell_registration),
         0,
@@ -2801,6 +2798,7 @@ async fn verify_enable_failure_mmio_does_not_set_driver_ok(_driver: DefaultDrive
             },
         }),
         &_driver,
+        GuestMemory::empty(),
         interrupt,
         Some(doorbell_registration),
         0,
@@ -2851,6 +2849,7 @@ async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver
             },
         }),
         &_driver,
+        GuestMemory::empty(),
         PciInterruptModel::Msix(msi_conn.target()),
         Some(doorbell_registration),
         &mut ExternallyManagedMmioIntercepts,
@@ -3607,6 +3606,7 @@ impl MmioTestTransport {
         let mut dev = VirtioMmioDevice::new(
             device,
             driver,
+            GuestMemory::empty(),
             interrupt,
             Some(doorbell_registration),
             0,
@@ -3673,6 +3673,7 @@ impl PciTestTransport {
         let mut dev = VirtioPciDevice::new(
             device,
             driver,
+            GuestMemory::empty(),
             PciInterruptModel::Msix(msi_conn.target()),
             Some(doorbell_registration),
             &mut ExternallyManagedMmioIntercepts,
@@ -3963,9 +3964,9 @@ async fn pci_intx_line_deasserted_on_reset(driver: DefaultDriver) {
             Some(Arc::new(|_i, mut work: VirtioQueueCallbackWork| {
                 work.complete(42);
             })),
-            &mem,
         )),
         &driver,
+        mem,
         PciInterruptModel::IntX(pci_core::PciInterruptPin::IntA, line),
         Some(doorbell_registration),
         &mut ExternallyManagedMmioIntercepts,
@@ -4140,9 +4141,9 @@ async fn mmio_save_restore_round_trip(driver: DefaultDriver) {
                 ..Default::default()
             },
             None,
-            &mem,
         )),
         &driver_source.simple(),
+        mem.clone(),
         interrupt,
         Some(doorbell_registration.clone()),
         0,
@@ -4174,9 +4175,9 @@ async fn mmio_save_restore_round_trip(driver: DefaultDriver) {
                 ..Default::default()
             },
             None,
-            &mem,
         )),
         &driver_source.simple(),
+        mem.clone(),
         interrupt2,
         Some(doorbell_registration),
         0,
@@ -4229,9 +4230,9 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
                 ..Default::default()
             },
             None,
-            &mem,
         )),
         &driver,
+        mem,
         PciInterruptModel::Msix(msi_conn.target()),
         None,
         &mut ExternallyManagedMmioIntercepts,
@@ -4264,6 +4265,7 @@ async fn pci_save_not_supported_device(_driver: DefaultDriver) {
             },
         }),
         &_driver,
+        GuestMemory::empty(),
         PciInterruptModel::Msix(msi_conn.target()),
         None,
         &mut ExternallyManagedMmioIntercepts,
@@ -4292,6 +4294,7 @@ async fn mmio_save_not_supported_device(_driver: DefaultDriver) {
             },
         }),
         &_driver,
+        GuestMemory::empty(),
         interrupt,
         None,
         0,
@@ -4382,9 +4385,9 @@ async fn mmio_restore_reinstalls_doorbells(driver: DefaultDriver) {
                 ..Default::default()
             },
             None,
-            &mem,
         )),
         &driver,
+        mem.clone(),
         interrupt,
         Some(doorbell_registration.clone()),
         0,
@@ -4418,9 +4421,9 @@ async fn mmio_restore_reinstalls_doorbells(driver: DefaultDriver) {
                 ..Default::default()
             },
             None,
-            &mem,
         )),
         &driver,
+        mem.clone(),
         interrupt2,
         Some(doorbell_registration),
         0,

--- a/vm/devices/virtio/virtio/src/transport/mmio.rs
+++ b/vm/devices/virtio/virtio/src/transport/mmio.rs
@@ -27,6 +27,7 @@ use device_emulators::ReadWriteRequestType;
 use device_emulators::read_as_u32_chunks;
 use device_emulators::write_as_u32_chunks;
 use guestmem::DoorbellRegistration;
+use guestmem::GuestMemory;
 use inspect::Inspect;
 use inspect::InspectMut;
 use mesh::rpc::Rpc;
@@ -79,6 +80,8 @@ pub struct VirtioMmioDevice {
     #[inspect(skip)]
     saved_queue_states: Vec<Option<QueueState>>,
     supports_save_restore: bool,
+    #[inspect(skip)]
+    guest_memory: GuestMemory,
 }
 
 #[derive(Inspect)]
@@ -109,6 +112,7 @@ impl VirtioMmioDevice {
     pub fn new(
         device: Box<dyn DynVirtioDevice>,
         driver: &impl Spawn,
+        guest_memory: GuestMemory,
         interrupt: LineInterrupt,
         doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
         mmio_gpa: u64,
@@ -174,6 +178,7 @@ impl VirtioMmioDevice {
             interrupt_state,
             saved_queue_states: vec![None; traits.max_queues as usize],
             supports_save_restore,
+            guest_memory,
         }
     }
 
@@ -461,6 +466,7 @@ impl VirtioMmioDevice {
                                     params: *q,
                                     notify,
                                     event: self.events[i].clone(),
+                                    guest_memory: self.guest_memory.clone(),
                                 },
                             )
                         })
@@ -532,6 +538,7 @@ impl ChangeDeviceState for VirtioMmioDevice {
                         params: *q,
                         notify,
                         event: self.events[i].clone(),
+                        guest_memory: self.guest_memory.clone(),
                     },
                     initial_state,
                 ));

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -33,6 +33,7 @@ use device_emulators::ReadWriteRequestType;
 use device_emulators::read_as_u32_chunks;
 use device_emulators::write_as_u32_chunks;
 use guestmem::DoorbellRegistration;
+use guestmem::GuestMemory;
 use guestmem::MemoryMapper;
 use inspect::InspectMut;
 use mesh::rpc::Rpc;
@@ -122,12 +123,15 @@ pub struct VirtioPciDevice {
     #[inspect(skip)]
     saved_queue_states: Vec<Option<QueueState>>,
     supports_save_restore: bool,
+    #[inspect(skip)]
+    guest_memory: GuestMemory,
 }
 
 impl VirtioPciDevice {
     pub fn new(
         mut device: Box<dyn DynVirtioDevice>,
         driver: &impl Spawn,
+        guest_memory: GuestMemory,
         interrupt_model: PciInterruptModel<'_>,
         doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
         mmio_registration: &mut dyn RegisterMmioIntercept,
@@ -304,6 +308,7 @@ impl VirtioPciDevice {
             shared_memory_size,
             saved_queue_states: vec![None; traits.max_queues as usize],
             supports_save_restore,
+            guest_memory,
         })
     }
 
@@ -577,6 +582,7 @@ impl VirtioPciDevice {
                                     params: *q,
                                     notify,
                                     event: self.events[i].clone(),
+                                    guest_memory: self.guest_memory.clone(),
                                 },
                             )
                         })
@@ -707,6 +713,7 @@ impl ChangeDeviceState for VirtioPciDevice {
                         params: *q,
                         notify,
                         event: self.events[i].clone(),
+                        guest_memory: self.guest_memory.clone(),
                     },
                     initial_state,
                 ));

--- a/vm/devices/virtio/virtio_blk/src/integration_tests.rs
+++ b/vm/devices/virtio/virtio_blk/src/integration_tests.rs
@@ -183,7 +183,7 @@ impl TestHarness {
         init_used_ring(&mem, USED_ADDR);
 
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
-        let device = VirtioBlkDevice::new(&driver_source, mem.clone(), disk, read_only);
+        let device = VirtioBlkDevice::new(&driver_source, disk, read_only);
 
         let queue_event = Event::new();
         let interrupt_event = Event::new();
@@ -217,6 +217,7 @@ impl TestHarness {
                     },
                     notify: interrupt,
                     event: self.queue_event.clone(),
+                    guest_memory: self.mem.clone(),
                 },
                 &VirtioDeviceFeatures::new(),
                 None,

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -62,7 +62,7 @@ pub struct VirtioBlkDevice {
 
 /// Persistent worker state. Survives across enable/disable cycles.
 ///
-/// Holds the disk backend, guest memory, stats counters, and the
+/// Holds the disk backend, stats counters, and the
 /// `FuturesUnordered` that tracks in-flight IOs. The IO futures
 /// live here (not in `BlkQueueState`) so they survive when the
 /// task is stopped — they're drained in `poll_disable()` before
@@ -70,8 +70,6 @@ pub struct VirtioBlkDevice {
 #[derive(Inspect)]
 struct BlkWorker {
     disk: Disk,
-    #[inspect(skip)]
-    memory: GuestMemory,
     read_only: bool,
     #[inspect(flatten)]
     stats: WorkerStats,
@@ -82,6 +80,7 @@ struct BlkWorker {
 /// Transient queue state, created in `enable()` and removed in `poll_disable()`.
 struct BlkQueueState {
     queue: VirtioQueue,
+    memory: GuestMemory,
 }
 
 #[derive(Inspect, Default)]
@@ -185,7 +184,7 @@ impl AsyncRun<BlkQueueState> for BlkWorker {
                 match event {
                     Event::NewWork(Ok(work)) => {
                         let disk = self.disk.clone();
-                        let mem = self.memory.clone();
+                        let mem = state.memory.clone();
                         let read_only = self.read_only;
                         self.ios.push(Box::pin(async move {
                             process_request(&disk, &mem, read_only, work).await
@@ -209,12 +208,7 @@ impl AsyncRun<BlkQueueState> for BlkWorker {
 
 impl VirtioBlkDevice {
     /// Creates a new virtio-blk device backed by the given disk.
-    pub fn new(
-        driver_source: &VmTaskDriverSource,
-        memory: GuestMemory,
-        disk: Disk,
-        read_only: bool,
-    ) -> Self {
+    pub fn new(driver_source: &VmTaskDriverSource, disk: Disk, read_only: bool) -> Self {
         let sector_count = disk.sector_count();
         let sector_size = disk.sector_size();
         let physical_sector_size = disk.physical_sector_size();
@@ -283,7 +277,6 @@ impl VirtioBlkDevice {
         Self {
             worker: TaskControl::new(BlkWorker {
                 disk,
-                memory,
                 read_only,
                 stats: WorkerStats::default(),
                 ios: FuturesUnordered::new(),
@@ -365,7 +358,7 @@ impl VirtioDevice for VirtioBlkDevice {
         let queue = VirtioQueue::new(
             features.clone(),
             resources.params,
-            self.worker.task().memory.clone(),
+            resources.guest_memory.clone(),
             resources.notify,
             queue_event,
             initial_state,
@@ -375,7 +368,10 @@ impl VirtioDevice for VirtioBlkDevice {
         self.worker.insert(
             self.driver.clone(),
             "virtio-blk-worker",
-            BlkQueueState { queue },
+            BlkQueueState {
+                queue,
+                memory: resources.guest_memory,
+            },
         );
         self.worker.start();
         Ok(())

--- a/vm/devices/virtio/virtio_blk/src/resolver.rs
+++ b/vm/devices/virtio/virtio_blk/src/resolver.rs
@@ -43,12 +43,6 @@ impl AsyncResolveResource<VirtioDeviceHandle, VirtioBlkHandle> for VirtioBlkReso
             )
             .await?;
 
-        Ok(VirtioBlkDevice::new(
-            input.driver_source,
-            input.guest_memory.clone(),
-            disk.0,
-            resource.read_only,
-        )
-        .into())
+        Ok(VirtioBlkDevice::new(input.driver_source, disk.0, resource.read_only).into())
     }
 }

--- a/vm/devices/virtio/virtio_console/src/lib.rs
+++ b/vm/devices/virtio/virtio_console/src/lib.rs
@@ -70,21 +70,15 @@ pub struct VirtioConsoleDevice {
     config: VirtioConsoleConfig,
     #[inspect(skip)]
     worker: TaskControl<ConsoleWorker, ConsoleWorkerState>,
-    memory: GuestMemory,
 }
 
 impl VirtioConsoleDevice {
     /// Create a new virtio console device backed by the given serial I/O.
-    pub fn new(
-        driver_source: &VmTaskDriverSource,
-        memory: GuestMemory,
-        io: Box<dyn SerialIo>,
-    ) -> Self {
+    pub fn new(driver_source: &VmTaskDriverSource, io: Box<dyn SerialIo>) -> Self {
         Self {
             driver: driver_source.simple(),
             config: VirtioConsoleConfig::default(),
             worker: TaskControl::new(ConsoleWorker { io }),
-            memory,
         }
     }
 }
@@ -117,10 +111,11 @@ impl VirtioDevice for VirtioConsoleDevice {
         features: &VirtioDeviceFeatures,
         initial_state: Option<QueueState>,
     ) -> anyhow::Result<()> {
+        let guest_memory = resources.guest_memory.clone();
         let queue = VirtioQueue::new(
             features.clone(),
             resources.params,
-            self.memory.clone(),
+            resources.guest_memory,
             resources.notify,
             pal_async::wait::PolledWait::new(&self.driver, resources.event)?,
             initial_state,
@@ -154,7 +149,7 @@ impl VirtioDevice for VirtioConsoleDevice {
                 ConsoleWorkerState {
                     receiveq,
                     transmitq,
-                    mem: self.memory.clone(),
+                    mem: guest_memory,
                     partial_transmit: 0,
                 },
             );

--- a/vm/devices/virtio/virtio_console/src/resolver.rs
+++ b/vm/devices/virtio/virtio_console/src/resolver.rs
@@ -43,11 +43,7 @@ impl AsyncResolveResource<VirtioDeviceHandle, VirtioConsoleHandle> for VirtioCon
             )
             .await?;
 
-        let device = VirtioConsoleDevice::new(
-            input.driver_source,
-            input.guest_memory.clone(),
-            io.0.into_io(),
-        );
+        let device = VirtioConsoleDevice::new(input.driver_source, io.0.into_io());
 
         Ok(device.into())
     }

--- a/vm/devices/virtio/virtio_console/src/tests.rs
+++ b/vm/devices/virtio/virtio_console/src/tests.rs
@@ -362,7 +362,7 @@ impl TestHarness {
         let (io, handle) = new_mock_serial();
 
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
-        let device = VirtioConsoleDevice::new(&driver_source, mem.clone(), Box::new(io));
+        let device = VirtioConsoleDevice::new(&driver_source, Box::new(io));
 
         let rx_event = Event::new();
         let rx_interrupt_event = Event::new();
@@ -404,6 +404,7 @@ impl TestHarness {
                     },
                     notify: Interrupt::from_event(self.rx_interrupt_event.clone()),
                     event: self.rx_event.clone(),
+                    guest_memory: self.mem.clone(),
                 },
                 &features,
                 None,
@@ -425,6 +426,7 @@ impl TestHarness {
                     },
                     notify: Interrupt::from_event(self.tx_interrupt_event.clone()),
                     event: self.tx_event.clone(),
+                    guest_memory: self.mem.clone(),
                 },
                 &features,
                 None,
@@ -717,10 +719,9 @@ async fn disable_and_reenable(driver: DefaultDriver) {
 /// Traits report correct device ID, queue count, and feature bits.
 #[async_test]
 async fn traits_are_correct(driver: DefaultDriver) {
-    let mem = GuestMemory::allocate(64);
     let (io, _handle) = new_mock_serial();
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let device = VirtioConsoleDevice::new(&driver_source, mem, Box::new(io));
+    let device = VirtioConsoleDevice::new(&driver_source, Box::new(io));
     let traits = device.traits();
     assert_eq!(traits.device_id, 3); // VIRTIO_DEVICE_ID_CONSOLE
     assert_eq!(traits.max_queues, 2); // receiveq + transmitq
@@ -848,10 +849,9 @@ async fn rx_zero_length_buffer_no_disconnect(driver: DefaultDriver) {
 /// Config space read returns cols | (rows << 16) at offset 0.
 #[async_test]
 async fn config_read(driver: DefaultDriver) {
-    let mem = GuestMemory::allocate(64);
     let (io, _handle) = new_mock_serial();
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let mut device = VirtioConsoleDevice::new(&driver_source, mem, Box::new(io));
+    let mut device = VirtioConsoleDevice::new(&driver_source, Box::new(io));
     // Default config: cols=0, rows=0
     let val = device.read_registers_u32(0).await;
     assert_eq!(val, 0);
@@ -878,6 +878,7 @@ async fn tx_only_single_queue(driver: DefaultDriver) {
                 },
                 notify: Interrupt::from_event(harness.tx_interrupt_event.clone()),
                 event: harness.tx_event.clone(),
+                guest_memory: harness.mem.clone(),
             },
             &features,
             None,
@@ -914,6 +915,7 @@ async fn rx_only_single_queue(driver: DefaultDriver) {
                 },
                 notify: Interrupt::from_event(harness.rx_interrupt_event.clone()),
                 event: harness.rx_event.clone(),
+                guest_memory: harness.mem.clone(),
             },
             &features,
             None,

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -227,7 +227,6 @@ struct Adapter {
 
 pub struct Device {
     registers: NetConfig,
-    memory: GuestMemory,
     coordinator: TaskControl<CoordinatorState, Coordinator>,
     adapter: Arc<Adapter>,
     driver_source: VmTaskDriverSource,
@@ -306,13 +305,14 @@ impl VirtioDevice for Device {
         features: &VirtioDeviceFeatures,
         initial_state: Option<QueueState>,
     ) -> anyhow::Result<()> {
+        let guest_memory = resources.guest_memory.clone();
         let queue_size = resources.params.size;
         let queue_event = PolledWait::new(&self.adapter.driver, resources.event)
             .context("failed creating queue event")?;
         let queue = VirtioQueue::new(
             features.clone(),
             resources.params,
-            self.memory.clone(),
+            resources.guest_memory,
             resources.notify,
             queue_event,
             initial_state,
@@ -375,7 +375,7 @@ impl VirtioDevice for Device {
                     tx_queue,
                     tx_queue_size,
                 };
-                self.insert_worker(virtio_state, pair_idx, negotiated_features);
+                self.insert_worker(virtio_state, pair_idx, &guest_memory, negotiated_features);
 
                 if first_pair {
                     self.coordinator.start();
@@ -519,7 +519,6 @@ impl NicBuilder {
     pub fn build(
         self,
         driver_source: &VmTaskDriverSource,
-        memory: GuestMemory,
         endpoint: Box<dyn Endpoint>,
         mac_address: MacAddress,
     ) -> Device {
@@ -557,7 +556,6 @@ impl NicBuilder {
 
         Device {
             registers,
-            memory,
             coordinator,
             adapter,
             driver_source: driver_source.clone(),
@@ -604,6 +602,7 @@ impl Device {
         &mut self,
         virtio_state: VirtioState,
         idx: usize,
+        guest_memory: &GuestMemory,
         negotiated_features: NetworkFeaturesBank0,
     ) {
         let mut builder = self.driver_source.builder();
@@ -617,7 +616,7 @@ impl Device {
         let driver = builder.build("virtio-net");
 
         let active_state = ActiveState::new(
-            self.memory.clone(),
+            guest_memory.clone(),
             virtio_state.rx_queue_size,
             virtio_state.tx_queue_size,
         );

--- a/vm/devices/virtio/virtio_net/src/resolver.rs
+++ b/vm/devices/virtio/virtio_net/src/resolver.rs
@@ -47,12 +47,7 @@ impl AsyncResolveResource<VirtioDeviceHandle, VirtioNetHandle> for VirtioNetReso
             )
             .await?;
 
-        let device = builder.build(
-            input.driver_source,
-            input.guest_memory.clone(),
-            endpoint.0,
-            resource.mac_address,
-        );
+        let device = builder.build(input.driver_source, endpoint.0, resource.mac_address);
 
         Ok(device.into())
     }

--- a/vm/devices/virtio/virtio_net/src/tests.rs
+++ b/vm/devices/virtio/virtio_net/src/tests.rs
@@ -530,7 +530,7 @@ impl TestHarness {
 
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
         let mac = MacAddress::new([0x00, 0x15, 0x5d, 0xaa, 0xbb, 0xcc]);
-        let device = Device::builder().build(&driver_source, mem.clone(), Box::new(endpoint), mac);
+        let device = Device::builder().build(&driver_source, Box::new(endpoint), mac);
 
         let rx_event = Event::new();
         let rx_interrupt_event = Event::new();
@@ -582,6 +582,7 @@ impl TestHarness {
                     },
                     notify: rx_interrupt,
                     event: self.rx_event.clone(),
+                    guest_memory: self.mem.clone(),
                 },
                 &features,
                 None,
@@ -603,6 +604,7 @@ impl TestHarness {
                     },
                     notify: tx_interrupt,
                     event: self.tx_event.clone(),
+                    guest_memory: self.mem.clone(),
                 },
                 &features,
                 None,
@@ -1627,7 +1629,6 @@ async fn rx_offload_data_valid_validated_but_wrong(driver: DefaultDriver) {
 /// endpoint supports TCP/UDP/TSO offloads.
 #[async_test]
 async fn feature_negotiation_with_offloads(driver: DefaultDriver) {
-    let mem = GuestMemory::allocate(4096);
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
     let mac = MacAddress::new([0x00, 0x15, 0x5d, 0x01, 0x02, 0x03]);
 
@@ -1640,7 +1641,7 @@ async fn feature_negotiation_with_offloads(driver: DefaultDriver) {
         },
     };
 
-    let device = Device::builder().build(&driver_source, mem, Box::new(endpoint), mac);
+    let device = Device::builder().build(&driver_source, Box::new(endpoint), mac);
     let traits = device.traits();
 
     let bank0 = NetworkFeaturesBank0::from(traits.device_features.bank(0));
@@ -1664,7 +1665,6 @@ async fn feature_negotiation_with_offloads(driver: DefaultDriver) {
 /// endpoint supports none.
 #[async_test]
 async fn feature_negotiation_no_offloads(driver: DefaultDriver) {
-    let mem = GuestMemory::allocate(4096);
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
     let mac = MacAddress::new([0x00, 0x15, 0x5d, 0x01, 0x02, 0x03]);
 
@@ -1672,7 +1672,7 @@ async fn feature_negotiation_no_offloads(driver: DefaultDriver) {
         offloads: TxOffloadSupport::default(),
     };
 
-    let device = Device::builder().build(&driver_source, mem, Box::new(endpoint), mac);
+    let device = Device::builder().build(&driver_source, Box::new(endpoint), mac);
     let traits = device.traits();
 
     let bank0 = NetworkFeaturesBank0::from(traits.device_features.bank(0));

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -45,7 +45,6 @@ impl VirtioPlan9Device {
         driver_source: &VmTaskDriverSource,
         tag: &str,
         fs: Plan9FileSystem,
-        memory: GuestMemory,
     ) -> VirtioPlan9Device {
         // The tag uses the same format as 9p protocol strings (2 byte length followed by string).
         let length = tag.len() + size_of::<u16>();
@@ -65,7 +64,7 @@ impl VirtioPlan9Device {
         VirtioPlan9Device {
             tag: tag_buffer,
             driver: driver_source.simple(),
-            worker: TaskControl::new(Plan9Worker { mem: memory, fs }),
+            worker: TaskControl::new(Plan9Worker { fs }),
         }
     }
 }
@@ -115,15 +114,21 @@ impl VirtioDevice for VirtioPlan9Device {
         let queue = VirtioQueue::new(
             features.clone(),
             resources.params,
-            self.worker.task().mem.clone(),
+            resources.guest_memory.clone(),
             resources.notify,
             queue_event,
             initial_state,
         )
         .context("failed to create virtio queue")?;
 
-        self.worker
-            .insert(self.driver.clone(), "virtio-9p-queue", Plan9Queue { queue });
+        self.worker.insert(
+            self.driver.clone(),
+            "virtio-9p-queue",
+            Plan9Queue {
+                queue,
+                mem: resources.guest_memory,
+            },
+        );
         self.worker.start();
         Ok(())
     }
@@ -145,7 +150,6 @@ impl VirtioDevice for VirtioPlan9Device {
 
 #[derive(InspectMut)]
 struct Plan9Worker {
-    mem: GuestMemory,
     #[inspect(skip)]
     fs: Plan9FileSystem,
 }
@@ -153,6 +157,7 @@ struct Plan9Worker {
 #[derive(InspectMut)]
 struct Plan9Queue {
     queue: VirtioQueue,
+    mem: GuestMemory,
 }
 
 impl InspectTaskMut<Plan9Queue> for Plan9Worker {
@@ -172,7 +177,7 @@ impl AsyncRun<Plan9Queue> for Plan9Worker {
             let Some(work) = work else { break };
             match work {
                 Ok(work) => {
-                    process_9p_request(self, work);
+                    process_9p_request(&state.mem, &self.fs, work);
                 }
                 Err(err) => {
                     tracing::error!(error = &err as &dyn std::error::Error, "queue error");
@@ -184,10 +189,10 @@ impl AsyncRun<Plan9Queue> for Plan9Worker {
     }
 }
 
-fn process_9p_request(worker: &Plan9Worker, mut work: VirtioQueueCallbackWork) {
+fn process_9p_request(mem: &GuestMemory, fs: &Plan9FileSystem, mut work: VirtioQueueCallbackWork) {
     // Make a copy of the incoming message.
     let mut message = vec![0; work.get_payload_length(false) as usize];
-    if let Err(e) = work.read(&worker.mem, &mut message) {
+    if let Err(e) = work.read(mem, &mut message) {
         tracing::error!(
             error = &e as &dyn std::error::Error,
             "[VIRTIO 9P] Failed to read guest memory"
@@ -197,9 +202,9 @@ fn process_9p_request(worker: &Plan9Worker, mut work: VirtioQueueCallbackWork) {
 
     // Allocate a temporary buffer for the response.
     let mut response = vec![9; work.get_payload_length(true) as usize];
-    if let Ok(size) = worker.fs.process_message(&message, &mut response) {
+    if let Ok(size) = fs.process_message(&message, &mut response) {
         // Write out the response.
-        if let Err(e) = work.write(&worker.mem, &response[0..size]) {
+        if let Err(e) = work.write(mem, &response[0..size]) {
             tracing::error!(
                 error = &e as &dyn std::error::Error,
                 "[VIRTIO 9P] Failed to write guest memory"

--- a/vm/devices/virtio/virtio_p9/src/resolver.rs
+++ b/vm/devices/virtio/virtio_p9/src/resolver.rs
@@ -33,7 +33,6 @@ impl ResolveResource<VirtioDeviceHandle, VirtioPlan9Handle> for VirtioPlan9Resol
             input.driver_source,
             &resource.tag,
             Plan9FileSystem::new(&resource.root_path, resource.debug)?,
-            input.guest_memory.clone(),
         );
         Ok(device.into())
     }

--- a/vm/devices/virtio/virtio_pmem/src/lib.rs
+++ b/vm/devices/virtio/virtio_pmem/src/lib.rs
@@ -42,7 +42,6 @@ pub struct Device {
 impl Device {
     pub fn new(
         driver_source: &VmTaskDriverSource,
-        memory: GuestMemory,
         file: fs::File,
         writable: bool,
     ) -> anyhow::Result<Self> {
@@ -52,11 +51,7 @@ impl Device {
             .context("failed to create file mapping")?;
         Ok(Self {
             driver: driver_source.simple(),
-            worker: TaskControl::new(PmemWorker {
-                writable,
-                file,
-                mem: memory,
-            }),
+            worker: TaskControl::new(PmemWorker { writable, file }),
             mappable,
             len,
             writable,
@@ -117,7 +112,7 @@ impl VirtioDevice for Device {
         let queue = VirtioQueue::new(
             features.clone(),
             resources.params,
-            self.worker.task().mem.clone(),
+            resources.guest_memory.clone(),
             resources.notify,
             queue_event,
             initial_state,
@@ -127,7 +122,10 @@ impl VirtioDevice for Device {
         self.worker.insert(
             self.driver.clone(),
             "virtio-pmem-queue",
-            PmemQueue { queue },
+            PmemQueue {
+                queue,
+                mem: resources.guest_memory,
+            },
         );
         self.worker.start();
         Ok(())
@@ -152,7 +150,6 @@ impl VirtioDevice for Device {
 struct PmemWorker {
     writable: bool,
     file: fs::File,
-    mem: GuestMemory,
 }
 
 impl InspectTaskMut<PmemQueue> for PmemWorker {
@@ -164,6 +161,7 @@ impl InspectTaskMut<PmemQueue> for PmemWorker {
 #[derive(InspectMut)]
 struct PmemQueue {
     queue: VirtioQueue,
+    mem: GuestMemory,
 }
 
 impl AsyncRun<PmemQueue> for PmemWorker {
@@ -177,7 +175,7 @@ impl AsyncRun<PmemQueue> for PmemWorker {
             let Some(work) = work else { break };
             match work {
                 Ok(work) => {
-                    process_pmem_request(self, work);
+                    process_pmem_request(self, &state.mem, work);
                 }
                 Err(err) => {
                     tracing::error!(error = &err as &dyn std::error::Error, "queue error");
@@ -189,9 +187,9 @@ impl AsyncRun<PmemQueue> for PmemWorker {
     }
 }
 
-fn process_pmem_request(worker: &PmemWorker, mut work: VirtioQueueCallbackWork) {
+fn process_pmem_request(worker: &PmemWorker, mem: &GuestMemory, mut work: VirtioQueueCallbackWork) {
     let mut req = [0; 4];
-    let err = match work.read(&worker.mem, &mut req) {
+    let err = match work.read(mem, &mut req) {
         Ok(_) => match u32::from_le_bytes(req) {
             0 if !worker.writable => {
                 // Ignore the request for read-only devices.
@@ -214,6 +212,6 @@ fn process_pmem_request(worker: &PmemWorker, mut work: VirtioQueueCallbackWork) 
             1
         }
     };
-    let _ = work.write(&worker.mem, &u32::to_le_bytes(err));
+    let _ = work.write(mem, &u32::to_le_bytes(err));
     work.complete(4);
 }

--- a/vm/devices/virtio/virtio_pmem/src/resolver.rs
+++ b/vm/devices/virtio/virtio_pmem/src/resolver.rs
@@ -29,6 +29,6 @@ impl ResolveResource<VirtioDeviceHandle, VirtioPmemHandle> for VirtioPmemResolve
         input: VirtioResolveInput<'_>,
     ) -> Result<Self::Output, Self::Error> {
         let file = fs_err::File::open(resource.path)?.into();
-        Ok(Device::new(input.driver_source, input.guest_memory.clone(), file, false)?.into())
+        Ok(Device::new(input.driver_source, file, false)?.into())
     }
 }

--- a/vm/devices/virtio/virtio_rng/src/lib.rs
+++ b/vm/devices/virtio/virtio_rng/src/lib.rs
@@ -45,10 +45,10 @@ pub struct VirtioRngDevice {
 }
 
 impl VirtioRngDevice {
-    pub fn new(driver_source: &VmTaskDriverSource, memory: GuestMemory) -> Self {
+    pub fn new(driver_source: &VmTaskDriverSource) -> Self {
         Self {
             driver: driver_source.simple(),
-            worker: TaskControl::new(RngWorker { mem: memory }),
+            worker: TaskControl::new(RngWorker),
         }
     }
 }
@@ -84,15 +84,21 @@ impl VirtioDevice for VirtioRngDevice {
         let queue = VirtioQueue::new(
             features.clone(),
             resources.params,
-            self.worker.task().mem.clone(),
+            resources.guest_memory.clone(),
             resources.notify,
             queue_event,
             initial_state,
         )
         .context("failed to create virtio queue")?;
 
-        self.worker
-            .insert(self.driver.clone(), "virtio-rng-queue", RngQueue { queue });
+        self.worker.insert(
+            self.driver.clone(),
+            "virtio-rng-queue",
+            RngQueue {
+                queue,
+                mem: resources.guest_memory,
+            },
+        );
         self.worker.start();
         Ok(())
     }
@@ -113,13 +119,12 @@ impl VirtioDevice for VirtioRngDevice {
 }
 
 #[derive(InspectMut)]
-struct RngWorker {
-    mem: GuestMemory,
-}
+struct RngWorker;
 
 #[derive(InspectMut)]
 struct RngQueue {
     queue: VirtioQueue,
+    mem: GuestMemory,
 }
 
 impl InspectTaskMut<RngQueue> for RngWorker {
@@ -143,7 +148,7 @@ impl AsyncRun<RngQueue> for RngWorker {
             let Some(work) = work else { break };
             match work {
                 Ok(work) => {
-                    process_rng_request(&self.mem, work);
+                    process_rng_request(&state.mem, work);
                 }
                 Err(err) => {
                     tracelimit::error_ratelimited!(
@@ -299,7 +304,7 @@ mod tests {
             init_rings(&mem);
 
             let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
-            let device = VirtioRngDevice::new(&driver_source, mem.clone());
+            let device = VirtioRngDevice::new(&driver_source);
             let queue_event = Event::new();
             let interrupt_event = Event::new();
 
@@ -330,6 +335,7 @@ mod tests {
                         },
                         notify: interrupt,
                         event: self.queue_event.clone(),
+                        guest_memory: self.mem.clone(),
                     },
                     &VirtioDeviceFeatures::new(),
                     None,

--- a/vm/devices/virtio/virtio_rng/src/resolver.rs
+++ b/vm/devices/virtio/virtio_rng/src/resolver.rs
@@ -28,7 +28,7 @@ impl ResolveResource<VirtioDeviceHandle, VirtioRngHandle> for VirtioRngResolver 
         _resource: VirtioRngHandle,
         input: VirtioResolveInput<'_>,
     ) -> Result<Self::Output, Self::Error> {
-        let device = VirtioRngDevice::new(input.driver_source, input.guest_memory.clone());
+        let device = VirtioRngDevice::new(input.driver_source);
         Ok(device.into())
     }
 }

--- a/vm/devices/virtio/virtiofs/src/resolver.rs
+++ b/vm/devices/virtio/virtiofs/src/resolver.rs
@@ -42,7 +42,6 @@ impl ResolveResource<VirtioDeviceHandle, VirtioFsHandle> for VirtioFsResolver {
                     root_path,
                     Some(&LxVolumeOptions::from_option_string(mount_options)),
                 )?,
-                input.guest_memory.clone(),
                 0,
                 None,
             ),
@@ -52,7 +51,6 @@ impl ResolveResource<VirtioDeviceHandle, VirtioFsHandle> for VirtioFsResolver {
                     input.driver_source,
                     &resource.tag,
                     crate::SectionFs::new(root_path)?,
-                    input.guest_memory.clone(),
                     8 * 1024 * 1024 * 1024, // 8GB of shared memory,
                     None,
                 )

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -47,7 +47,6 @@ pub struct VirtioFsDevice {
     driver: VmTaskDriver,
     #[inspect(skip)]
     config: VirtioFsDeviceConfig,
-    mem: GuestMemory,
     #[inspect(skip)]
     fs: Arc<fuse::Session>,
     #[inspect(skip)]
@@ -65,7 +64,6 @@ impl VirtioFsDevice {
         driver_source: &VmTaskDriverSource,
         tag: &str,
         fs: Fs,
-        memory: GuestMemory,
         shmem_size: u64,
         notify_corruption: Option<Arc<dyn Fn() + Sync + Send>>,
     ) -> Self
@@ -91,7 +89,6 @@ impl VirtioFsDevice {
             task_name: format!("virtiofs-{}", tag).into(),
             driver: driver_source.simple(),
             config,
-            mem: memory,
             fs: Arc::new(fuse::Session::new(fs)),
             workers: Vec::new(),
             shmem_size,
@@ -150,7 +147,6 @@ impl VirtioDevice for VirtioFsDevice {
     ) -> anyhow::Result<()> {
         let mut tc = TaskControl::new(VirtioFsWorker {
             fs: self.fs.clone(),
-            mem: self.mem.clone(),
             shared_memory_region: self.shared_memory_region.clone(),
             shared_memory_size: self.shmem_size,
             notify_corruption: self.notify_corruption.clone(),
@@ -161,7 +157,7 @@ impl VirtioDevice for VirtioFsDevice {
         let queue = VirtioQueue::new(
             features.clone(),
             resources.params,
-            self.mem.clone(),
+            resources.guest_memory.clone(),
             resources.notify,
             queue_event,
             initial_state,
@@ -171,7 +167,10 @@ impl VirtioDevice for VirtioFsDevice {
         tc.insert(
             self.driver.clone(),
             &*self.task_name,
-            VirtioFsQueue { queue },
+            VirtioFsQueue {
+                queue,
+                mem: resources.guest_memory,
+            },
         );
         tc.start();
 
@@ -180,7 +179,6 @@ impl VirtioDevice for VirtioFsDevice {
             self.workers.resize_with(idx + 1, || {
                 TaskControl::new(VirtioFsWorker {
                     fs: self.fs.clone(),
-                    mem: self.mem.clone(),
                     shared_memory_region: None,
                     shared_memory_size: 0,
                     notify_corruption: self.notify_corruption.clone(),
@@ -218,7 +216,6 @@ impl VirtioDevice for VirtioFsDevice {
 
 struct VirtioFsWorker {
     fs: Arc<fuse::Session>,
-    mem: GuestMemory,
     shared_memory_region: Option<Arc<dyn MappedMemoryRegion>>,
     shared_memory_size: u64,
     notify_corruption: Arc<dyn Fn() + Sync + Send>,
@@ -226,6 +223,7 @@ struct VirtioFsWorker {
 
 struct VirtioFsQueue {
     queue: VirtioQueue,
+    mem: GuestMemory,
 }
 
 impl AsyncRun<VirtioFsQueue> for VirtioFsWorker {
@@ -239,7 +237,7 @@ impl AsyncRun<VirtioFsQueue> for VirtioFsWorker {
             let Some(work) = work else { break };
             match work {
                 Ok(work) => {
-                    process_virtiofs_request(self, work);
+                    process_virtiofs_request(self, &state.mem, work);
                 }
                 Err(err) => {
                     tracing::error!(
@@ -254,9 +252,13 @@ impl AsyncRun<VirtioFsQueue> for VirtioFsWorker {
     }
 }
 
-fn process_virtiofs_request(worker: &VirtioFsWorker, mut work: VirtioQueueCallbackWork) {
+fn process_virtiofs_request(
+    worker: &VirtioFsWorker,
+    mem: &GuestMemory,
+    mut work: VirtioQueueCallbackWork,
+) {
     // Parse the request.
-    let reader = VirtioPayloadReader::new(&worker.mem, &work);
+    let reader = VirtioPayloadReader::new(mem, &work);
     let request = match fuse::Request::new(reader) {
         Ok(request) => request,
         Err(e) => {
@@ -274,10 +276,7 @@ fn process_virtiofs_request(worker: &VirtioFsWorker, mut work: VirtioQueueCallba
     };
 
     // Dispatch to the file system.
-    let mut sender = VirtioReplySender {
-        work,
-        mem: &worker.mem,
-    };
+    let mut sender = VirtioReplySender { work, mem };
     let mapper = worker
         .shared_memory_region
         .as_ref()


### PR DESCRIPTION
Move GuestMemory from virtio device construction time to queue start time. This allows the transport to provide the correct GuestMemory at the point where it's actually needed (when queues are activated), rather than requiring it up front.

This is useful in particular for vhost-user, where the memory cannot be provided until the VMM actually attaches.