### PR TITLE
net_tap: change TapHandle from device name to pre-opened fd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5356,6 +5356,7 @@ dependencies = [
  "mesh_rpc",
  "mesh_worker",
  "net_backend_resources",
+ "net_tap",
  "netvsp_resources",
  "nvme_resources",
  "openssl",

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -105,6 +105,9 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 unicycle.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+net_tap.workspace = true
+
 [target.'cfg(windows)'.dependencies]
 vmswitch.workspace = true
 virt_whp.workspace = true

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1850,7 +1850,17 @@ fn parse_endpoint(
             }
         }
         EndpointConfigCli::Tap { name } => {
-            net_backend_resources::tap::TapHandle { name: name.clone() }.into_resource()
+            #[cfg(target_os = "linux")]
+            {
+                let fd = net_tap::tap::open_tap(name).context("failed to open TAP device")?;
+                net_backend_resources::tap::TapHandle { fd }.into_resource()
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = name;
+                bail!("TAP backend is only supported on Linux")
+            }
         }
     };
 

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -704,6 +704,10 @@ impl VmService {
     }
 }
 
+#[cfg_attr(
+    not(any(windows, target_os = "linux")),
+    allow(unreachable_code, unused_variables)
+)]
 fn parse_nic_config(
     nic: vmservice::NicConfig,
 ) -> anyhow::Result<(DeviceVtl, Resource<VmbusDeviceHandleKind>)> {
@@ -724,9 +728,17 @@ fn parse_nic_config(
             },
         }
         .into_resource(),
-        #[cfg(unix)]
         Backend::Tap(tap) => {
-            net_backend_resources::tap::TapHandle { name: tap.name }.into_resource()
+            #[cfg(target_os = "linux")]
+            {
+                let fd = net_tap::tap::open_tap(&tap.name).context("failed to open TAP device")?;
+                net_backend_resources::tap::TapHandle { fd }.into_resource()
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = tap;
+                anyhow::bail!("TAP backend is only supported on Linux")
+            }
         }
         _ => anyhow::bail!("unsupported backend"),
     };

--- a/vm/devices/net/net_backend_resources/src/lib.rs
+++ b/vm/devices/net/net_backend_resources/src/lib.rs
@@ -72,6 +72,7 @@ pub mod dio {
 }
 
 /// Linux TAP backend.
+#[cfg(target_os = "linux")]
 pub mod tap {
     use mesh::MeshPayload;
     use vm_resource::ResourceId;
@@ -80,10 +81,9 @@ pub mod tap {
     /// A handle to a TAP device.
     #[derive(MeshPayload)]
     pub struct TapHandle {
-        /// The name of the TAP device.
-        ///
-        /// FUTURE: change this to a pre-opened `File`.
-        pub name: String,
+        /// A pre-opened TAP file descriptor, configured with
+        /// `IFF_TAP | IFF_NO_PI | IFF_VNET_HDR`.
+        pub fd: std::os::fd::OwnedFd,
     }
 
     impl ResourceId<NetEndpointHandleKind> for TapHandle {

--- a/vm/devices/net/net_tap/Cargo.toml
+++ b/vm/devices/net/net_tap/Cargo.toml
@@ -6,7 +6,7 @@ name = "net_tap"
 edition.workspace = true
 rust-version.workspace = true
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 net_backend.workspace = true
 net_backend_resources.workspace = true
 linux_net_bindings.workspace = true
@@ -27,7 +27,7 @@ thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
 
-[target.'cfg(unix)'.dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 guestmem.workspace = true
 libtest-mimic.workspace = true
 net_backend.workspace = true

--- a/vm/devices/net/net_tap/src/lib.rs
+++ b/vm/devices/net/net_tap/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! A TAP interface based endpoint.
 
-#![cfg(unix)]
+#![cfg(target_os = "linux")]
 #![expect(missing_docs)]
 
 pub mod resolver;

--- a/vm/devices/net/net_tap/src/resolver.rs
+++ b/vm/devices/net/net_tap/src/resolver.rs
@@ -26,10 +26,7 @@ impl ResolveResource<NetEndpointHandleKind, TapHandle> for TapResolver {
         resource: TapHandle,
         _input: ResolveEndpointParams,
     ) -> Result<Self::Output, Self::Error> {
-        // TODO: accept a pre-opened fd from the resource handle instead of
-        // opening by name here, to support fd passing from Kata and similar.
-        let fd = tap::open_tap(&resource.name)?;
-        let tap = tap::Tap::new(fd)?;
+        let tap = tap::Tap::new(resource.fd)?;
 
         Ok(TapEndpoint::new(tap)?.into())
     }


### PR DESCRIPTION
`TapHandle` in `net_backend_resources` carried a device name string and the resolver opened the TAP device. Change it to carry a pre-opened `OwnedFd` so the opener (`openvmm_entry` or a test harness) controls namespace and permission details. This resolves a long-standing TODO and enables fd passing from Kata and similar environments.

Also tighten both `TapHandle` and `net_tap` from `cfg(unix)` to `cfg(target_os = "linux")` since TAP uses Linux-specific /dev/net/tun ioctls.