### PR TITLE
virtio: remove per-work Arc<Mutex> clone from queue completion path

### DIFF
--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -358,7 +358,10 @@ impl VirtioQueue {
     ///
     /// Writes `bytes_written` to the used ring and delivers an interrupt
     /// to the guest (unless interrupt suppression is active).
-    pub fn complete(&mut self, work: &mut VirtioQueueCallbackWork, bytes_written: u32) {
+    ///
+    /// Takes ownership of the work item, ensuring it can only be completed
+    /// once.
+    pub fn complete(&mut self, work: VirtioQueueCallbackWork, bytes_written: u32) {
         match self.complete.complete_descriptor(&work.work, bytes_written) {
             Ok(true) => {
                 self.notify_guest.deliver();

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -1922,12 +1922,12 @@ async fn verify_queue_simple_inner(mut guest: VirtioTestGuest) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     assert_eq!(work.payload.len(), 1);
                     assert_eq!(work.payload[0].length, 0x1000);
                     match work.payload[0].address {
-                        addr if addr == base_addr => queue.complete(&mut work, 123),
-                        addr if addr == base_addr + 0x1000 => queue.complete(&mut work, 456),
+                        addr if addr == base_addr => queue.complete(work, 123),
+                        addr if addr == base_addr + 0x1000 => queue.complete(work, 456),
                         _ => panic!("Unexpected address {}", work.payload[0].address),
                     }
                 },
@@ -1977,10 +1977,10 @@ async fn verify_queue_simple_interrupt_control_inner(mut guest: VirtioTestGuest,
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     assert_eq!(work.payload.len(), 1);
                     assert_eq!(work.payload[0].length, 0x1000);
-                    queue.complete(&mut work, 123);
+                    queue.complete(work, 123);
                 },
             ),
             notify: Interrupt::from_fn(move || {
@@ -2074,12 +2074,12 @@ async fn verify_queue_indirect_inner(mut guest: VirtioTestGuest) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     assert_eq!(work.payload.len(), 1);
                     assert_eq!(work.payload[0].length, 0x1000);
                     match work.payload[0].address {
-                        0xffffffff00000000u64 => queue.complete(&mut work, 123),
-                        addr if addr == base_addr + 0x1000 => queue.complete(&mut work, 456),
+                        0xffffffff00000000u64 => queue.complete(work, 123),
+                        addr if addr == base_addr + 0x1000 => queue.complete(work, 456),
                         _ => panic!("Unexpected address {}", work.payload[0].address),
                     }
                 },
@@ -2130,16 +2130,16 @@ async fn verify_queue_linked_inner(mut guest: VirtioTestGuest) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     if work.payload.len() == 3 {
                         for i in 0..work.payload.len() {
                             assert_eq!(work.payload[i].address, base_address + 0x1000 * i as u64);
                             assert_eq!(work.payload[i].length, 0x1000);
                         }
-                        queue.complete(&mut work, 123);
+                        queue.complete(work, 123);
                     } else {
                         assert_eq!(work.payload.len(), 1);
-                        queue.complete(&mut work, 456);
+                        queue.complete(work, 456);
                     }
                 },
             ),
@@ -2196,9 +2196,9 @@ async fn verify_packed_queue_linked_wrapping(driver: DefaultDriver) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     let len = work.payload.len() as u32;
-                    queue.complete(&mut work, len);
+                    queue.complete(work, len);
                 },
             ),
             notify: Interrupt::from_fn(move || {
@@ -2247,9 +2247,9 @@ async fn verify_packed_indirect_ignores_next_flag(driver: DefaultDriver) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     let len = work.payload.len() as u32;
-                    queue.complete(&mut work, len);
+                    queue.complete(work, len);
                 },
             ),
             notify: Interrupt::from_fn(move || {
@@ -2310,9 +2310,9 @@ async fn verify_packed_queue_non_power_of_two(driver: DefaultDriver) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     let len = work.payload.len() as u32;
-                    queue.complete(&mut work, len);
+                    queue.complete(work, len);
                 },
             ),
             notify: Interrupt::from_fn(move || {
@@ -2350,7 +2350,7 @@ async fn verify_queue_indirect_linked_inner(mut guest: VirtioTestGuest) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     if work.payload.len() == 3 {
                         for i in 0..work.payload.len() {
                             assert_eq!(
@@ -2359,10 +2359,10 @@ async fn verify_queue_indirect_linked_inner(mut guest: VirtioTestGuest) {
                             );
                             assert_eq!(work.payload[i].length, 0x1000);
                         }
-                        queue.complete(&mut work, 123);
+                        queue.complete(work, 123);
                     } else {
                         assert_eq!(work.payload.len(), 1);
-                        queue.complete(&mut work, 456);
+                        queue.complete(work, 456);
                     }
                 },
             ),
@@ -2414,13 +2414,13 @@ async fn verify_queue_avail_rollover_inner(mut guest: VirtioTestGuest) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     assert_eq!(work.payload.len(), 1);
                     assert_eq!(work.payload[0].length, 0x1000);
                     if work.payload[0].address == base_addr {
-                        queue.complete(&mut work, 123);
+                        queue.complete(work, 123);
                     } else if work.payload[0].address == base_addr + 0x1000 {
-                        queue.complete(&mut work, 456);
+                        queue.complete(work, 456);
                     } else {
                         panic!(
                             "Unexpected descriptor address {:x}",
@@ -2477,11 +2477,11 @@ async fn verify_multi_queue_inner(mut guest: VirtioTestGuest) {
         let base_addr = guest.get_queue_descriptor_backing_memory_address(queue_index);
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     assert_eq!(work.payload.len(), 1);
                     assert_eq!(work.payload[0].address, base_addr);
                     assert_eq!(work.payload[0].length, 0x1000);
-                    queue.complete(&mut work, 123 * queue_index as u32);
+                    queue.complete(work, 123 * queue_index as u32);
                 },
             ),
             notify: Interrupt::from_fn(move || {
@@ -2557,11 +2557,11 @@ async fn verify_device_queue_simple_inner(
     let interrupt = LineInterrupt::new_with_target("test", target.clone(), 0);
     let base_addr = guest.get_queue_descriptor_backing_memory_address(0);
     let queue_work = Arc::new(
-        move |_: u16, queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+        move |_: u16, queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
             assert_eq!(work.payload.len(), 1);
             assert_eq!(work.payload[0].address, base_addr);
             assert_eq!(work.payload[0].length, 0x1000);
-            queue.complete(&mut work, 123);
+            queue.complete(work, 123);
         },
     );
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(guest.driver()));
@@ -2646,11 +2646,11 @@ async fn verify_device_multi_queue_inner(
         .map(|i| guest.get_queue_descriptor_backing_memory_address(i))
         .collect();
     let queue_work = Arc::new(
-        move |i: u16, queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+        move |i: u16, queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
             assert_eq!(work.payload.len(), 1);
             assert_eq!(work.payload[0].address, base_addr[i as usize]);
             assert_eq!(work.payload[0].length, 0x1000);
-            queue.complete(&mut work, 123 * i as u32);
+            queue.complete(work, 123 * i as u32);
         },
     );
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(guest.driver()));
@@ -2748,11 +2748,11 @@ async fn verify_device_multi_queue_pci_inner(
         &driver,
         num_queues + 1,
         &test_mem,
-        Some(Arc::new(move |i, queue: &mut VirtioQueue, mut work| {
+        Some(Arc::new(move |i, queue: &mut VirtioQueue, work| {
             assert_eq!(work.payload.len(), 1);
             assert_eq!(work.payload[0].address, base_addr[i as usize]);
             assert_eq!(work.payload[0].length, 0x1000);
-            queue.complete(&mut work, 123 * i as u32);
+            queue.complete(work, 123 * i as u32);
         })),
     );
 
@@ -2986,9 +2986,9 @@ async fn verify_chain_at_queue_size_succeeds(driver: DefaultDriver) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     assert_eq!(work.payload.len(), queue_size as usize);
-                    queue.complete(&mut work, 42);
+                    queue.complete(work, 42);
                 },
             ),
             notify: Interrupt::from_fn(move || {
@@ -3115,9 +3115,9 @@ async fn verify_indirect_chain_at_queue_size_succeeds(driver: DefaultDriver) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     assert_eq!(work.payload.len(), queue_size as usize);
-                    queue.complete(&mut work, 99);
+                    queue.complete(work, 99);
                 },
             ),
             notify: Interrupt::from_fn(move || {
@@ -3151,11 +3151,11 @@ async fn verify_normal_then_indirect_succeeds(driver: DefaultDriver) {
         let tx = tx.clone();
         CreateDirectQueueParams {
             process_work: Box::new(
-                move |queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
                     // 1 normal descriptor + 3 indirect entries = 4 payload entries.
                     // (The indirect head descriptor is not itself a payload entry.)
                     assert_eq!(work.payload.len(), 4);
-                    queue.complete(&mut work, 77);
+                    queue.complete(work, 77);
                 },
             ),
             notify: Interrupt::from_fn(move || {
@@ -3271,8 +3271,8 @@ async fn verify_peek_does_not_advance(mut guest: VirtioTestGuest) {
     );
 
     // Consume the peeked work and complete it.
-    let mut work = peeked2.consume();
-    queue.complete(&mut work, 42);
+    let work = peeked2.consume();
+    queue.complete(work, 42);
 
     // Now the used ring should have the completion.
     let (_, len) = guest.get_next_completed(0).expect("completion expected");
@@ -3349,21 +3349,21 @@ async fn verify_peek_then_next(mut guest: VirtioTestGuest) {
     }
 
     // try_next should return the same first descriptor (peek didn't advance).
-    let mut work = queue
+    let work = queue
         .try_next()
         .unwrap()
         .expect("first descriptor via next");
     let first_desc = work.descriptor_index();
-    queue.complete(&mut work, 10);
+    queue.complete(work, 10);
 
     // Now the next descriptor should be different.
-    let mut work2 = queue.try_next().unwrap().expect("second descriptor");
+    let work2 = queue.try_next().unwrap().expect("second descriptor");
     assert_ne!(
         work2.descriptor_index(),
         first_desc,
         "second descriptor should differ"
     );
-    queue.complete(&mut work2, 20);
+    queue.complete(work2, 20);
 
     let (_, len) = guest.get_next_completed(0).expect("first completion");
     assert_eq!(len, 10);
@@ -3434,9 +3434,9 @@ async fn verify_packed_peek_linked(mut guest: VirtioTestGuest) {
     assert_eq!(peeked2.payload().len(), desc_count as usize);
 
     // Consume and complete.
-    let mut work = peeked2.consume();
+    let work = peeked2.consume();
     assert_eq!(work.payload.len(), desc_count as usize);
-    queue.complete(&mut work, 99);
+    queue.complete(work, 99);
 
     let (_, len) = guest.get_next_completed(0).expect("completion expected");
     assert_eq!(len, 99);
@@ -3472,11 +3472,11 @@ async fn split_queue_state_advances_on_pop(driver: DefaultDriver) {
     .unwrap();
 
     guest.queue_available_desc(0, 0);
-    let mut work = queue.try_next().unwrap().unwrap();
+    let work = queue.try_next().unwrap().unwrap();
     let state = queue.queue_state();
     assert_eq!(state.avail_index, 1);
     // Complete the descriptor → used_index advances
-    queue.complete(&mut work, 0);
+    queue.complete(work, 0);
     let state = queue.queue_state();
     assert_eq!(state.used_index, 1);
 }
@@ -4009,8 +4009,8 @@ async fn pci_intx_line_deasserted_on_reset(driver: DefaultDriver) {
                 ..Default::default()
             },
             Some(Arc::new(
-                |_i, queue: &mut VirtioQueue, mut work: VirtioQueueCallbackWork| {
-                    queue.complete(&mut work, 42);
+                |_i, queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
+                    queue.complete(work, 42);
                 },
             )),
         )),

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -123,8 +123,8 @@ enum IoStat {
 
 impl BlkWorker {
     /// Complete a descriptor and accumulate stats.
-    fn finish_io(&mut self, queue: &mut VirtioQueue, mut completion: IoCompletion) {
-        queue.complete(&mut completion.work, completion.bytes_written);
+    fn finish_io(&mut self, queue: &mut VirtioQueue, completion: IoCompletion) {
+        queue.complete(completion.work, completion.bytes_written);
         match completion.stat {
             IoStat::Read => self.stats.read_ops.increment(),
             IoStat::Write => self.stats.write_ops.increment(),

--- a/vm/devices/virtio/virtio_console/src/lib.rs
+++ b/vm/devices/virtio/virtio_console/src/lib.rs
@@ -279,8 +279,8 @@ impl ConsoleWorker {
                     };
                     loop {
                         let work = transmitq.peek().await.map_err(WorkerError::Virtio)?;
-                        let mut work = work.consume();
-                        transmitq.complete(&mut work, 0);
+                        let work = work.consume();
+                        transmitq.complete(work, 0);
                         *partial_transmit = 0;
                     }
                 };
@@ -309,8 +309,8 @@ impl ConsoleWorker {
                             // Guest posted a zero-length buffer; complete it
                             // immediately without calling poll_read (which
                             // would return Ok(0) and look like a disconnect).
-                            let mut work = work.consume();
-                            receiveq.complete(&mut work, 0);
+                            let work = work.consume();
+                            receiveq.complete(work, 0);
                             continue 'rx;
                         }
                         let n = BUF_SIZE.min(writeable_len);
@@ -323,15 +323,15 @@ impl ConsoleWorker {
                                 break 'rx Ok(false);
                             }
                             Ok(n) => {
-                                let mut work = work.consume();
+                                let work = work.consume();
                                 if let Err(err) = work.write(mem, &buf[..n]) {
                                     tracelimit::error_ratelimited!(
                                         error = &err as &dyn std::error::Error,
                                         "failed to write to guest receive buffer"
                                     );
-                                    receiveq.complete(&mut work, 0);
+                                    receiveq.complete(work, 0);
                                 } else {
-                                    receiveq.complete(&mut work, n as u32);
+                                    receiveq.complete(work, n as u32);
                                 }
                             }
                             Err(_) => {
@@ -377,8 +377,8 @@ impl ConsoleWorker {
                             }
                         }
                         *partial_transmit = 0;
-                        let mut work = work.consume();
-                        transmitq.complete(&mut work, 0);
+                        let work = work.consume();
+                        transmitq.complete(work, 0);
                     }
                 };
 

--- a/vm/devices/virtio/virtio_net/src/buffers.rs
+++ b/vm/devices/virtio/virtio_net/src/buffers.rs
@@ -98,7 +98,8 @@ impl VirtioWorkPool {
     /// Take the RX work item for the given packet, returning it with the
     /// computed payload length. The caller is responsible for completing
     /// the descriptor via the queue.
-    pub fn complete_packet(&mut self, rx_id: RxId) -> (VirtioQueueCallbackWork, u32) {
+    #[must_use = "caller must complete the returned work via VirtioQueue::complete"]
+    pub fn take_rx_work(&mut self, rx_id: RxId) -> (VirtioQueueCallbackWork, u32) {
         let packet = self.rx_packets[rx_id.0 as usize]
             .take()
             .expect("valid packet index");

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -913,7 +913,7 @@ impl Worker {
         Ok(did_work)
     }
 
-    fn queue_tx_packet(&mut self, mut work: VirtioQueueCallbackWork) {
+    fn queue_tx_packet(&mut self, work: VirtioQueueCallbackWork) {
         let seg_start = self.active_state.data.tx_segments.len();
         match self.try_queue_tx_packet(&work) {
             Ok(idx) => {
@@ -926,7 +926,7 @@ impl Worker {
                 );
                 self.active_state.stats.tx_dropped.increment();
                 self.active_state.data.tx_segments.truncate(seg_start);
-                self.virtio_state.tx_queue.complete(&mut work, 0);
+                self.virtio_state.tx_queue.complete(work, 0);
             }
         }
     }
@@ -1203,10 +1203,10 @@ impl Worker {
             tracing::trace!("rx packet");
             match self.active_state.pending_rx_packets.queue_work(work) {
                 Ok(rx_id) => rx_ids.push(rx_id),
-                Err(mut work) => {
+                Err(work) => {
                     // Reason has been traced by the callee.
                     self.active_state.stats.rx_dropped.increment();
-                    self.virtio_state.rx_queue.complete(&mut work, 0);
+                    self.virtio_state.rx_queue.complete(work, 0);
                 }
             }
         }
@@ -1232,8 +1232,8 @@ impl Worker {
 
         for ready_id in state.data.rx_ready[..n].iter() {
             state.stats.rx_packets.increment();
-            let (mut work, bytes) = state.pending_rx_packets.complete_packet(*ready_id);
-            self.virtio_state.rx_queue.complete(&mut work, bytes);
+            let (work, bytes) = state.pending_rx_packets.take_rx_work(*ready_id);
+            self.virtio_state.rx_queue.complete(work, bytes);
         }
 
         state.stats.rx_packets_per_wake.add_sample(n as u64);
@@ -1305,8 +1305,8 @@ impl Worker {
 
     fn complete_tx_packet(&mut self, id: TxId) -> Result<(), WorkerError> {
         let state = &mut self.active_state;
-        let mut tx_packet = state.pending_tx_packets[id.0 as usize].take().unwrap();
-        self.virtio_state.tx_queue.complete(&mut tx_packet.work, 0);
+        let tx_packet = state.pending_tx_packets[id.0 as usize].take().unwrap();
+        self.virtio_state.tx_queue.complete(tx_packet.work, 0);
         self.active_state.stats.tx_packets.increment();
         Ok(())
     }

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -183,9 +183,9 @@ impl AsyncRun<Plan9Queue> for Plan9Worker {
             let work = stop.until_stopped(state.queue.next()).await?;
             let Some(work) = work else { break };
             match work {
-                Ok(mut work) => {
+                Ok(work) => {
                     let bytes = process_9p_request(&state.mem, &self.fs, &work);
-                    state.queue.complete(&mut work, bytes);
+                    state.queue.complete(work, bytes);
                 }
                 Err(err) => {
                     tracing::error!(error = &err as &dyn std::error::Error, "queue error");

--- a/vm/devices/virtio/virtio_pmem/src/lib.rs
+++ b/vm/devices/virtio/virtio_pmem/src/lib.rs
@@ -180,9 +180,9 @@ impl AsyncRun<PmemQueue> for PmemWorker {
             let work = stop.until_stopped(state.queue.next()).await?;
             let Some(work) = work else { break };
             match work {
-                Ok(mut work) => {
+                Ok(work) => {
                     let bytes = process_pmem_request(self, &state.mem, &work);
-                    state.queue.complete(&mut work, bytes);
+                    state.queue.complete(work, bytes);
                 }
                 Err(err) => {
                     tracing::error!(error = &err as &dyn std::error::Error, "queue error");

--- a/vm/devices/virtio/virtio_rng/src/lib.rs
+++ b/vm/devices/virtio/virtio_rng/src/lib.rs
@@ -151,9 +151,9 @@ impl AsyncRun<RngQueue> for RngWorker {
             let work = stop.until_stopped(state.queue.next()).await?;
             let Some(work) = work else { break };
             match work {
-                Ok(mut work) => {
+                Ok(work) => {
                     let bytes = process_rng_request(&state.mem, &work);
-                    state.queue.complete(&mut work, bytes);
+                    state.queue.complete(work, bytes);
                 }
                 Err(err) => {
                     tracelimit::error_ratelimited!(

--- a/vm/devices/virtio/virtio_vsock/src/lib.rs
+++ b/vm/devices/virtio/virtio_vsock/src/lib.rs
@@ -318,7 +318,7 @@ struct VsockWorker {
 
 impl VsockWorker {
     /// Handle a work item from the tx virtqueue (guest -> host).
-    fn handle_guest_tx(&mut self, state: &mut VsockWorkerState, mut work: VirtioQueueCallbackWork) {
+    fn handle_guest_tx(&mut self, state: &mut VsockWorkerState, work: VirtioQueueCallbackWork) {
         if let Err(err) = self.handle_guest_tx_inner(state, &work) {
             tracelimit::error_ratelimited!(
                 error = err.as_ref() as &dyn std::error::Error,
@@ -326,7 +326,7 @@ impl VsockWorker {
             );
         }
 
-        state.tx_queue.get_mut().complete(&mut work, 0);
+        state.tx_queue.get_mut().complete(work, 0);
     }
 
     /// Handle a work item from the TX virtqueue (guest -> host).
@@ -440,7 +440,7 @@ impl VsockWorker {
 
         // If there's a packet to send, write it to the guest.
         if let Some(packet) = packet {
-            let mut queue_work = peeked_work.consume();
+            let queue_work = peeked_work.consume();
             let bytes = match Self::write_packet(state, &queue_work, &packet) {
                 Ok(bytes) => bytes,
                 Err(err) => {
@@ -457,7 +457,7 @@ impl VsockWorker {
                     0
                 }
             };
-            state.rx_queue.complete(&mut queue_work, bytes);
+            state.rx_queue.complete(queue_work, bytes);
         }
 
         state.queue_pending(pending);

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -240,9 +240,9 @@ impl AsyncRun<VirtioFsQueue> for VirtioFsWorker {
             let work = stop.until_stopped(state.queue.next()).await?;
             let Some(work) = work else { break };
             match work {
-                Ok(mut work) => {
+                Ok(work) => {
                     let bytes = process_virtiofs_request(self, &state.mem, &work);
-                    state.queue.complete(&mut work, bytes);
+                    state.queue.complete(work, bytes);
                 }
                 Err(err) => {
                     tracing::error!(


### PR DESCRIPTION
Every `VirtioQueueCallbackWork` currently clones an `Arc<Mutex<VirtioQueueUsedHandler>>` so that it can independently call `complete()` on itself. This means every descriptor processed by every virtio device pays for an atomic ref-count increment/decrement pair plus a mutex lock on the completion path—overhead that adds up on high-throughput devices like virtio-net and virtio-blk.

This PR moves completion responsibility from the work item to the queue: callers now invoke `VirtioQueue::complete(work, bytes_written)` instead of `work.complete(bytes_written)`. Because the queue already owns the used-ring handler, the `Arc<Mutex>` clone per work item, the `completed` tracking flag, and the `Drop` guard on `VirtioQueue` are all eliminated.

All in-tree virtio device crates are updated to the new pattern. For virtio-vsock, the refactor also fixes a latent bug where `write_packet` could early-return on error without completing the work item; the caller now always completes it.