### PR TITLE
Make interrupt counters visible in release for cvms

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -275,6 +275,7 @@ impl DiagState {
 
 #[derive(Inspect)]
 struct Workers {
+    #[inspect(safe)]
     vm: WorkerHandle,
     #[inspect(skip)]
     vm_rpc: mesh::Sender<UhVmRpc>,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3545,7 +3545,8 @@ async fn new_underhill_vm(
         state_units
             .add("partition")
             .depends_on(devices.chipset_unit())
-            .depends_on(vmtime.handle()),
+            .depends_on(vmtime.handle())
+            .inspect_sensitivity(inspect::SensitivityLevel::Safe),
         WrappedPartition(partition.clone()),
         PartitionUnitParams {
             processor_topology: &processor_topology,

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -380,6 +380,7 @@ struct UhCvmVpState {
     /// Hypervisor enlightenment emulator state.
     hv: VtlArray<ProcessorVtlHv, 2>,
     /// LAPIC state.
+    #[inspect(safe)]
     lapics: VtlArray<LapicState, 2>,
     /// Guest VSM state for this vp. Some when VTL 1 is enabled.
     vtl1: Option<GuestVsmVpState>,

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -117,7 +117,7 @@ pub struct UhProcessor<'a, T: Backing> {
     // together by the compiler.
     #[inspect(skip)]
     runner: ProcessorRunner<'a, T::HclBacking<'a>>,
-    #[inspect(mut)]
+    #[inspect(mut, safe)]
     backing: T,
 }
 
@@ -157,6 +157,7 @@ impl VtlsTlbLocked {
 #[cfg(guest_arch = "x86_64")]
 #[derive(Inspect)]
 pub(crate) struct LapicState {
+    #[inspect(safe)]
     lapic: LocalApic,
     activity: MpState,
     nmi_pending: bool,

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -717,7 +717,7 @@ struct Inner {
 pub struct VpSet {
     #[inspect(flatten)]
     inner: Arc<Inner>,
-    #[inspect(rename = "vp", iter_by_index)]
+    #[inspect(rename = "vp", iter_by_index, safe)]
     vps: Vec<Vp>,
     #[inspect(skip)]
     started: bool,

--- a/vmm_core/state_unit/src/lib.rs
+++ b/vmm_core/state_unit/src/lib.rs
@@ -234,6 +234,7 @@ struct Unit {
     dependencies: Vec<u64>,
     dependents: Vec<u64>,
     state: State,
+    inspect_sensitivity: inspect::SensitivityLevel,
 }
 
 /// An error returned when a state unit name is already in use.
@@ -313,7 +314,7 @@ impl Inspect for Inner {
     fn inspect(&self, req: inspect::Request<'_>) {
         let mut resp = req.respond();
         for unit in self.units.values() {
-            resp.child(unit.name.as_ref(), |req| {
+            resp.sensitivity_child(unit.name.as_ref(), unit.inspect_sensitivity, |req| {
                 let mut resp = req.respond();
                 if !unit.dependencies.is_empty() {
                     resp.field_with("dependencies", || {
@@ -444,6 +445,7 @@ impl StateUnits {
             name: name.into(),
             dependencies: Vec::new(),
             dependents: Vec::new(),
+            inspect_sensitivity: inspect::SensitivityLevel::Unspecified,
         }
     }
 
@@ -827,6 +829,7 @@ pub struct UnitBuilder<'a> {
     name: Arc<str>,
     dependencies: Vec<u64>,
     dependents: Vec<u64>,
+    inspect_sensitivity: inspect::SensitivityLevel,
 }
 
 impl UnitBuilder<'_> {
@@ -845,6 +848,12 @@ impl UnitBuilder<'_> {
     /// its dependants, and that it will reset or restore before its dependants.
     pub fn dependency_of(mut self, handle: &UnitHandle) -> Self {
         self.dependents.push(self.handle_id(handle));
+        self
+    }
+
+    /// Sets the sensitivity level for this unit's inspect data. Defaults to Unspecified.
+    pub fn inspect_sensitivity(mut self, sensitivity: inspect::SensitivityLevel) -> Self {
+        self.inspect_sensitivity = sensitivity;
         self
     }
 
@@ -891,6 +900,7 @@ impl UnitBuilder<'_> {
                     dependencies: self.dependencies,
                     dependents: self.dependents,
                     state: State::Stopped,
+                    inspect_sensitivity: self.inspect_sensitivity,
                 },
             );
             let unit_id = UnitId {

--- a/vmm_core/virt_support_apic/src/lib.rs
+++ b/vmm_core/virt_support_apic/src/lib.rs
@@ -114,24 +114,39 @@ pub struct LocalApic {
     needs_offload_reeval: bool,
     scan_irr: bool,
 
+    #[inspect(safe)]
     stats: Stats,
 }
 
 #[derive(Inspect, Default)]
 struct Stats {
+    #[inspect(safe)]
     eoi: Counter,
+    #[inspect(safe)]
     eoi_level: Counter,
+    #[inspect(safe)]
     spurious_eoi: Counter,
+    #[inspect(safe)]
     lazy_eoi: Counter,
+    #[inspect(safe)]
     interrupt: Counter,
+    #[inspect(safe)]
     nmi: Counter,
+    #[inspect(safe)]
     extint: Counter,
+    #[inspect(safe)]
     init: Counter,
+    #[inspect(safe)]
     sipi: Counter,
+    #[inspect(safe)]
     self_ipi: Counter,
+    #[inspect(safe)]
     broadcast_ipi: Counter,
+    #[inspect(safe)]
     other_ipi: Counter,
+    #[inspect(safe)]
     offload_push: Counter,
+    #[inspect(safe)]
     offload_pull: Counter,
 }
 


### PR DESCRIPTION
In past investigations with the legacy HCL, interrupt counters helped to identify which VTL may have been the source of an issue and narrow down where to look. This change makes some existing counters, which should not be sensitive information, available in release builds of openhcl for CVMs.

Test: inspect -r with and without changes on an SNP VM and confirmed that only the new counters appeared.