### PR TITLE
virtio_net: fix RX buffer capacity to exclude virtio-net header

### DIFF
--- a/vm/devices/virtio/virtio_net/src/buffers.rs
+++ b/vm/devices/virtio/virtio_net/src/buffers.rs
@@ -16,10 +16,10 @@ use virtio::VirtioQueueCallbackWork;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
 
-#[derive(Default)]
 struct RxPacket {
-    work: Option<VirtioQueueCallbackWork>,
+    work: VirtioQueueCallbackWork,
     len: u32,
+    cap: u32,
 }
 
 /// Holds virtio buffers available for a network backend to send data to the client.
@@ -28,7 +28,7 @@ struct RxPacket {
 pub struct VirtioWorkPool {
     mem: GuestMemory,
     #[inspect(skip)]
-    rx_packets: Arc<Vec<Mutex<RxPacket>>>,
+    rx_packets: Arc<Vec<Mutex<Option<RxPacket>>>>,
 }
 
 impl VirtioWorkPool {
@@ -37,7 +37,7 @@ impl VirtioWorkPool {
             "pending_rx_packets",
             self.rx_packets
                 .iter()
-                .filter(|p| p.lock().work.is_some())
+                .filter(|p| p.lock().is_some())
                 .count(),
         );
     }
@@ -46,11 +46,7 @@ impl VirtioWorkPool {
     pub fn new(mem: GuestMemory, queue_size: u16) -> Self {
         Self {
             mem,
-            rx_packets: Arc::new(
-                (0..queue_size)
-                    .map(|_| Mutex::new(RxPacket::default()))
-                    .collect(),
-            ),
+            rx_packets: Arc::new((0..queue_size).map(|_| Mutex::new(None)).collect()),
         }
     }
 
@@ -59,7 +55,7 @@ impl VirtioWorkPool {
         self.rx_packets
             .iter()
             .enumerate()
-            .filter_map(|(i, e)| e.lock().work.as_ref().map(|_| RxId(i as u32)))
+            .filter_map(|(i, e)| e.lock().as_ref().map(|_| RxId(i as u32)))
             .collect::<Vec<RxId>>()
     }
 
@@ -73,19 +69,36 @@ impl VirtioWorkPool {
     ) -> Result<RxId, VirtioQueueCallbackWork> {
         let idx = work.descriptor_index();
         let mut packet = self.rx_packets[idx as usize].lock();
-        if packet.work.is_some() {
+        if packet.is_some() {
+            tracelimit::warn_ratelimited!("dropping RX buffer: descriptor index already in use");
             return Err(work);
         }
-        packet.work = Some(work);
-        packet.len = 0;
+        let payload_length = work.get_payload_length(true) as u32;
+        let Some(cap) = payload_length.checked_sub(header_size() as u32) else {
+            tracelimit::warn_ratelimited!(
+                len = payload_length,
+                "dropping RX buffer: payload length smaller than virtio-net header size"
+            );
+            return Err(work);
+        };
+        *packet = Some(RxPacket { len: 0, cap, work });
         Ok(RxId(idx.into()))
     }
 
     /// Notify the client that a receive packet is ready (network packet available).
     pub fn complete_packet(&self, rx_id: RxId) {
-        let mut packet = self.rx_packets[rx_id.0 as usize].lock();
-        let mut work = packet.work.take().expect("valid packet index");
-        work.complete(packet.len);
+        let mut packet = self.rx_packets[rx_id.0 as usize]
+            .lock()
+            .take()
+            .expect("valid packet index");
+        let payload_len = if packet.len == 0 {
+            // Header was not written, so treat as empty packet.
+            tracelimit::warn_ratelimited!("dropping RX buffer: header not written");
+            0
+        } else {
+            packet.len + header_size() as u32
+        };
+        packet.work.complete(payload_len);
     }
 }
 
@@ -96,22 +109,26 @@ impl BufferAccess for VirtioWorkPool {
 
     fn write_data(&mut self, id: RxId, data: &[u8]) {
         let mut locked_packet = self.rx_packets[id.0 as usize].lock();
-        let work = locked_packet.work.as_ref().expect("invalid buffer index");
-        if let Err(err) = work.write_at_offset(header_size() as u64, &self.mem, data) {
-            tracing::warn!(
+        let packet = locked_packet.as_mut().expect("invalid buffer index");
+        if let Err(err) = packet
+            .work
+            .write_at_offset(header_size() as u64, &self.mem, data)
+        {
+            tracelimit::warn_ratelimited!(
                 len = data.len(),
                 error = &err as &dyn std::error::Error,
                 "rx memory write failure"
             );
         }
-        locked_packet.len = (header_size() + data.len()) as u32;
     }
 
     fn push_guest_addresses(&self, id: RxId, buf: &mut Vec<RxBufferSegment>) {
         let locked_packet = self.rx_packets[id.0 as usize].lock();
-        let work = locked_packet.work.as_ref().expect("invalid buffer index");
+        let packet = locked_packet.as_ref().expect("invalid buffer index");
         buf.extend(
-            work.payload
+            packet
+                .work
+                .payload
                 .iter()
                 .filter(|x| x.writeable)
                 .map(|p| RxBufferSegment {
@@ -122,9 +139,11 @@ impl BufferAccess for VirtioWorkPool {
     }
 
     fn capacity(&self, id: RxId) -> u32 {
-        let locked_packet = self.rx_packets[id.0 as usize].lock();
-        let work = locked_packet.work.as_ref().expect("invalid buffer index");
-        work.get_payload_length(true) as u32
+        self.rx_packets[id.0 as usize]
+            .lock()
+            .as_ref()
+            .expect("invalid buffer index")
+            .cap
     }
 
     fn write_header(&mut self, id: RxId, metadata: &RxMetadata) {
@@ -143,14 +162,24 @@ impl BufferAccess for VirtioWorkPool {
             num_buffers: 1,
             ..FromZeros::new_zeroed()
         };
-        let locked_packet = self.rx_packets[id.0 as usize].lock();
-        let work = locked_packet.work.as_ref().expect("invalid buffer index");
-        assert_eq!(metadata.len + header_size(), locked_packet.len as usize);
-        if let Err(err) = work.write(&self.mem, &virtio_net_header.as_bytes()[..header_size()]) {
-            tracing::warn!(
+        let mut locked_packet = self.rx_packets[id.0 as usize].lock();
+        let packet = locked_packet.as_mut().expect("invalid buffer index");
+        if let Err(err) = packet
+            .work
+            .write(&self.mem, &virtio_net_header.as_bytes()[..header_size()])
+        {
+            tracelimit::warn_ratelimited!(
                 error = &err as &dyn std::error::Error,
                 "failure writing header"
             );
+            return;
         }
+        assert!(
+            metadata.len <= packet.cap as usize,
+            "packet len {} exceeds buffer capacity {}",
+            metadata.len,
+            packet.cap
+        );
+        packet.len = metadata.len as u32;
     }
 }

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -1217,9 +1217,7 @@ impl Worker {
             match self.active_state.pending_rx_packets.queue_work(work) {
                 Ok(rx_id) => rx_ids.push(rx_id),
                 Err(mut work) => {
-                    tracelimit::warn_ratelimited!(
-                        "dropping RX buffer: descriptor index already in use"
-                    );
+                    // Reason has been traced by the callee.
                     self.active_state.stats.rx_dropped.increment();
                     work.complete(0);
                 }


### PR DESCRIPTION
`VirtioWorkPool::capacity()` was returning the full writeable payload length, which includes the 12-byte virtio-net header. Backends use `capacity()` to determine the maximum Ethernet frame size they can deliver (via `rx_mtu()`), so they would construct frames up to `capacity()` bytes. `write_data()` then writes at offset `header_size()`, needing `header_size() + frame_len` total bytes -- overflowing the descriptor for max-size packets. This caused silent truncation of the last 12 bytes and reported a `used_len` exceeding the descriptor size.

Fix this by computing the data capacity (`payload_length - header_size`) at `queue_work()` time and caching it in the `RxPacket`. `capacity()` now returns this value, and `complete_packet()` adds `header_size()` back to get the correct `used_len`.