### PR TITLE
ci: add kernel binary size checks

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -15,9 +15,6 @@ on:
     branches:
     - main
     - release/*
-    paths-ignore:
-    - Guide/**
-    - petri/logview/**
 jobs:
   job0:
     name: xtask fmt (windows)
@@ -33,7 +30,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -43,7 +40,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -51,7 +48,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -189,7 +186,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -199,7 +196,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -207,7 +204,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -360,7 +357,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -370,7 +367,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -378,7 +375,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -437,7 +434,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 10 flowey_lib_common::git_checkout 0
-        flowey.exe v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
         flowey.exe v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -445,7 +442,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -465,14 +462,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 10 flowey_lib_common::cache 4
-        flowey.exe v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -505,9 +502,6 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 10 flowey_lib_common::run_cargo_clippy 0
       shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 10 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 10 flowey_lib_common::download_cargo_nextest 0
@@ -518,14 +512,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 10 flowey_lib_common::cache 0
-        flowey.exe v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -556,34 +550,13 @@ jobs:
         flowey.exe e 10 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 10 flowey_lib_common::publish_test_results 5
-        flowey.exe e 10 flowey_lib_common::publish_test_results 6
-        flowey.exe e 10 flowey_lib_common::publish_test_results 4
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
         flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
         flowey.exe e 10 flowey_lib_common::publish_test_results 0
         flowey.exe e 10 flowey_lib_common::publish_test_results 1
         flowey.exe e 10 flowey_lib_common::publish_test_results 2
@@ -593,14 +566,12 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: |-
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      run: flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
       run: flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -616,7 +587,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -627,7 +598,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -637,7 +608,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -645,7 +616,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -704,7 +675,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -712,7 +683,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -732,14 +703,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -763,36 +734,6 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: |-
-        flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_clippy 1
         flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build xtask
@@ -807,13 +748,31 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine clippy exclusions
+      run: |-
+        flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_clippy 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
       run: flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 11 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -825,14 +784,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -848,54 +807,10 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 11 flowey_lib_common::install_cargo_nextest 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 11 flowey_lib_common::publish_test_results 5
-        flowey e 11 flowey_lib_common::publish_test_results 6
-        flowey e 11 flowey_lib_common::publish_test_results 4
-        flowey v 11 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 11 flowey_lib_common::publish_test_results 8
-        flowey e 11 flowey_lib_common::publish_test_results 9
-        flowey e 11 flowey_lib_common::publish_test_results 10
-        flowey v 11 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
         flowey e 11 flowey_lib_common::run_cargo_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
@@ -906,37 +821,19 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 11 flowey_lib_common::publish_test_results 12
-        flowey e 11 flowey_lib_common::publish_test_results 13
-        flowey e 11 flowey_lib_common::publish_test_results 14
-        flowey v 11 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
         flowey e 11 flowey_lib_common::publish_test_results 0
         flowey e 11 flowey_lib_common::publish_test_results 1
         flowey e 11 flowey_lib_common::publish_test_results 2
@@ -946,14 +843,12 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
       run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -969,7 +864,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -980,7 +875,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -990,7 +885,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -998,7 +893,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1057,7 +952,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
         flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1065,7 +960,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1089,14 +984,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1109,7 +1004,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract X64 sysroot.tar.gz
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -1122,19 +1017,6 @@ jobs:
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 6
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_clippy 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1158,7 +1040,7 @@ jobs:
       run: flowey e 12 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1170,14 +1052,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1193,96 +1075,10 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 12 flowey_lib_common::publish_test_results 5
-        flowey e 12 flowey_lib_common::publish_test_results 6
-        flowey e 12 flowey_lib_common::publish_test_results 4
-        flowey v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 12 flowey_lib_common::publish_test_results 8
-        flowey e 12 flowey_lib_common::publish_test_results 9
-        flowey e 12 flowey_lib_common::publish_test_results 10
-        flowey v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 12 flowey_lib_common::publish_test_results 12
-        flowey e 12 flowey_lib_common::publish_test_results 13
-        flowey e 12 flowey_lib_common::publish_test_results 14
-        flowey v 12 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 12 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 12 flowey_lib_common::publish_test_results 16
-        flowey e 12 flowey_lib_common::publish_test_results 17
-        flowey e 12 flowey_lib_common::publish_test_results 18
-        flowey v 12 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 12 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_common::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1293,16 +1089,19 @@ jobs:
         flowey e 12 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
         flowey e 12 flowey_lib_common::publish_test_results 0
         flowey e 12 flowey_lib_common::publish_test_results 1
         flowey e 12 flowey_lib_common::publish_test_results 2
@@ -1312,14 +1111,12 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: x64-linux-musl-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
       run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1346,7 +1143,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1356,7 +1153,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1364,7 +1161,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1423,7 +1220,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
         flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1431,7 +1228,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1451,14 +1248,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1491,9 +1288,6 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 0
       shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 13 flowey_lib_common::download_cargo_nextest 0
@@ -1504,14 +1298,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1542,34 +1336,13 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 13 flowey_lib_common::publish_test_results 5
-        flowey.exe e 13 flowey_lib_common::publish_test_results 6
-        flowey.exe e 13 flowey_lib_common::publish_test_results 4
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
         flowey.exe e 13 flowey_lib_common::publish_test_results 0
         flowey.exe e 13 flowey_lib_common::publish_test_results 1
         flowey.exe e 13 flowey_lib_common::publish_test_results 2
@@ -1579,14 +1352,12 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-windows-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-windows-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: |-
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
       run: flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1613,7 +1384,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1623,7 +1394,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1631,7 +1402,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1696,7 +1467,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1704,7 +1475,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1724,14 +1495,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1769,15 +1540,6 @@ jobs:
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 14 flowey_lib_common::download_cargo_nextest 0
@@ -1788,14 +1550,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1811,54 +1573,10 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 14 flowey_lib_common::publish_test_results 5
-        flowey e 14 flowey_lib_common::publish_test_results 6
-        flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 8
-        flowey e 14 flowey_lib_common::publish_test_results 9
-        flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
         flowey e 14 flowey_lib_common::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1869,37 +1587,19 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
@@ -1909,14 +1609,12 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
       run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1943,7 +1641,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1953,7 +1651,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1961,7 +1659,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -2020,7 +1718,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2028,7 +1726,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2052,14 +1750,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2085,19 +1783,6 @@ jobs:
       run: |-
         flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 5
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2121,7 +1806,7 @@ jobs:
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2133,14 +1818,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2156,96 +1841,10 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 3
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 15 flowey_lib_common::publish_test_results 5
-        flowey e 15 flowey_lib_common::publish_test_results 6
-        flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 15 flowey_lib_common::publish_test_results 8
-        flowey e 15 flowey_lib_common::publish_test_results 9
-        flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey e 15 flowey_lib_common::publish_test_results 17
-        flowey e 15 flowey_lib_common::publish_test_results 18
-        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
         flowey e 15 flowey_lib_common::run_cargo_build 1
         flowey e 15 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2256,16 +1855,19 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
         flowey e 15 flowey_lib_common::publish_test_results 2
@@ -2275,14 +1877,12 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-musl-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
       run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -3194,8 +2794,6 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
@@ -3205,6 +2803,8 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3377,7 +2977,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3387,7 +2987,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3395,7 +2995,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3577,11 +3177,11 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-linux-amd-kvm]
+    name: run vmm-tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3721,7 +3321,7 @@ jobs:
     - name: setting up vmm_tests env
       run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
-    - name: ensure hypervisor device is accessible
+    - name: ensure /dev/kvm is accessible
       run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3796,9 +3396,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-linux-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3812,9 +3412,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-linux-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -3829,306 +3429,6 @@ jobs:
       run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-linux-intel-mshv]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job5
-    - job7
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 21 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 21 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey e 21 flowey_core::pipeline::artifact::resolve 7
-        flowey e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey e 21 flowey_core::pipeline::artifact::resolve 6
-        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 21 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 21 flowey_lib_common::cache 8
-        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 21 flowey_lib_common::cache 10
-        flowey e 21 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 21 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 21 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 21 flowey_lib_common::cache 4
-        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 21 flowey_lib_common::cache 6
-        flowey e 21 flowey_lib_common::download_gh_cli 1
-        flowey v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 21 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 21 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey e 21 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 21 flowey_lib_common::cache 0
-        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 21 flowey_lib_common::cache 2
-        flowey e 21 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 21 flowey_lib_common::git_checkout 0
-        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 21 flowey_lib_common::git_checkout 3
-        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 21 flowey_core::pipeline::artifact::resolve 5
-        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 21 flowey_lib_common::publish_test_results 4
-        flowey e 21 flowey_lib_common::publish_test_results 5
-        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 21 flowey_lib_common::publish_test_results 0
-        flowey e 21 flowey_lib_common::publish_test_results 1
-        flowey e 21 flowey_lib_common::publish_test_results 2
-        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 21 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 21 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 21 flowey_lib_common::cache 11
-      shell: bash
-  job22:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -4148,7 +3448,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4158,7 +3458,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4166,7 +3466,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4209,35 +3509,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 22 'verbose' update
+        cat <<'EOF' | flowey.exe v 21 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 22 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 21 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 21 flowey_lib_common::cache 0
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4247,17 +3547,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 22 flowey_lib_common::cache 2
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 21 flowey_lib_common::cache 2
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 21 flowey_lib_common::git_checkout 0
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4269,35 +3569,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 22 flowey_lib_common::git_checkout 3
-        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_lib_common::git_checkout 3
+        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 21 flowey_lib_common::cache 8
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4307,31 +3607,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 22 flowey_lib_common::cache 10
-        flowey.exe e 22 flowey_lib_common::download_gh_release 1
+        flowey.exe e 21 flowey_lib_common::cache 10
+        flowey.exe e 21 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 21 flowey_lib_common::cache 4
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4341,63 +3641,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 22 flowey_lib_common::cache 6
-        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 21 flowey_lib_common::cache 6
+        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe e 22 flowey_lib_common::publish_test_results 5
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 21 flowey_lib_common::publish_test_results 4
+        flowey.exe e 21 flowey_lib_common::publish_test_results 5
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4408,12 +3708,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 22 flowey_lib_common::publish_test_results 0
-        flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe e 22 flowey_lib_common::publish_test_results 2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 21 flowey_lib_common::publish_test_results 0
+        flowey.exe e 21 flowey_lib_common::publish_test_results 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4423,18 +3723,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 22 flowey_lib_common::cache 3
+      run: flowey.exe e 21 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 22 flowey_lib_common::cache 7
+      run: flowey.exe e 21 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 22 flowey_lib_common::cache 11
+      run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
-  job23:
+  job22:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -4446,7 +3746,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4456,7 +3756,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4464,7 +3764,121 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 22 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 22 flowey_lib_common::git_checkout 0
+        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 22 flowey_lib_common::git_checkout 3
+        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 22 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: |-
+        flowey e 22 flowey_lib_common::install_rust 1
+        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job23:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4508,28 +3922,42 @@ jobs:
         cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: check if openvmm needs to be cloned
+    - name: checking if packages need to be installed
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 23 flowey_lib_common::cache 0
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
       with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
+        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_common::cache 2
+        flowey e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 23 flowey_lib_common::install_rust 0
@@ -4540,144 +3968,13 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 23 flowey_lib_common::install_rust 2
-        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 23 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job24:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 24 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 24 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 24 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 24 flowey_lib_common::cache 2
-        flowey e 24 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 24 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 24 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 24 flowey_lib_common::install_rust 2
-        flowey e 24 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 23 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4689,172 +3986,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 24 flowey_lib_common::git_checkout 3
-        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 24 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 23 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 24 flowey_lib_common::resolve_protoc 0
-        flowey e 24 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 23 flowey_lib_common::resolve_protoc 0
+        flowey e 23 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 24 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 24 flowey_lib_hvlite::init_cross_build 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 23 flowey_lib_hvlite::init_cross_build 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 24 flowey_lib_common::run_cargo_build 3
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 23 flowey_lib_common::run_cargo_build 3
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 24 flowey_lib_hvlite::build_sidecar 0
-        flowey e 24 flowey_lib_hvlite::init_cross_build 1
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 23 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 23 flowey_lib_hvlite::build_sidecar 0
+        flowey e 23 flowey_lib_hvlite::init_cross_build 1
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 24 flowey_lib_common::run_cargo_build 1
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 23 flowey_lib_common::run_cargo_build 1
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 24 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 23 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 23 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 24 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract X64 sysroot.tar.gz
       run: |-
-        flowey e 24 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 24 flowey_lib_hvlite::init_cross_build 3
+        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 23 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 24 flowey_lib_common::run_cargo_build 2
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 24 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 23 flowey_lib_common::run_cargo_build 2
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 23 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 23 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 24 flowey_lib_hvlite::init_cross_build 2
+        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 23 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 24 flowey_lib_common::run_cargo_build 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 23 flowey_lib_common::run_cargo_build 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 24 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 24 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 23 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 23 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 23 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 24 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 23 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 23 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 24 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 23 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 24 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 23 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 24 flowey_lib_common::cache 3
+      run: flowey e 23 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -4868,18 +4165,18 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job25:
+  job24:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job24
+    - job23
     - job5
     - job7
     - job9
@@ -4901,39 +4198,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
 
-        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 25 'verbose' update
+        cat <<'EOF' | flowey.exe v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 25 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 25 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 25 flowey_lib_common::cache 0
-        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 24 flowey_lib_common::cache 0
+        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4943,17 +4240,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 25 flowey_lib_common::cache 2
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 24 flowey_lib_common::cache 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 25 flowey_lib_common::git_checkout 0
-        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_common::git_checkout 0
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4965,38 +4262,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 25 flowey_lib_common::git_checkout 3
-        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_lib_common::git_checkout 3
+        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 25 flowey_lib_common::cache 8
-        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 24 flowey_lib_common::cache 8
+        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5006,31 +4303,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 25 flowey_lib_common::cache 10
-        flowey.exe e 25 flowey_lib_common::download_gh_release 1
+        flowey.exe e 24 flowey_lib_common::cache 10
+        flowey.exe e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 25 flowey_lib_common::cache 4
-        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 24 flowey_lib_common::cache 4
+        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5040,63 +4337,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 25 flowey_lib_common::cache 6
-        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 24 flowey_lib_common::cache 6
+        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 25 flowey_lib_common::publish_test_results 4
-        flowey.exe e 25 flowey_lib_common::publish_test_results 5
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 24 flowey_lib_common::publish_test_results 4
+        flowey.exe e 24 flowey_lib_common::publish_test_results 5
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5107,12 +4404,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 25 flowey_lib_common::publish_test_results 0
-        flowey.exe e 25 flowey_lib_common::publish_test_results 1
-        flowey.exe e 25 flowey_lib_common::publish_test_results 2
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 24 flowey_lib_common::publish_test_results 0
+        flowey.exe e 24 flowey_lib_common::publish_test_results 1
+        flowey.exe e 24 flowey_lib_common::publish_test_results 2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5122,18 +4419,18 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 25 flowey_lib_common::cache 3
+      run: flowey.exe e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 25 flowey_lib_common::cache 7
+      run: flowey.exe e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 25 flowey_lib_common::cache 11
+      run: flowey.exe e 24 flowey_lib_common::cache 11
       shell: bash
-  job26:
+  job25:
     name: publish vmgstool
     runs-on: ubuntu-latest
     permissions:
@@ -5158,7 +4455,6 @@ jobs:
     - job22
     - job23
     - job24
-    - job25
     - job3
     - job4
     - job5
@@ -5184,25 +4480,25 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9/flowey
 
-        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 26 'verbose' update
+        cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 26 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 26 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 26 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 25 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 25 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 25 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: create gh cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5212,31 +4508,31 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_gh_cli 1
-        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_gh_cli 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
       run: |-
-        flowey e 26 flowey_lib_common::use_gh_cli 0
-        flowey e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_lib_common::use_gh_cli 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey e 25 flowey_core::pipeline::artifact::resolve 2
       shell: bash
     - name: enumerate vmgstool release files
-      run: flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
+      run: flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5248,29 +4544,29 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: get current commit
       run: |-
-        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
-        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
+        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
+        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
       shell: bash
     - name: get cargo crate version
       run: |-
-        flowey e 26 flowey_lib_common::get_cargo_crate_version 0
-        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
-        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
-        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
+        flowey e 25 flowey_lib_common::get_cargo_crate_version 0
+        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
+        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
+        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
       shell: bash
     - name: publish github releases
-      run: flowey e 26 flowey_lib_common::publish_gh_release 0
+      run: flowey e 25 flowey_lib_common::publish_gh_release 0
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 26 flowey_lib_common::cache 3
+      run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
@@ -5288,7 +4584,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5298,7 +4594,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5306,7 +4602,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5606,7 +4902,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5616,7 +4912,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5624,7 +4920,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5825,7 +5121,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5835,7 +5131,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5843,7 +5139,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6140,7 +5436,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6151,7 +5447,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6161,7 +5457,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6169,7 +5465,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6481,7 +5777,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6492,7 +5788,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6502,7 +5798,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6510,7 +5806,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6878,7 +6174,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6889,7 +6185,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6899,7 +6195,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6907,7 +6203,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -7159,7 +6455,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
         flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
-    - name: copying openhcl build to publish dir
+    - name: copying openhcl build and kernels to publish dir
       run: |-
         flowey e 8 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 3
@@ -7227,7 +6523,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7238,7 +6534,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -7248,7 +6544,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -7256,7 +6552,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -7300,16 +6596,10 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 9 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
@@ -7328,22 +6618,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 9 flowey_lib_common::cache 6
+        flowey e 9 flowey_lib_common::cache 2
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
@@ -7363,7 +6653,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -7371,7 +6661,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -7394,18 +6684,18 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 17
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 11
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 18
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_sidecar 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 2
@@ -7430,15 +6720,15 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract X64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
         flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 1
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
@@ -7593,51 +6883,9 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: copying openhcl build to publish dir
-      run: |-
-        flowey e 9 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 9 flowey_lib_hvlite::build_pipette 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 8
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 19
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 12
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 20
-        flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 2
         flowey e 9 flowey_lib_hvlite::run_cargo_build 6
@@ -7646,81 +6894,41 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::build_openvmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: copying openhcl build and kernels to publish dir
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 9 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 3
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::build_pipette 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: create cargo-nextest cache dir
+    - name: cargo build tmk_vmm
       run: |-
-        flowey e 9 flowey_lib_common::download_cargo_nextest 0
-        flowey e 9 flowey_lib_common::download_cargo_nextest 1
-        flowey e 9 flowey_lib_common::download_cargo_nextest 2
-        flowey e 9 flowey_lib_common::download_cargo_nextest 3
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
-    - name: Pre-processing cache vars
+    - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 9 flowey_lib_common::cache 2
-        flowey e 9 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 9 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 9 flowey_lib_common::install_cargo_nextest 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 9 flowey_lib_common::cache 3
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
+        flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 9 flowey_lib_common::cache 7
+      run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
@@ -7732,12 +6940,6 @@ jobs:
       with:
         name: x64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-baseline
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -15,6 +15,9 @@ on:
     branches:
     - main
     - release/*
+    paths-ignore:
+    - Guide/**
+    - petri/logview/**
 jobs:
   job0:
     name: xtask fmt (windows)
@@ -30,7 +33,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -40,7 +43,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -48,7 +51,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -186,7 +189,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -196,7 +199,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -204,7 +207,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -357,7 +360,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -367,7 +370,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -375,7 +378,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -434,7 +437,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 10 flowey_lib_common::git_checkout 0
-        flowey.exe v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
+        flowey.exe v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
         flowey.exe v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -442,7 +445,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar6 }}
+        persist-credentials: ${{ env.floweyvar7 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -462,14 +465,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 10 flowey_lib_common::cache 4
-        flowey.exe v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -502,6 +505,9 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 10 flowey_lib_common::run_cargo_clippy 0
       shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 10 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 10 flowey_lib_common::download_cargo_nextest 0
@@ -512,14 +518,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 10 flowey_lib_common::cache 0
-        flowey.exe v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -550,13 +556,34 @@ jobs:
         flowey.exe e 10 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
+        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 10 flowey_lib_common::publish_test_results 5
+        flowey.exe e 10 flowey_lib_common::publish_test_results 6
+        flowey.exe e 10 flowey_lib_common::publish_test_results 4
+        flowey.exe v 10 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 10 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
         flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 10 flowey_lib_common::publish_test_results 0
         flowey.exe e 10 flowey_lib_common::publish_test_results 1
         flowey.exe e 10 flowey_lib_common::publish_test_results 2
@@ -566,12 +593,14 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
+      run: |-
+        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
       run: flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -587,7 +616,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -598,7 +627,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -608,7 +637,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -616,7 +645,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -675,7 +704,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -683,7 +712,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar6 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -703,14 +732,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -734,27 +763,6 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine clippy exclusions
-      run: |-
-        flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_clippy 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
@@ -769,10 +777,43 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
+      run: |-
+        flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 11 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 11 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 11 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_clippy 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine clippy exclusions
       run: flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 11 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 11 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -784,14 +825,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -807,10 +848,54 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 11 flowey_lib_common::install_cargo_nextest 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
+    - name: generate nextest command
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 11 flowey_lib_common::publish_test_results 5
+        flowey e 11 flowey_lib_common::publish_test_results 6
+        flowey e 11 flowey_lib_common::publish_test_results 4
+        flowey v 11 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 11 flowey_lib_common::publish_test_results 8
+        flowey e 11 flowey_lib_common::publish_test_results 9
+        flowey e 11 flowey_lib_common::publish_test_results 10
+        flowey v 11 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
         flowey e 11 flowey_lib_common::run_cargo_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
@@ -821,19 +906,37 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine unit test exclusions
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 11 flowey_lib_common::publish_test_results 12
+        flowey e 11 flowey_lib_common::publish_test_results 13
+        flowey e 11 flowey_lib_common::publish_test_results 14
+        flowey v 11 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 11 flowey_lib_common::publish_test_results 0
         flowey e 11 flowey_lib_common::publish_test_results 1
         flowey e 11 flowey_lib_common::publish_test_results 2
@@ -843,12 +946,14 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
       run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -864,7 +969,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -875,7 +980,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -885,7 +990,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -893,7 +998,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -952,7 +1057,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -960,7 +1065,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar6 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -984,14 +1089,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1004,7 +1109,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -1017,6 +1122,19 @@ jobs:
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 6
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_clippy 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1040,7 +1158,7 @@ jobs:
       run: flowey e 12 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1052,14 +1170,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1075,10 +1193,96 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
+    - name: generate nextest command
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 12 flowey_lib_common::publish_test_results 5
+        flowey e 12 flowey_lib_common::publish_test_results 6
+        flowey e 12 flowey_lib_common::publish_test_results 4
+        flowey v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 12 flowey_lib_common::publish_test_results 8
+        flowey e 12 flowey_lib_common::publish_test_results 9
+        flowey e 12 flowey_lib_common::publish_test_results 10
+        flowey v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 12 flowey_lib_common::publish_test_results 12
+        flowey e 12 flowey_lib_common::publish_test_results 13
+        flowey e 12 flowey_lib_common::publish_test_results 14
+        flowey v 12 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 12 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 12 flowey_lib_common::publish_test_results 16
+        flowey e 12 flowey_lib_common::publish_test_results 17
+        flowey e 12 flowey_lib_common::publish_test_results 18
+        flowey v 12 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 12 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_common::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1089,19 +1293,16 @@ jobs:
         flowey e 12 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 12 flowey_lib_common::publish_test_results 0
         flowey e 12 flowey_lib_common::publish_test_results 1
         flowey e 12 flowey_lib_common::publish_test_results 2
@@ -1111,12 +1312,14 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-musl-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
       run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1143,7 +1346,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1153,7 +1356,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1161,7 +1364,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1220,7 +1423,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
         flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1228,7 +1431,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar6 }}
+        persist-credentials: ${{ env.floweyvar7 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1248,14 +1451,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1288,6 +1491,9 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 0
       shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 13 flowey_lib_common::download_cargo_nextest 0
@@ -1298,14 +1504,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1336,13 +1542,34 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 13 flowey_lib_common::publish_test_results 5
+        flowey.exe e 13 flowey_lib_common::publish_test_results 6
+        flowey.exe e 13 flowey_lib_common::publish_test_results 4
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 13 flowey_lib_common::publish_test_results 0
         flowey.exe e 13 flowey_lib_common::publish_test_results 1
         flowey.exe e 13 flowey_lib_common::publish_test_results 2
@@ -1352,12 +1579,14 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
+      run: |-
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
       run: flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1384,7 +1613,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1394,7 +1623,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1402,7 +1631,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1467,7 +1696,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1475,7 +1704,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar6 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1495,14 +1724,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1540,6 +1769,15 @@ jobs:
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 14 flowey_lib_common::download_cargo_nextest 0
@@ -1550,14 +1788,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1573,10 +1811,54 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::publish_test_results 5
+        flowey e 14 flowey_lib_common::publish_test_results 6
+        flowey e 14 flowey_lib_common::publish_test_results 4
+        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::publish_test_results 8
+        flowey e 14 flowey_lib_common::publish_test_results 9
+        flowey e 14 flowey_lib_common::publish_test_results 10
+        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
         flowey e 14 flowey_lib_common::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1587,19 +1869,37 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
@@ -1609,12 +1909,14 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
       run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1641,7 +1943,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1651,7 +1953,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1659,7 +1961,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1718,7 +2020,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1726,7 +2028,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar6 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1750,14 +2052,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1783,6 +2085,19 @@ jobs:
       run: |-
         flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_clippy 5
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1806,7 +2121,7 @@ jobs:
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1818,14 +2133,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1841,10 +2156,96 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 15 flowey_lib_common::publish_test_results 5
+        flowey e 15 flowey_lib_common::publish_test_results 6
+        flowey e 15 flowey_lib_common::publish_test_results 4
+        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 15 flowey_lib_common::publish_test_results 8
+        flowey e 15 flowey_lib_common::publish_test_results 9
+        flowey e 15 flowey_lib_common::publish_test_results 10
+        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey e 15 flowey_lib_common::publish_test_results 13
+        flowey e 15 flowey_lib_common::publish_test_results 14
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_common::publish_test_results 16
+        flowey e 15 flowey_lib_common::publish_test_results 17
+        flowey e 15 flowey_lib_common::publish_test_results 18
+        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
         flowey e 15 flowey_lib_common::run_cargo_build 1
         flowey e 15 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1855,19 +2256,16 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 3
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
         flowey e 15 flowey_lib_common::publish_test_results 2
@@ -1877,12 +2275,14 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 1
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
       run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2794,6 +3194,8 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
@@ -2803,8 +3205,6 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -2977,7 +3377,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2987,7 +3387,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -2995,7 +3395,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3177,11 +3577,11 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-linux]
+    name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3321,7 +3721,7 @@ jobs:
     - name: setting up vmm_tests env
       run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
-    - name: ensure /dev/kvm is accessible
+    - name: ensure hypervisor device is accessible
       run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3396,9 +3796,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmm-tests-logs
+        name: x64-linux-amd-kvm-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3412,9 +3812,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmm-tests-junit-xml
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -3429,6 +3829,306 @@ jobs:
       run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
+    name: run vmm-tests [x64-linux-intel-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job5
+    - job7
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 21 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 21 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 8
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 10
+        flowey e 21 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 21 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 4
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 6
+        flowey e 21 flowey_lib_common::download_gh_cli 1
+        flowey v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 21 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 21 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 21 flowey_lib_common::git_checkout 0
+        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 21 flowey_lib_common::git_checkout 3
+        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_common::publish_test_results 4
+        flowey e 21 flowey_lib_common::publish_test_results 5
+        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-intel-mshv-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 21 flowey_lib_common::publish_test_results 0
+        flowey e 21 flowey_lib_common::publish_test_results 1
+        flowey e 21 flowey_lib_common::publish_test_results 2
+        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 21 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 21 flowey_lib_common::cache 11
+      shell: bash
+  job22:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -3448,7 +4148,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3458,7 +4158,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3466,7 +4166,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3509,35 +4209,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 21 'verbose' update
+        cat <<'EOF' | flowey.exe v 22 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 21 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 22 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3547,17 +4247,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3569,35 +4269,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 21 flowey_lib_common::git_checkout 3
-        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3607,31 +4307,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 10
-        flowey.exe e 21 flowey_lib_common::download_gh_release 1
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3641,63 +4341,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -3708,12 +4408,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 21 flowey_lib_common::publish_test_results 0
-        flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -3723,18 +4423,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 21 flowey_lib_common::cache 3
+      run: flowey.exe e 22 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 21 flowey_lib_common::cache 7
+      run: flowey.exe e 22 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
+      run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
-  job22:
+  job23:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -3746,7 +4446,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3756,7 +4456,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3764,121 +4464,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 22 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 22 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: |-
-        flowey e 22 flowey_lib_common::install_rust 1
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job23:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3922,42 +4508,28 @@ jobs:
         cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
+    - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
       run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
         EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 23 flowey_lib_common::install_rust 0
@@ -3968,13 +4540,144 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 23 flowey_lib_common::install_rust 2
-        flowey e 23 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 23 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job24:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 24 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 24 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 24 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 24 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 24 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 24 flowey_lib_common::install_rust 2
+        flowey e 24 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3986,172 +4689,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 23 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 24 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 23 flowey_lib_common::resolve_protoc 0
-        flowey e 23 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 24 flowey_lib_common::resolve_protoc 0
+        flowey e 24 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 24 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 24 flowey_lib_common::run_cargo_build 3
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 23 flowey_lib_hvlite::build_sidecar 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 24 flowey_lib_hvlite::build_sidecar 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 1
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 24 flowey_lib_common::run_cargo_build 1
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 24 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
-    - name: extract X64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 3
+        flowey e 24 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 23 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 24 flowey_lib_common::run_cargo_build 2
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 24 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 23 flowey_lib_hvlite::init_cross_build 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 24 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 24 flowey_lib_common::run_cargo_build 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 24 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 24 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 23 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 24 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 23 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 24 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 3
+      run: flowey e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -4165,18 +4868,18 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job24:
+  job25:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job23
+    - job24
     - job5
     - job7
     - job9
@@ -4198,39 +4901,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 25 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 25 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 25 flowey_lib_common::cache 0
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4240,17 +4943,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 25 flowey_lib_common::cache 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_common::git_checkout 0
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4262,38 +4965,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_lib_common::git_checkout 3
+        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 25 flowey_lib_common::cache 8
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4303,31 +5006,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 25 flowey_lib_common::cache 10
+        flowey.exe e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 25 flowey_lib_common::cache 4
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4337,63 +5040,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 25 flowey_lib_common::cache 6
+        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 25 flowey_lib_common::publish_test_results 4
+        flowey.exe e 25 flowey_lib_common::publish_test_results 5
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4404,12 +5107,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_common::publish_test_results 0
+        flowey.exe e 25 flowey_lib_common::publish_test_results 1
+        flowey.exe e 25 flowey_lib_common::publish_test_results 2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4419,18 +5122,18 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 25 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job26:
     name: publish vmgstool
     runs-on: ubuntu-latest
     permissions:
@@ -4455,6 +5158,7 @@ jobs:
     - job22
     - job23
     - job24
+    - job25
     - job3
     - job4
     - job5
@@ -4480,25 +5184,25 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 25 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 25 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 25 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 26 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 26 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 26 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      run: flowey e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4508,31 +5212,31 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_gh_cli 1
+        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
       run: |-
-        flowey e 25 flowey_lib_common::use_gh_cli 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 26 flowey_lib_common::use_gh_cli 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey e 26 flowey_core::pipeline::artifact::resolve 2
       shell: bash
     - name: enumerate vmgstool release files
-      run: flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
+      run: flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4544,29 +5248,29 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: get current commit
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
       shell: bash
     - name: get cargo crate version
       run: |-
-        flowey e 25 flowey_lib_common::get_cargo_crate_version 0
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
+        flowey e 26 flowey_lib_common::get_cargo_crate_version 0
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
       shell: bash
     - name: publish github releases
-      run: flowey e 25 flowey_lib_common::publish_gh_release 0
+      run: flowey e 26 flowey_lib_common::publish_gh_release 0
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 3
+      run: flowey e 26 flowey_lib_common::cache 3
       shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
@@ -4584,7 +5288,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4594,7 +5298,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4602,7 +5306,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4902,7 +5606,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4912,7 +5616,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4920,7 +5624,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5121,7 +5825,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5131,7 +5835,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5139,7 +5843,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5436,7 +6140,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5447,7 +6151,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5457,7 +6161,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5465,7 +6169,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5777,7 +6481,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5788,7 +6492,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5798,7 +6502,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5806,7 +6510,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6174,7 +6878,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6185,7 +6889,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6195,7 +6899,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6203,7 +6907,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6523,7 +7227,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6534,7 +7238,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6544,7 +7248,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6552,7 +7256,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6596,10 +7300,16 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 9 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
@@ -6618,22 +7328,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 9 flowey_lib_common::cache 4
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::cache 6
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
@@ -6653,7 +7363,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar5
         flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -6661,7 +7371,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -6684,18 +7394,18 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 17
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 11
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 18
         flowey e 9 flowey_lib_hvlite::build_sidecar 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 2
@@ -6720,15 +7430,15 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
         flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 1
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
@@ -6883,9 +7593,51 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build and kernels to publish dir
+      run: |-
+        flowey e 9 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::build_pipette 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 8
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 19
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 12
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 20
+        flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 2
         flowey e 9 flowey_lib_hvlite::run_cargo_build 6
@@ -6894,41 +7646,81 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
-    - name: copying openhcl build and kernels to publish dir
+    - name: cargo build openvmm_vhost
       run: |-
-        flowey e 9 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 9 flowey_lib_hvlite::build_pipette 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 3
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
+        flowey e 9 flowey_lib_common::download_cargo_nextest 0
+        flowey e 9 flowey_lib_common::download_cargo_nextest 1
+        flowey e 9 flowey_lib_common::download_cargo_nextest 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 3
       shell: bash
-    - name: split debug symbols
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
-        flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 9 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 9 flowey_lib_common::install_cargo_nextest 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 9 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
@@ -6940,6 +7732,12 @@ jobs:
       with:
         name: x64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-baseline
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -554,7 +554,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract X64 sysroot.tar.gz
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 5
@@ -958,7 +958,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract X64 sysroot.tar.gz
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -986,7 +986,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:10:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:151:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
@@ -1005,6 +1005,12 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 3
         flowey e 11 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
       shell: bash
     - name: create gh cache dir
       run: flowey e 11 flowey_lib_common::download_gh_cli 0
@@ -1708,7 +1714,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract X64 sysroot.tar.gz
       run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -5270,7 +5276,7 @@ jobs:
         flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
         flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract X64 sysroot.tar.gz
       run: |-
         flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 26 flowey_lib_hvlite::init_cross_build 3
@@ -7662,7 +7668,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 9 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 9 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:151:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
@@ -7681,6 +7687,9 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 3
         flowey e 9 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
       shell: bash
     - name: create gh cache dir
       run: flowey e 9 flowey_lib_common::download_gh_cli 0

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -554,7 +554,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 5
@@ -958,7 +958,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -986,7 +986,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:10:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:151:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:10:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:137:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
@@ -1714,7 +1714,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -5276,7 +5276,7 @@ jobs:
         flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
         flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
-    - name: extract X64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 26 flowey_lib_hvlite::init_cross_build 3
@@ -7668,7 +7668,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 9 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 9 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:151:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:137:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -13,6 +13,7 @@ use flowey::node::prelude::ReadVar;
 use flowey::pipeline::prelude::*;
 use flowey_lib_common::git_checkout::RepoSource;
 use flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe::OpenhclIgvmBuildParams;
+use flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline::KernelCheck;
 use flowey_lib_hvlite::build_openhcl_igvm_from_recipe::OpenhclIgvmRecipe;
 use flowey_lib_hvlite::build_openvmm_hcl::OpenvmmHclBuildProfile;
 use flowey_lib_hvlite::build_openvmm_hcl::OpenvmmHclFeature;
@@ -747,7 +748,6 @@ impl IntoPipeline for CheckinGatesCli {
             all_jobs.push(job.finish());
         }
 
-        use flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline::KernelCheck;
         use flowey_lib_hvlite::resolve_openhcl_kernel_package::OpenhclKernelPackageKind;
 
         // emit openhcl build job

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -747,6 +747,9 @@ impl IntoPipeline for CheckinGatesCli {
             all_jobs.push(job.finish());
         }
 
+        use flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline::KernelCheck;
+        use flowey_lib_hvlite::resolve_openhcl_kernel_package::OpenhclKernelPackageKind;
+
         // emit openhcl build job
         for arch in [CommonArch::Aarch64, CommonArch::X86_64] {
             let arch_tag = match arch {
@@ -772,6 +775,23 @@ impl IntoPipeline for CheckinGatesCli {
                 } else {
                     (None, None)
                 };
+
+            let arch_kernel_checks: Vec<KernelCheck> = match arch {
+                CommonArch::X86_64 => vec![
+                    KernelCheck {
+                        kind: OpenhclKernelPackageKind::Main,
+                        label: "kernel-main".into(),
+                    },
+                    KernelCheck {
+                        kind: OpenhclKernelPackageKind::Cvm,
+                        label: "kernel-cvm".into(),
+                    },
+                ],
+                CommonArch::Aarch64 => vec![KernelCheck {
+                    kind: OpenhclKernelPackageKind::Main,
+                    label: "kernel-main".into(),
+                }],
+            };
 
             // also build pipette musl on this job, as until we land the
             // refactor that allows building musl without the full openhcl
@@ -874,6 +894,7 @@ impl IntoPipeline for CheckinGatesCli {
                         artifact_dir_openhcl_igvm_extras: ctx
                             .publish_artifact(pub_openhcl_igvm_extras),
                         artifact_openhcl_verify_size_baseline: publish_baseline_artifact,
+                        kernel_checks_for_baseline: arch_kernel_checks.clone(),
                         done: ctx.new_done_handle(),
                     }
                 })
@@ -958,6 +979,7 @@ impl IntoPipeline for CheckinGatesCli {
                                 arch,
                                 platform: CommonPlatform::LinuxMusl,
                             },
+                            kernel_checks: arch_kernel_checks,
                             done,
                             pipeline_name: "openvmm-ci.yaml".into(),
                             job_name: build_openhcl_job_tag(arch_tag),
@@ -1528,6 +1550,7 @@ impl IntoPipeline for CheckinGatesCli {
                         artifact_dir_openhcl_igvm_extras: ctx
                             .publish_artifact(pub_mi_secure_igvm_extras),
                         artifact_openhcl_verify_size_baseline: None,
+                        kernel_checks_for_baseline: vec![],
                         done: ctx.new_done_handle(),
                     }
                 });

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs
@@ -35,6 +35,7 @@ flowey_request! {
         pub artifact_dir_openhcl_igvm: ReadVar<PathBuf>,
         pub artifact_dir_openhcl_igvm_extras: ReadVar<PathBuf>,
         pub artifact_openhcl_verify_size_baseline: Option<ReadVar<PathBuf>>,
+        pub kernel_checks_for_baseline: Vec<build_and_publish_openvmm_hcl_baseline::KernelCheck>,
         pub done: WriteVar<SideEffect>,
     }
 }
@@ -58,6 +59,7 @@ impl SimpleFlowNode for Node {
             artifact_dir_openhcl_igvm,
             artifact_dir_openhcl_igvm_extras,
             artifact_openhcl_verify_size_baseline,
+            kernel_checks_for_baseline,
             done,
         } = request;
 
@@ -149,6 +151,7 @@ impl SimpleFlowNode for Node {
                     did_publish.push(ctx.reqv(|v| {
                         build_and_publish_openvmm_hcl_baseline::Request {
                             target: custom_target,
+                            kernel_checks: kernel_checks_for_baseline,
                             artifact_dir: sizecheck_artifact,
                             done: v,
                         }

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm_hcl_baseline.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm_hcl_baseline.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Builds and publishes an OpenHCL binary for size comparison with PRs.
+//! Builds and publishes an OpenHCL binary and kernel binaries for size
+//! comparison with PRs.
 
 use crate::artifact_openvmm_hcl_sizecheck;
 use crate::build_openhcl_igvm_from_recipe::OpenhclIgvmRecipe;
@@ -10,11 +11,21 @@ use crate::build_openvmm_hcl::OpenvmmHclBuildParams;
 use crate::build_openvmm_hcl::OpenvmmHclBuildProfile;
 use crate::common::CommonArch;
 use crate::common::CommonTriple;
+use crate::resolve_openhcl_kernel_package::OpenhclKernelPackageArch;
+use crate::resolve_openhcl_kernel_package::OpenhclKernelPackageKind;
 use flowey::node::prelude::*;
+
+/// A kernel to include in the baseline artifact.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct KernelCheck {
+    pub kind: OpenhclKernelPackageKind,
+    pub label: String,
+}
 
 flowey_request! {
     pub struct Request {
         pub target: CommonTriple,
+        pub kernel_checks: Vec<KernelCheck>,
         pub artifact_dir: ReadVar<PathBuf>,
         pub done: WriteVar<SideEffect>,
     }
@@ -28,16 +39,20 @@ impl SimpleFlowNode for Node {
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<artifact_openvmm_hcl_sizecheck::publish::Node>();
         ctx.import::<build_openvmm_hcl::Node>();
+        ctx.import::<crate::resolve_openhcl_kernel_package::Node>();
     }
 
     fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
         let Request {
             target,
+            kernel_checks,
             done,
             artifact_dir,
         } = request;
 
-        let recipe = match target.common_arch().unwrap() {
+        let arch = target.common_arch().unwrap();
+
+        let recipe = match arch {
             CommonArch::X86_64 => OpenhclIgvmRecipe::X64,
             CommonArch::Aarch64 => OpenhclIgvmRecipe::Aarch64,
         }
@@ -54,8 +69,32 @@ impl SimpleFlowNode for Node {
             openvmm_hcl_output: v,
         });
 
+        let kernel_arch = match arch {
+            CommonArch::X86_64 => OpenhclKernelPackageArch::X86_64,
+            CommonArch::Aarch64 => OpenhclKernelPackageArch::Aarch64,
+        };
+
+        let kernel_baselines: Vec<_> = kernel_checks
+            .into_iter()
+            .map(|kc| {
+                let kernel =
+                    ctx.reqv(
+                        |v| crate::resolve_openhcl_kernel_package::Request::GetKernel {
+                            kind: kc.kind,
+                            arch: kernel_arch,
+                            kernel: v,
+                        },
+                    );
+                artifact_openvmm_hcl_sizecheck::publish::KernelBaseline {
+                    label: kc.label,
+                    kernel,
+                }
+            })
+            .collect();
+
         ctx.req(artifact_openvmm_hcl_sizecheck::publish::Request {
             openvmm_openhcl: baseline_hcl_build,
+            kernel_baselines,
             artifact_dir,
             done,
         });

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm_hcl_baseline.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm_hcl_baseline.rs
@@ -11,7 +11,6 @@ use crate::build_openvmm_hcl::OpenvmmHclBuildParams;
 use crate::build_openvmm_hcl::OpenvmmHclBuildProfile;
 use crate::common::CommonArch;
 use crate::common::CommonTriple;
-use crate::resolve_openhcl_kernel_package::OpenhclKernelPackageArch;
 use crate::resolve_openhcl_kernel_package::OpenhclKernelPackageKind;
 use flowey::node::prelude::*;
 
@@ -69,10 +68,7 @@ impl SimpleFlowNode for Node {
             openvmm_hcl_output: v,
         });
 
-        let kernel_arch = match arch {
-            CommonArch::X86_64 => OpenhclKernelPackageArch::X86_64,
-            CommonArch::Aarch64 => OpenhclKernelPackageArch::Aarch64,
-        };
+        let kernel_arch = arch;
 
         let kernel_baselines: Vec<_> = kernel_checks
             .into_iter()

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_openhcl_igvm_from_recipe_nix.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_openhcl_igvm_from_recipe_nix.rs
@@ -56,6 +56,7 @@ impl SimpleFlowNode for Node {
                 artifact_dir_openhcl_igvm,
                 artifact_dir_openhcl_igvm_extras,
                 artifact_openhcl_verify_size_baseline,
+                kernel_checks_for_baseline: Vec::new(),
                 done,
             },
         );

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Compares the size of the OpenHCL binary in the current PR with the size of the binary from the last successful merge to main.
+//! Compares the size of the OpenHCL binary and kernel binaries in the current
+//! PR with the sizes from the last successful merge to main.
 
-use crate::artifact_openhcl_igvm_from_recipe_extras;
+use crate::_jobs::build_and_publish_openvmm_hcl_baseline::KernelCheck;
 use crate::build_openhcl_igvm_from_recipe;
 use crate::build_openhcl_igvm_from_recipe::OpenhclIgvmRecipe;
 use crate::build_openvmm_hcl;
@@ -11,6 +12,7 @@ use crate::build_openvmm_hcl::OpenvmmHclBuildParams;
 use crate::build_openvmm_hcl::OpenvmmHclBuildProfile::OpenvmmHclShip;
 use crate::common::CommonArch;
 use crate::common::CommonTriple;
+use crate::resolve_openhcl_kernel_package::OpenhclKernelPackageArch;
 use flowey::node::prelude::*;
 use flowey_lib_common::download_gh_artifact;
 use flowey_lib_common::gh_workflow_id;
@@ -19,6 +21,7 @@ use flowey_lib_common::git_merge_commit;
 flowey_request! {
     pub struct Request {
         pub target: CommonTriple,
+        pub kernel_checks: Vec<KernelCheck>,
         pub done: WriteVar<SideEffect>,
         pub pipeline_name: String,
         pub job_name: String,
@@ -33,21 +36,24 @@ impl SimpleFlowNode for Node {
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::build_xtask::Node>();
         ctx.import::<crate::git_checkout_openvmm_repo::Node>();
+        ctx.import::<crate::resolve_openhcl_kernel_package::Node>();
         ctx.import::<download_gh_artifact::Node>();
         ctx.import::<git_merge_commit::Node>();
         ctx.import::<gh_workflow_id::Node>();
         ctx.import::<build_openhcl_igvm_from_recipe::Node>();
         ctx.import::<build_openvmm_hcl::Node>();
-        ctx.import::<artifact_openhcl_igvm_from_recipe_extras::publish::Node>();
     }
 
     fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
         let Request {
             target,
+            kernel_checks,
             done,
             pipeline_name,
             job_name,
         } = request;
+
+        let arch = target.common_arch().unwrap();
 
         let xtask_target = CommonTriple::Common {
             arch: ctx.arch().try_into()?,
@@ -60,7 +66,7 @@ impl SimpleFlowNode for Node {
         });
         let openvmm_repo_path = ctx.reqv(crate::git_checkout_openvmm_repo::req::GetRepoDir);
 
-        let recipe = match target.common_arch().unwrap() {
+        let recipe = match arch {
             CommonArch::X86_64 => OpenhclIgvmRecipe::X64,
             CommonArch::Aarch64 => OpenhclIgvmRecipe::Aarch64,
         }
@@ -77,7 +83,27 @@ impl SimpleFlowNode for Node {
             openvmm_hcl_output: v,
         });
 
-        let file_name = match target.common_arch().unwrap() {
+        let kernel_arch = match arch {
+            CommonArch::X86_64 => OpenhclKernelPackageArch::X86_64,
+            CommonArch::Aarch64 => OpenhclKernelPackageArch::Aarch64,
+        };
+
+        let current_kernels: Vec<_> = kernel_checks
+            .iter()
+            .map(|kc| {
+                let kernel =
+                    ctx.reqv(
+                        |v| crate::resolve_openhcl_kernel_package::Request::GetKernel {
+                            kind: kc.kind,
+                            arch: kernel_arch,
+                            kernel: v,
+                        },
+                    );
+                (kc.label.clone(), kernel)
+            })
+            .collect();
+
+        let file_name = match arch {
             CommonArch::X86_64 => "x64-openhcl-baseline",
             CommonArch::Aarch64 => "aarch64-openhcl-baseline",
         };
@@ -111,10 +137,6 @@ impl SimpleFlowNode for Node {
         });
 
         // Publish the built binary as an artifact for offline analysis.
-        //
-        // FUTURE: Flowey should have a general mechanism for this. We cannot
-        // use the existing artifact support because all artifacts are only
-        // published at the end of the job, if everything else succeeds.
         let publish_artifact = if ctx.backend() == FlowBackend::Github {
             let dir = ctx.emit_rust_stepv("collect openvmm_hcl files for analysis", |ctx| {
                 let built_openvmm_hcl = built_openvmm_hcl.clone().claim(ctx);
@@ -152,13 +174,16 @@ impl SimpleFlowNode for Node {
         };
 
         let comparison = ctx.emit_rust_step("binary size comparison", |ctx| {
-            // Ensure the artifact is published before the analysis since this step may fail.
             let _publish_artifact = publish_artifact.claim(ctx);
             let xtask = xtask.claim(ctx);
             let openvmm_repo_path = openvmm_repo_path.claim(ctx);
             let old_openhcl = merge_head_artifact.claim(ctx);
             let new_openhcl = built_openvmm_hcl.claim(ctx);
             let merge_run = merge_run.claim(ctx);
+            let current_kernels: Vec<_> = current_kernels
+                .into_iter()
+                .map(|(label, k)| (label, k.claim(ctx)))
+                .collect();
 
             move |rt| {
                 let xtask = match rt.read(xtask) {
@@ -170,21 +195,35 @@ impl SimpleFlowNode for Node {
                 let new_openhcl = rt.read(new_openhcl);
                 let merge_run = rt.read(merge_run);
 
-                let old_path = old_openhcl.join(file_name).join("openhcl");
-                let new_path = new_openhcl.bin;
+                let path = rt.read(openvmm_repo_path);
+                rt.sh.change_dir(&path);
 
                 println!(
                     "comparing HEAD to merge commit {} and workflow {}",
                     merge_run.commit, merge_run.id
                 );
 
-                let path = rt.read(openvmm_repo_path);
-                rt.sh.change_dir(path);
+                // Compare usermode binary
+                let old_path = old_openhcl.join(file_name).join("openhcl");
+                let new_path = &new_openhcl.bin;
+                println!("== openvmm_hcl usermode binary ==");
                 flowey::shell_cmd!(
                     rt,
                     "{xtask} verify-size --original {old_path} --new {new_path}"
                 )
                 .run()?;
+
+                // Compare kernel binaries
+                for (label, kernel_var) in current_kernels {
+                    let new_kernel = rt.read(kernel_var);
+                    let old_kernel = old_openhcl.join(file_name).join(&label);
+                    println!("== kernel: {label} ==");
+                    flowey::shell_cmd!(
+                        rt,
+                        "{xtask} verify-size --original {old_kernel} --new {new_kernel}"
+                    )
+                    .run()?;
+                }
 
                 Ok(())
             }

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -12,7 +12,6 @@ use crate::build_openvmm_hcl::OpenvmmHclBuildParams;
 use crate::build_openvmm_hcl::OpenvmmHclBuildProfile::OpenvmmHclShip;
 use crate::common::CommonArch;
 use crate::common::CommonTriple;
-use crate::resolve_openhcl_kernel_package::OpenhclKernelPackageArch;
 use flowey::node::prelude::*;
 use flowey_lib_common::download_gh_artifact;
 use flowey_lib_common::gh_workflow_id;
@@ -83,10 +82,7 @@ impl SimpleFlowNode for Node {
             openvmm_hcl_output: v,
         });
 
-        let kernel_arch = match arch {
-            CommonArch::X86_64 => OpenhclKernelPackageArch::X86_64,
-            CommonArch::Aarch64 => OpenhclKernelPackageArch::Aarch64,
-        };
+        let kernel_arch = arch;
 
         let current_kernels: Vec<_> = kernel_checks
             .iter()
@@ -215,6 +211,13 @@ impl SimpleFlowNode for Node {
 
                 // Compare kernel binaries
                 for (label, kernel_var) in current_kernels {
+                    anyhow::ensure!(
+                        !label.is_empty()
+                            && !label.contains('/')
+                            && !label.contains('\\')
+                            && !label.starts_with('.'),
+                        "invalid kernel label: {label}"
+                    );
                     let new_kernel = rt.read(kernel_var);
                     let old_kernel = old_openhcl.join(file_name).join(&label);
                     println!("== kernel: {label} ==");

--- a/flowey/flowey_lib_hvlite/src/artifact_openvmm_hcl_sizecheck.rs
+++ b/flowey/flowey_lib_hvlite/src/artifact_openvmm_hcl_sizecheck.rs
@@ -1,16 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Artifact: `openhcl` binary to use for PR binary size comparison
+//! Artifact: `openhcl` binary and kernel binaries to use for PR binary size comparison
 
 /// Publish the artifact.
 pub mod publish {
     use crate::build_openvmm_hcl::OpenvmmHclOutput;
     use flowey::node::prelude::*;
 
+    /// A kernel binary to include in the sizecheck artifact.
+    #[derive(Serialize, Deserialize)]
+    pub struct KernelBaseline {
+        /// Label used as the filename in the artifact dir (e.g., "kernel-main").
+        pub label: String,
+        /// Path to the kernel binary.
+        pub kernel: ReadVar<PathBuf>,
+    }
+
     flowey_request! {
         pub struct Request {
             pub openvmm_openhcl: ReadVar<OpenvmmHclOutput>,
+            pub kernel_baselines: Vec<KernelBaseline>,
             pub artifact_dir: ReadVar<PathBuf>,
             pub done: WriteVar<SideEffect>,
         }
@@ -26,19 +36,35 @@ pub mod publish {
         fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
             let Request {
                 openvmm_openhcl,
+                kernel_baselines,
                 artifact_dir,
                 done,
             } = request;
 
-            ctx.emit_rust_step("copying openhcl build to publish dir", |ctx| {
+            ctx.emit_rust_step("copying openhcl build and kernels to publish dir", |ctx| {
                 done.claim(ctx);
                 let artifact_dir = artifact_dir.claim(ctx);
                 let openvmm_openhcl = openvmm_openhcl.claim(ctx);
+                let kernel_baselines: Vec<_> = kernel_baselines
+                    .into_iter()
+                    .map(|kb| (kb.label, kb.kernel.claim(ctx)))
+                    .collect();
 
                 move |rt| {
                     let artifact_dir = rt.read(artifact_dir);
                     let openvmm_openhcl = rt.read(openvmm_openhcl);
                     fs_err::copy(openvmm_openhcl.bin, artifact_dir.join("openhcl"))?;
+
+                    for (label, kernel_var) in kernel_baselines {
+                        assert!(
+                            !label.contains('/')
+                                && !label.contains('\\')
+                                && !label.starts_with('.'),
+                            "kernel baseline label must be a simple filename: {label}"
+                        );
+                        let kernel_path = rt.read(kernel_var);
+                        fs_err::copy(kernel_path, artifact_dir.join(&label))?;
+                    }
 
                     Ok(())
                 }

--- a/flowey/flowey_lib_hvlite/src/artifact_openvmm_hcl_sizecheck.rs
+++ b/flowey/flowey_lib_hvlite/src/artifact_openvmm_hcl_sizecheck.rs
@@ -55,12 +55,18 @@ pub mod publish {
                     let openvmm_openhcl = rt.read(openvmm_openhcl);
                     fs_err::copy(openvmm_openhcl.bin, artifact_dir.join("openhcl"))?;
 
+                    let mut seen_labels = std::collections::HashSet::new();
                     for (label, kernel_var) in kernel_baselines {
-                        assert!(
-                            !label.contains('/')
+                        anyhow::ensure!(
+                            !label.is_empty()
+                                && !label.contains('/')
                                 && !label.contains('\\')
                                 && !label.starts_with('.'),
-                            "kernel baseline label must be a simple filename: {label}"
+                            "kernel baseline label must be a non-empty simple filename: {label}"
+                        );
+                        anyhow::ensure!(
+                            seen_labels.insert(label.clone()),
+                            "duplicate kernel baseline label: {label}"
                         );
                         let kernel_path = rt.read(kernel_var);
                         fs_err::copy(kernel_path, artifact_dir.join(&label))?;

--- a/xtask/src/tasks/verify_size.rs
+++ b/xtask/src/tasks/verify_size.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 use crate::Xtask;
-use anyhow::Context;
 use object::read::Object;
 use object::read::ObjectSection;
 use std::collections::HashSet;
@@ -79,19 +78,28 @@ impl Xtask for VerifySize {
         let original = fs_err::read(&self.original)?;
         let new = fs_err::read(&self.new)?;
 
-        let original_elf = object::File::parse(&*original).with_context(|| {
-            format!(
-                r#"Unable to parse target file "{}"."#,
-                &self.original.display()
-            )
-        })?;
-
-        let new_elf = object::File::parse(&*new).with_context(|| {
-            format!(r#"Unable to parse target file "{}"."#, &self.new.display(),)
-        })?;
+        let original_elf = object::File::parse(&*original);
+        let new_elf = object::File::parse(&*new);
 
         println!("Verifying size for {}:", (&self.new.display()));
-        let (total_diff, net_diff) = verify_sections_size(&new_elf, &original_elf)?;
+
+        let (total_diff, net_diff) = match (original_elf, new_elf) {
+            (Ok(orig), Ok(new_parsed)) => verify_sections_size(&new_parsed, &orig)?,
+            _ => {
+                // Fall back to raw file size comparison for non-object files
+                // (e.g. aarch64 raw kernel Image).
+                println!("(file is not a parseable object file, comparing raw file sizes)");
+                let orig_size = original.len() as u64 / 1024;
+                let new_size = new.len() as u64 / 1024;
+                let diff = (new_size as i64) - (orig_size as i64);
+                println!(
+                    "{:20} {:>15} {:>15} {:>16}",
+                    "raw file", orig_size, new_size, diff
+                );
+                println!("Total Size: {new_size} KiB.");
+                (diff.unsigned_abs(), diff)
+            }
+        };
 
         println!("Net difference: {net_diff} KiB.");
         println!("Total difference: {total_diff} KiB.");

--- a/xtask/src/tasks/verify_size.rs
+++ b/xtask/src/tasks/verify_size.rs
@@ -19,18 +19,26 @@ pub struct VerifySize {
     new: std::path::PathBuf,
 }
 
+fn kib_away_from_zero(bytes: i64) -> i64 {
+    if bytes >= 0 {
+        (bytes as u64).div_ceil(1024) as i64
+    } else {
+        -(((-bytes) as u64).div_ceil(1024) as i64)
+    }
+}
+
 fn verify_sections_size(
     new: &object::File<'_>,
     original: &object::File<'_>,
 ) -> anyhow::Result<(u64, i64)> {
     println!(
-        "{:20} {:>15} {:>15} {:>16}",
-        "Section", "Old Size (KiB)", "New Size (KiB)", "Difference (KiB)"
+        "{:20} {:>20} {:>20} {:>20}",
+        "Section", "Old Size", "New Size", "Difference"
     );
 
-    let mut total_diff: u64 = 0;
-    let mut net_diff: i64 = 0;
-    let mut total_size: u64 = 0;
+    let mut total_diff_bytes: u64 = 0;
+    let mut net_diff_bytes: i64 = 0;
+    let mut total_size_bytes: u64 = 0;
 
     let all_original_sections: Vec<_> = original
         .sections()
@@ -49,28 +57,37 @@ fn verify_sections_size(
     for section in all_sections {
         let name = section;
 
-        let new_size = new
+        let new_bytes = new
             .section_by_name(name.as_str())
-            .map(|s| s.size() / 1024)
+            .map(|s| s.size())
             .unwrap_or(0);
-        let original_size = original
+        let original_bytes = original
             .section_by_name(name.as_str())
-            .map(|s| s.size() / 1024)
+            .map(|s| s.size())
             .unwrap_or(0);
-        let diff = (new_size as i64) - (original_size as i64);
-        total_diff += diff.unsigned_abs();
-        net_diff += diff;
-        total_size += new_size;
+        let diff_bytes = (new_bytes as i64) - (original_bytes as i64);
+        total_diff_bytes += diff_bytes.unsigned_abs();
+        net_diff_bytes += diff_bytes;
+        total_size_bytes += new_bytes;
 
         // Print any sections that have changed in size
-        if new_size != original_size {
-            println!("{name:20} {original_size:15} {new_size:15} {diff:16}");
+        if new_bytes != original_bytes {
+            let new_kib = new_bytes.div_ceil(1024);
+            let original_kib = original_bytes.div_ceil(1024);
+            let diff_kib = kib_away_from_zero(diff_bytes);
+            println!(
+                "{name:20} {:>15} KiB {:>15} KiB {:>15} KiB",
+                original_kib, new_kib, diff_kib
+            );
         }
     }
 
-    println!("Total Size: {total_size} KiB.");
+    println!("Total Size: {} KiB.", total_size_bytes.div_ceil(1024));
 
-    Ok((total_diff, net_diff))
+    let total_diff_kib = total_diff_bytes.div_ceil(1024);
+    let net_diff_kib = kib_away_from_zero(net_diff_bytes);
+
+    Ok((total_diff_kib, net_diff_kib))
 }
 
 impl Xtask for VerifySize {
@@ -85,19 +102,46 @@ impl Xtask for VerifySize {
 
         let (total_diff, net_diff) = match (original_elf, new_elf) {
             (Ok(orig), Ok(new_parsed)) => verify_sections_size(&new_parsed, &orig)?,
-            _ => {
-                // Fall back to raw file size comparison for non-object files
-                // (e.g. aarch64 raw kernel Image).
-                println!("(file is not a parseable object file, comparing raw file sizes)");
-                let orig_size = original.len() as u64 / 1024;
-                let new_size = new.len() as u64 / 1024;
-                let diff = (new_size as i64) - (orig_size as i64);
+            // Both files fail to parse — assume they are raw binary images
+            // (e.g. aarch64 raw kernel Image). If only one fails, that's an
+            // error indicating mismatched file formats.
+            (Err(orig_err), Err(new_err)) => {
+                println!(
+                    "(files are not parseable object files, comparing raw file sizes)\n\
+                     original parse error: {orig_err}\n\
+                     new parse error: {new_err}"
+                );
+                let orig_bytes = original.len() as u64;
+                let new_bytes = new.len() as u64;
+                let diff_bytes = (new_bytes as i64) - (orig_bytes as i64);
+                let orig_kib = orig_bytes.div_ceil(1024);
+                let new_kib = new_bytes.div_ceil(1024);
+                let diff_kib = kib_away_from_zero(diff_bytes);
                 println!(
                     "{:20} {:>15} {:>15} {:>16}",
-                    "raw file", orig_size, new_size, diff
+                    "Section", "Original", "New", "Difference"
                 );
-                println!("Total Size: {new_size} KiB.");
-                (diff.unsigned_abs(), diff)
+                println!(
+                    "{:20} {:>15} {:>15} {:>16}",
+                    "raw file",
+                    format!("{orig_kib} KiB ({orig_bytes} B)"),
+                    format!("{new_kib} KiB ({new_bytes} B)"),
+                    format!("{diff_kib} KiB ({diff_bytes:+} B)")
+                );
+                println!("Total Size: {new_kib} KiB ({new_bytes} bytes).");
+                // Compare in bytes for accuracy, convert to KiB for the
+                // threshold check below.
+                let total_diff_kib = diff_bytes.unsigned_abs().div_ceil(1024);
+                (total_diff_kib, diff_kib)
+            }
+            (Err(e), Ok(_)) => {
+                anyhow::bail!(
+                    "failed to parse original binary '{}': {e}",
+                    self.original.display()
+                );
+            }
+            (Ok(_), Err(e)) => {
+                anyhow::bail!("failed to parse new binary '{}': {e}", self.new.display());
             }
         };
 


### PR DESCRIPTION
Add size regression checks for OpenHCL kernel binaries in the OSS CI pipeline, matching the pattern used for the usermode openvmm_hcl binary.

On post-merge CI, kernel baselines are published as artifacts. On PRs, the current kernel is compared against the baseline using xtask verify-size (50 KiB tolerance).

Kernel variants checked:
- x64 Main kernel
- x64 CVM kernel
- aarch64 Main kernel