### PR TITLE
hvsock: Accept lowercase handshake prefix

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/hvsock.rs
+++ b/vm/devices/vmbus/vmbus_server/src/hvsock.rs
@@ -245,7 +245,7 @@ impl ListenerWorker {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum ServiceIdFormat {
     Vsock,
     HyperV,
@@ -607,6 +607,10 @@ async fn relay_connected<T: RingMem + Unpin>(
 
 #[cfg(test)]
 mod tests {
+    use super::Guid;
+    use super::ServiceIdFormat;
+    use super::VSOCK_TEMPLATE;
+    use super::read_hybrid_vsock_connect;
     use super::relay_connected;
     use crate::ring::FlatRingMem;
     use futures::AsyncReadExt;
@@ -709,5 +713,39 @@ mod tests {
         assert_eq!(s.read(&mut v).await.unwrap(), 0);
         drop(s);
         task.await.unwrap();
+    }
+
+    #[async_test]
+    async fn test_read_hybrid_vsock_connect_uppercase(driver: DefaultDriver) {
+        let (s1, s2) = UnixStream::pair().unwrap();
+        let mut s1 = PolledSocket::new(&driver, s1).unwrap();
+        let mut s2 = PolledSocket::new(&driver, s2).unwrap();
+        s2.write_all(b"CONNECT 1234\n").await.unwrap();
+        let (service_id, format) = read_hybrid_vsock_connect(&mut s1).await.unwrap();
+        assert_eq!(format, ServiceIdFormat::Vsock);
+        assert_eq!(
+            service_id,
+            Guid {
+                data1: 1234,
+                ..VSOCK_TEMPLATE
+            }
+        );
+    }
+
+    #[async_test]
+    async fn test_read_hybrid_vsock_connect_lowercase(driver: DefaultDriver) {
+        let (s1, s2) = UnixStream::pair().unwrap();
+        let mut s1 = PolledSocket::new(&driver, s1).unwrap();
+        let mut s2 = PolledSocket::new(&driver, s2).unwrap();
+        s2.write_all(b"connect 1234\n").await.unwrap();
+        let (service_id, format) = read_hybrid_vsock_connect(&mut s1).await.unwrap();
+        assert_eq!(format, ServiceIdFormat::Vsock);
+        assert_eq!(
+            service_id,
+            Guid {
+                data1: 1234,
+                ..VSOCK_TEMPLATE
+            }
+        );
     }
 }


### PR DESCRIPTION
OpenVMM only accepts `CONNECT` but Cloud Hypervisor also accepts `connect` [1], and Kata sends `connect` [2] as well, so align with them.

[1] https://github.com/cloud-hypervisor/cloud-hypervisor/blob/57e766bdbbfcdf1f36f696fc735fbebbea97f5ca/virtio-devices/src/vsock/unix/muxer.rs#L493-L506
[2] https://github.com/kata-containers/kata-containers/blob/8c2b7ed619badeb9c0e0cf24e23f6b09bc109fcf/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs#L73