### PR TITLE
xflowey: fix --custom-openvmm-hcl command

### DIFF
--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -456,14 +456,9 @@ impl SimpleFlowNode for Node {
             let path = path.clone();
             ctx.emit_rust_stepv("set custom_openvmm_hcl", |_ctx| {
                 |_rt| {
-                    let fake_dbg_path = std::env::current_dir()?
-                        .join("fake_openvmm_hcl.dbg")
-                        .absolute()?;
-                    fs_err::write(&fake_dbg_path, "")?;
-
                     Ok(crate::build_openvmm_hcl::OpenvmmHclOutput {
                         bin: path,
-                        dbg: Some(fake_dbg_path),
+                        dbg: None,
                     })
                 }
             })
@@ -505,9 +500,7 @@ impl SimpleFlowNode for Node {
         let openhcl_boot_bin = if let Some(path) = custom_openhcl_boot {
             ctx.emit_rust_stepv("set custom_openhcl_boot", |_ctx| {
                 |_rt| {
-                    let fake_dbg_path = std::env::current_dir()?
-                        .join("fake_openhcl_boot.dbg")
-                        .absolute()?;
+                    let fake_dbg_path = std::env::current_dir()?.join("fake.dbg").absolute()?;
                     fs_err::write(&fake_dbg_path, "")?;
 
                     Ok(crate::build_openhcl_boot::OpenhclBootOutput {


### PR DESCRIPTION
This PR fixes a bug that the `--custom-openvmm-hcl` xflowey command does not use the provided custom hcl as `--custom-openhcl-boot` and `--custom-sidecar` do.