### PR TITLE
Revert "flowey: add JobId label to self-hosted GitHub runner jobs (#3140)"

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -347,7 +347,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -588,7 +587,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -865,7 +863,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1133,7 +1130,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Windows-ARM64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1374,7 +1370,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-ARM64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1631,7 +1626,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-ARM64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1899,7 +1893,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2433,7 +2426,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2967,7 +2959,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3182,7 +3173,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3984,7 +3974,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4302,7 +4291,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4521,7 +4509,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4847,7 +4834,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5167,7 +5153,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5543,7 +5528,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5892,7 +5876,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -31,7 +31,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -388,7 +387,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -631,7 +629,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -845,7 +842,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1071,7 +1067,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Windows-ARM64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1314,7 +1309,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-ARM64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1573,7 +1567,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-ARM64-Pool-WestUS2
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-ARM64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1843,7 +1836,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2379,7 +2371,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2915,7 +2906,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3132,7 +3122,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3758,7 +3747,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4078,7 +4066,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4299,7 +4286,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4627,7 +4613,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4905,7 +4890,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5239,7 +5223,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5522,7 +5505,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -30,7 +30,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -387,7 +386,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1197,7 +1195,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1411,7 +1408,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2397,7 +2393,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2933,7 +2928,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3150,7 +3144,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3686,7 +3679,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4374,7 +4366,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4694,7 +4685,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4915,7 +4905,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Windows-Prerelease
-    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5243,7 +5232,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5521,7 +5509,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5855,7 +5842,6 @@ jobs:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     - 1ES.ImageOverride=OpenVMM-CI-Ubuntu24.04-AMD64
-    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -574,18 +574,7 @@ EOF
             github_yaml_defs::Job {
                 name: label.clone(),
                 timeout_minutes,
-                runs_on: gh_pool.clone().map(|runner| {
-                    let mut yaml_runner = runner_kind_to_yaml(&runner);
-                    if let github_yaml_defs::Runner::SelfHosted(ref mut labels) = yaml_runner {
-                        if labels.iter().any(|l| l.starts_with("1ES.Pool=")) {
-                            labels.push(format!(
-                                "JobId=job{}-${{{{ github.run_id }}}}-${{{{ github.run_number }}}}-${{{{ github.run_attempt }}}}",
-                                job_idx.index()
-                            ));
-                        }
-                    }
-                    yaml_runner
-                }),
+                runs_on: gh_pool.clone().map(|runner| runner_kind_to_yaml(&runner)),
                 permissions: job_permissions
                     .iter()
                     .map(|k| (perm_kind_to_yaml(k.0), perm_val_to_yaml(k.1)))


### PR DESCRIPTION
Testing this to see if this unblocks 1ES runners...

This reverts commit 8126a9eb8c17fd3b34b7c9012ca48fcb71fb30b3.