### PR TITLE
mana_driver: vf reconfiguration revokes vtl0 vf faster

### DIFF
--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -210,7 +210,11 @@ impl<T: DeviceBacking> GdmaDriver<T> {
 
 impl<T: DeviceBacking> Drop for GdmaDriver<T> {
     fn drop(&mut self) {
-        tracing::info!(?self.state_saved, ?self.hwc_failure, "dropping gdma driver");
+        tracing::info!(?self.state_saved, ?self.hwc_failure, ?self.vf_reconfiguration_pending, "dropping gdma driver");
+
+        if self.vf_reconfiguration_pending {
+            return;
+        }
 
         // Don't destroy anything if we're saving its state for restoration.
         if self.state_saved {
@@ -222,7 +226,7 @@ impl<T: DeviceBacking> Drop for GdmaDriver<T> {
             return;
         }
 
-        if self.hwc_failure || self.vf_reconfiguration_pending {
+        if self.hwc_failure {
             return;
         }
 

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -75,7 +75,6 @@ use gdma_defs::SmcProtoHdr;
 use inspect::Inspect;
 use pal_async::driver::Driver;
 use std::collections::HashMap;
-use std::mem;
 use std::mem::ManuallyDrop;
 use std::sync::Arc;
 use std::time::Duration;
@@ -223,7 +222,7 @@ impl<T: DeviceBacking> Drop for GdmaDriver<T> {
             return;
         }
 
-        if self.hwc_failure {
+        if self.hwc_failure || self.vf_reconfiguration_pending {
             return;
         }
 
@@ -689,6 +688,10 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         interrupt_loss: bool,
         ms_elapsed: u32,
     ) {
+        // Don't report timeout once VF reconfiguration is pending, SoC will not respond.
+        if self.vf_reconfiguration_pending {
+            return;
+        }
         // Perform initial check for ownership, failing without wait if device
         // is not present or owns shmem region
         let data = self
@@ -783,8 +786,8 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         self.link_toggle.drain(..).collect()
     }
 
-    pub fn get_vf_reconfiguration_pending(&mut self) -> bool {
-        mem::take(&mut self.vf_reconfiguration_pending)
+    pub fn get_vf_reconfiguration_pending(&self) -> bool {
+        self.vf_reconfiguration_pending
     }
 
     pub fn device(&self) -> &T {
@@ -839,6 +842,9 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         dev_id: GdmaDevId,
         req: Req,
     ) -> anyhow::Result<(Resp, u32)> {
+        if self.vf_reconfiguration_pending {
+            anyhow::bail!("VF reconfiguration pending");
+        }
         if self.hwc_failure {
             anyhow::bail!("Previous hardware failure");
         }

--- a/vm/devices/net/mana_driver/src/resources.rs
+++ b/vm/devices/net/mana_driver/src/resources.rs
@@ -63,11 +63,25 @@ impl ResourceArena {
     }
 
     pub(crate) async fn destroy<T: DeviceBacking>(mut self, gdma: &mut GdmaDriver<T>) {
+        let skip_hwc = gdma.get_vf_reconfiguration_pending();
+        if skip_hwc {
+            tracing::info!(
+                count = self.resources.len(),
+                "skipping HWC resource teardown during VF reconfiguration"
+            );
+        }
         for resource in self.resources.drain(..).rev() {
             let r = match resource {
                 Resource::MemoryBlock(mem) => {
                     drop(ManuallyDrop::into_inner(mem));
                     Ok(())
+                }
+                // During VF reconfiguration, skip sending teardown commands for HWC resources.
+                // HWC requests will fail and the device reclaims resources on its own reset.
+                Resource::DmaRegion { .. } | Resource::Eq { .. } | Resource::BnicQueue { .. }
+                    if skip_hwc =>
+                {
+                    continue;
                 }
                 Resource::DmaRegion {
                     dev_id,

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -232,11 +232,34 @@ async fn test_gdma_reconfig_vf(driver: DefaultDriver) {
         "vf_reconfiguration_pending should be false"
     );
 
+    // Get the device ID while HWC is still alive (needed for deregister later).
+    let dev_id = gdma
+        .list_devices()
+        .await
+        .unwrap()
+        .iter()
+        .copied()
+        .find(|dev_id| dev_id.ty == GdmaDevType::GDMA_DEVICE_MANA)
+        .unwrap();
+
     // Trigger the reconfig event (EQE 135).
     gdma.generate_reconfig_vf_event().await.unwrap();
-    gdma.process_all_eqs();
+
     assert!(
         gdma.get_vf_reconfiguration_pending(),
         "vf_reconfiguration_pending should be true after reconfig event"
+    );
+
+    // Deregister should fail immediately because vf_reconfiguration_pending is set.
+    let deregister_result = gdma.deregister_device(dev_id).await;
+    let err = deregister_result.expect_err("deregister_device should fail after EQE 135");
+    let err_msg = format!("{err:#}");
+    assert!(
+        err_msg.contains("VF reconfiguration pending"),
+        "unexpected error: {err_msg}"
+    );
+    assert!(
+        gdma.get_vf_reconfiguration_pending(),
+        "vf_reconfiguration_pending should remain true after deregister_device"
     );
 }


### PR DESCRIPTION
When VF Reconfiguration attempts to revoke the VTL0 VF, it can get stuck attempting to send HWC commands which have no chance of succeeding. This is causing try_notify_guest_and_revoke_vtl0_vf() to timeout, leaving the Guest in an inconsistent state that can cause the Reconfiguration to fail to restore the VTL0 VF.

* Once `vf_reconfiguration_pending` is set both `request_version()`, `report_hwc_timeout()` and device `drop()` will exit early to avoid making calls to the SoC.
* test_gdma_reconfig_vf test updated to exercise the new logic.
* Modify resource destroy to skip teardown for HWC resources when vf_reconfiguration_pending is set. Request would fail, but this way there's only one info trace instead of many ignorable error traces.