### PR TITLE
flowey: don't leave the vhd download prompt open forever, timeout after 30s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,8 +972,11 @@ dependencies = [
  "bitflags 2.9.3",
  "crossterm_winapi",
  "document-features",
+ "mio",
  "parking_lot",
  "rustix 1.0.8",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -2082,6 +2085,7 @@ name = "flowey_lib_hvlite"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "crossterm",
  "flowey",
  "flowey_lib_common",
  "fs-err",
@@ -4374,6 +4378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -7092,6 +7097,17 @@ checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
 ]
 
 [[package]]

--- a/flowey/flowey_lib_hvlite/Cargo.toml
+++ b/flowey/flowey_lib_hvlite/Cargo.toml
@@ -15,12 +15,16 @@ vmm_test_images = { workspace = true, features = ["serde"] }
 igvmfilegen_config.workspace = true
 
 anyhow.workspace = true
+crossterm = { workspace = true, features = ["events"] }
 fs-err.workspace = true
 log.workspace = true
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 target-lexicon = { workspace = true, features = ["serde_support"] }
 which.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+crossterm = { workspace = true, features = ["windows"] }
 
 [lints]
 workspace = true

--- a/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_artifacts.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_artifacts.rs
@@ -7,6 +7,7 @@
 
 use flowey::node::prelude::*;
 use std::collections::BTreeSet;
+use std::io::IsTerminal;
 use vmm_test_images::KnownTestArtifacts;
 
 const STORAGE_ACCOUNT: &str = "hvlitetestvhds";
@@ -221,14 +222,42 @@ If running locally, you can re-run with `--help` for info on how to:
 - tweak the selected download folder (e.g: download images to an external HDD)
 - skip this warning prompt in the future
 
-If you're OK with starting the download, please press <enter>.
-Otherwise, press `ctrl-c` to cancel the run.
+If you're OK with starting the download, please press just <enter>.
+Otherwise, press anything else with <enter> to cancel the run.
 ================================================================================
 "#
                         );
                         log::warn!("{}", msg.trim());
-                        if !skip_prompt {
-                            let _ = std::io::stdin().read_line(&mut String::new());
+
+                        // If this is not an interactive terminal, just allow the download to proceed
+                        let is_terminal = std::io::stdin().is_terminal();
+
+                        if !skip_prompt && is_terminal {
+                            // Only display the prompt for 30s before timing out
+                            let result = crossterm::event::poll(std::time::Duration::from_secs(30));
+                            match result {
+                                Ok(true) => {
+                                    if let crossterm::event::Event::Key(key_event) =
+                                        crossterm::event::read().unwrap()
+                                    {
+                                        if key_event.code == crossterm::event::KeyCode::Enter {
+                                            // proceed with download
+                                        } else {
+                                            anyhow::bail!("user cancelled the run");
+                                        }
+                                    } else {
+                                        anyhow::bail!(
+                                            "unexpected event while waiting for user input"
+                                        );
+                                    }
+                                }
+                                Ok(false) => {
+                                    anyhow::bail!("timed out waiting for user input");
+                                }
+                                Err(e) => {
+                                    anyhow::bail!("error while waiting for user input: {e}");
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This behavior is really annoying when you start a terminal, or run it in an agent. Fail the download step after 30s if the user didn't accept, or if the user didn't ask to skip the prompt in the first place. 