### PR TITLE
virtio: reject spec-noncompliant indirect descriptor table sizes

### DIFF
--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -62,6 +62,10 @@ pub enum QueueError {
     TooLong,
     #[error("Invalid queue size {0}. Must be a power of 2.")]
     InvalidQueueSize(u16),
+    #[error(
+        "indirect descriptor table has invalid byte length {0}; must be a non-zero multiple of the descriptor size (16 bytes)"
+    )]
+    InvalidIndirectSize(u32),
 }
 
 pub struct QueueDescriptor {
@@ -529,6 +533,17 @@ impl<'a> DescriptorChain<'a> {
             if self.indirect_queue.is_some() {
                 return Err(QueueError::DoubleIndirect);
             }
+            let indirect_byte_len = descriptor.length;
+            if indirect_byte_len == 0
+                || !(indirect_byte_len as usize).is_multiple_of(size_of::<SplitDescriptor>())
+            {
+                return Err(QueueError::InvalidIndirectSize(indirect_byte_len));
+            }
+            let entry_count = indirect_byte_len / size_of::<SplitDescriptor>() as u32;
+            if entry_count > u16::MAX as u32 {
+                return Err(QueueError::InvalidIndirectSize(indirect_byte_len));
+            }
+            let indirect_len = entry_count as u16;
             let indirect_queue = self.indirect_queue.insert(
                 self.queue
                     .mem
@@ -536,7 +551,6 @@ impl<'a> DescriptorChain<'a> {
                     .map_err(QueueError::Memory)?,
             );
             self.descriptor_index = Some(0);
-            let indirect_len = (descriptor.length / size_of::<SplitDescriptor>() as u32) as u16;
             self.indirect_table_len = Some(indirect_len);
             self.queue
                 .descriptor(indirect_queue, 0, Some(indirect_len))?

--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -62,9 +62,7 @@ pub enum QueueError {
     TooLong,
     #[error("Invalid queue size {0}. Must be a power of 2.")]
     InvalidQueueSize(u16),
-    #[error(
-        "indirect descriptor table has invalid byte length {0}; must be a non-zero multiple of the descriptor size (16 bytes) and no larger than 65535 entries (1048560 bytes)"
-    )]
+    #[error("invalid indirect descriptor table byte length {0}")]
     InvalidIndirectSize(u32),
 }
 
@@ -540,10 +538,8 @@ impl<'a> DescriptorChain<'a> {
                 return Err(QueueError::InvalidIndirectSize(indirect_byte_len));
             }
             let entry_count = indirect_byte_len / size_of::<SplitDescriptor>() as u32;
-            if entry_count > u16::MAX as u32 {
-                return Err(QueueError::InvalidIndirectSize(indirect_byte_len));
-            }
-            let indirect_len = entry_count as u16;
+            let indirect_len = u16::try_from(entry_count)
+                .map_err(|_| QueueError::InvalidIndirectSize(indirect_byte_len))?;
             let indirect_queue = self.indirect_queue.insert(
                 self.queue
                     .mem

--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -63,7 +63,7 @@ pub enum QueueError {
     #[error("Invalid queue size {0}. Must be a power of 2.")]
     InvalidQueueSize(u16),
     #[error(
-        "indirect descriptor table has invalid byte length {0}; must be a non-zero multiple of the descriptor size (16 bytes)"
+        "indirect descriptor table has invalid byte length {0}; must be a non-zero multiple of the descriptor size (16 bytes) and no larger than 65535 entries (1048560 bytes)"
     )]
     InvalidIndirectSize(u32),
 }

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -13,6 +13,7 @@ use crate::QueueResources;
 use crate::VirtioDevice;
 use crate::VirtioQueue;
 use crate::VirtioQueueCallbackWork;
+use crate::queue::QueueError;
 use crate::queue::QueueParams;
 use crate::queue::QueueState;
 use crate::spec::pci::*;
@@ -4578,7 +4579,25 @@ async fn stop_during_failed_enable_resets_config_pci(_driver: DefaultDriver) {
     verify_stop_during_failed_enable_resets_config(&mut transport).await;
 }
 
-/// An indirect descriptor with zero byte length must be rejected.
+/// Asserts that the queue rejected a descriptor with
+/// [`QueueError::InvalidIndirectSize`]. `try_next` wraps the underlying
+/// [`QueueError`] in an [`std::io::Error`], so unwrap the source to check the
+/// concrete variant rather than accepting any error.
+fn assert_invalid_indirect_size(result: Result<Option<VirtioQueueCallbackWork>, io::Error>) {
+    let Err(err) = result else {
+        panic!("indirect table with invalid size must be rejected");
+    };
+    let queue_err = err.get_ref().and_then(|e| e.downcast_ref::<QueueError>());
+    assert!(
+        matches!(queue_err, Some(QueueError::InvalidIndirectSize(_))),
+        "expected QueueError::InvalidIndirectSize, got {err:?}"
+    );
+}
+
+/// An indirect descriptor table byte length of zero is not a valid (non-zero)
+/// multiple of the descriptor size, so the device must reject it
+/// (virtio spec §2.7.5.3: the table length "MUST be a multiple of the size of
+/// the descriptor").
 #[async_test]
 async fn verify_indirect_zero_length_rejected(driver: DefaultDriver) {
     let queue_size: u16 = 4;
@@ -4612,15 +4631,12 @@ async fn verify_indirect_zero_length_rejected(driver: DefaultDriver) {
 
     guest.queue_available_desc(0, desc_index);
 
-    let result = queue.try_next();
-    assert!(
-        result.is_err(),
-        "Zero-length indirect table must be rejected"
-    );
+    assert_invalid_indirect_size(queue.try_next());
 }
 
-/// An indirect descriptor with a byte length that is not a multiple of 16
-/// must be rejected.
+/// An indirect descriptor table byte length that is not a multiple of the
+/// descriptor size (16 bytes) must be rejected rather than silently truncating
+/// the trailing partial descriptor via integer division (virtio spec §2.7.5.3).
 #[async_test]
 async fn verify_indirect_misaligned_length_rejected(driver: DefaultDriver) {
     let queue_size: u16 = 4;
@@ -4653,9 +4669,43 @@ async fn verify_indirect_misaligned_length_rejected(driver: DefaultDriver) {
 
     guest.queue_available_desc(0, desc_index);
 
-    let result = queue.try_next();
-    assert!(
-        result.is_err(),
-        "Misaligned indirect table must be rejected"
+    assert_invalid_indirect_size(queue.try_next());
+}
+
+/// A packed indirect descriptor table whose entry count exceeds `u16::MAX`
+/// must be rejected rather than silently truncated.
+///
+/// The byte length is converted to an entry count (`length / 16`) that is
+/// tracked as a `u16`. A table of exactly `0x1_0000` entries (1 MiB) is one
+/// past `u16::MAX`, so without an explicit bound the `as u16` cast wrapped the
+/// count to 0. For packed indirect tables the entry count — not the NEXT flag —
+/// bounds how many descriptors are consumed (virtio spec §2.7.7), so this
+/// silently changed how much of the guest's table was processed. The oversized
+/// length must be rejected up front. Validation happens before the table is
+/// read, so the backing memory need not be populated.
+#[async_test]
+async fn verify_indirect_entry_count_overflow_rejected(driver: DefaultDriver) {
+    let queue_size: u16 = 4;
+    let test_mem = VirtioTestMemoryAccess::new();
+    let mut guest = VirtioTestGuest::new_packed(&driver, &test_mem, 1, queue_size, true);
+    let event = Event::new();
+    let queue_event = PolledWait::new(&driver, event.clone()).unwrap();
+    let mut queue = VirtioQueue::new(
+        guest.queue_features(),
+        guest.queue_params(0),
+        guest.mem(),
+        Interrupt::from_fn(|| {}),
+        queue_event,
+        None,
+    )
+    .unwrap();
+
+    // 0x1_0000 entries * 16 bytes == 1 MiB, i.e. u16::MAX + 1 descriptors.
+    guest.make_packed_descriptors_available(
+        0,
+        vec![DescriptorFlags::new().with_indirect(true)],
+        Some(0x1_0000),
     );
+
+    assert_invalid_indirect_size(queue.try_next());
 }

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -4577,3 +4577,85 @@ async fn stop_during_failed_enable_resets_config_pci(_driver: DefaultDriver) {
         PciTestTransport::new(Box::new(PartialFailTestDevice::new(1, 0)), &_driver, 1);
     verify_stop_during_failed_enable_resets_config(&mut transport).await;
 }
+
+/// An indirect descriptor with zero byte length must be rejected.
+#[async_test]
+async fn verify_indirect_zero_length_rejected(driver: DefaultDriver) {
+    let queue_size: u16 = 4;
+    let test_mem = VirtioTestMemoryAccess::new();
+    let mut guest = VirtioTestGuest::new_split(&driver, &test_mem, 1, queue_size, true);
+    let event = Event::new();
+    let queue_event = PolledWait::new(&driver, event.clone()).unwrap();
+    let mut queue = VirtioQueue::new(
+        guest.queue_features(),
+        guest.queue_params(0),
+        guest.mem(),
+        Interrupt::from_fn(|| {}),
+        queue_event,
+        None,
+    )
+    .unwrap();
+
+    let desc_index = 0u16;
+    let desc_base = guest.get_queue_descriptor(0, desc_index);
+    // Set INDIRECT flag.
+    test_mem.modify_memory_map(
+        desc_base + 12,
+        &u16::from(DescriptorFlags::new().with_indirect(true)).to_le_bytes(),
+        false,
+    );
+    // Set length to 0.
+    test_mem.modify_memory_map(desc_base + 8, &0u32.to_le_bytes(), false);
+    // Point to a valid address.
+    let buffer_addr = guest.get_queue_descriptor_backing_memory_address(0);
+    test_mem.modify_memory_map(desc_base, &buffer_addr.to_le_bytes(), false);
+
+    guest.queue_available_desc(0, desc_index);
+
+    let result = queue.try_next();
+    assert!(
+        result.is_err(),
+        "Zero-length indirect table must be rejected"
+    );
+}
+
+/// An indirect descriptor with a byte length that is not a multiple of 16
+/// must be rejected.
+#[async_test]
+async fn verify_indirect_misaligned_length_rejected(driver: DefaultDriver) {
+    let queue_size: u16 = 4;
+    let test_mem = VirtioTestMemoryAccess::new();
+    let mut guest = VirtioTestGuest::new_split(&driver, &test_mem, 1, queue_size, true);
+    let event = Event::new();
+    let queue_event = PolledWait::new(&driver, event.clone()).unwrap();
+    let mut queue = VirtioQueue::new(
+        guest.queue_features(),
+        guest.queue_params(0),
+        guest.mem(),
+        Interrupt::from_fn(|| {}),
+        queue_event,
+        None,
+    )
+    .unwrap();
+
+    let desc_index = 0u16;
+    let desc_base = guest.get_queue_descriptor(0, desc_index);
+    // Set INDIRECT flag.
+    test_mem.modify_memory_map(
+        desc_base + 12,
+        &u16::from(DescriptorFlags::new().with_indirect(true)).to_le_bytes(),
+        false,
+    );
+    // Set length to 17 (not a multiple of 16).
+    test_mem.modify_memory_map(desc_base + 8, &17u32.to_le_bytes(), false);
+    let buffer_addr = guest.get_queue_descriptor_backing_memory_address(0);
+    test_mem.modify_memory_map(desc_base, &buffer_addr.to_le_bytes(), false);
+
+    guest.queue_available_desc(0, desc_index);
+
+    let result = queue.try_next();
+    assert!(
+        result.is_err(),
+        "Misaligned indirect table must be rejected"
+    );
+}


### PR DESCRIPTION
The virtio spec defines the number of entries in an indirect descriptor table as `len / sizeof(struct virtq_desc)` (16 bytes), and a conformant device must reject tables whose byte length isn't a valid non-zero multiple of that size. OpenVMM advertises `VIRTIO_F_INDIRECT_DESC` but did not validate the guest-supplied length, leaving two spec-compliance gaps:

- **Misaligned / zero length:** a length that isn't a multiple of 16 silently dropped the trailing partial descriptor via integer division; a zero length produced an empty table.
- **Entry-count overflow:** the count was truncated with `as u16`, so a table of exactly `0x1_0000` entries (1 MiB) wrapped to 0. For **packed** indirect tables — where the entry count, not the `NEXT` flag, bounds how many descriptors are consumed — this silently changed how much of the guest's table was processed.

None of these can corrupt host memory (reads stay bounded by the guest-memory subrange), but they are spec violations that cause the device to misinterpret a malformed table instead of rejecting it.

This change validates the length up front and returns a new `QueueError::InvalidIndirectSize` for zero, misaligned, or overflowing tables.

Tests assert the specific `InvalidIndirectSize` rejection for zero-length, misaligned, and packed entry-count-overflow tables.
