### PR TITLE
virtio: remove Drop auto-completion from VirtioQueueCallbackWork

### DIFF
--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -125,6 +125,12 @@ impl VirtioQueueUsedHandler {
     }
 }
 
+/// A descriptor chain popped from a [`VirtioQueue`].
+///
+/// The device must call [`complete`](Self::complete) exactly once to post a
+/// completion to the guest's used ring. Dropping without completing is a bug
+/// and will not automatically post a completion.
+#[must_use]
 pub struct VirtioQueueCallbackWork {
     used_queue_handler: Arc<Mutex<VirtioQueueUsedHandler>>,
     work: QueueWork,
@@ -225,14 +231,6 @@ pub enum VirtioWriteError {
     NotAllWritten(usize),
 }
 
-impl Drop for VirtioQueueCallbackWork {
-    fn drop(&mut self) {
-        if !self.completed {
-            self.complete(0);
-        }
-    }
-}
-
 /// A descriptor that has been peeked from a [`VirtioQueue`] without advancing
 /// the available index.
 ///
@@ -280,8 +278,8 @@ impl<'a> PeekedWork<'a> {
 
     /// Consume this peeked work, advancing the queue's available index.
     ///
-    /// Returns a [`VirtioQueueCallbackWork`] that must be completed (or will
-    /// auto-complete with 0 bytes on drop).
+    /// Returns a [`VirtioQueueCallbackWork`] that must be explicitly
+    /// completed via [`VirtioQueueCallbackWork::complete`].
     pub fn consume(self) -> VirtioQueueCallbackWork {
         self.queue.core.advance(&self.work);
         VirtioQueueCallbackWork::new(self.work, &self.queue.used_handler)

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -3428,11 +3428,11 @@ async fn split_queue_state_advances_on_pop(driver: DefaultDriver) {
     .unwrap();
 
     guest.queue_available_desc(0, 0);
-    let work = queue.try_next().unwrap().unwrap();
+    let mut work = queue.try_next().unwrap().unwrap();
     let state = queue.queue_state();
     assert_eq!(state.avail_index, 1);
     // Complete the descriptor → used_index advances
-    drop(work);
+    work.complete(0);
     let state = queue.queue_state();
     assert_eq!(state.used_index, 1);
 }

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -176,8 +176,9 @@ impl AsyncRun<Plan9Queue> for Plan9Worker {
             let work = stop.until_stopped(state.queue.next()).await?;
             let Some(work) = work else { break };
             match work {
-                Ok(work) => {
-                    process_9p_request(&state.mem, &self.fs, work);
+                Ok(mut work) => {
+                    let bytes = process_9p_request(&state.mem, &self.fs, &work);
+                    work.complete(bytes);
                 }
                 Err(err) => {
                     tracing::error!(error = &err as &dyn std::error::Error, "queue error");
@@ -189,7 +190,11 @@ impl AsyncRun<Plan9Queue> for Plan9Worker {
     }
 }
 
-fn process_9p_request(mem: &GuestMemory, fs: &Plan9FileSystem, mut work: VirtioQueueCallbackWork) {
+fn process_9p_request(
+    mem: &GuestMemory,
+    fs: &Plan9FileSystem,
+    work: &VirtioQueueCallbackWork,
+) -> u32 {
     // Make a copy of the incoming message.
     let mut message = vec![0; work.get_payload_length(false) as usize];
     if let Err(e) = work.read(mem, &mut message) {
@@ -197,21 +202,23 @@ fn process_9p_request(mem: &GuestMemory, fs: &Plan9FileSystem, mut work: VirtioQ
             error = &e as &dyn std::error::Error,
             "[VIRTIO 9P] Failed to read guest memory"
         );
-        return;
+        return 0;
     }
 
     // Allocate a temporary buffer for the response.
     let mut response = vec![9; work.get_payload_length(true) as usize];
-    if let Ok(size) = fs.process_message(&message, &mut response) {
-        // Write out the response.
-        if let Err(e) = work.write(mem, &response[0..size]) {
-            tracing::error!(
-                error = &e as &dyn std::error::Error,
-                "[VIRTIO 9P] Failed to write guest memory"
-            );
-            return;
-        }
+    let Ok(size) = fs.process_message(&message, &mut response) else {
+        return 0;
+    };
 
-        work.complete(size as u32);
+    // Write out the response.
+    if let Err(e) = work.write(mem, &response[0..size]) {
+        tracing::error!(
+            error = &e as &dyn std::error::Error,
+            "[VIRTIO 9P] Failed to write guest memory"
+        );
+        return 0;
     }
+
+    size as u32
 }

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -273,8 +273,16 @@ fn process_virtiofs_request(
         }
     };
 
-    // Dispatch to the file system.
-    let mut sender = VirtioReplySender { work, mem };
+    // Dispatch to the file system. The sender writes the reply into guest
+    // memory but does not complete the descriptor—completion happens once,
+    // after dispatch returns. For FUSE no-reply operations (Forget,
+    // BatchForget, Destroy), send() is never called and bytes_written
+    // stays 0.
+    let mut sender = VirtioReplySender {
+        work: &work,
+        mem,
+        bytes_written: 0,
+    };
     let mapper = worker
         .shared_memory_region
         .as_ref()
@@ -287,16 +295,21 @@ fn process_virtiofs_request(
         &mut sender,
         mapper.as_ref().map(|x| x as &dyn fuse::Mapper),
     );
+    work.complete(sender.bytes_written);
 }
 /// An implementation of `ReplySender` for virtio payload.
+///
+/// Writes the FUSE reply into guest memory and records the byte count.
+/// Does not complete the descriptor—the caller is responsible for that.
 struct VirtioReplySender<'a> {
-    work: VirtioQueueCallbackWork,
+    work: &'a VirtioQueueCallbackWork,
     mem: &'a GuestMemory,
+    bytes_written: u32,
 }
 
 impl fuse::ReplySender for VirtioReplySender<'_> {
     fn send(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<()> {
-        let mut writer = VirtioPayloadWriter::new(self.mem, &self.work);
+        let mut writer = VirtioPayloadWriter::new(self.mem, self.work);
         let mut size = 0;
 
         // Write all the slices to the payload buffers.
@@ -306,7 +319,7 @@ impl fuse::ReplySender for VirtioReplySender<'_> {
             size += buf.len();
         }
 
-        self.work.complete(size as u32);
+        self.bytes_written = size as u32;
         Ok(())
     }
 }


### PR DESCRIPTION
Remove the Drop impl that silently called complete(0) when a work item was dropped without explicit completion. This is prep work for two planned changes to the virtio queue API:

- Moving complete() from the work item to the queue, which enables batched completions and eliminates the per-work-item Arc<Mutex> clone.
- Making completion an explicit queue operation, which is incompatible with auto-completing on drop.

The implicit drop behavior was also error-prone in its own right: a device that forgets to call complete() silently posts a zero-length completion to the guest, which has device-specific meaning (e.g. a zero-length read response) rather than being an obvious failure.

Two devices relied on the implicit drop and needed minor refactoring:

- virtiofs: VirtioReplySender now borrows the work item and records bytes_written. The caller completes after dispatch() returns. This cleanly handles FUSE no-reply operations (Forget, BatchForget, Destroy) which never call send().

- virtio_p9: process_9p_request now takes &work and returns the byte count. The caller makes the single complete() call, so error paths just return 0 instead of each needing their own complete().