### PR TITLE
Add a missing reply in FUSE_DESTROY handler.

### DIFF
--- a/vm/devices/support/fs/fuse/src/session.rs
+++ b/vm/devices/support/fs/fuse/src/session.rs
@@ -321,6 +321,7 @@ impl Session {
                     mapper.clear();
                 }
                 self.destroy();
+                sender.send_empty(request.unique())?;
             }
             FuseOperation::Ioctl { arg, data } => {
                 let out = self.fs.ioctl(&request, arg, data)?;


### PR DESCRIPTION
The missing reply may have caused the crash in the guest, during unmount of a virtiofs mount, since the guest is waiting indefinitely for the fuse_destroy request reply, such as demonstrated by the captured stack below.

Process: 1583 (parent:  1569)
cmd:
stat:
1583 (weston) Z 1569 1 1 58624 1 4228364 5042 0 0 0 12 2 0 0 20 0 2 0 16448 0 0 18446744073709551615 0 0 0 0 0 0 84480 0 2 0 0 0 17 6 0 0 0 0 0 0 0 0 0 0 0 0 9 tid: 1583 - weston
tid: 1585 - weston
[<0>] request_wait_answer+0x138/0x220
[<0>] fuse_simple_request+0x189/0x2d0
[<0>] fuse_send_destroy+0x66/0x70
[<0>] fuse_conn_destroy+0xae/0xc0
[<0>] virtio_kill_sb+0xc2/0x180
[<0>] deactivate_locked_super+0x39/0xb0
[<0>] deactivate_super+0x44/0x50
[<0>] cleanup_mnt+0xc3/0x160
[<0>] __cleanup_mnt+0x16/0x20
[<0>] task_work_run+0x65/0xa0
[<0>] do_exit+0x37a/0xb30
[<0>] do_group_exit+0x39/0x90
[<0>] get_signal+0xa9a/0xaa0