### PR TITLE
burette: use host architecture instead of hardcoded x86_64

### DIFF
--- a/petri/burette/src/main.rs
+++ b/petri/burette/src/main.rs
@@ -316,14 +316,26 @@ fn cmd_package(args: PackageArgs) -> anyhow::Result<()> {
     // Each entry: (artifact ID, resolved path, bundle-relative destination).
     // Bundle destinations come from resolve_bundle_name, which returns the
     // same file_name that get_path uses — so VMM_TESTS_CONTENT_DIR finds them.
-    let artifact_ids = [
-        petri_artifacts_vmm_test::artifacts::OPENVMM_NATIVE.erase(),
-        petri_artifacts_common::artifacts::PIPETTE_LINUX_X64.erase(),
-        petri_artifacts_vmm_test::artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_X64.erase(),
-        petri_artifacts_vmm_test::artifacts::loadable::LINUX_DIRECT_TEST_INITRD_X64.erase(),
-        petri_artifacts_vmm_test::artifacts::loadable::UEFI_FIRMWARE_X64.erase(),
-        petri_artifacts_vmm_test::artifacts::test_vhd::ALPINE_3_23_X64.erase(),
-    ];
+    use petri_artifacts_common::tags::MachineArch;
+    let arch = MachineArch::host();
+    let artifact_ids = match arch {
+        MachineArch::X86_64 => vec![
+            petri_artifacts_vmm_test::artifacts::OPENVMM_NATIVE.erase(),
+            petri_artifacts_common::artifacts::PIPETTE_LINUX_X64.erase(),
+            petri_artifacts_vmm_test::artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_X64.erase(),
+            petri_artifacts_vmm_test::artifacts::loadable::LINUX_DIRECT_TEST_INITRD_X64.erase(),
+            petri_artifacts_vmm_test::artifacts::loadable::UEFI_FIRMWARE_X64.erase(),
+            petri_artifacts_vmm_test::artifacts::test_vhd::ALPINE_3_23_X64.erase(),
+        ],
+        MachineArch::Aarch64 => vec![
+            petri_artifacts_vmm_test::artifacts::OPENVMM_NATIVE.erase(),
+            petri_artifacts_common::artifacts::PIPETTE_LINUX_AARCH64.erase(),
+            petri_artifacts_vmm_test::artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_AARCH64.erase(),
+            petri_artifacts_vmm_test::artifacts::loadable::LINUX_DIRECT_TEST_INITRD_AARCH64.erase(),
+            petri_artifacts_vmm_test::artifacts::loadable::UEFI_FIRMWARE_AARCH64.erase(),
+            petri_artifacts_vmm_test::artifacts::test_vhd::ALPINE_3_23_AARCH64.erase(),
+        ],
+    };
 
     let mut files: Vec<(PathBuf, String)> = Vec::new();
 

--- a/petri/burette/src/tests/boot_time.rs
+++ b/petri/burette/src/tests/boot_time.rs
@@ -11,8 +11,9 @@
 use crate::report::MetricResult;
 use anyhow::Context as _;
 
-pub const ARCH: petri_artifacts_common::tags::MachineArch =
-    petri_artifacts_common::tags::MachineArch::X86_64;
+pub fn arch() -> petri_artifacts_common::tags::MachineArch {
+    petri_artifacts_common::tags::MachineArch::host()
+}
 
 /// Boot time configuration profile.
 ///
@@ -138,7 +139,7 @@ pub struct BootTimeTest {
 
 /// Build the firmware configuration for Linux direct boot.
 pub fn build_firmware(resolver: &petri::ArtifactResolver<'_>) -> petri::Firmware {
-    petri::Firmware::linux_direct(resolver, ARCH)
+    petri::Firmware::linux_direct(resolver, arch())
 }
 
 /// Build artifacts for the OpenVMM backend.
@@ -147,7 +148,10 @@ pub fn build_artifacts(
 ) -> anyhow::Result<petri::PetriVmArtifacts<petri::openvmm::OpenVmmPetriBackend>> {
     let firmware = build_firmware(resolver);
     petri::PetriVmArtifacts::<petri::openvmm::OpenVmmPetriBackend>::new(
-        resolver, firmware, ARCH, true,
+        resolver,
+        firmware,
+        arch(),
+        true,
     )
     .context("firmware/arch not compatible with OpenVMM backend")
 }
@@ -156,7 +160,10 @@ pub fn build_artifacts(
 pub fn register_artifacts(resolver: &petri::ArtifactResolver<'_>) {
     let firmware = build_firmware(resolver);
     petri::PetriVmArtifacts::<petri::openvmm::OpenVmmPetriBackend>::new(
-        resolver, firmware, ARCH, true,
+        resolver,
+        firmware,
+        arch(),
+        true,
     );
 }
 

--- a/petri/burette/src/tests/network.rs
+++ b/petri/burette/src/tests/network.rs
@@ -14,8 +14,11 @@ use crate::report::MetricResult;
 use anyhow::Context as _;
 use petri::pipette::cmd;
 
-const ARCH: petri_artifacts_common::tags::MachineArch =
-    petri_artifacts_common::tags::MachineArch::X86_64;
+use petri_artifacts_common::tags::MachineArch;
+
+fn arch() -> MachineArch {
+    MachineArch::host()
+}
 
 /// Which NIC backend to use for the network test.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -57,18 +60,28 @@ pub struct NetworkTestState {
 }
 
 fn build_firmware(resolver: &petri::ArtifactResolver<'_>) -> petri::Firmware {
+    use petri_artifacts_vmm_test::artifacts::test_vhd::ALPINE_3_23_AARCH64;
     use petri_artifacts_vmm_test::artifacts::test_vhd::ALPINE_3_23_X64;
 
-    let vhd = resolver.require(ALPINE_3_23_X64);
-    let guest = petri::UefiGuest::Vhd(petri::BootImageConfig::from_vhd(vhd));
-    petri::Firmware::uefi(resolver, ARCH, guest)
+    let arch = arch();
+    let boot_image = match arch {
+        MachineArch::X86_64 => petri::BootImageConfig::from_vhd(resolver.require(ALPINE_3_23_X64)),
+        MachineArch::Aarch64 => {
+            petri::BootImageConfig::from_vhd(resolver.require(ALPINE_3_23_AARCH64))
+        }
+    };
+    let guest = petri::UefiGuest::Vhd(boot_image);
+    petri::Firmware::uefi(resolver, arch, guest)
 }
 
 /// Register artifacts needed by the network test.
 pub fn register_artifacts(resolver: &petri::ArtifactResolver<'_>) {
     let firmware = build_firmware(resolver);
     petri::PetriVmArtifacts::<petri::openvmm::OpenVmmPetriBackend>::new(
-        resolver, firmware, ARCH, true,
+        resolver,
+        firmware,
+        arch(),
+        true,
     );
 }
 
@@ -105,7 +118,10 @@ impl crate::harness::WarmPerfTest for NetworkTest {
         let firmware = build_firmware(resolver);
 
         let artifacts = petri::PetriVmArtifacts::<petri::openvmm::OpenVmmPetriBackend>::new(
-            resolver, firmware, ARCH, true,
+            resolver,
+            firmware,
+            arch(),
+            true,
         )
         .context("firmware/arch not compatible with OpenVMM backend")?;
 


### PR DESCRIPTION
Replace hardcoded MachineArch::X86_64 with MachineArch::host() in all burette performance tests (boot_time, network) and the package command. This allows burette to run on both x86_64 and aarch64 hosts by automatically selecting the correct artifacts (UEFI firmware, Alpine VHD, pipette, kernel/initrd) for the host architecture.