### PR TITLE
mana_driver: fix shutdown/save panic with outstanding vport references

### DIFF
--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -787,8 +787,24 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         mem::take(&mut self.vf_reconfiguration_pending)
     }
 
+    #[cfg(test)]
     pub fn device(&self) -> &T {
-        self.device.as_ref().unwrap()
+        self.device.as_ref().expect("device has been taken")
+    }
+
+    /// Returns a reference to the device, or `None` if the device has been
+    /// taken via [`take_device`](Self::take_device).
+    pub fn try_device(&self) -> Option<&T> {
+        self.device.as_ref()
+    }
+
+    /// Takes the device backing out of the driver, leaving `None`.
+    ///
+    /// After this call, operations that require the device (e.g. DMA
+    /// allocation, interrupt retargeting) will fail with an error instead
+    /// of panicking.
+    pub fn take_device(&mut self) -> Option<T> {
+        self.device.take()
     }
 
     pub fn check_vf_resources(&self, num_vps: u32, num_queues_needed: u32) {
@@ -1308,10 +1324,6 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             .await
     }
 
-    pub fn into_device(mut self) -> T {
-        self.device.take().unwrap()
-    }
-
     fn start_listening(&mut self, eq_id: u32, msix: u32) -> DeviceInterrupt {
         let interrupt = self.interrupts[msix as usize]
             .clone()
@@ -1331,7 +1343,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
 
     fn get_msix_for_cpu(&mut self, cpu: u32) -> anyhow::Result<u32> {
         let msix = cpu % self.num_msix;
-        let device = self.device.as_mut().expect("device should be present");
+        let device = self.device.as_mut().context("device has been taken")?;
         let interrupt = device.map_interrupt(msix, cpu)?;
         self.interrupts[msix as usize] = Some(interrupt);
 

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -177,19 +177,29 @@ impl<T: DeviceBacking> ManaDevice<T> {
         if let Some(hwc_task) = self.hwc_task {
             hwc_task.cancel().await;
         }
-        let inner = Arc::into_inner(self.inner).unwrap();
-        let mut driver = inner.gdma.into_inner();
 
-        if let Ok(saved_state) = driver.save().await {
-            let mana_saved_state = ManaDeviceSavedState { gdma: saved_state };
+        // Perform save and extract the device through the Mutex. Avoid exclusive
+        // Arc ownership, which can fail if a Vport reference exists.
+        let mut gdma = self.inner.gdma.lock().await;
+        let save_result = gdma.save().await;
+        let device = gdma
+            .take_device()
+            .expect("device should not have been taken yet");
+        drop(gdma);
+        drop(self.inner);
 
-            (Ok(mana_saved_state), driver.into_device())
-        } else {
-            tracing::error!("Failed to save MANA device state");
-            (
-                Err(anyhow::anyhow!("Failed to save MANA device state")),
-                driver.into_device(),
-            )
+        match save_result {
+            Ok(saved_state) => {
+                let mana_saved_state = ManaDeviceSavedState { gdma: saved_state };
+                (Ok(mana_saved_state), device)
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = err.as_ref() as &dyn std::error::Error,
+                    "Failed to save MANA device state"
+                );
+                (Err(err), device)
+            }
         }
     }
 
@@ -304,10 +314,19 @@ impl<T: DeviceBacking> ManaDevice<T> {
         if let Some(hwc_task) = self.hwc_task {
             hwc_task.cancel().await;
         }
-        let inner = Arc::into_inner(self.inner).unwrap();
-        let mut driver = inner.gdma.into_inner();
-        let result = driver.deregister_device(inner.dev_id).await;
-        (result, driver.into_device())
+
+        // Perform deregister and extract the device through the Mutex. Avoid exclusive
+        // Arc ownership, which can fail if a Vport reference exists.
+        let dev_id = self.inner.dev_id;
+        let mut gdma = self.inner.gdma.lock().await;
+        let result = gdma.deregister_device(dev_id).await;
+        let device = gdma
+            .take_device()
+            .expect("device should not have been taken yet");
+        drop(gdma);
+        drop(self.inner);
+
+        (result, device)
     }
     /// Queries the configuration of a specific vport.
     pub async fn query_vport_config(&self, vport: u32) -> anyhow::Result<ManaQueryVportCfgResp> {
@@ -398,7 +417,10 @@ impl<T: DeviceBacking> Vport<T> {
         cpu: u32,
     ) -> anyhow::Result<BnicEq> {
         let mut gdma = self.inner.gdma.lock().await;
-        let dma_client = gdma.device().dma_client_for(DmaPool::Ephemeral)?;
+        let dma_client = gdma
+            .try_device()
+            .context("device has been taken")?
+            .dma_client_for(DmaPool::Ephemeral)?;
         let mem = dma_client
             .allocate_dma_buffer(size as usize)
             .context("Failed to allocate DMA buffer")?;
@@ -440,7 +462,10 @@ impl<T: DeviceBacking> Vport<T> {
         assert!(cq_size >= PAGE_SIZE as u32 && cq_size.is_power_of_two());
         let mut gdma = self.inner.gdma.lock().await;
 
-        let dma_client = gdma.device().dma_client_for(DmaPool::Ephemeral)?;
+        let dma_client = gdma
+            .try_device()
+            .context("device has been taken")?
+            .dma_client_for(DmaPool::Ephemeral)?;
 
         let mem = dma_client
             .allocate_dma_buffer((wq_size + cq_size) as usize)
@@ -605,8 +630,12 @@ impl<T: DeviceBacking> Vport<T> {
     }
 
     /// Returns an object that can allocate dma memory to be shared with the device.
-    pub async fn dma_client(&self) -> Arc<dyn DmaClient> {
-        self.inner.gdma.lock().await.device().dma_client()
+    pub async fn dma_client(&self) -> anyhow::Result<Arc<dyn DmaClient>> {
+        let gdma = self.inner.gdma.lock().await;
+        Ok(gdma
+            .try_device()
+            .context("device has been taken")?
+            .dma_client())
     }
 }
 

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -630,6 +630,9 @@ impl<T: DeviceBacking> Vport<T> {
     }
 
     /// Returns an object that can allocate dma memory to be shared with the device.
+    ///
+    /// Returns an error if the device backing has been taken via
+    /// [`ManaDevice::shutdown`] or [`ManaDevice::save`].
     pub async fn dma_client(&self) -> anyhow::Result<Arc<dyn DmaClient>> {
         let gdma = self.inner.gdma.lock().await;
         Ok(gdma

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -240,3 +240,148 @@ async fn test_gdma_reconfig_vf(driver: DefaultDriver) {
         "vf_reconfiguration_pending should be true after reconfig event"
     );
 }
+
+#[async_test]
+async fn test_take_device(driver: DefaultDriver) {
+    let mem = DeviceTestMemory::new(128, false, "test_take_device");
+    let msi_conn = MsiConnection::new();
+    let device = gdma::GdmaDevice::new(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        mem.guest_memory(),
+        msi_conn.target(),
+        vec![VportConfig {
+            mac_address: [1, 2, 3, 4, 5, 6].into(),
+            endpoint: Box::new(NullEndpoint::new()),
+        }],
+        &mut ExternallyManagedMmioIntercepts,
+    );
+    let mem_dma_client = mem.dma_client();
+    let device = EmulatedDevice::new(device, msi_conn, mem_dma_client);
+    let device_dma_client = device.dma_client();
+    let buffer = device_dma_client
+        .allocate_dma_buffer(6 * PAGE_SIZE)
+        .unwrap();
+
+    let mut gdma = GdmaDriver::new(&driver, device, 1, Some(buffer))
+        .await
+        .unwrap();
+
+    assert!(
+        gdma.try_device().is_some(),
+        "try_device should return Some before take"
+    );
+
+    assert!(
+        gdma.take_device().is_some(),
+        "take_device should return Some the first time"
+    );
+
+    assert!(
+        gdma.try_device().is_none(),
+        "try_device should return None after take"
+    );
+
+    assert!(
+        gdma.take_device().is_none(),
+        "take_device should return None the second time"
+    );
+}
+
+#[async_test]
+#[should_panic(expected = "device has been taken")]
+async fn test_device_panics_after_take(driver: DefaultDriver) {
+    let mem = DeviceTestMemory::new(128, false, "test_device_panics");
+    let msi_conn = MsiConnection::new();
+    let device = gdma::GdmaDevice::new(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        mem.guest_memory(),
+        msi_conn.target(),
+        vec![VportConfig {
+            mac_address: [1, 2, 3, 4, 5, 6].into(),
+            endpoint: Box::new(NullEndpoint::new()),
+        }],
+        &mut ExternallyManagedMmioIntercepts,
+    );
+    let dma_client = mem.dma_client();
+    let device = EmulatedDevice::new(device, msi_conn, dma_client);
+    let dma_client = device.dma_client();
+    let buffer = dma_client.allocate_dma_buffer(6 * PAGE_SIZE).unwrap();
+
+    let mut gdma = GdmaDriver::new(&driver, device, 1, Some(buffer))
+        .await
+        .unwrap();
+
+    let _ = gdma.take_device();
+    // gdma.device() should panic because the device has been taken.
+    let _ = gdma.device();
+}
+
+#[async_test]
+async fn test_mana_shutdown_with_stale_vport(driver: DefaultDriver) {
+    use crate::mana::ManaDevice;
+
+    let mem = DeviceTestMemory::new(128, false, "test_mana_shutdown_stale");
+    let msi_conn = MsiConnection::new();
+    let device = gdma::GdmaDevice::new(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        mem.guest_memory(),
+        msi_conn.target(),
+        vec![VportConfig {
+            mac_address: [1, 2, 3, 4, 5, 6].into(),
+            endpoint: Box::new(NullEndpoint::new()),
+        }],
+        &mut ExternallyManagedMmioIntercepts,
+    );
+    let dma_client = mem.dma_client();
+    let device = EmulatedDevice::new(device, msi_conn, dma_client);
+
+    let mana = ManaDevice::new(&driver, device, 1, 1, None).await.unwrap();
+
+    // Create a vport which holds an Arc<Inner> reference.
+    let vport = mana.new_vport(0, None, mana.dev_config()).await.unwrap();
+
+    // shutdown() should succeed, and not panic, even though a Vport still holds a reference.
+    let (result, _device) = mana.shutdown().await;
+    assert!(result.is_ok(), "shutdown should succeed");
+
+    let dma_result = vport.dma_client().await;
+    assert!(
+        dma_result.is_err(),
+        "dma_client on stale vport should return Err, not panic"
+    );
+}
+
+#[async_test]
+async fn test_mana_save_with_stale_vport(driver: DefaultDriver) {
+    use crate::mana::ManaDevice;
+
+    let mem = DeviceTestMemory::new(128, false, "test_mana_save_stale");
+    let msi_conn = MsiConnection::new();
+    let device = gdma::GdmaDevice::new(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        mem.guest_memory(),
+        msi_conn.target(),
+        vec![VportConfig {
+            mac_address: [1, 2, 3, 4, 5, 6].into(),
+            endpoint: Box::new(NullEndpoint::new()),
+        }],
+        &mut ExternallyManagedMmioIntercepts,
+    );
+    let dma_client = mem.dma_client();
+    let device = EmulatedDevice::new(device, msi_conn, dma_client);
+
+    let mana = ManaDevice::new(&driver, device, 1, 1, None).await.unwrap();
+
+    // Create a vport which holds an Arc<Inner> reference.
+    let vport = mana.new_vport(0, None, mana.dev_config()).await.unwrap();
+
+    // save() should succeed even though a Vport still holds a reference.
+    let (result, _device) = mana.save().await;
+    assert!(result.is_ok(), "save should succeed");
+
+    let dma_result = vport.dma_client().await;
+    assert!(
+        dma_result.is_err(),
+        "dma_client on stale vport should return Err, not panic"
+    );
+}

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -331,7 +331,7 @@ impl<T: DeviceBacking> ManaEndpoint<T> {
         let tx_max = tx_cq_size / size_of::<Cqe>() as u32;
 
         let tx_bounce_buffer = ContiguousBufferManager::new(
-            self.vport.dma_client().await,
+            self.vport.dma_client().await?,
             if self.bounce_buffer {
                 TX_BOUNCE_BUFFER_PAGE_LIMIT
             } else {
@@ -343,7 +343,7 @@ impl<T: DeviceBacking> ManaEndpoint<T> {
         let rx_bounce_buffer = if self.bounce_buffer {
             Some(
                 ContiguousBufferManager::new(
-                    self.vport.dma_client().await,
+                    self.vport.dma_client().await?,
                     RX_BOUNCE_BUFFER_PAGE_LIMIT,
                 )
                 .context("failed to allocate rx bounce buffer")?,


### PR DESCRIPTION
Both manadevice::shutdown and manadevice::save call Arc::into_inner(self.inner).unrwap() which will panic if any vport still holds a Arc<inner> reference.  For example: a race where shutdown runs while vport actions like retarget_interrupts are in-flight.

* Removing the exclusive Arc ownership requirement. 
* Locks the driver and use new take_device() method to extract the device backing directly. 
* Driver is cleaned up when the last Arc<Inner> reference is dropped. There is still a chance for it to be immediate, but it may have to wait for vport operations to conclude.
* Added tests to verify the new behavior.