### PR TITLE
vmm_tests: storage: Increase timeout for storvsp_dynamic_add_disk

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -91,7 +91,7 @@ async fn test_storage_linux(
     controller_guid: Guid,
     expected_devices: Vec<ExpectedGuestDevice>,
 ) -> anyhow::Result<()> {
-    const DEVICE_DISCOVER_RETRIES: u32 = 10;
+    const DEVICE_DISCOVER_RETRIES: u32 = 20;
     const DEVICE_DISCOVER_SLEEP_SECS: u64 = 3;
 
     let sh = agent.unix_shell();


### PR DESCRIPTION
See Issue https://github.com/microsoft/openvmm/issues/3107

In one run, 7/8 disks appear (`sdb`-`sdh`), while the last one (`sdi`) is detected by the guest kernel (I see it in dmesg) but doesn't show up in /sys where we probe for it (and thus also not in /dev which we print just for debugging). We retry for 30 secs but it's still not there. Increase the number of retries from 10 to 20 (with 3s between retries, as before).