### PR TITLE
virtio_spec: extract virtio::spec into standalone crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8953,14 +8953,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitfield-struct 0.11.0",
  "chipset_device",
  "device_emulators",
  "futures",
  "guestmem",
  "inspect",
  "mesh",
- "open_enum",
  "pal_async",
  "pal_event",
  "parking_lot",
@@ -8972,6 +8970,7 @@ dependencies = [
  "tracelimit",
  "tracing",
  "virtio_resources",
+ "virtio_spec",
  "vm_resource",
  "vmcore",
  "zerocopy",
@@ -9126,6 +9125,16 @@ dependencies = [
  "virtio_resources",
  "vm_resource",
  "vmcore",
+]
+
+[[package]]
+name = "virtio_spec"
+version = "0.0.0"
+dependencies = [
+ "bitfield-struct 0.11.0",
+ "inspect",
+ "open_enum",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,6 +342,7 @@ video_core = { path = "vm/devices/video_core" }
 vga = { path = "vm/devices/vga" }
 vga_proxy = { path = "vm/devices/vga_proxy" }
 virtio = { path = "vm/devices/virtio/virtio" }
+virtio_spec = { path = "vm/devices/virtio/virtio_spec" }
 virtio_blk = { path = "vm/devices/virtio/virtio_blk" }
 virtio_console = { path = "vm/devices/virtio/virtio_console" }
 virtio_p9 = { path = "vm/devices/virtio/virtio_p9" }

--- a/vm/devices/virtio/virtio/Cargo.toml
+++ b/vm/devices/virtio/virtio/Cargo.toml
@@ -11,6 +11,7 @@ device_emulators.workspace = true
 pci_core.workspace = true
 pci_resources.workspace = true
 virtio_resources.workspace = true
+virtio_spec.workspace = true
 
 chipset_device.workspace = true
 guestmem.workspace = true
@@ -26,9 +27,7 @@ tracelimit.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
-bitfield-struct.workspace = true
 futures.workspace = true
-open_enum.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -10,6 +10,7 @@ use crate::queue::QueueWork;
 use crate::queue::VirtioQueuePayload;
 use crate::queue::new_queue;
 use crate::spec::VirtioDeviceFeatures;
+use crate::spec::VirtioDeviceType;
 use futures::FutureExt;
 use futures::Stream;
 use guestmem::DoorbellRegistration;
@@ -446,13 +447,25 @@ pub struct DeviceTraitsSharedMemory {
     pub size: u64,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct DeviceTraits {
-    pub device_id: u16,
+    pub device_id: VirtioDeviceType,
     pub device_features: VirtioDeviceFeatures,
     pub max_queues: u16,
     pub device_register_length: u32,
     pub shared_memory: DeviceTraitsSharedMemory,
+}
+
+impl Default for DeviceTraits {
+    fn default() -> Self {
+        Self {
+            device_id: VirtioDeviceType(0),
+            device_features: Default::default(),
+            max_queues: 0,
+            device_register_length: 0,
+            shared_memory: Default::default(),
+        }
+    }
 }
 
 pub struct QueueResources {

--- a/vm/devices/virtio/virtio/src/lib.rs
+++ b/vm/devices/virtio/virtio/src/lib.rs
@@ -10,7 +10,6 @@ pub mod device;
 pub mod queue;
 pub mod resolve;
 pub mod resolver;
-pub mod spec;
 mod tests;
 pub mod transport;
 
@@ -18,5 +17,6 @@ pub use common::*;
 pub use device::DynVirtioDevice;
 pub use device::VirtioDevice;
 pub use transport::*;
+pub use virtio_spec as spec;
 
 pub const QUEUE_MAX_SIZE: u16 = 0x40; // TODO: make queue size configurable

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -1402,7 +1402,7 @@ impl VirtioPciTestDevice {
             Box::new(TestDevice::new(
                 &driver_source,
                 DeviceTraits {
-                    device_id: 3,
+                    device_id: VirtioDeviceType::CONSOLE,
                     device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                     max_queues: num_queues,
                     device_register_length: 12,
@@ -1453,7 +1453,7 @@ async fn verify_chipset_config(driver: DefaultDriver) {
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues: 1,
                 device_register_length: 0,
@@ -2541,7 +2541,7 @@ async fn verify_device_queue_simple_inner(
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: features.clone(),
                 max_queues: 1,
                 device_register_length: 0,
@@ -2627,7 +2627,7 @@ async fn verify_device_multi_queue_inner(
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: features.clone(),
                 max_queues: num_queues + 1,
                 device_register_length: 0,
@@ -2793,7 +2793,7 @@ async fn verify_enable_failure_mmio_does_not_set_driver_ok(_driver: DefaultDrive
     let mut dev = VirtioMmioDevice::new(
         Box::new(FailingTestDevice {
             traits: DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues: 1,
                 device_register_length: 0,
@@ -2843,7 +2843,7 @@ async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver
     let mut dev = VirtioPciDevice::new(
         Box::new(FailingTestDevice {
             traits: DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues: 1,
                 device_register_length: 12,
@@ -3524,7 +3524,7 @@ impl PartialFailTestDevice {
     fn new(max_queues: u16, fail_at: u16) -> Self {
         Self {
             traits: DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues,
                 device_register_length: 0,
@@ -3954,7 +3954,7 @@ async fn pci_intx_line_deasserted_on_reset(driver: DefaultDriver) {
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues: 1,
                 device_register_length: 12,
@@ -4133,7 +4133,7 @@ async fn mmio_save_restore_round_trip(driver: DefaultDriver) {
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues: 1,
                 device_register_length: 0,
@@ -4167,7 +4167,7 @@ async fn mmio_save_restore_round_trip(driver: DefaultDriver) {
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues: 1,
                 device_register_length: 0,
@@ -4222,7 +4222,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new(), // no device-specific features
                 max_queues: 1,
                 device_register_length: 12,
@@ -4256,7 +4256,7 @@ async fn pci_save_not_supported_device(_driver: DefaultDriver) {
     let mut dev = VirtioPciDevice::new(
         Box::new(FailingTestDevice {
             traits: DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new(),
                 max_queues: 1,
                 device_register_length: 0,
@@ -4284,7 +4284,7 @@ async fn mmio_save_not_supported_device(_driver: DefaultDriver) {
     let mut dev = VirtioMmioDevice::new(
         Box::new(FailingTestDevice {
             traits: DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new(),
                 max_queues: 1,
                 device_register_length: 0,
@@ -4375,7 +4375,7 @@ async fn mmio_restore_reinstalls_doorbells(driver: DefaultDriver) {
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues: 1,
                 device_register_length: 0,
@@ -4411,7 +4411,7 @@ async fn mmio_restore_reinstalls_doorbells(driver: DefaultDriver) {
         Box::new(TestDevice::new(
             &driver_source,
             DeviceTraits {
-                device_id: 3,
+                device_id: VirtioDeviceType::CONSOLE,
                 device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
                 max_queues: 1,
                 device_register_length: 0,

--- a/vm/devices/virtio/virtio/src/transport/mmio.rs
+++ b/vm/devices/virtio/virtio/src/transport/mmio.rs
@@ -158,7 +158,7 @@ impl VirtioMmioDevice {
             device_sender: sender,
             _device_task,
             state: TransportState::Ready,
-            device_id: traits.device_id as u32,
+            device_id: traits.device_id.0 as u32,
             vendor_id: 0x1af4,
             device_feature,
             device_feature_select: 0,

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -147,7 +147,7 @@ impl VirtioPciDevice {
 
         let hardware_ids = HardwareIds {
             vendor_id: VIRTIO_VENDOR_ID,
-            device_id: VIRTIO_PCI_DEVICE_ID_BASE + traits.device_id,
+            device_id: VIRTIO_PCI_DEVICE_ID_BASE + traits.device_id.0,
             revision_id: 1,
             prog_if: ProgrammingInterface::NONE,
             base_class: ClassCode::BASE_SYSTEM_PERIPHERAL,

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -314,7 +314,7 @@ impl VirtioDevice for VirtioBlkDevice {
         }
 
         DeviceTraits {
-            device_id: VIRTIO_BLK_DEVICE_ID,
+            device_id: virtio::spec::VirtioDeviceType::BLK,
             device_features: VirtioDeviceFeatures::new()
                 .with_bank0(VirtioDeviceFeaturesBank0::new().with_device_specific(features)),
             max_queues: 1,

--- a/vm/devices/virtio/virtio_blk/src/spec.rs
+++ b/vm/devices/virtio/virtio_blk/src/spec.rs
@@ -17,9 +17,6 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
-/// Virtio block device ID (spec §5.2.1).
-pub const VIRTIO_BLK_DEVICE_ID: u16 = 2;
-
 // Feature bits (spec §5.2.3). These are device-specific bits in bank 0 (bits 0..23).
 /// Maximum size of any single segment is in `size_max`.
 pub const VIRTIO_BLK_F_SIZE_MAX: u32 = 1 << 1;

--- a/vm/devices/virtio/virtio_console/src/lib.rs
+++ b/vm/devices/virtio/virtio_console/src/lib.rs
@@ -44,7 +44,6 @@ use guestmem::GuestMemory;
 use inspect::InspectMut;
 use serial_core::SerialIo;
 use spec::VIRTIO_CONSOLE_F_SIZE;
-use spec::VIRTIO_DEVICE_ID_CONSOLE;
 use spec::VirtioConsoleConfig;
 use std::future::poll_fn;
 use std::pin::Pin;
@@ -94,7 +93,7 @@ impl VirtioDevice for VirtioConsoleDevice {
         let mut features = VirtioDeviceFeatures::new();
         features.set_bank(0, 1 << VIRTIO_CONSOLE_F_SIZE);
         DeviceTraits {
-            device_id: VIRTIO_DEVICE_ID_CONSOLE,
+            device_id: virtio::spec::VirtioDeviceType::CONSOLE,
             device_features: features,
             max_queues: 2, // receiveq (0) + transmitq (1)
             device_register_length: size_of::<VirtioConsoleConfig>() as u32,

--- a/vm/devices/virtio/virtio_console/src/spec.rs
+++ b/vm/devices/virtio/virtio_console/src/spec.rs
@@ -3,9 +3,6 @@
 
 //! Virtio console spec constants and configuration types.
 
-/// Virtio console device ID.
-pub const VIRTIO_DEVICE_ID_CONSOLE: u16 = 3;
-
 /// Feature bit: console size (cols, rows) is available in config space.
 pub const VIRTIO_CONSOLE_F_SIZE: u64 = 0;
 

--- a/vm/devices/virtio/virtio_console/src/tests.rs
+++ b/vm/devices/virtio/virtio_console/src/tests.rs
@@ -722,7 +722,7 @@ async fn traits_are_correct(driver: DefaultDriver) {
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
     let device = VirtioConsoleDevice::new(&driver_source, mem, Box::new(io));
     let traits = device.traits();
-    assert_eq!(traits.device_id, 3); // VIRTIO_DEVICE_ID_CONSOLE
+    assert_eq!(traits.device_id, virtio::spec::VirtioDeviceType::CONSOLE);
     assert_eq!(traits.max_queues, 2); // receiveq + transmitq
 }
 

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -270,7 +270,7 @@ impl VirtioDevice for Device {
             .with_host_tso6(host_tso6);
 
         DeviceTraits {
-            device_id: 1,
+            device_id: virtio::spec::VirtioDeviceType::NET,
             device_features: VirtioDeviceFeatures::new().with_bank(0, features_bank0.into_bits()),
             max_queues: 2 * self.registers.max_virtqueue_pairs,
             device_register_length: size_of::<NetConfig>() as u32,

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -28,8 +28,6 @@ use virtio::spec::VirtioDeviceFeatures;
 use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
 
-const VIRTIO_DEVICE_TYPE_9P_TRANSPORT: u16 = 9;
-
 const VIRTIO_9P_F_MOUNT_TAG: u32 = 1;
 
 #[derive(InspectMut)]
@@ -73,7 +71,7 @@ impl VirtioPlan9Device {
 impl VirtioDevice for VirtioPlan9Device {
     fn traits(&self) -> DeviceTraits {
         DeviceTraits {
-            device_id: VIRTIO_DEVICE_TYPE_9P_TRANSPORT,
+            device_id: virtio::spec::VirtioDeviceType::P9,
             device_features: VirtioDeviceFeatures::new().with_bank(0, VIRTIO_9P_F_MOUNT_TAG),
             max_queues: 1,
             device_register_length: self.tag.len() as u32,

--- a/vm/devices/virtio/virtio_pmem/src/lib.rs
+++ b/vm/devices/virtio/virtio_pmem/src/lib.rs
@@ -73,7 +73,7 @@ struct PmemConfig {
 impl VirtioDevice for Device {
     fn traits(&self) -> DeviceTraits {
         DeviceTraits {
-            device_id: 27,
+            device_id: virtio::spec::VirtioDeviceType::PMEM,
             device_features: VirtioDeviceFeatures::new(),
             max_queues: 1,
             device_register_length: size_of::<PmemConfig>() as u32,

--- a/vm/devices/virtio/virtio_rng/src/lib.rs
+++ b/vm/devices/virtio/virtio_rng/src/lib.rs
@@ -35,8 +35,6 @@ use virtio::spec::VirtioDeviceFeatures;
 use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
 
-const VIRTIO_RNG_DEVICE_ID: u16 = 4;
-
 #[derive(InspectMut)]
 pub struct VirtioRngDevice {
     driver: VmTaskDriver,
@@ -56,7 +54,7 @@ impl VirtioRngDevice {
 impl VirtioDevice for VirtioRngDevice {
     fn traits(&self) -> DeviceTraits {
         DeviceTraits {
-            device_id: VIRTIO_RNG_DEVICE_ID,
+            device_id: virtio::spec::VirtioDeviceType::RNG,
             device_features: VirtioDeviceFeatures::new(),
             max_queues: 1,
             device_register_length: 0,
@@ -404,7 +402,7 @@ mod tests {
     async fn rng_reports_correct_traits(driver: DefaultDriver) {
         let harness = TestHarness::new(&driver);
         let traits = harness.device.traits();
-        assert_eq!(traits.device_id, 4);
+        assert_eq!(traits.device_id, virtio::spec::VirtioDeviceType::RNG);
         assert_eq!(traits.max_queues, 1);
         assert_eq!(traits.device_register_length, 0);
     }

--- a/vm/devices/virtio/virtio_spec/Cargo.toml
+++ b/vm/devices/virtio/virtio_spec/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "virtio_spec"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+inspect.workspace = true
+
+bitfield-struct.workspace = true
+open_enum.workspace = true
+zerocopy.workspace = true
+
+[lints]
+workspace = true

--- a/vm/devices/virtio/virtio_spec/src/lib.rs
+++ b/vm/devices/virtio/virtio_spec/src/lib.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Constants defined by the virtio spec
+//! Types and constants defined by the virtio specification.
+//!
+//! Reference: <https://docs.oasis-open.org/virtio/virtio/v1.2/virtio-v1.2.html>
+
+#![expect(missing_docs)]
 
 use bitfield_struct::bitfield;
 use inspect::Inspect;
@@ -119,6 +123,21 @@ pub struct VirtioDeviceStatus {
 impl VirtioDeviceStatus {
     pub fn as_u32(&self) -> u32 {
         self.into_bits() as u32
+    }
+}
+
+open_enum::open_enum! {
+    /// Virtio device type IDs as defined by the virtio specification.
+    ///
+    /// Reference: <https://docs.oasis-open.org/virtio/virtio/v1.2/virtio-v1.2.html> §5
+    pub enum VirtioDeviceType: u16 {
+        NET = 1,
+        BLK = 2,
+        CONSOLE = 3,
+        RNG = 4,
+        P9 = 9,
+        FS = 26,
+        PMEM = 27,
     }
 }
 

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -30,8 +30,6 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
-const VIRTIO_DEVICE_TYPE_FS: u16 = 26;
-
 /// PCI configuration space values for virtio-fs devices.
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
@@ -104,7 +102,7 @@ impl VirtioFsDevice {
 impl VirtioDevice for VirtioFsDevice {
     fn traits(&self) -> DeviceTraits {
         DeviceTraits {
-            device_id: VIRTIO_DEVICE_TYPE_FS,
+            device_id: virtio::spec::VirtioDeviceType::FS,
             device_features: VirtioDeviceFeatures::new(),
             max_queues: 2,
             device_register_length: self.config.as_bytes().len() as u32,


### PR DESCRIPTION
Move the virtio specification constants and types (VirtioDeviceType, VirtioDeviceFeatures, VirtioDeviceStatus, PCI/MMIO register offsets, queue structures) into a new virtio_spec crate.

Re-export as 'pub use virtio_spec as spec' from the virtio crate so all existing virtio::spec::* paths continue to work.

Also change DeviceTraits::device_id from u16 to VirtioDeviceType for type safety.