### PR TITLE
flowey: add JobId label to self-hosted GitHub runner jobs

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -347,6 +347,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -587,6 +588,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -863,6 +865,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1130,6 +1133,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Windows-ARM64
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1370,6 +1374,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-ARM64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1626,6 +1631,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-ARM64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1893,6 +1899,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2426,6 +2433,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2959,6 +2967,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3173,6 +3182,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3974,6 +3984,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4291,6 +4302,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4509,6 +4521,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4834,6 +4847,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5153,6 +5167,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5528,6 +5543,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5876,6 +5892,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -31,6 +31,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -387,6 +388,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -629,6 +631,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -842,6 +845,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1067,6 +1071,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Windows-ARM64
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1309,6 +1314,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-ARM64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1567,6 +1573,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-ARM64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1836,6 +1843,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2371,6 +2379,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2906,6 +2915,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3122,6 +3132,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3747,6 +3758,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4066,6 +4078,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4286,6 +4299,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4613,6 +4627,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4890,6 +4905,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5223,6 +5239,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5505,6 +5522,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -30,6 +30,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -386,6 +387,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1195,6 +1197,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1408,6 +1411,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2393,6 +2397,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2928,6 +2933,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3144,6 +3150,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3679,6 +3686,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4366,6 +4374,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4685,6 +4694,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4905,6 +4915,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
+    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5232,6 +5243,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5509,6 +5521,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5842,6 +5855,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
+    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -574,7 +574,18 @@ EOF
             github_yaml_defs::Job {
                 name: label.clone(),
                 timeout_minutes,
-                runs_on: gh_pool.clone().map(|runner| runner_kind_to_yaml(&runner)),
+                runs_on: gh_pool.clone().map(|runner| {
+                    let mut yaml_runner = runner_kind_to_yaml(&runner);
+                    if let github_yaml_defs::Runner::SelfHosted(ref mut labels) = yaml_runner {
+                        if labels.iter().any(|l| l.starts_with("1ES.Pool=")) {
+                            labels.push(format!(
+                                "JobId=job{}-${{{{ github.run_id }}}}-${{{{ github.run_number }}}}-${{{{ github.run_attempt }}}}",
+                                job_idx.index()
+                            ));
+                        }
+                    }
+                    yaml_runner
+                }),
                 permissions: job_permissions
                     .iter()
                     .map(|k| (perm_kind_to_yaml(k.0), perm_val_to_yaml(k.1)))


### PR DESCRIPTION
Add a unique JobId label to all self-hosted runner jobs to improve runner assignment reliability. The label uses the format:

```
  JobId=<job>-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
```

This is a recommended practice for 1ES GitHub runner pools to ensure deterministic runner-to-job mapping and avoid potential scheduling issues with concurrent workflows.