### PR TITLE
Add Guest Watchdog to chipset resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "inspect",
  "mesh",
  "vm_resource",
+ "watchdog_core",
 ]
 
 [[package]]
@@ -2943,11 +2944,16 @@ dependencies = [
 name = "guest_watchdog"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "chipset_device",
+ "chipset_device_resources",
+ "chipset_resources",
  "inspect",
  "mesh",
  "open_enum",
+ "thiserror 2.0.16",
  "tracelimit",
+ "vm_resource",
  "vmcore",
  "watchdog_core",
 ]
@@ -5450,6 +5456,7 @@ dependencies = [
  "chipset_legacy",
  "debug_worker",
  "disk_striped",
+ "guest_watchdog",
  "hyperv_ic",
  "mesh_worker",
  "missing_dev",
@@ -5539,6 +5546,7 @@ dependencies = [
  "guest_crash_device",
  "guest_emulation_device",
  "guest_emulation_log",
+ "guest_watchdog",
  "hyperv_ic",
  "mesh_worker",
  "missing_dev",
@@ -10075,7 +10083,6 @@ dependencies = [
  "framebuffer",
  "futures",
  "generation_id",
- "guest_watchdog",
  "guestmem",
  "ide",
  "inspect",
@@ -10362,8 +10369,10 @@ dependencies = [
  "inspect",
  "mesh",
  "pal_async",
+ "parking_lot",
  "thiserror 2.0.16",
  "tracing",
+ "vm_resource",
  "vmcore",
  "watchdog_vmgs_format",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,6 @@ dependencies = [
  "inspect",
  "mesh",
  "vm_resource",
- "watchdog_core",
 ]
 
 [[package]]

--- a/openhcl/openvmm_hcl_resources/Cargo.toml
+++ b/openhcl/openvmm_hcl_resources/Cargo.toml
@@ -33,6 +33,7 @@ chipset_legacy.workspace = true
 hyperv_ic.workspace = true
 missing_dev.workspace = true
 serial_16550.workspace = true
+guest_watchdog.workspace = true
 tpm_device = { workspace = true, optional = true, features = ["tpm"] }
 vmgs_broker.workspace = true
 

--- a/openhcl/openvmm_hcl_resources/src/lib.rs
+++ b/openhcl/openvmm_hcl_resources/src/lib.rs
@@ -30,6 +30,7 @@ vm_resource::register_static_resolvers! {
     #[cfg(guest_arch = "aarch64")]
     serial_pl011::resolver::SerialPl011Resolver,
     chipset::battery::resolver::BatteryResolver,
+    guest_watchdog::resolver::HyperVGuestWatchdogResolver,
 
     // Non-volatile stores
     vmcore::non_volatile_store::resources::EphemeralNonVolatileStoreResolver,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -188,7 +188,6 @@ use vmotherboard::options::BaseChipsetDevices;
 use vmotherboard::options::BaseChipsetFoundation;
 use watchdog_core::platform::WatchdogCallback;
 use watchdog_core::platform::WatchdogPlatform;
-use watchdog_core::resources::ResolvedWatchdogPlatform;
 use watchdog_core::resources::StaticWatchdogPlatformResolver;
 use zerocopy::FromZeros;
 
@@ -2844,9 +2843,9 @@ async fn new_underhill_vm(
             UnderhillWatchdogPlatform::new(store, get_client.clone()).await?;
         underhill_watchdog_platform.add_callback(Box::new(watchdog_callback));
 
-        resolver.add_resolver(StaticWatchdogPlatformResolver(
-            ResolvedWatchdogPlatform::new(Box::new(underhill_watchdog_platform)),
-        ));
+        resolver.add_resolver(StaticWatchdogPlatformResolver::new(Box::new(
+            underhill_watchdog_platform,
+        )));
     }
 
     let deps_generic_psp = { chipset.with_generic_psp.then_some(dev::GenericPspDeps {}) };

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -188,11 +188,12 @@ use vmotherboard::options::BaseChipsetDevices;
 use vmotherboard::options::BaseChipsetFoundation;
 use watchdog_core::platform::WatchdogCallback;
 use watchdog_core::platform::WatchdogPlatform;
+use watchdog_core::resources::ResolvedWatchdogPlatform;
+use watchdog_core::resources::StaticWatchdogPlatformResolver;
 use zerocopy::FromZeros;
 
 pub(crate) const PM_BASE: u16 = 0x400;
 pub(crate) const SYSTEM_IRQ_ACPI: u32 = 9;
-pub(crate) const WDAT_PORT: u16 = 0x30;
 
 pub const UNDERHILL_WORKER: WorkerId<UnderhillWorkerParameters> = WorkerId::new("UnderhillWorker");
 
@@ -2714,7 +2715,6 @@ async fn new_underhill_vm(
     }
 
     let emuplat_adjust_gpa_range;
-
     let synic = virt::Hv1::synic(partition.as_ref());
 
     let deps_generic_ioapic = chipset.with_generic_ioapic.then(|| dev::GenericIoApicDeps {
@@ -2825,34 +2825,29 @@ async fn new_underhill_vm(
                 register_host_io_fastpath: Box::new(UhRegisterHostIoFastPath(partition.clone())),
             });
 
-    let deps_hyperv_guest_watchdog = if chipset.with_hyperv_guest_watchdog {
-        Some(dev::HyperVGuestWatchdogDeps {
-            port_base: WDAT_PORT,
-            watchdog_platform: {
-                let store = if let Some(vmgs_client) = vmgs_client.as_ref() {
-                    vmgs_client
-                        .as_non_volatile_store(vmgs::FileId::GUEST_WATCHDOG, false)
-                        .context("failed to instantiate guest watchdog store")?
-                } else {
-                    EphemeralNonVolatileStore::new_boxed()
-                };
+    if capabilities.with_guest_watchdog {
+        let store = if let Some(vmgs_client) = vmgs_client.as_ref() {
+            vmgs_client
+                .as_non_volatile_store(vmgs::FileId::GUEST_WATCHDOG, false)
+                .context("failed to instantiate guest watchdog store")?
+        } else {
+            EphemeralNonVolatileStore::new_boxed()
+        };
 
-                let watchdog_callback = WatchdogTimeoutReset {
-                    halt_vps: halt_vps.clone(),
-                    watchdog_send: None, // This is not the UEFI watchdog, so no need to send
-                                         // watchdog notifications.
-                };
+        let watchdog_callback = WatchdogTimeoutReset {
+            halt_vps: halt_vps.clone(),
+            watchdog_send: None, // This is not the UEFI watchdog, so no need to send
+                                 // watchdog notifications.
+        };
 
-                let mut underhill_watchdog_platform =
-                    UnderhillWatchdogPlatform::new(store, get_client.clone()).await?;
-                underhill_watchdog_platform.add_callback(Box::new(watchdog_callback));
+        let mut underhill_watchdog_platform =
+            UnderhillWatchdogPlatform::new(store, get_client.clone()).await?;
+        underhill_watchdog_platform.add_callback(Box::new(watchdog_callback));
 
-                Box::new(underhill_watchdog_platform)
-            },
-        })
-    } else {
-        None
-    };
+        resolver.add_resolver(StaticWatchdogPlatformResolver(
+            ResolvedWatchdogPlatform::new(Box::new(underhill_watchdog_platform)),
+        ));
+    }
 
     let deps_generic_psp = { chipset.with_generic_psp.then_some(dev::GenericPspDeps {}) };
 
@@ -2963,7 +2958,6 @@ async fn new_underhill_vm(
         deps_generic_ioapic,
         deps_generic_psp,
         deps_hyperv_firmware_uefi,
-        deps_hyperv_guest_watchdog,
         deps_hyperv_power_management,
         deps_generic_isa_dma,
         deps_generic_isa_floppy: None,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -151,11 +151,11 @@ use vpci::bus::VpciBus;
 use watchdog_core::platform::BaseWatchdogPlatform;
 use watchdog_core::platform::WatchdogCallback;
 use watchdog_core::platform::WatchdogPlatform;
+use watchdog_core::resources::ResolvedWatchdogPlatform;
+use watchdog_core::resources::StaticWatchdogPlatformResolver;
 
 const PM_BASE: u16 = 0x400;
 const SYSTEM_IRQ_ACPI: u32 = 9;
-
-const WDAT_PORT: u16 = 0x30;
 
 /// Creates a thread to run low-performance devices on.
 pub fn new_device_thread() -> (JoinHandle<()>, DefaultDriver) {
@@ -1377,38 +1377,33 @@ impl InitializedVm {
             }
         }
 
-        let deps_hyperv_guest_watchdog = if cfg.chipset.with_hyperv_guest_watchdog {
-            Some(dev::HyperVGuestWatchdogDeps {
-                port_base: WDAT_PORT,
-                watchdog_platform: {
-                    use vmcore::non_volatile_store::EphemeralNonVolatileStore;
+        if cfg.chipset_capabilities.with_guest_watchdog {
+            use vmcore::non_volatile_store::EphemeralNonVolatileStore;
 
-                    let store = match vmgs_client {
-                        Some(vmgs) => vmgs
-                            .as_non_volatile_store(vmgs::FileId::GUEST_WATCHDOG, false)
-                            .context("failed to instantiate guest watchdog store")?,
-                        None => EphemeralNonVolatileStore::new_boxed(),
-                    };
+            let store = match vmgs_client {
+                Some(vmgs) => vmgs
+                    .as_non_volatile_store(vmgs::FileId::GUEST_WATCHDOG, false)
+                    .context("failed to instantiate guest watchdog store")?,
+                None => EphemeralNonVolatileStore::new_boxed(),
+            };
 
-                    // Create the base watchdog platform
-                    let mut base_watchdog_platform = BaseWatchdogPlatform::new(store).await?;
+            // Create the base watchdog platform
+            let mut base_watchdog_platform = BaseWatchdogPlatform::new(store).await?;
 
-                    // Create callback to reset on watchdog timeout
-                    let watchdog_callback = WatchdogTimeoutReset {
-                        halt_vps: halt_vps.clone(),
-                        watchdog_send: None, // This is not the UEFI watchdog, so no need to send
-                                             // watchdog notifications
-                    };
+            // Create callback to reset on watchdog timeout
+            let watchdog_callback = WatchdogTimeoutReset {
+                halt_vps: halt_vps.clone(),
+                watchdog_send: None, // This is not the UEFI watchdog, so no need to send
+                                     // watchdog notifications
+            };
 
-                    // Add callbacks
-                    base_watchdog_platform.add_callback(Box::new(watchdog_callback));
+            // Add callbacks
+            base_watchdog_platform.add_callback(Box::new(watchdog_callback));
 
-                    Box::new(base_watchdog_platform)
-                },
-            })
-        } else {
-            None
-        };
+            resolver.add_resolver(StaticWatchdogPlatformResolver(
+                ResolvedWatchdogPlatform::new(Box::new(base_watchdog_platform)),
+            ));
+        }
 
         let initial_rtc_cmos = if matches!(cfg.load_mode, LoadMode::Pcat { .. }) {
             Some(firmware_pcat::default_cmos_values(&mem_layout))
@@ -1603,7 +1598,6 @@ impl InitializedVm {
                 deps_hyperv_firmware_pcat,
                 deps_hyperv_firmware_uefi,
                 deps_hyperv_framebuffer,
-                deps_hyperv_guest_watchdog,
                 deps_hyperv_ide,
                 deps_hyperv_power_management,
                 deps_hyperv_vga,
@@ -2494,7 +2488,7 @@ impl LoadedVmInner {
                     frontpage: !disable_frontpage,
                     tpm: enable_tpm,
                     battery: enable_battery,
-                    guest_watchdog: self.chipset_cfg.with_hyperv_guest_watchdog,
+                    guest_watchdog: self.chipset_capabilities.with_guest_watchdog,
                     vpci_boot: enable_vpci_boot,
                     serial: enable_serial,
                     uefi_console_mode,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -151,7 +151,6 @@ use vpci::bus::VpciBus;
 use watchdog_core::platform::BaseWatchdogPlatform;
 use watchdog_core::platform::WatchdogCallback;
 use watchdog_core::platform::WatchdogPlatform;
-use watchdog_core::resources::ResolvedWatchdogPlatform;
 use watchdog_core::resources::StaticWatchdogPlatformResolver;
 
 const PM_BASE: u16 = 0x400;
@@ -1400,9 +1399,9 @@ impl InitializedVm {
             // Add callbacks
             base_watchdog_platform.add_callback(Box::new(watchdog_callback));
 
-            resolver.add_resolver(StaticWatchdogPlatformResolver(
-                ResolvedWatchdogPlatform::new(Box::new(base_watchdog_platform)),
-            ));
+            resolver.add_resolver(StaticWatchdogPlatformResolver::new(Box::new(
+                base_watchdog_platform,
+            )));
         }
 
         let initial_rtc_cmos = if matches!(cfg.load_mode, LoadMode::Pcat { .. }) {

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -51,6 +51,7 @@ disklayer_sqlite = { workspace = true, optional = true }
 chipset.workspace = true
 chipset_legacy.workspace = true
 missing_dev.workspace = true
+guest_watchdog.workspace = true
 tpm_device = { workspace = true, optional = true, features = ["tpm"] }
 
 # Non-volatile stores

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -29,6 +29,7 @@ vm_resource::register_static_resolvers! {
     #[cfg(guest_arch = "aarch64")]
     serial_pl011::resolver::SerialPl011Resolver,
     chipset::battery::resolver::BatteryResolver,
+    guest_watchdog::resolver::HyperVGuestWatchdogResolver,
 
     // Non-volatile stores
     vmcore::non_volatile_store::resources::EphemeralNonVolatileStoreResolver,

--- a/vm/devices/chipset_resources/Cargo.toml
+++ b/vm/devices/chipset_resources/Cargo.toml
@@ -8,7 +8,6 @@ rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true
-watchdog_core.workspace = true
 
 inspect.workspace = true
 mesh.workspace = true

--- a/vm/devices/chipset_resources/Cargo.toml
+++ b/vm/devices/chipset_resources/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true
+watchdog_core.workspace = true
 
 inspect.workspace = true
 mesh.workspace = true

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -175,6 +175,9 @@ pub mod hyperv_guest_watchdog {
     use vm_resource::kind::ChipsetDeviceHandleKind;
     use watchdog_core::resources::WatchdogPlatformHandleKind;
 
+    /// Default base port IO address for the Hyper-V guest watchdog register window.
+    pub const DEFAULT_WDAT_PORT_BASE: u16 = 0x30;
+
     /// A handle to the Hyper-V guest watchdog device.
     #[derive(MeshPayload)]
     pub struct HyperVGuestWatchdogDeviceHandle {

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -165,3 +165,26 @@ pub mod piix4_uhci {
         const ID: &'static str = "piix4PciUsbUhciStub";
     }
 }
+
+pub mod hyperv_guest_watchdog {
+    //! Resource definitions for the Hyper-V guest watchdog device.
+
+    use mesh::MeshPayload;
+    use vm_resource::Resource;
+    use vm_resource::ResourceId;
+    use vm_resource::kind::ChipsetDeviceHandleKind;
+    use watchdog_core::resources::WatchdogPlatformHandleKind;
+
+    /// A handle to the Hyper-V guest watchdog device.
+    #[derive(MeshPayload)]
+    pub struct HyperVGuestWatchdogDeviceHandle {
+        /// Base port IO address for the watchdog register window.
+        pub port_base: u16,
+        /// One-shot watchdog platform capability.
+        pub platform: Resource<WatchdogPlatformHandleKind>,
+    }
+
+    impl ResourceId<ChipsetDeviceHandleKind> for HyperVGuestWatchdogDeviceHandle {
+        const ID: &'static str = "hyperv_guest_watchdog";
+    }
+}

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -170,10 +170,8 @@ pub mod hyperv_guest_watchdog {
     //! Resource definitions for the Hyper-V guest watchdog device.
 
     use mesh::MeshPayload;
-    use vm_resource::Resource;
     use vm_resource::ResourceId;
     use vm_resource::kind::ChipsetDeviceHandleKind;
-    use watchdog_core::resources::WatchdogPlatformHandleKind;
 
     /// Default base port IO address for the Hyper-V guest watchdog register window.
     pub const DEFAULT_WDAT_PORT_BASE: u16 = 0x30;
@@ -183,8 +181,6 @@ pub mod hyperv_guest_watchdog {
     pub struct HyperVGuestWatchdogDeviceHandle {
         /// Base port IO address for the watchdog register window.
         pub port_base: u16,
-        /// One-shot watchdog platform capability.
-        pub platform: Resource<WatchdogPlatformHandleKind>,
     }
 
     impl ResourceId<ChipsetDeviceHandleKind> for HyperVGuestWatchdogDeviceHandle {

--- a/vm/devices/watchdog/guest_watchdog/Cargo.toml
+++ b/vm/devices/watchdog/guest_watchdog/Cargo.toml
@@ -8,14 +8,20 @@ rust-version.workspace = true
 
 [dependencies]
 vmcore.workspace = true
+vm_resource.workspace = true
 
 chipset_device.workspace = true
+chipset_device_resources.workspace = true
+chipset_resources.workspace = true
 watchdog_core.workspace = true
 
 inspect.workspace = true
 mesh.workspace = true
 open_enum.workspace = true
 tracelimit.workspace = true
+
+async-trait.workspace = true
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/watchdog/guest_watchdog/src/lib.rs
+++ b/vm/devices/watchdog/guest_watchdog/src/lib.rs
@@ -4,12 +4,13 @@
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
 
+pub mod resolver;
+
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::pio::ControlPortIoIntercept;
 use chipset_device::pio::PortIoIntercept;
-use chipset_device::pio::RegisterPortIoIntercept;
 use chipset_device::poll_device::PollDevice;
 use inspect::Inspect;
 use inspect::InspectMut;
@@ -52,14 +53,9 @@ impl GuestWatchdogServices {
     pub async fn new(
         vmtime: VmTimeAccess,
         watchdog_platform: Box<dyn WatchdogPlatform>,
-        register_pio: &mut dyn RegisterPortIoIntercept,
-        pio_wdat_port: u16,
+        pio_static_wdat_port: Box<dyn ControlPortIoIntercept>,
         is_restoring: bool,
     ) -> GuestWatchdogServices {
-        let mut pio_static_wdat_port = register_pio.new_io_region("wdat_port", 8);
-
-        pio_static_wdat_port.map(pio_wdat_port);
-
         GuestWatchdogServices {
             watchdog: WatchdogServices::new(
                 "guest-watchdog",

--- a/vm/devices/watchdog/guest_watchdog/src/resolver.rs
+++ b/vm/devices/watchdog/guest_watchdog/src/resolver.rs
@@ -10,6 +10,8 @@ use chipset_device_resources::ResolvedChipsetDevice;
 use chipset_resources::hyperv_guest_watchdog::HyperVGuestWatchdogDeviceHandle;
 use thiserror::Error;
 use vm_resource::AsyncResolveResource;
+use vm_resource::IntoResource;
+use vm_resource::PlatformResource;
 use vm_resource::ResolveError;
 use vm_resource::ResourceResolver;
 use vm_resource::declare_static_async_resolver;
@@ -49,7 +51,7 @@ impl AsyncResolveResource<ChipsetDeviceHandleKind, HyperVGuestWatchdogDeviceHand
         pio_static_wdat_port.map(resource.port_base);
 
         let watchdog_platform = resolver
-            .resolve::<WatchdogPlatformHandleKind, _>(resource.platform, ())
+            .resolve::<WatchdogPlatformHandleKind, _>(PlatformResource.into_resource(), ())
             .await
             .map_err(ResolveGuestWatchdogError::ResolvePlatform)?
             .into_inner();

--- a/vm/devices/watchdog/guest_watchdog/src/resolver.rs
+++ b/vm/devices/watchdog/guest_watchdog/src/resolver.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resource resolver for the Hyper-V guest watchdog chipset device.
+
+use crate::GuestWatchdogServices;
+use async_trait::async_trait;
+use chipset_device_resources::ResolveChipsetDeviceHandleParams;
+use chipset_device_resources::ResolvedChipsetDevice;
+use chipset_resources::hyperv_guest_watchdog::HyperVGuestWatchdogDeviceHandle;
+use thiserror::Error;
+use vm_resource::AsyncResolveResource;
+use vm_resource::ResolveError;
+use vm_resource::ResourceResolver;
+use vm_resource::declare_static_async_resolver;
+use vm_resource::kind::ChipsetDeviceHandleKind;
+use watchdog_core::resources::WatchdogPlatformHandleKind;
+
+/// Resolver for the Hyper-V guest watchdog device.
+pub struct HyperVGuestWatchdogResolver;
+
+declare_static_async_resolver! {
+    HyperVGuestWatchdogResolver,
+    (ChipsetDeviceHandleKind, HyperVGuestWatchdogDeviceHandle),
+}
+
+/// Errors that can occur while resolving a guest watchdog handle.
+#[derive(Debug, Error)]
+pub enum ResolveGuestWatchdogError {
+    /// Failed to resolve the watchdog platform capability.
+    #[error("failed to resolve watchdog platform capability")]
+    ResolvePlatform(#[source] ResolveError),
+    /// The platform capability has already been consumed.
+    #[error("watchdog platform capability has already been consumed")]
+    PlatformAlreadyConsumed,
+}
+
+#[async_trait]
+impl AsyncResolveResource<ChipsetDeviceHandleKind, HyperVGuestWatchdogDeviceHandle>
+    for HyperVGuestWatchdogResolver
+{
+    type Output = ResolvedChipsetDevice;
+    type Error = ResolveGuestWatchdogError;
+
+    async fn resolve(
+        &self,
+        resolver: &ResourceResolver,
+        resource: HyperVGuestWatchdogDeviceHandle,
+        input: ResolveChipsetDeviceHandleParams<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        let mut pio_static_wdat_port = input.register_pio.new_io_region("wdat_port", 8);
+        pio_static_wdat_port.map(resource.port_base);
+
+        let resolved_platform = resolver
+            .resolve::<WatchdogPlatformHandleKind, _>(resource.platform, ())
+            .await
+            .map_err(ResolveGuestWatchdogError::ResolvePlatform)?;
+
+        let watchdog_platform = resolved_platform
+            .take()
+            .ok_or(ResolveGuestWatchdogError::PlatformAlreadyConsumed)?;
+
+        let device = GuestWatchdogServices::new(
+            input.vmtime.access("guest-watchdog-time"),
+            watchdog_platform,
+            pio_static_wdat_port,
+            input.is_restoring,
+        )
+        .await;
+
+        Ok(device.into())
+    }
+}

--- a/vm/devices/watchdog/guest_watchdog/src/resolver.rs
+++ b/vm/devices/watchdog/guest_watchdog/src/resolver.rs
@@ -30,9 +30,6 @@ pub enum ResolveGuestWatchdogError {
     /// Failed to resolve the watchdog platform capability.
     #[error("failed to resolve watchdog platform capability")]
     ResolvePlatform(#[source] ResolveError),
-    /// The platform capability has already been consumed.
-    #[error("watchdog platform capability has already been consumed")]
-    PlatformAlreadyConsumed,
 }
 
 #[async_trait]
@@ -51,14 +48,11 @@ impl AsyncResolveResource<ChipsetDeviceHandleKind, HyperVGuestWatchdogDeviceHand
         let mut pio_static_wdat_port = input.register_pio.new_io_region("wdat_port", 8);
         pio_static_wdat_port.map(resource.port_base);
 
-        let resolved_platform = resolver
+        let watchdog_platform = resolver
             .resolve::<WatchdogPlatformHandleKind, _>(resource.platform, ())
             .await
-            .map_err(ResolveGuestWatchdogError::ResolvePlatform)?;
-
-        let watchdog_platform = resolved_platform
-            .take()
-            .ok_or(ResolveGuestWatchdogError::PlatformAlreadyConsumed)?;
+            .map_err(ResolveGuestWatchdogError::ResolvePlatform)?
+            .into_inner();
 
         let device = GuestWatchdogServices::new(
             input.vmtime.access("guest-watchdog-time"),

--- a/vm/devices/watchdog/watchdog_core/Cargo.toml
+++ b/vm/devices/watchdog/watchdog_core/Cargo.toml
@@ -11,10 +11,12 @@ cvm_tracing.workspace = true
 watchdog_vmgs_format.workspace = true
 
 vmcore.workspace = true
+vm_resource.workspace = true
 
 inspect.workspace = true
 mesh.workspace = true
 pal_async.workspace = true
+parking_lot.workspace = true
 
 async-trait.workspace = true
 bitfield-struct.workspace = true

--- a/vm/devices/watchdog/watchdog_core/src/lib.rs
+++ b/vm/devices/watchdog/watchdog_core/src/lib.rs
@@ -12,6 +12,7 @@
 #![forbid(unsafe_code)]
 
 pub mod platform;
+pub mod resources;
 use inspect::Inspect;
 use std::task::Context;
 use std::task::Poll;

--- a/vm/devices/watchdog/watchdog_core/src/resources.rs
+++ b/vm/devices/watchdog/watchdog_core/src/resources.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Watchdog platform capability resources.
+
+use crate::platform::WatchdogPlatform;
+use parking_lot::Mutex;
+use std::convert::Infallible;
+use std::sync::Arc;
+use vm_resource::CanResolveTo;
+use vm_resource::PlatformResource;
+use vm_resource::ResolveResource;
+use vm_resource::ResourceKind;
+
+/// Resource kind for obtaining a guest-watchdog platform capability.
+///
+/// This is primarily used with [`PlatformResource`].
+pub enum WatchdogPlatformHandleKind {}
+
+impl ResourceKind for WatchdogPlatformHandleKind {
+    const NAME: &'static str = "watchdog_platform";
+}
+
+impl CanResolveTo<ResolvedWatchdogPlatform> for WatchdogPlatformHandleKind {
+    type Input<'a> = ();
+}
+
+/// A one-shot watchdog platform capability.
+///
+/// The underlying platform object is consumed once via [`Self::take`].
+#[derive(Clone)]
+pub struct ResolvedWatchdogPlatform(Arc<Mutex<Option<Box<dyn WatchdogPlatform>>>>);
+
+impl ResolvedWatchdogPlatform {
+    /// Creates a new one-shot platform capability around `platform`.
+    pub fn new(platform: Box<dyn WatchdogPlatform>) -> Self {
+        Self(Arc::new(Mutex::new(Some(platform))))
+    }
+
+    /// Takes ownership of the platform object.
+    ///
+    /// Returns `None` if it has already been taken.
+    pub fn take(&self) -> Option<Box<dyn WatchdogPlatform>> {
+        let mut guard = self.0.lock();
+        guard.take()
+    }
+}
+
+/// A static platform resolver that serves a pre-built watchdog platform.
+pub struct StaticWatchdogPlatformResolver(pub ResolvedWatchdogPlatform);
+
+impl ResolveResource<WatchdogPlatformHandleKind, PlatformResource>
+    for StaticWatchdogPlatformResolver
+{
+    type Output = ResolvedWatchdogPlatform;
+    type Error = Infallible;
+
+    fn resolve(
+        &self,
+        _resource: PlatformResource,
+        _input: (),
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(self.0.clone())
+    }
+}

--- a/vm/devices/watchdog/watchdog_core/src/resources.rs
+++ b/vm/devices/watchdog/watchdog_core/src/resources.rs
@@ -5,7 +5,6 @@
 
 use crate::platform::WatchdogPlatform;
 use parking_lot::Mutex;
-use std::sync::Arc;
 use thiserror::Error;
 use vm_resource::CanResolveTo;
 use vm_resource::PlatformResource;
@@ -41,11 +40,11 @@ pub enum ResolveWatchdogPlatformError {
 }
 
 /// A static platform resolver that serves a pre-built watchdog platform.
-pub struct StaticWatchdogPlatformResolver(Arc<Mutex<Option<Box<dyn WatchdogPlatform>>>>);
+pub struct StaticWatchdogPlatformResolver(Mutex<Option<Box<dyn WatchdogPlatform>>>);
 
 impl StaticWatchdogPlatformResolver {
     pub fn new(platform: Box<dyn WatchdogPlatform>) -> Self {
-        Self(Arc::new(Mutex::new(Some(platform))))
+        Self(Mutex::new(Some(platform)))
     }
 }
 

--- a/vm/devices/watchdog/watchdog_core/src/resources.rs
+++ b/vm/devices/watchdog/watchdog_core/src/resources.rs
@@ -5,8 +5,8 @@
 
 use crate::platform::WatchdogPlatform;
 use parking_lot::Mutex;
-use std::convert::Infallible;
 use std::sync::Arc;
+use thiserror::Error;
 use vm_resource::CanResolveTo;
 use vm_resource::PlatformResource;
 use vm_resource::ResolveResource;
@@ -25,41 +25,45 @@ impl CanResolveTo<ResolvedWatchdogPlatform> for WatchdogPlatformHandleKind {
     type Input<'a> = ();
 }
 
-/// A one-shot watchdog platform capability.
-///
-/// The underlying platform object is consumed once via [`Self::take`].
-#[derive(Clone)]
-pub struct ResolvedWatchdogPlatform(Arc<Mutex<Option<Box<dyn WatchdogPlatform>>>>);
+/// An owned watchdog platform capability consumed at resolve-time.
+pub struct ResolvedWatchdogPlatform(Box<dyn WatchdogPlatform>);
 
 impl ResolvedWatchdogPlatform {
-    /// Creates a new one-shot platform capability around `platform`.
-    pub fn new(platform: Box<dyn WatchdogPlatform>) -> Self {
-        Self(Arc::new(Mutex::new(Some(platform))))
-    }
-
-    /// Takes ownership of the platform object.
-    ///
-    /// Returns `None` if it has already been taken.
-    pub fn take(&self) -> Option<Box<dyn WatchdogPlatform>> {
-        let mut guard = self.0.lock();
-        guard.take()
+    pub fn into_inner(self) -> Box<dyn WatchdogPlatform> {
+        self.0
     }
 }
 
+#[derive(Debug, Error)]
+pub enum ResolveWatchdogPlatformError {
+    #[error("watchdog platform capability has already been consumed")]
+    AlreadyConsumed,
+}
+
 /// A static platform resolver that serves a pre-built watchdog platform.
-pub struct StaticWatchdogPlatformResolver(pub ResolvedWatchdogPlatform);
+pub struct StaticWatchdogPlatformResolver(Arc<Mutex<Option<Box<dyn WatchdogPlatform>>>>);
+
+impl StaticWatchdogPlatformResolver {
+    pub fn new(platform: Box<dyn WatchdogPlatform>) -> Self {
+        Self(Arc::new(Mutex::new(Some(platform))))
+    }
+}
 
 impl ResolveResource<WatchdogPlatformHandleKind, PlatformResource>
     for StaticWatchdogPlatformResolver
 {
     type Output = ResolvedWatchdogPlatform;
-    type Error = Infallible;
+    type Error = ResolveWatchdogPlatformError;
 
     fn resolve(
         &self,
         _resource: PlatformResource,
         _input: (),
     ) -> Result<Self::Output, Self::Error> {
-        Ok(self.0.clone())
+        let mut guard = self.0.lock();
+        guard
+            .take()
+            .map(ResolvedWatchdogPlatform)
+            .ok_or(ResolveWatchdogPlatformError::AlreadyConsumed)
     }
 }

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -20,6 +20,7 @@ use chipset_resources::LEGACY_CHIPSET_PCI_BUS_NAME;
 use chipset_resources::battery::BatteryDeviceHandleAArch64;
 use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
+use chipset_resources::hyperv_guest_watchdog::HyperVGuestWatchdogDeviceHandle;
 use chipset_resources::i8042::I8042DeviceHandle;
 use chipset_resources::pic::PicDeviceHandle;
 use chipset_resources::piix4_pci_isa_bridge::PIIX4_PCI_ISA_BRIDGE_BDF;
@@ -36,6 +37,7 @@ use serial_pl011_resources::SerialPl011DeviceHandle;
 use std::iter::zip;
 use thiserror::Error;
 use vm_resource::IntoResource;
+use vm_resource::PlatformResource;
 use vm_resource::Resource;
 use vm_resource::ResourceId;
 use vm_resource::kind::SerialBackendHandle;
@@ -100,6 +102,7 @@ pub struct VmChipsetResult {
     pub capabilities: VmChipsetCapabilities,
 }
 
+const WDAT_PORT: u16 = 0x30;
 /// Error type for building a VM manifest.
 #[derive(Debug, Error)]
 #[error(transparent)]
@@ -230,6 +233,7 @@ impl VmManifestBuilder {
                 with_pic: false,
                 with_pit: false,
                 with_psp: false,
+                with_guest_watchdog: false,
             },
         };
 
@@ -264,7 +268,6 @@ impl VmManifestBuilder {
                     with_hyperv_firmware_pcat: true,
                     with_hyperv_firmware_uefi: false,
                     with_hyperv_framebuffer: !self.proxy_vga,
-                    with_hyperv_guest_watchdog: false,
                     with_hyperv_ide: true,
                     with_hyperv_power_management: false,
                     with_hyperv_vga: !self.proxy_vga,
@@ -296,7 +299,6 @@ impl VmManifestBuilder {
                     with_hyperv_firmware_pcat: false,
                     with_hyperv_firmware_uefi: false,
                     with_hyperv_framebuffer: self.framebuffer,
-                    with_hyperv_guest_watchdog: self.guest_watchdog,
                     with_hyperv_ide: false,
                     with_hyperv_power_management: is_x86,
                     with_hyperv_vga: false,
@@ -325,6 +327,9 @@ impl VmManifestBuilder {
                 if let Some(recv) = self.battery_status_recv {
                     result.attach_battery(self.arch, recv);
                 }
+                if self.guest_watchdog {
+                    result.attach_guest_watchdog();
+                }
             }
             BaseChipsetType::HypervGen2Uefi | BaseChipsetType::HyperVGen2LinuxDirect => {
                 let is_x86 = matches!(self.arch, MachineArch::X86_64);
@@ -338,7 +343,6 @@ impl VmManifestBuilder {
                     with_hyperv_firmware_pcat: false,
                     with_hyperv_firmware_uefi: matches!(self.ty, BaseChipsetType::HypervGen2Uefi),
                     with_hyperv_framebuffer: self.framebuffer,
-                    with_hyperv_guest_watchdog: self.guest_watchdog,
                     with_hyperv_ide: false,
                     with_hyperv_power_management: is_x86,
                     with_hyperv_vga: false,
@@ -362,6 +366,9 @@ impl VmManifestBuilder {
                     .attach_missing_arch_ports(self.arch, true);
                 if let Some(recv) = self.battery_status_recv {
                     result.attach_battery(self.arch, recv);
+                }
+                if self.guest_watchdog {
+                    result.attach_guest_watchdog();
                 }
             }
             BaseChipsetType::HclHost => {
@@ -454,6 +461,19 @@ impl VmChipsetResult {
             pci_bus_name: LEGACY_CHIPSET_PCI_BUS_NAME.to_string(),
             bdf: PIIX4_PCI_ISA_BRIDGE_BDF,
         });
+        self
+    }
+
+    fn attach_guest_watchdog(&mut self) -> &mut Self {
+        self.chipset_devices.push(ChipsetDeviceHandle {
+            name: "hyperv-guest-watchdog".to_owned(),
+            resource: HyperVGuestWatchdogDeviceHandle {
+                port_base: WDAT_PORT,
+                platform: PlatformResource.into_resource(),
+            }
+            .into_resource(),
+        });
+        self.capabilities.with_guest_watchdog = true;
         self
     }
 

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -20,6 +20,7 @@ use chipset_resources::LEGACY_CHIPSET_PCI_BUS_NAME;
 use chipset_resources::battery::BatteryDeviceHandleAArch64;
 use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
+use chipset_resources::hyperv_guest_watchdog::DEFAULT_WDAT_PORT_BASE;
 use chipset_resources::hyperv_guest_watchdog::HyperVGuestWatchdogDeviceHandle;
 use chipset_resources::i8042::I8042DeviceHandle;
 use chipset_resources::pic::PicDeviceHandle;
@@ -102,7 +103,6 @@ pub struct VmChipsetResult {
     pub capabilities: VmChipsetCapabilities,
 }
 
-const WDAT_PORT: u16 = 0x30;
 /// Error type for building a VM manifest.
 #[derive(Debug, Error)]
 #[error(transparent)]
@@ -466,9 +466,9 @@ impl VmChipsetResult {
 
     fn attach_guest_watchdog(&mut self) -> &mut Self {
         self.chipset_devices.push(ChipsetDeviceHandle {
-            name: "hyperv-guest-watchdog".to_owned(),
+            name: "guest-watchdog".to_owned(),
             resource: HyperVGuestWatchdogDeviceHandle {
-                port_base: WDAT_PORT,
+                port_base: DEFAULT_WDAT_PORT_BASE,
                 platform: PlatformResource.into_resource(),
             }
             .into_resource(),

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -38,7 +38,6 @@ use serial_pl011_resources::SerialPl011DeviceHandle;
 use std::iter::zip;
 use thiserror::Error;
 use vm_resource::IntoResource;
-use vm_resource::PlatformResource;
 use vm_resource::Resource;
 use vm_resource::ResourceId;
 use vm_resource::kind::SerialBackendHandle;
@@ -469,7 +468,6 @@ impl VmChipsetResult {
             name: "guest-watchdog".to_owned(),
             resource: HyperVGuestWatchdogDeviceHandle {
                 port_base: DEFAULT_WDAT_PORT_BASE,
-                platform: PlatformResource.into_resource(),
             }
             .into_resource(),
         });

--- a/vmm_core/vmotherboard/Cargo.toml
+++ b/vmm_core/vmotherboard/Cargo.toml
@@ -33,7 +33,6 @@ framebuffer.workspace = true
 floppy = { optional = true, workspace = true }
 floppy_pcat_stub = { optional = true, workspace = true }
 generation_id.workspace = true
-guest_watchdog.workspace = true
 ide.workspace = true
 missing_dev.workspace = true
 pci_bus.workspace = true

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -223,7 +223,6 @@ impl<'a> BaseChipsetBuilder<'a> {
             deps_hyperv_firmware_pcat,
             deps_hyperv_firmware_uefi,
             deps_hyperv_framebuffer,
-            deps_hyperv_guest_watchdog,
             deps_hyperv_ide,
             deps_hyperv_power_management,
             deps_hyperv_vga,
@@ -523,28 +522,6 @@ impl<'a> BaseChipsetBuilder<'a> {
                     }
                     pm
                 })?;
-        }
-
-        if let Some(options::dev::HyperVGuestWatchdogDeps {
-            watchdog_platform,
-            port_base: pio_wdat_port,
-        }) = deps_hyperv_guest_watchdog
-        {
-            builder
-                .arc_mutex_device("guest-watchdog")
-                .add_async(async |services| {
-                    let vmtime = services.register_vmtime();
-                    let mut register_pio = services.register_pio();
-                    guest_watchdog::GuestWatchdogServices::new(
-                        vmtime.access("guest-watchdog-time"),
-                        watchdog_platform,
-                        &mut register_pio,
-                        pio_wdat_port,
-                        foundation.is_restoring,
-                    )
-                    .await
-                })
-                .await?;
         }
 
         if let Some(options::dev::HyperVFirmwareUefi {
@@ -1120,7 +1097,6 @@ pub mod options {
             hyperv_firmware_pcat:        dev::HyperVFirmwarePcat,
             hyperv_firmware_uefi:        dev::HyperVFirmwareUefi,
             hyperv_framebuffer:          dev::HyperVFramebufferDeps,
-            hyperv_guest_watchdog:       dev::HyperVGuestWatchdogDeps,
             hyperv_ide:                  dev::HyperVIdeDeps,
             hyperv_power_management:     dev::HyperVPowerManagementDeps,
             hyperv_vga:                  dev::HyperVVgaDeps,
@@ -1149,6 +1125,8 @@ pub mod options {
         pub with_pit: bool,
         /// Whether the VM exposes a PSP.
         pub with_psp: bool,
+        /// Whether the VM exposes the Hyper-V guest watchdog device.
+        pub with_guest_watchdog: bool,
     }
 
     /// Device specific dependencies
@@ -1338,15 +1316,6 @@ pub mod options {
             pub line_interrupt_no: u32,
             /// Channel to receive updated battery state
             pub battery_status_recv: mesh::Receiver<HostBatteryUpdate>,
-        }
-
-        /// Hyper-V specific Guest Watchdog device
-        pub struct HyperVGuestWatchdogDeps {
-            /// Port io address of the device's register region
-            pub port_base: u16,
-            /// Device-specific functions the platform must provide in order to
-            /// use this device.
-            pub watchdog_platform: Box<dyn watchdog_core::platform::WatchdogPlatform>,
         }
 
         /// Hyper-V specific UEFI Helper Device


### PR DESCRIPTION
- Added Hyper-V guest watchdog resource handle support and resolver-based instantiation for chipset wiring.
- Updated VM manifest construction to include the guest watchdog via chipset-device resources instead of legacy direct deps wiring.
- Removed deprecated base-chipset guest watchdog dependency plumbing and manual runtime device-id checks.
- Added watchdog platform capability resource resolution and moved enablement to chipset capabilities (with_guest_watchdog).
- Registered the watchdog resolver path in both OpenVMM and OpenHCL static resource registries, including required crate/dependency updates.