### PR TITLE
pcie: implement save/restore for PCIe infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5769,6 +5769,7 @@ dependencies = [
  "chipset_device",
  "inspect",
  "memory_range",
+ "mesh",
  "pal_async",
  "pci_bus",
  "pci_core",

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -45,18 +45,14 @@ impl PetriVmConfigOpenVmm {
             framebuffer_view,
         } = self;
 
-        let has_pcie = !config.pcie_root_complexes.is_empty();
-
         // TODO: OpenHCL needs virt_whp support
         // TODO: PCAT needs vga device support
         // TODO: arm64 is broken?
         // TODO: VPCI and NVMe don't support save/restore
-        // TODO: PCIe emulators don't support save/restore yet
         let supports_save_restore = !resources.properties.is_openhcl
             && !resources.properties.is_pcat
             && !matches!(arch, MachineArch::Aarch64)
-            && !resources.properties.using_vpci
-            && !has_pcie;
+            && !resources.properties.using_vpci;
 
         // Add the GED and VTL 2 settings.
         if let Some(mut ged) = ged {

--- a/vm/devices/pci/pci_core/src/capabilities/pci_express.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/pci_express.rs
@@ -583,7 +583,29 @@ mod save_restore {
             #[mesh(2)]
             pub device_status: u16,
             #[mesh(3)]
-            pub flr_handler: u16,
+            pub link_control: u16,
+            #[mesh(4)]
+            pub link_status: u16,
+            #[mesh(5)]
+            pub slot_control: u16,
+            #[mesh(6)]
+            pub slot_status: u16,
+            #[mesh(7)]
+            pub root_control: u16,
+            #[mesh(8)]
+            pub root_status: u32,
+            #[mesh(9)]
+            pub device_control_2: u16,
+            #[mesh(10)]
+            pub device_status_2: u16,
+            #[mesh(11)]
+            pub link_control_2: u16,
+            #[mesh(12)]
+            pub link_status_2: u16,
+            #[mesh(13)]
+            pub slot_control_2: u16,
+            #[mesh(14)]
+            pub slot_status_2: u16,
         }
     }
 
@@ -591,11 +613,59 @@ mod save_restore {
         type SavedState = state::SavedState;
 
         fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-            Err(SaveError::NotSupported)
+            let state = self.state.lock();
+            Ok(state::SavedState {
+                device_control: state.device_control.into_bits(),
+                device_status: state.device_status.into_bits(),
+                link_control: state.link_control.into_bits(),
+                link_status: state.link_status.into_bits(),
+                slot_control: state.slot_control.into_bits(),
+                slot_status: state.slot_status.into_bits(),
+                root_control: state.root_control.into_bits(),
+                root_status: state.root_status.into_bits(),
+                device_control_2: state.device_control_2.into_bits(),
+                device_status_2: state.device_status_2.into_bits(),
+                link_control_2: state.link_control_2.into_bits(),
+                link_status_2: state.link_status_2.into_bits(),
+                slot_control_2: state.slot_control_2.into_bits(),
+                slot_status_2: state.slot_status_2.into_bits(),
+            })
         }
 
-        fn restore(&mut self, _: Self::SavedState) -> Result<(), RestoreError> {
-            Err(RestoreError::SavedStateNotSupported)
+        fn restore(&mut self, saved_state: Self::SavedState) -> Result<(), RestoreError> {
+            let state::SavedState {
+                device_control,
+                device_status,
+                link_control,
+                link_status,
+                slot_control,
+                slot_status,
+                root_control,
+                root_status,
+                device_control_2,
+                device_status_2,
+                link_control_2,
+                link_status_2,
+                slot_control_2,
+                slot_status_2,
+            } = saved_state;
+
+            let mut state = self.state.lock();
+            state.device_control = pci_express::DeviceControl::from_bits(device_control);
+            state.device_status = pci_express::DeviceStatus::from_bits(device_status);
+            state.link_control = pci_express::LinkControl::from_bits(link_control);
+            state.link_status = pci_express::LinkStatus::from_bits(link_status);
+            state.slot_control = pci_express::SlotControl::from_bits(slot_control);
+            state.slot_status = pci_express::SlotStatus::from_bits(slot_status);
+            state.root_control = pci_express::RootControl::from_bits(root_control);
+            state.root_status = pci_express::RootStatus::from_bits(root_status);
+            state.device_control_2 = pci_express::DeviceControl2::from_bits(device_control_2);
+            state.device_status_2 = pci_express::DeviceStatus2::from_bits(device_status_2);
+            state.link_control_2 = pci_express::LinkControl2::from_bits(link_control_2);
+            state.link_status_2 = pci_express::LinkStatus2::from_bits(link_status_2);
+            state.slot_control_2 = pci_express::SlotControl2::from_bits(slot_control_2);
+            state.slot_status_2 = pci_express::SlotStatus2::from_bits(slot_status_2);
+            Ok(())
         }
     }
 }
@@ -1448,5 +1518,63 @@ mod tests {
         // Should not panic and should be silently ignored
         cap.set_presence_detect_state(true);
         cap.set_presence_detect_state(false);
+    }
+
+    #[test]
+    fn test_save_restore_roundtrip() {
+        use vmcore::save_restore::SaveRestore;
+
+        let mut cap = PciExpressCapability::new(DevicePortType::RootPort, None);
+
+        // Write some values via config space to change mutable state
+        // Device Control + Status is at offset 0x08
+        cap.write_u32(0x08, 0x0010); // Set relaxed ordering enable in DeviceControl
+        // Slot Control + Status at offset 0x18
+        cap.write_u32(0x18, 0x01); // Set attention button pressed enable
+
+        let saved = cap.save().expect("save should succeed");
+
+        // Create a fresh capability and restore
+        let mut cap2 = PciExpressCapability::new(DevicePortType::RootPort, None);
+        cap2.restore(saved).expect("restore should succeed");
+
+        // Verify the restored state matches
+        assert_eq!(cap.read_u32(0x08), cap2.read_u32(0x08));
+        assert_eq!(cap.read_u32(0x18), cap2.read_u32(0x18));
+    }
+
+    #[test]
+    fn test_save_restore_all_registers() {
+        use vmcore::save_restore::SaveRestore;
+
+        let mut cap =
+            PciExpressCapability::new(DevicePortType::RootPort, None).with_hotplug_support(1);
+
+        // Modify various registers through config space writes.
+        // Device Control/Status at 0x08
+        cap.write_u32(0x08, 0x2810); // correctable error reporting + relaxed ordering
+        // Link Control/Status at 0x10
+        cap.write_u32(0x10, 0x0002); // ASPM L1
+        // Root Control at 0x1C (upper 16 bits reserved if part of Root Caps)
+        cap.write_u32(0x1C, 0x0001); // system error on correctable error enable
+        // Device Control 2 / Status 2 at 0x28
+        cap.write_u32(0x28, 0x0010); // completion timeout disable
+
+        let saved = cap.save().expect("save should succeed");
+
+        let mut cap2 =
+            PciExpressCapability::new(DevicePortType::RootPort, None).with_hotplug_support(1);
+
+        cap2.restore(saved).expect("restore should succeed");
+
+        // Compare all register offsets that contain mutable state.
+        for offset in (0x08..=0x38).step_by(4) {
+            assert_eq!(
+                cap.read_u32(offset),
+                cap2.read_u32(offset),
+                "mismatch at offset {:#x}",
+                offset
+            );
+        }
     }
 }

--- a/vm/devices/pci/pcie/Cargo.toml
+++ b/vm/devices/pci/pcie/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 anyhow.workspace = true
 chipset_device.workspace = true
 inspect.workspace = true
+mesh.workspace = true
 memory_range.workspace = true
 pal_async.workspace = true
 pci_bus.workspace = true

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -464,22 +464,68 @@ impl RootPort {
 
 mod save_restore {
     use super::*;
+    use vmcore::save_restore::ProtobufSaveRestore;
+    use vmcore::save_restore::RestoreError;
     use vmcore::save_restore::SaveError;
     use vmcore::save_restore::SaveRestore;
-    use vmcore::save_restore::SavedStateNotSupported;
 
-    impl SaveRestore for GenericPcieRootComplex {
-        type SavedState = SavedStateNotSupported;
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateBlob;
+        use vmcore::save_restore::SavedStateRoot;
 
-        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-            Err(SaveError::NotSupported)
+        /// Saved state for a single root port's configuration space.
+        #[derive(Protobuf)]
+        #[mesh(package = "pcie.root")]
+        pub struct PortSavedState {
+            /// The port number (device_function index in the ports HashMap).
+            #[mesh(1)]
+            pub port_number: u8,
+            /// The port's Type 1 configuration space state.
+            #[mesh(2)]
+            pub cfg_space: SavedStateBlob,
         }
 
-        fn restore(
-            &mut self,
-            state: Self::SavedState,
-        ) -> Result<(), vmcore::save_restore::RestoreError> {
-            match state {}
+        /// Saved state for the entire PCIe root complex.
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "pcie.root")]
+        pub struct SavedState {
+            /// Saved state for each root port.
+            #[mesh(1)]
+            pub ports: Vec<PortSavedState>,
+        }
+    }
+
+    impl SaveRestore for GenericPcieRootComplex {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            let mut ports = Vec::new();
+            for (&port_number, (_, root_port)) in self.ports.iter_mut() {
+                let cfg_space = ProtobufSaveRestore::save(&mut root_port.port.cfg_space)?;
+                ports.push(state::PortSavedState {
+                    port_number,
+                    cfg_space,
+                });
+            }
+            Ok(state::SavedState { ports })
+        }
+
+        fn restore(&mut self, saved_state: Self::SavedState) -> Result<(), RestoreError> {
+            for port_state in saved_state.ports {
+                let (_, root_port) = self.ports.get_mut(&port_state.port_number).ok_or_else(
+                    || {
+                        RestoreError::InvalidSavedState(
+                            anyhow::anyhow!(
+                                "saved state references port {:#x} which does not exist in current topology",
+                                port_state.port_number
+                            ),
+                        )
+                    },
+                )?;
+                ProtobufSaveRestore::restore(&mut root_port.port.cfg_space, port_state.cfg_space)?;
+            }
+            Ok(())
         }
     }
 }
@@ -795,5 +841,30 @@ mod tests {
             .port
             .forward_cfg_write_with_routing(&1, &0, 0x0, value);
         assert!(matches!(result, IoResult::Ok));
+    }
+
+    #[test]
+    fn test_root_complex_save_restore_roundtrip() {
+        use vmcore::save_restore::SaveRestore;
+
+        let mut rc = instantiate_root_complex(0, 255, 2);
+
+        // Program some bridge state via ECAM writes.
+        // Port 0 is at device 0 (device_function = 0x00), bus 0.
+        // Bus number register is at config offset 0x18.
+        // ECAM address: (device_function << 12) + cfg_offset
+        let addr = 0x18u64;
+        rc.mmio_write(addr, &[0x00, 0x01, 0x01, 0x00]).unwrap(); // primary=0, secondary=1, subordinate=1
+
+        let saved = rc.save().expect("save should succeed");
+
+        // Create a fresh root complex with the same topology
+        let mut rc2 = instantiate_root_complex(0, 255, 2);
+        rc2.restore(saved).expect("restore should succeed");
+
+        // Verify the bus numbers were restored
+        let mut data = [0u8; 4];
+        rc2.mmio_read(addr, &mut data).unwrap();
+        assert_eq!(data, [0x00, 0x01, 0x01, 0x00]);
     }
 }

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -447,22 +447,87 @@ impl PciConfigSpace for GenericPcieSwitch {
 
 mod save_restore {
     use super::*;
+    use vmcore::save_restore::ProtobufSaveRestore;
+    use vmcore::save_restore::RestoreError;
     use vmcore::save_restore::SaveError;
     use vmcore::save_restore::SaveRestore;
-    use vmcore::save_restore::SavedStateNotSupported;
 
-    impl SaveRestore for GenericPcieSwitch {
-        type SavedState = SavedStateNotSupported;
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateBlob;
+        use vmcore::save_restore::SavedStateRoot;
 
-        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-            Err(SaveError::NotSupported)
+        /// Saved state for a single downstream switch port.
+        #[derive(Protobuf)]
+        #[mesh(package = "pcie.switch")]
+        pub struct DownstreamPortSavedState {
+            /// The port number (index in the downstream_ports HashMap).
+            #[mesh(1)]
+            pub port_number: u8,
+            /// The port's Type 1 configuration space state.
+            #[mesh(2)]
+            pub cfg_space: SavedStateBlob,
         }
 
-        fn restore(
-            &mut self,
-            state: Self::SavedState,
-        ) -> Result<(), vmcore::save_restore::RestoreError> {
-            match state {}
+        /// Saved state for the entire PCIe switch.
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "pcie.switch")]
+        pub struct SavedState {
+            /// Saved state for the upstream port's configuration space.
+            #[mesh(1)]
+            pub upstream_cfg_space: SavedStateBlob,
+            /// Saved state for each downstream port.
+            #[mesh(2)]
+            pub downstream_ports: Vec<DownstreamPortSavedState>,
+        }
+    }
+
+    impl SaveRestore for GenericPcieSwitch {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            let upstream_cfg_space = ProtobufSaveRestore::save(&mut self.upstream_port.cfg_space)?;
+
+            let mut downstream_ports = Vec::new();
+            for (&port_number, (_, downstream_port)) in self.downstream_ports.iter_mut() {
+                let cfg_space = ProtobufSaveRestore::save(&mut downstream_port.port.cfg_space)?;
+                downstream_ports.push(state::DownstreamPortSavedState {
+                    port_number,
+                    cfg_space,
+                });
+            }
+
+            Ok(state::SavedState {
+                upstream_cfg_space,
+                downstream_ports,
+            })
+        }
+
+        fn restore(&mut self, saved_state: Self::SavedState) -> Result<(), RestoreError> {
+            ProtobufSaveRestore::restore(
+                &mut self.upstream_port.cfg_space,
+                saved_state.upstream_cfg_space,
+            )?;
+
+            for port_state in saved_state.downstream_ports {
+                let (_, downstream_port) =
+                    self.downstream_ports
+                        .get_mut(&port_state.port_number)
+                        .ok_or_else(|| {
+                            RestoreError::InvalidSavedState(
+                                anyhow::anyhow!(
+                                    "saved state references downstream port {} which does not exist in current topology",
+                                    port_state.port_number
+                                ),
+                            )
+                        })?;
+                ProtobufSaveRestore::restore(
+                    &mut downstream_port.port.cfg_space,
+                    port_state.cfg_space,
+                )?;
+            }
+
+            Ok(())
         }
     }
 }
@@ -937,5 +1002,64 @@ mod tests {
             switch_with_hotplug.name().as_ref(),
             "test-switch-with-hotplug"
         );
+    }
+
+    #[test]
+    fn test_switch_save_restore_roundtrip() {
+        use vmcore::save_restore::SaveRestore;
+
+        let mut switch = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
+            name: "test-switch".into(),
+            downstream_port_count: 2,
+            hotplug: false,
+        });
+
+        // Program upstream port bus numbers via config space write.
+        // PCI bus number register at offset 0x18.
+        switch
+            .upstream_port
+            .cfg_space
+            .write_u32(0x18, 0x0003_0200)
+            .unwrap();
+        // primary=0, secondary=2, subordinate=3
+
+        // Program downstream port 0 bus numbers.
+        let (_, ds_port_0) = switch.downstream_ports.get_mut(&0).unwrap();
+        ds_port_0
+            .port
+            .cfg_space
+            .write_u32(0x18, 0x0002_0200)
+            .unwrap();
+        // primary=2, secondary=2, subordinate=2 (just a leaf)
+
+        let saved = switch.save().expect("save should succeed");
+
+        // Create a fresh switch with the same topology
+        let mut switch2 = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
+            name: "test-switch".into(),
+            downstream_port_count: 2,
+            hotplug: false,
+        });
+
+        switch2.restore(saved).expect("restore should succeed");
+
+        // Verify upstream port bus numbers were restored
+        let mut value = 0u32;
+        switch2
+            .upstream_port
+            .cfg_space
+            .read_u32(0x18, &mut value)
+            .unwrap();
+        assert_eq!(value, 0x0003_0200);
+
+        // Verify downstream port 0 bus numbers were restored
+        let (_, ds_port_0_restored) = switch2.downstream_ports.get_mut(&0).unwrap();
+        let mut value2 = 0u32;
+        ds_port_0_restored
+            .port
+            .cfg_space
+            .read_u32(0x18, &mut value2)
+            .unwrap();
+        assert_eq!(value2, 0x0002_0200);
     }
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -177,3 +177,106 @@ async fn pcie_root_emulation(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
     vm.wait_for_clean_teardown().await?;
     Ok(())
 }
+
+/// Verify PCIe root complex state survives a save/restore cycle.
+///
+/// This test:
+/// 1. Boots a VM with a PCIe root complex and 4 root ports
+/// 2. Enumerates PCI devices visible to the guest
+/// 3. Pulses save/restore (pause → save → restore → resume)
+/// 4. Re-enumerates PCI devices and verifies they match
+#[openvmm_test(linux_direct_x64)]
+async fn pcie_save_restore(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    const ECAM_SIZE: u64 = 256 * 1024 * 1024;
+    const LOW_MMIO_SIZE: u64 = 64 * 1024 * 1024;
+    const HIGH_MMIO_SIZE: u64 = 1024 * 1024 * 1024;
+
+    let os_flavor = config.os_flavor();
+    let (mut vm, agent) = config
+        .modify_backend(|b| {
+            b.with_custom_config(|c| {
+                let low_mmio_start = c.memory.mmio_gaps[0].start();
+                let high_mmio_end = c.memory.mmio_gaps[1].end();
+                let pcie_low = MemoryRange::new(low_mmio_start - LOW_MMIO_SIZE..low_mmio_start);
+                let pcie_high = MemoryRange::new(high_mmio_end..high_mmio_end + HIGH_MMIO_SIZE);
+                let ecam_range = MemoryRange::new(pcie_low.start() - ECAM_SIZE..pcie_low.start());
+                c.memory.pci_ecam_gaps.push(ecam_range);
+                c.memory.pci_mmio_gaps.push(pcie_low);
+                c.memory.pci_mmio_gaps.push(pcie_high);
+                c.pcie_root_complexes.push(PcieRootComplexConfig {
+                    index: 0,
+                    name: "rc0".into(),
+                    segment: 0,
+                    start_bus: 0,
+                    end_bus: 255,
+                    ecam_range,
+                    low_mmio: pcie_low,
+                    high_mmio: pcie_high,
+                    ports: vec![
+                        PcieRootPortConfig {
+                            name: "rp0".into(),
+                            hotplug: false,
+                        },
+                        PcieRootPortConfig {
+                            name: "rp1".into(),
+                            hotplug: false,
+                        },
+                        PcieRootPortConfig {
+                            name: "rp2".into(),
+                            hotplug: false,
+                        },
+                        PcieRootPortConfig {
+                            name: "rp3".into(),
+                            hotplug: false,
+                        },
+                    ],
+                })
+            })
+        })
+        .run()
+        .await?;
+
+    // Snapshot pre-save PCI topology from the guest
+    let devices_before = parse_guest_pci_devices(os_flavor, &agent).await?;
+    tracing::info!(?devices_before, "PCI devices before save/restore");
+
+    let root_ports_before = devices_before
+        .iter()
+        .filter(|d| d.vendor_id == 0x1414 && d.device_id == 0xc030 && d.class_code == 0x060400)
+        .count();
+    assert_eq!(
+        root_ports_before, 4,
+        "expected 4 root ports before save/restore"
+    );
+
+    // Pulse save/restore — drop agent first (vsock won't survive)
+    drop(agent);
+    vm.backend().verify_save_restore().await?;
+
+    // Reconnect to the guest
+    let agent = vm.backend().wait_for_agent(false).await?;
+
+    // Re-enumerate and compare
+    let devices_after = parse_guest_pci_devices(os_flavor, &agent).await?;
+    tracing::info!(?devices_after, "PCI devices after save/restore");
+
+    let root_ports_after = devices_after
+        .iter()
+        .filter(|d| d.vendor_id == 0x1414 && d.device_id == 0xc030 && d.class_code == 0x060400)
+        .count();
+    assert_eq!(
+        root_ports_after, 4,
+        "expected 4 root ports after save/restore"
+    );
+
+    // Verify total device count is unchanged (no devices lost or duplicated)
+    assert_eq!(
+        devices_before.len(),
+        devices_after.len(),
+        "PCI device count changed across save/restore"
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}


### PR DESCRIPTION
Implement save/restore for the three PCIe components that previously returned SaveError::NotSupported:

- PciExpressCapability: save/restore all 14 mutable register fields from PciExpressState. The flr_handler (trait object) is not serialized; it is re-attached on topology reconstruction. Mesh index 3 is skipped for wire format compatibility.

- GenericPcieRootComplex: save/restore each root port's Type 1 configuration space via ProtobufSaveRestore, keyed by port_number.

- GenericPcieSwitch: save/restore the upstream port and all downstream port configuration spaces, also keyed by port_number.

Remove the has_pcie exclusion from petri's verify_save_restore guard and add an explicit pcie_save_restore VMM test.

Includes unit test roundtrips for all three components.