### PR TITLE
virtio: validate descriptor index from avail ring

### DIFF
--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -62,6 +62,8 @@ pub enum QueueError {
     TooLong,
     #[error("Invalid queue size {0}. Must be a power of 2.")]
     InvalidQueueSize(u16),
+    #[error("descriptor index {0} is out of range")]
+    InvalidDescriptorIndex(u16),
 }
 
 pub struct QueueDescriptor {

--- a/vm/devices/virtio/virtio/src/queue/split.rs
+++ b/vm/devices/virtio/virtio/src/queue/split.rs
@@ -152,13 +152,17 @@ impl SplitQueueGetWork {
     }
 
     pub fn get_available_descriptor_index(&self, wrapped_index: u16) -> Result<u16, QueueError> {
-        Ok(self
+        let desc_index = self
             .queue_avail
             .read_plain::<u16_le>(
                 spec::AVAIL_OFFSET_RING + spec::AVAIL_ELEMENT_SIZE * wrapped_index as u64,
             )
             .map_err(QueueError::Memory)?
-            .get())
+            .get();
+        if desc_index >= self.queue_size {
+            return Err(QueueError::InvalidDescriptorIndex(desc_index));
+        }
+        Ok(desc_index)
     }
 
     fn set_available_event(&self, index: u16) -> Result<(), QueueError> {


### PR DESCRIPTION
The descriptor index read from the guest's available ring was used directly without checking it against `queue_size`. A malicious or buggy guest could supply an out-of-range index.

This cannot corrupt host memory: `queue_desc` is a guest-memory subrange bounded to `queue_size * sizeof(virtq_desc)`, so an out-of-range index already produces a `QueueError::Memory` when the descriptor read falls outside the subrange. However, the device should reject such an index up front per the virtio spec rather than letting it surface as a generic memory error, which is both clearer and spec-compliant.

Add an `InvalidDescriptorIndex` error variant to `QueueError` and validate the index against `queue_size` in `SplitQueueGetWork::get_available_descriptor_index()`.
