### PR TITLE
consomme/tcp: replace Debug-based TCP tracing with structured fields

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -1450,13 +1450,7 @@ fn trace_tcp_packet(tcp: &TcpRepr<'_>, payload_len: usize, label: &str) {
             TcpControl::None => None,
         },
         seq = tcp.seq_number.0 as u32,
-        next_seq = (tcp.seq_number.0 as u32).wrapping_add(
-            payload_len as u32
-                + match tcp.control {
-                    TcpControl::Syn | TcpControl::Fin | TcpControl::Rst => 1u32,
-                    _ => 0,
-                },
-        ),
+        next_seq = (tcp.seq_number.0 as u32).wrapping_add((payload_len + tcp.control.len()) as u32),
         ack = tcp.ack_number.map(|a| a.0 as u32),
         window = tcp.window_len,
         payload_len,


### PR DESCRIPTION
Replace the four tracing::trace! calls that dumped TcpRepr via Debug (which included raw payload bytes and produced huge, hard-to-filter output) with a trace_tcp_packet() helper that logs structured key/value fields: label, flags, seq, next_seq, ack, window, and payload_len.

This makes traces lightweight, filterable, and avoids logging payload data entirely.