### PR TITLE
netvsp: fix untrusted guest input errors

### DIFF
--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -35,8 +35,8 @@ pub enum GuestBuffersError {
     SubAllocationTooSmall { sub_allocation_size: u32, mtu: u32 },
     #[error("GPADL has no ranges")]
     EmptyGpadl,
-    #[error("guest memory error")]
-    Memory(#[source] GuestMemoryError),
+    #[error("failed to lock guest page numbers")]
+    GpnLock(#[source] GuestMemoryError),
 }
 
 /// A type providing access to the netvsp receive buffer.
@@ -74,6 +74,9 @@ impl GuestBuffers {
         sub_allocation_size: u32,
         mtu: u32,
     ) -> Result<(), GuestBuffersError> {
+        if gpadl.first().is_none() {
+            return Err(GuestBuffersError::EmptyGpadl);
+        }
         mtu.checked_add(RX_HEADER_LEN)
             .and_then(|v| v.checked_add(BROKEN_CO_NETVSC_FOOTER_LEN))
             .ok_or(GuestBuffersError::InvalidMtu { mtu })?;
@@ -82,9 +85,6 @@ impl GuestBuffers {
                 sub_allocation_size,
                 mtu,
             });
-        }
-        if gpadl.first().is_none() {
-            return Err(GuestBuffersError::EmptyGpadl);
         }
         Ok(())
     }
@@ -97,14 +97,10 @@ impl GuestBuffers {
     ) -> Result<Self, GuestBuffersError> {
         Self::validate_config(&gpadl, sub_allocation_size, mtu)?;
 
-        let gpns = gpadl
-            .first()
-            .ok_or(GuestBuffersError::EmptyGpadl)?
-            .gpns()
-            .to_vec();
+        let gpns = gpadl.first().unwrap().gpns().to_vec();
         let locked_pages = mem
             .lock_gpns(false, &gpns)
-            .map_err(GuestBuffersError::Memory)?;
+            .map_err(GuestBuffersError::GpnLock)?;
         Ok(Self {
             mem,
             _gpadl: gpadl,

--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -29,6 +29,8 @@ const PAGE_SIZE32: u32 = 4096;
 
 #[derive(Debug, Error)]
 pub enum GuestBuffersError {
+    #[error("invalid mtu {mtu}")]
+    InvalidMtu { mtu: u32 },
     #[error("sub_allocation_size {sub_allocation_size} is too small for mtu {mtu}")]
     SubAllocationTooSmall { sub_allocation_size: u32, mtu: u32 },
     #[error("GPADL has no ranges")]
@@ -72,6 +74,9 @@ impl GuestBuffers {
         sub_allocation_size: u32,
         mtu: u32,
     ) -> Result<(), GuestBuffersError> {
+        mtu.checked_add(RX_HEADER_LEN)
+            .and_then(|v| v.checked_add(BROKEN_CO_NETVSC_FOOTER_LEN))
+            .ok_or(GuestBuffersError::InvalidMtu { mtu })?;
         if sub_allocation_size < sub_allocation_size_for_mtu(mtu) {
             return Err(GuestBuffersError::SubAllocationTooSmall {
                 sub_allocation_size,
@@ -304,6 +309,33 @@ mod tests {
             Err(GuestBuffersError::SubAllocationTooSmall { .. }) => {}
             Err(e) => panic!("expected SubAllocationTooSmall, got {e}"),
             Ok(_) => panic!("expected SubAllocationTooSmall, got Ok"),
+        }
+    }
+
+    /// Verify that an MTU near u32::MAX returns InvalidMtu instead of
+    /// wrapping the sub_allocation_size calculation.
+    #[test]
+    fn overflowing_mtu_returns_error() {
+        let num_pages = 16;
+        let hdr = GpaRange {
+            len: (num_pages * 4096) as u32,
+            offset: 0,
+        };
+        let mut buf = vec![u64::from_le_bytes(hdr.as_bytes().try_into().unwrap())];
+        buf.extend((0..num_pages).map(|i| i as u64));
+        let multipaged_ranged_buf = MultiPagedRangeBuf::from_range_buffer(1, buf).unwrap();
+
+        let gpadl_map = GpadlMap::new();
+        let gpadl_id = GpadlId(3);
+        gpadl_map.add(gpadl_id, multipaged_ranged_buf);
+        let gpadl_view = gpadl_map.view().map(gpadl_id).unwrap();
+
+        // An MTU of u32::MAX would overflow the sub_allocation_size addition.
+        let result = GuestBuffers::validate_config(&gpadl_view, 1806, u32::MAX);
+        match result {
+            Err(GuestBuffersError::InvalidMtu { .. }) => {}
+            Err(e) => panic!("expected InvalidMtu, got {e}"),
+            Ok(_) => panic!("expected InvalidMtu, got Ok"),
         }
     }
 

--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -65,18 +65,32 @@ impl BufferPool {
 }
 
 impl GuestBuffers {
-    pub fn new(
-        mem: GuestMemory,
-        gpadl: GpadlView,
+    /// Validates that the GPADL and sub_allocation_size are compatible with the MTU
+    /// without performing any allocations.
+    pub fn validate_config(
+        gpadl: &GpadlView,
         sub_allocation_size: u32,
         mtu: u32,
-    ) -> Result<Self, GuestBuffersError> {
+    ) -> Result<(), GuestBuffersError> {
         if sub_allocation_size < sub_allocation_size_for_mtu(mtu) {
             return Err(GuestBuffersError::SubAllocationTooSmall {
                 sub_allocation_size,
                 mtu,
             });
         }
+        if gpadl.first().is_none() {
+            return Err(GuestBuffersError::EmptyGpadl);
+        }
+        Ok(())
+    }
+
+    pub fn new(
+        mem: GuestMemory,
+        gpadl: GpadlView,
+        sub_allocation_size: u32,
+        mtu: u32,
+    ) -> Result<Self, GuestBuffersError> {
+        Self::validate_config(&gpadl, sub_allocation_size, mtu)?;
 
         let gpns = gpadl
             .first()

--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -17,6 +17,7 @@ use net_backend::RxMetadata;
 use safeatomic::AtomicSliceOps;
 use std::ops::Range;
 use std::sync::Arc;
+use thiserror::Error;
 use vmbus_channel::gpadl::GpadlView;
 use zerocopy::FromZeros;
 use zerocopy::Immutable;
@@ -25,6 +26,16 @@ use zerocopy::KnownLayout;
 
 const PAGE_SIZE: usize = 4096;
 const PAGE_SIZE32: u32 = 4096;
+
+#[derive(Debug, Error)]
+pub enum GuestBuffersError {
+    #[error("sub_allocation_size {sub_allocation_size} is too small for mtu {mtu}")]
+    SubAllocationTooSmall { sub_allocation_size: u32, mtu: u32 },
+    #[error("GPADL has no ranges")]
+    EmptyGpadl,
+    #[error("guest memory error")]
+    Memory(#[source] GuestMemoryError),
+}
 
 /// A type providing access to the netvsp receive buffer.
 pub struct GuestBuffers {
@@ -59,11 +70,22 @@ impl GuestBuffers {
         gpadl: GpadlView,
         sub_allocation_size: u32,
         mtu: u32,
-    ) -> Result<Self, GuestMemoryError> {
-        assert!(sub_allocation_size >= sub_allocation_size_for_mtu(mtu));
+    ) -> Result<Self, GuestBuffersError> {
+        if sub_allocation_size < sub_allocation_size_for_mtu(mtu) {
+            return Err(GuestBuffersError::SubAllocationTooSmall {
+                sub_allocation_size,
+                mtu,
+            });
+        }
 
-        let gpns = gpadl.first().unwrap().gpns().to_vec();
-        let locked_pages = mem.lock_gpns(false, &gpns)?;
+        let gpns = gpadl
+            .first()
+            .ok_or(GuestBuffersError::EmptyGpadl)?
+            .gpns()
+            .to_vec();
+        let locked_pages = mem
+            .lock_gpns(false, &gpns)
+            .map_err(GuestBuffersError::Memory)?;
         Ok(Self {
             mem,
             _gpadl: gpadl,
@@ -222,8 +244,74 @@ impl BufferAccess for BufferPool {
 
 #[cfg(test)]
 mod tests {
+    use crate::buffers::GuestBuffers;
+    use crate::buffers::GuestBuffersError;
     use crate::buffers::compute_buffer_segments;
+    use crate::buffers::sub_allocation_size_for_mtu;
+    use guestmem::GuestMemory;
     use net_backend::RxBufferSegment;
+    use vmbus_channel::gpadl::GpadlMap;
+    use vmbus_core::protocol::GpadlId;
+    use vmbus_ring::gparange::GpaRange;
+    use vmbus_ring::gparange::MultiPagedRangeBuf;
+    use zerocopy::IntoBytes;
+
+    /// Verify that inconsistent sub_allocation_size and MTU from saved state
+    /// returns an error instead of panicking.
+    #[test]
+    fn sub_allocation_too_small_for_mtu() {
+        let default_mtu = 1514;
+        let max_mtu = 9216;
+        let sub_alloc_for_default = sub_allocation_size_for_mtu(default_mtu);
+
+        // The sub_allocation for default MTU must be smaller than for max MTU.
+        assert!(sub_alloc_for_default < sub_allocation_size_for_mtu(max_mtu));
+
+        // Build a multipaged ranged buffer.
+        let num_pages = 16;
+        let hdr = GpaRange {
+            len: (num_pages * 4096) as u32,
+            offset: 0,
+        };
+        let mut buf = vec![u64::from_le_bytes(hdr.as_bytes().try_into().unwrap())];
+        // Append one GPN per page.
+        buf.extend((0..num_pages).map(|i| i as u64));
+        let multipaged_ranged_buf = MultiPagedRangeBuf::from_range_buffer(1, buf).unwrap();
+
+        // Build a minimal GpadlView (won't be accessed — the check fires first).
+        let gpadl_map = GpadlMap::new();
+        let gpadl_id = GpadlId(1);
+        gpadl_map.add(gpadl_id, multipaged_ranged_buf);
+        let gpadl_view = gpadl_map.view().map(gpadl_id).unwrap();
+
+        let mem = GuestMemory::empty();
+        let result = GuestBuffers::new(mem, gpadl_view, sub_alloc_for_default, max_mtu);
+        match result {
+            Err(GuestBuffersError::SubAllocationTooSmall { .. }) => {}
+            Err(e) => panic!("expected SubAllocationTooSmall, got {e}"),
+            Ok(_) => panic!("expected SubAllocationTooSmall, got Ok"),
+        }
+    }
+
+    /// Verify that a GPADL with zero ranges returns EmptyGpadl instead of
+    /// panicking.
+    #[test]
+    fn empty_gpadl_returns_error() {
+        let multipaged_ranged_buf = MultiPagedRangeBuf::from_range_buffer(0, vec![]).unwrap();
+
+        let gpadl_map = GpadlMap::new();
+        let gpadl_id = GpadlId(2);
+        gpadl_map.add(gpadl_id, multipaged_ranged_buf);
+        let gpadl_view = gpadl_map.view().map(gpadl_id).unwrap();
+
+        let mem = GuestMemory::empty();
+        let result = GuestBuffers::new(mem, gpadl_view, 1806, 1514);
+        match result {
+            Err(GuestBuffersError::EmptyGpadl) => {}
+            Err(e) => panic!("expected EmptyGpadl, got {e}"),
+            Ok(_) => panic!("expected EmptyGpadl, got Ok"),
+        }
+    }
 
     #[test]
     fn test_buffer_segments() {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4471,8 +4471,8 @@ impl Coordinator {
 
     async fn restart_queues(&mut self, c_state: &mut CoordinatorState) -> Result<(), WorkerError> {
         // Pre-compute the active queue count and validate the rx buffer configuration.
-        // For invalid configurations, the error is logged and we exit without performing
-        // any destructive operations (dropping queues, stopping the endpoint).
+        // For invalid configurations, log the error and exit without performing
+        // destructive operations (dropping queues, stopping the endpoint).
         let (num_queues, active_queues, active_queue_count) = if let Some(state) = self.workers[0]
             .state()
             .and_then(|worker| worker.state.ready())
@@ -4502,6 +4502,13 @@ impl Coordinator {
                 state.buffers.recv_buffer.count,
                 active_queue_count.into(),
             )?;
+
+            GuestBuffers::validate_config(
+                &state.buffers.recv_buffer.gpadl,
+                state.buffers.recv_buffer.sub_allocation_size,
+                state.buffers.ndis_config.mtu,
+            )
+            .map_err(WorkerError::GuestBuffers)?;
 
             (num_queues, active_queues, active_queue_count)
         } else {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -414,7 +414,7 @@ struct RxBufferRanges {
 
 impl RxBufferRanges {
     /// Validates that the given parameters produce a valid RX buffer configuration.
-    fn validate_params(buffer_count: u32, queue_count: u32) -> Result<(), WorkerError> {
+    fn validate_params(buffer_count: u32, queue_count: u32) -> Result<u32, WorkerError> {
         if queue_count == 0 {
             return Err(WorkerError::InvalidRxBufferConfig(
                 RxBufferConfigError::ZeroQueueCount,
@@ -431,15 +431,14 @@ impl RxBufferRanges {
                 RxBufferConfigError::ZeroBuffersPerQueue,
             ));
         }
-        Ok(())
+        Ok(buffers_per_queue)
     }
 
     fn new(
         buffer_count: u32,
         queue_count: u32,
     ) -> Result<(Self, Vec<mpsc::UnboundedReceiver<u32>>), WorkerError> {
-        Self::validate_params(buffer_count, queue_count)?;
-        let buffers_per_queue = (buffer_count - RX_RESERVED_CONTROL_BUFFERS) / queue_count;
+        let buffers_per_queue = Self::validate_params(buffer_count, queue_count)?;
         #[expect(clippy::disallowed_methods)] // TODO
         let (send, recv): (Vec<_>, Vec<_>) = (0..queue_count).map(|_| mpsc::unbounded()).unzip();
         Ok((

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1288,9 +1288,7 @@ impl VmbusDevice for Nic {
     }
 
     fn max_subchannels(&self) -> u16 {
-        // max_queues includes the primary channel, therefore max_subchannels is one less.
-        // max_queues is clamped to min 1 in NicBuilder.
-        self.adapter.max_queues.saturating_sub(1)
+        self.adapter.max_queues
     }
 
     fn install(&mut self, resources: DeviceResources) {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4470,9 +4470,9 @@ impl Coordinator {
     }
 
     async fn restart_queues(&mut self, c_state: &mut CoordinatorState) -> Result<(), WorkerError> {
-        // Pre-compute the active queue count and validate the rx buffer configuration.
-        // For invalid configurations, log the error and exit without performing
-        // destructive operations (dropping queues, stopping the endpoint).
+        // Pre-compute the active queue count and validate the rx buffer configuration
+        // before continuing with the queue restart work in this function.
+        // Invalid configurations are returned to the caller as errors.
         let (num_queues, active_queues, active_queue_count) = if let Some(state) = self.workers[0]
             .state()
             .and_then(|worker| worker.state.ready())

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4479,24 +4479,29 @@ impl Coordinator {
         {
             let num_queues = state.state.primary.as_ref().unwrap().requested_num_queues;
             let mut active_queues = Vec::new();
-            let active_queue_count =
-                if let Some(rss_state) = state.state.primary.as_ref().unwrap().rss_state.as_ref() {
-                    active_queues.clone_from(&rss_state.indirection_table);
-                    active_queues.sort();
-                    active_queues.dedup();
-                    active_queues = active_queues
-                        .into_iter()
-                        .filter(|&index| index < num_queues)
-                        .collect::<Vec<_>>();
-                    if !active_queues.is_empty() {
-                        active_queues.len() as u16
-                    } else {
-                        tracelimit::warn_ratelimited!("Invalid RSS indirection table");
-                        num_queues
-                    }
+            let active_queue_count = if let Some(rss_state) =
+                state.state.primary.as_ref().unwrap().rss_state.as_ref()
+            {
+                active_queues.clone_from(&rss_state.indirection_table);
+                active_queues.sort();
+                active_queues.dedup();
+                active_queues = active_queues
+                    .into_iter()
+                    .filter(|&index| index < num_queues)
+                    .collect::<Vec<_>>();
+                if !active_queues.is_empty() {
+                    active_queues.len() as u16
                 } else {
+                    tracelimit::warn_ratelimited!(
+                        num_queues,
+                        indirection_table_len = rss_state.indirection_table.len(),
+                        "RSS indirection table has no entries within the valid queue range, falling back to num_queues",
+                    );
                     num_queues
-                };
+                }
+            } else {
+                num_queues
+            };
 
             RxBufferRanges::validate_params(
                 state.buffers.recv_buffer.count,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -397,23 +397,58 @@ impl RxBufferRange {
     }
 }
 
+#[derive(Debug, Error)]
+enum RxBufferConfigError {
+    #[error("queue_count must be at least 1")]
+    ZeroQueueCount,
+    #[error("buffer_count must be >= RX_RESERVED_CONTROL_BUFFERS")]
+    InsufficientBuffers,
+    #[error("buffers_per_queue must not be 0")]
+    ZeroBuffersPerQueue,
+}
+
 struct RxBufferRanges {
     buffers_per_queue: u32,
     buffer_id_send: Vec<mpsc::UnboundedSender<u32>>,
 }
 
 impl RxBufferRanges {
-    fn new(buffer_count: u32, queue_count: u32) -> (Self, Vec<mpsc::UnboundedReceiver<u32>>) {
+    /// Validates that the given parameters produce a valid RX buffer configuration.
+    fn validate_params(buffer_count: u32, queue_count: u32) -> Result<(), WorkerError> {
+        if queue_count == 0 {
+            return Err(WorkerError::InvalidRxBufferConfig(
+                RxBufferConfigError::ZeroQueueCount,
+            ));
+        }
+        if buffer_count < RX_RESERVED_CONTROL_BUFFERS {
+            return Err(WorkerError::InvalidRxBufferConfig(
+                RxBufferConfigError::InsufficientBuffers,
+            ));
+        }
+        let buffers_per_queue = (buffer_count - RX_RESERVED_CONTROL_BUFFERS) / queue_count;
+        if buffers_per_queue == 0 {
+            return Err(WorkerError::InvalidRxBufferConfig(
+                RxBufferConfigError::ZeroBuffersPerQueue,
+            ));
+        }
+        Ok(())
+    }
+
+    fn new(
+        buffer_count: u32,
+        queue_count: u32,
+    ) -> Result<(Self, Vec<mpsc::UnboundedReceiver<u32>>), WorkerError> {
+        Self::validate_params(buffer_count, queue_count)?;
         let buffers_per_queue = (buffer_count - RX_RESERVED_CONTROL_BUFFERS) / queue_count;
         #[expect(clippy::disallowed_methods)] // TODO
         let (send, recv): (Vec<_>, Vec<_>) = (0..queue_count).map(|_| mpsc::unbounded()).unzip();
-        (
+        Ok((
             Self {
                 buffers_per_queue,
                 buffer_id_send: send,
             },
             recv,
-        )
+        ))
     }
 }
 
@@ -1254,7 +1289,9 @@ impl VmbusDevice for Nic {
     }
 
     fn max_subchannels(&self) -> u16 {
-        self.adapter.max_queues
+        // max_queues includes the primary channel, therefore max_subchannels is one less.
+        // max_queues is clamped to min 1 in NicBuilder.
+        self.adapter.max_queues.saturating_sub(1)
     }
 
     fn install(&mut self, resources: DeviceResources) {
@@ -1988,8 +2025,8 @@ enum WorkerError {
     MissingTransactionId,
     #[error("invalid gpadl")]
     InvalidGpadl(#[source] guestmem::InvalidGpn),
-    #[error("gpadl error")]
-    GpadlError(#[source] GuestMemoryError),
+    #[error("guest buffers error")]
+    GuestBuffers(#[source] buffers::GuestBuffersError),
     #[error("gpa direct error")]
     GpaDirectError(#[source] GuestMemoryError),
     #[error("endpoint")]
@@ -2014,6 +2051,8 @@ enum WorkerError {
     EndpointRequiresQueueRestart(#[source] anyhow::Error),
     #[error("Failed to send message to coordinator")]
     CoordinatorMessageSendFailed(#[source] TrySendError<CoordinatorMessage>),
+    #[error("invalid rx buffer configuration: {0}")]
+    InvalidRxBufferConfig(#[source] RxBufferConfigError),
 }
 
 impl From<task_control::Cancelled> for WorkerError {
@@ -3597,7 +3636,7 @@ impl Adapter {
         if params.hash_secret_key_size != 40 {
             return Err(OidError::InvalidInput("hash_secret_key_size"));
         }
-        if params.indirection_table_size % 4 != 0 {
+        if params.indirection_table_size % 4 != 0 || params.indirection_table_size == 0 {
             return Err(OidError::InvalidInput("indirection_table_size"));
         }
         let indirection_table_size =
@@ -4431,6 +4470,45 @@ impl Coordinator {
     }
 
     async fn restart_queues(&mut self, c_state: &mut CoordinatorState) -> Result<(), WorkerError> {
+        // Pre-compute the active queue count and validate the rx buffer configuration.
+        // For invalid configurations, the error is logged and we exit without performing
+        // any destructive operations (dropping queues, stopping the endpoint).
+        let (num_queues, active_queues, active_queue_count) = if let Some(state) = self.workers[0]
+            .state()
+            .and_then(|worker| worker.state.ready())
+        {
+            let num_queues = state.state.primary.as_ref().unwrap().requested_num_queues;
+            let mut active_queues = Vec::new();
+            let active_queue_count =
+                if let Some(rss_state) = state.state.primary.as_ref().unwrap().rss_state.as_ref() {
+                    active_queues.clone_from(&rss_state.indirection_table);
+                    active_queues.sort();
+                    active_queues.dedup();
+                    active_queues = active_queues
+                        .into_iter()
+                        .filter(|&index| index < num_queues)
+                        .collect::<Vec<_>>();
+                    if !active_queues.is_empty() {
+                        active_queues.len() as u16
+                    } else {
+                        tracelimit::warn_ratelimited!("Invalid RSS indirection table");
+                        num_queues
+                    }
+                } else {
+                    num_queues
+                };
+
+            RxBufferRanges::validate_params(
+                state.buffers.recv_buffer.count,
+                active_queue_count.into(),
+            )?;
+
+            (num_queues, active_queues, active_queue_count)
+        } else {
+            // No ready state; restart_queues will return Ok(()).
+            (0, Vec::new(), 0)
+        };
+
         // Drop all the queues and stop the endpoint. Collect the worker drivers to pass to the queues.
         let drivers = self
             .workers
@@ -4464,31 +4542,9 @@ impl Coordinator {
         // Save the channel buffers for use in the subchannel workers.
         self.buffers = Some(state.buffers.clone());
 
-        let num_queues = state.state.primary.as_ref().unwrap().requested_num_queues;
-        let mut active_queues = Vec::new();
-        let active_queue_count =
-            if let Some(rss_state) = state.state.primary.as_ref().unwrap().rss_state.as_ref() {
-                // Active queue count is computed as the number of unique entries in the indirection table
-                active_queues.clone_from(&rss_state.indirection_table);
-                active_queues.sort();
-                active_queues.dedup();
-                active_queues = active_queues
-                    .into_iter()
-                    .filter(|&index| index < num_queues)
-                    .collect::<Vec<_>>();
-                if !active_queues.is_empty() {
-                    active_queues.len() as u16
-                } else {
-                    tracelimit::warn_ratelimited!("Invalid RSS indirection table");
-                    num_queues
-                }
-            } else {
-                num_queues
-            };
-
         // Distribute the rx buffers to only the active queues.
         let (ranges, mut remote_buffer_id_recvs) =
-            RxBufferRanges::new(state.buffers.recv_buffer.count, active_queue_count.into());
+            RxBufferRanges::new(state.buffers.recv_buffer.count, active_queue_count.into())?;
         let ranges = Arc::new(ranges);
 
         let mut queues = Vec::new();
@@ -4504,7 +4560,7 @@ impl Coordinator {
                     buffers.recv_buffer.sub_allocation_size,
                     buffers.ndis_config.mtu,
                 )
-                .map_err(WorkerError::GpadlError)?,
+                .map_err(WorkerError::GuestBuffers)?,
             );
 
             // Get the list of free rx buffers from each task, then partition

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -5569,8 +5569,11 @@ impl<T: 'static + RingMem> NetChannel<T> {
                     // the subchannels plus the primary channel must fit within the max_queues value,
                     // which means subchannels + 1 ≤ max_queues, so the subchannel count must be
                     // strictly less than max_queues.
+                    let num_queues = request.num_sub_channels + 1;
                     let status = if request.operation == protocol::SubchannelOperation::ALLOCATE
                         && request.num_sub_channels < self.adapter.max_queues.into()
+                        && RxBufferRanges::validate_params(buffers.recv_buffer.count, num_queues)
+                            .is_ok()
                     {
                         subchannel_count = request.num_sub_channels;
                         protocol::Status::SUCCESS
@@ -5579,6 +5582,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
                             operation = ?request.operation,
                             request_sub_channels = request.num_sub_channels,
                             max_supported_sub_channels = self.adapter.max_queues - 1,
+                            recv_buffer_count = buffers.recv_buffer.count,
                             "Subchannel request failed: either operation is not supported or requested more subchannels than supported"
                         );
                         protocol::Status::FAILURE

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -6175,3 +6175,141 @@ async fn subchannel_request_equal_to_max_queues_rejected(driver: DefaultDriver) 
         .await
         .expect("completion message");
 }
+
+/// Sending RSS parameters with `indirection_table_size == 0` should be rejected
+/// with `STATUS_INVALID_DATA`.
+#[async_test]
+async fn rss_set_with_zero_indirection_table_size_rejected(driver: DefaultDriver) {
+    let endpoint_state = TestNicEndpointState::new();
+    let endpoint = TestNicEndpoint::new(Some(endpoint_state.clone()));
+    let nic = Nic::builder().build(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        Guid::new_random(),
+        Box::new(endpoint),
+        [1, 2, 3, 4, 5, 6].into(),
+        0,
+    );
+
+    let mut nic = TestNicDevice::new_with_nic(&driver, nic).await;
+    nic.start_vmbus_channel();
+    let mut channel = nic.connect_vmbus_channel().await;
+    channel
+        .initialize(0, protocol::NdisConfigCapabilities::new())
+        .await;
+
+    // RNDIS Initialize.
+    channel
+        .send_rndis_control_message(
+            rndisprot::MESSAGE_TYPE_INITIALIZE_MSG,
+            rndisprot::InitializeRequest {
+                request_id: 1,
+                major_version: rndisprot::MAJOR_VERSION,
+                minor_version: rndisprot::MINOR_VERSION,
+                max_transfer_size: 0,
+            },
+            &[],
+        )
+        .await;
+    let _: rndisprot::InitializeComplete = channel
+        .read_rndis_control_message(rndisprot::MESSAGE_TYPE_INITIALIZE_CMPLT)
+        .await
+        .unwrap();
+
+    // Build RSS params with indirection_table_size == 0.
+    #[repr(C)]
+    #[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
+    struct RssParams {
+        params: rndisprot::NdisReceiveScaleParameters,
+        hash_secret_key: [u8; 40],
+    }
+
+    let rss_params = RssParams {
+        params: rndisprot::NdisReceiveScaleParameters {
+            header: rndisprot::NdisObjectHeader {
+                object_type: rndisprot::NdisObjectType::RSS_PARAMETERS,
+                revision: 1,
+                size: size_of::<RssParams>() as u16,
+            },
+            flags: 0,
+            base_cpu_number: 0,
+            hash_information: rndisprot::NDIS_HASH_FUNCTION_TOEPLITZ,
+            indirection_table_size: 0, // invalid — must be rejected
+            pad0: 0,
+            indirection_table_offset: size_of::<RssParams>() as u32,
+            hash_secret_key_size: 40,
+            pad1: 0,
+            hash_secret_key_offset: offset_of!(RssParams, hash_secret_key) as u32,
+            processor_masks_offset: 0,
+            number_of_processor_masks: 0,
+            processor_masks_entry_size: 0,
+            default_processor_number: 0,
+        },
+        hash_secret_key: [0; 40],
+    };
+
+    channel
+        .send_rndis_control_message(
+            rndisprot::MESSAGE_TYPE_SET_MSG,
+            rndisprot::SetRequest {
+                request_id: 0,
+                oid: rndisprot::Oid::OID_GEN_RECEIVE_SCALE_PARAMETERS,
+                information_buffer_length: size_of::<RssParams>() as u32,
+                information_buffer_offset: size_of::<rndisprot::SetRequest>() as u32,
+                device_vc_handle: 0,
+            },
+            rss_params.as_bytes(),
+        )
+        .await;
+
+    // Read the SET_CMPLT and verify it reports STATUS_INVALID_DATA.
+    let set_complete: rndisprot::SetComplete = channel
+        .read_rndis_control_message(rndisprot::MESSAGE_TYPE_SET_CMPLT)
+        .await
+        .unwrap();
+    assert_eq!(
+        set_complete.status,
+        rndisprot::STATUS_INVALID_DATA,
+        "indirection_table_size == 0 should be rejected with STATUS_INVALID_DATA"
+    );
+}
+
+#[test]
+fn rx_buffer_ranges_zero_queue_count() {
+    let result = RxBufferRanges::new(100, 0);
+    match result {
+        Err(WorkerError::InvalidRxBufferConfig(RxBufferConfigError::ZeroQueueCount)) => {}
+        Err(other) => panic!("expected InvalidRxBufferConfig(ZeroQueueCount), got: {other}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+}
+
+#[test]
+fn rx_buffer_ranges_buffer_count_below_reserved() {
+    let result = RxBufferRanges::new(RX_RESERVED_CONTROL_BUFFERS - 1, 1);
+    match result {
+        Err(WorkerError::InvalidRxBufferConfig(RxBufferConfigError::InsufficientBuffers)) => {}
+        Err(other) => panic!("expected InvalidRxBufferConfig(InsufficientBuffers), got: {other}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+}
+
+#[test]
+fn rx_buffer_ranges_zero_buffers_per_queue() {
+    // buffer_count == RX_RESERVED_CONTROL_BUFFERS means 0 buffers available for queues
+    let result = RxBufferRanges::new(RX_RESERVED_CONTROL_BUFFERS, 1);
+    match result {
+        Err(WorkerError::InvalidRxBufferConfig(RxBufferConfigError::ZeroBuffersPerQueue)) => {}
+        Err(other) => panic!("expected InvalidRxBufferConfig(ZeroBuffersPerQueue), got: {other}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+}
+
+#[test]
+fn rx_buffer_ranges_valid() {
+    let buffer_count = RX_RESERVED_CONTROL_BUFFERS + 4;
+    let queue_count = 2;
+    let (ranges, recvs) = RxBufferRanges::new(buffer_count, queue_count).unwrap();
+    assert_eq!(ranges.buffers_per_queue, 2);
+    assert_eq!(recvs.len(), queue_count as usize);
+    assert_eq!(ranges.buffer_id_send.len(), queue_count as usize);
+}


### PR DESCRIPTION
Fuzz testing found several places where netvsp and vmbus channel could panic on edge-case inputs: untrusted guest data, malformed save state, function calls with out-of-range channel indices. Adding defensive validation to turn those panics into Errors.

* Added checks for invalid GuestBuffer allocations
* RxBufferRanges added checks prevent underflow and division by zero from failing restart_queues
* Correcting logic in max_subchannels
* OID RSS set parameters checks for divide by zero indirection table size