### PR TITLE
virtio: move ring feature bits from transport to devices

### DIFF
--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -1400,7 +1400,9 @@ impl VirtioPciTestDevice {
                 &driver_source,
                 DeviceTraits {
                     device_id: VirtioDeviceType::CONSOLE,
-                    device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                    device_features: VirtioDeviceFeatures::new()
+                        .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX)
+                        .with_bank(1, VIRTIO_F_RING_PACKED),
                     max_queues: num_queues,
                     device_register_length: 12,
                     ..Default::default()
@@ -1451,7 +1453,9 @@ async fn verify_chipset_config(driver: DefaultDriver) {
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX)
+                    .with_bank(1, VIRTIO_F_RING_PACKED),
                 max_queues: 1,
                 device_register_length: 0,
                 ..Default::default()
@@ -2776,7 +2780,7 @@ async fn verify_device_packed_multi_queue_pci(driver: DefaultDriver) {
     let test_mem = VirtioTestMemoryAccess::new();
     let guest = VirtioTestGuest::new_packed(&driver, &test_mem, num_queues, 2, true);
     let features = VirtioDeviceFeatures::new()
-        .with_bank(0, VIRTIO_F_RING_EVENT_IDX | 2)
+        .with_bank(0, VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX | 2)
         .with_bank(1, VIRTIO_F_VERSION_1 | VIRTIO_F_RING_PACKED);
     verify_device_multi_queue_pci_inner(test_mem, guest, num_queues, features).await;
 }
@@ -2791,7 +2795,8 @@ async fn verify_enable_failure_mmio_does_not_set_driver_ok(_driver: DefaultDrive
         Box::new(FailingTestDevice {
             traits: DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX),
                 max_queues: 1,
                 device_register_length: 0,
                 ..Default::default()
@@ -2842,7 +2847,8 @@ async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver
         Box::new(FailingTestDevice {
             traits: DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX),
                 max_queues: 1,
                 device_register_length: 12,
                 ..Default::default()
@@ -3524,7 +3530,8 @@ impl PartialFailTestDevice {
         Self {
             traits: DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX),
                 max_queues,
                 device_register_length: 0,
                 ..Default::default()
@@ -3956,7 +3963,8 @@ async fn pci_intx_line_deasserted_on_reset(driver: DefaultDriver) {
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX),
                 max_queues: 1,
                 device_register_length: 12,
                 ..Default::default()
@@ -4135,7 +4143,8 @@ async fn mmio_save_restore_round_trip(driver: DefaultDriver) {
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX),
                 max_queues: 1,
                 device_register_length: 0,
                 ..Default::default()
@@ -4169,7 +4178,8 @@ async fn mmio_save_restore_round_trip(driver: DefaultDriver) {
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX),
                 max_queues: 1,
                 device_register_length: 0,
                 ..Default::default()
@@ -4224,7 +4234,8 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new(), // no device-specific features
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX), // no device-specific features
                 max_queues: 1,
                 device_register_length: 12,
                 ..Default::default()
@@ -4379,7 +4390,8 @@ async fn mmio_restore_reinstalls_doorbells(driver: DefaultDriver) {
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX),
                 max_queues: 1,
                 device_register_length: 0,
                 ..Default::default()
@@ -4415,7 +4427,8 @@ async fn mmio_restore_reinstalls_doorbells(driver: DefaultDriver) {
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: VirtioDeviceFeatures::new().with_bank(0, 2),
+                device_features: VirtioDeviceFeatures::new()
+                    .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX),
                 max_queues: 1,
                 device_register_length: 0,
                 ..Default::default()

--- a/vm/devices/virtio/virtio/src/transport/mmio.rs
+++ b/vm/devices/virtio/virtio/src/transport/mmio.rs
@@ -136,20 +136,7 @@ impl VirtioMmioDevice {
         let device_feature = traits
             .device_features
             .clone()
-            .with_bank0(
-                traits
-                    .device_features
-                    .bank0()
-                    .with_ring_event_idx(true)
-                    .with_ring_indirect_desc(true),
-            )
-            .with_bank1(
-                traits
-                    .device_features
-                    .bank1()
-                    .with_version_1(true)
-                    .with_ring_packed(true),
-            );
+            .with_bank1(traits.device_features.bank1().with_version_1(true));
 
         let supports_save_restore = device.supports_save_restore();
         let (sender, receiver) = mesh::channel();

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -264,20 +264,7 @@ impl VirtioPciDevice {
         let device_feature = traits
             .device_features
             .clone()
-            .with_bank0(
-                traits
-                    .device_features
-                    .bank0()
-                    .with_ring_event_idx(true)
-                    .with_ring_indirect_desc(true),
-            )
-            .with_bank1(
-                traits
-                    .device_features
-                    .bank1()
-                    .with_version_1(true)
-                    .with_ring_packed(true),
-            );
+            .with_bank1(traits.device_features.bank1().with_version_1(true));
         let supports_save_restore = device.supports_save_restore();
 
         let (sender, receiver) = mesh::channel();

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -309,7 +309,13 @@ impl VirtioDevice for VirtioBlkDevice {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::BLK,
             device_features: VirtioDeviceFeatures::new()
-                .with_bank0(VirtioDeviceFeaturesBank0::new().with_device_specific(features)),
+                .with_bank0(
+                    VirtioDeviceFeaturesBank0::new()
+                        .with_device_specific(features)
+                        .with_ring_event_idx(true)
+                        .with_ring_indirect_desc(true),
+                )
+                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
             max_queues: 1,
             // Config space is 60 bytes (size_of minus 4 bytes of struct padding).
             device_register_length: (size_of::<VirtioBlkConfig>() - 4) as u32,

--- a/vm/devices/virtio/virtio_console/src/lib.rs
+++ b/vm/devices/virtio/virtio_console/src/lib.rs
@@ -84,8 +84,14 @@ impl VirtioConsoleDevice {
 
 impl VirtioDevice for VirtioConsoleDevice {
     fn traits(&self) -> DeviceTraits {
-        let mut features = VirtioDeviceFeatures::new();
-        features.set_bank(0, 1 << VIRTIO_CONSOLE_F_SIZE);
+        let features = VirtioDeviceFeatures::new()
+            .with_bank0(
+                virtio::spec::VirtioDeviceFeaturesBank0::new()
+                    .with_device_specific(1 << VIRTIO_CONSOLE_F_SIZE)
+                    .with_ring_event_idx(true)
+                    .with_ring_indirect_desc(true),
+            )
+            .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true));
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::CONSOLE,
             device_features: features,

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -270,7 +270,13 @@ impl VirtioDevice for Device {
 
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::NET,
-            device_features: VirtioDeviceFeatures::new().with_bank(0, features_bank0.into_bits()),
+            device_features: VirtioDeviceFeatures::new()
+                .with_bank0(
+                    virtio::spec::VirtioDeviceFeaturesBank0::from_bits(features_bank0.into_bits())
+                        .with_ring_event_idx(true)
+                        .with_ring_indirect_desc(true),
+                )
+                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
             max_queues: 2 * self.registers.max_virtqueue_pairs,
             device_register_length: size_of::<NetConfig>() as u32,
             shared_memory: DeviceTraitsSharedMemory { id: 0, size: 0 },

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -73,7 +73,14 @@ impl VirtioDevice for VirtioPlan9Device {
     fn traits(&self) -> DeviceTraits {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::P9,
-            device_features: VirtioDeviceFeatures::new().with_bank(0, VIRTIO_9P_F_MOUNT_TAG),
+            device_features: VirtioDeviceFeatures::new()
+                .with_bank0(
+                    virtio::spec::VirtioDeviceFeaturesBank0::new()
+                        .with_device_specific(VIRTIO_9P_F_MOUNT_TAG)
+                        .with_ring_event_idx(true)
+                        .with_ring_indirect_desc(true),
+                )
+                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
             max_queues: 1,
             device_register_length: self.tag.len() as u32,
             ..Default::default()

--- a/vm/devices/virtio/virtio_pmem/src/lib.rs
+++ b/vm/devices/virtio/virtio_pmem/src/lib.rs
@@ -69,7 +69,13 @@ impl VirtioDevice for Device {
     fn traits(&self) -> DeviceTraits {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::PMEM,
-            device_features: VirtioDeviceFeatures::new(),
+            device_features: VirtioDeviceFeatures::new()
+                .with_bank0(
+                    virtio::spec::VirtioDeviceFeaturesBank0::new()
+                        .with_ring_event_idx(true)
+                        .with_ring_indirect_desc(true),
+                )
+                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
             max_queues: 1,
             device_register_length: size_of::<PmemConfig>() as u32,
             shared_memory: DeviceTraitsSharedMemory {

--- a/vm/devices/virtio/virtio_rng/src/lib.rs
+++ b/vm/devices/virtio/virtio_rng/src/lib.rs
@@ -55,7 +55,13 @@ impl VirtioDevice for VirtioRngDevice {
     fn traits(&self) -> DeviceTraits {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::RNG,
-            device_features: VirtioDeviceFeatures::new(),
+            device_features: VirtioDeviceFeatures::new()
+                .with_bank0(
+                    virtio::spec::VirtioDeviceFeaturesBank0::new()
+                        .with_ring_event_idx(true)
+                        .with_ring_indirect_desc(true),
+                )
+                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
             max_queues: 1,
             device_register_length: 0,
             shared_memory: DeviceTraitsSharedMemory::default(),

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -100,7 +100,13 @@ impl VirtioDevice for VirtioFsDevice {
     fn traits(&self) -> DeviceTraits {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::FS,
-            device_features: VirtioDeviceFeatures::new(),
+            device_features: VirtioDeviceFeatures::new()
+                .with_bank0(
+                    virtio::spec::VirtioDeviceFeaturesBank0::new()
+                        .with_ring_event_idx(true)
+                        .with_ring_indirect_desc(true),
+                )
+                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
             max_queues: 2,
             device_register_length: self.config.as_bytes().len() as u32,
             shared_memory: DeviceTraitsSharedMemory {


### PR DESCRIPTION
Previously the virtio transport layer (PCI and MMIO) unconditionally added VIRTIO_F_RING_INDIRECT_DESC, VIRTIO_F_RING_EVENT_IDX, and VIRTIO_F_RING_PACKED to every device's advertised features. This meant devices had no control over which ring features they supported.

Move the responsibility for declaring these feature bits to each device's traits() implementation. The transport still adds VIRTIO_F_VERSION_1 (which is a transport-level requirement), but the ring negotiation features are now owned by the device.

This enables future devices (e.g., vhost-user frontends) to advertise only the ring features their backend actually supports, rather than always claiming support for all of them.