### PR TITLE
build_support: add g++ cross-compilation wrappers for musl targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,6 +28,10 @@ CC_aarch64_underhill_linux_musl = { value = "build_support/underhill_cross/aarch
 CC_aarch64_unknown_linux_musl = { value = "build_support/underhill_cross/aarch64-underhill-musl-gcc", relative = true }
 CC_x86_64_underhill_linux_musl = { value = "build_support/underhill_cross/x86_64-underhill-musl-gcc", relative = true }
 CC_x86_64_unknown_linux_musl = { value = "build_support/underhill_cross/x86_64-underhill-musl-gcc", relative = true }
+CXX_aarch64_underhill_linux_musl = { value = "build_support/underhill_cross/aarch64-underhill-musl-g++", relative = true }
+CXX_aarch64_unknown_linux_musl = { value = "build_support/underhill_cross/aarch64-underhill-musl-g++", relative = true }
+CXX_x86_64_underhill_linux_musl = { value = "build_support/underhill_cross/x86_64-underhill-musl-g++", relative = true }
+CXX_x86_64_unknown_linux_musl = { value = "build_support/underhill_cross/x86_64-underhill-musl-g++", relative = true }
 
 # Use the packaged verison of protoc, symlinked by repo setup tooling
 PROTOC = { value = ".packages/Google.Protobuf.Tools/tools/protoc", relative = true }

--- a/build_support/underhill_cross/aarch64-underhill-musl-g++
+++ b/build_support/underhill_cross/aarch64-underhill-musl-g++
@@ -14,13 +14,29 @@ if [ -z "$REALGXX" ]; then
     fi
 fi
 
+if [ -z "$AARCH64_SYSROOT" ]; then
+    echo "error: AARCH64_SYSROOT is not set" >&2
+    exit 1
+fi
+
 # Auto-detect the C++ standard library headers in the sysroot.
 # The version directory (e.g., 11.5.0) varies by toolchain.
-cxx_flags=""
-for ver_dir in "$AARCH64_SYSROOT/include/c++"/*/; do
-    ver_dir="${ver_dir%/}"
-    cxx_flags="-isystem $ver_dir -isystem $ver_dir/aarch64-linux-musl"
-    break
+ver_dir=""
+for candidate in "$AARCH64_SYSROOT/include/c++"/*/; do
+    candidate="${candidate%/}"
+    if [ -d "$candidate" ]; then
+        ver_dir="$candidate"
+        break
+    fi
 done
 
-MUSL_ARCH=aarch64 MUSL_SYSROOT="$AARCH64_SYSROOT" exec "$REALGXX" "$@" -specs "$script_dir/musl-gcc.specs" $cxx_flags
+if [ -z "$ver_dir" ]; then
+    echo "error: could not find C++ headers under $AARCH64_SYSROOT/include/c++" >&2
+    exit 1
+fi
+
+MUSL_ARCH=aarch64 MUSL_SYSROOT="$AARCH64_SYSROOT" exec "$REALGXX" \
+    "$@" \
+    -specs "$script_dir/musl-gcc.specs" \
+    -isystem "$ver_dir" \
+    -isystem "$ver_dir/aarch64-linux-musl"

--- a/build_support/underhill_cross/aarch64-underhill-musl-g++
+++ b/build_support/underhill_cross/aarch64-underhill-musl-g++
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+script_dir="$(dirname "$0")"
+
+# Determine the G++ binary to use.
+# - REALGXX env var takes precedence (explicit override)
+# - aarch64-linux-gnu-g++ (Ubuntu/Fedora cross-prefix)
+# - g++ (Azure Linux / native aarch64 hosts where g++ has no prefix)
+if [ -z "$REALGXX" ]; then
+    if command -v aarch64-linux-gnu-g++ >/dev/null 2>&1; then
+        REALGXX=aarch64-linux-gnu-g++
+    else
+        REALGXX=g++
+    fi
+fi
+
+# Auto-detect the C++ standard library headers in the sysroot.
+# The version directory (e.g., 11.5.0) varies by toolchain.
+cxx_flags=""
+for ver_dir in "$AARCH64_SYSROOT/include/c++"/*/; do
+    ver_dir="${ver_dir%/}"
+    cxx_flags="-isystem $ver_dir -isystem $ver_dir/aarch64-linux-musl"
+    break
+done
+
+MUSL_ARCH=aarch64 MUSL_SYSROOT="$AARCH64_SYSROOT" exec "$REALGXX" "$@" -specs "$script_dir/musl-gcc.specs" $cxx_flags

--- a/build_support/underhill_cross/x86_64-underhill-musl-g++
+++ b/build_support/underhill_cross/x86_64-underhill-musl-g++
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+script_dir="$(dirname "$0")"
+
+# Determine the G++ binary to use.
+# - REALGXX env var takes precedence (explicit override)
+# - x86_64-linux-gnu-g++ (Ubuntu/Fedora cross-prefix)
+# - g++ (Azure Linux / native x86_64 hosts where g++ has no prefix)
+if [ -z "$REALGXX" ]; then
+    if command -v x86_64-linux-gnu-g++ >/dev/null 2>&1; then
+        REALGXX=x86_64-linux-gnu-g++
+    else
+        REALGXX=g++
+    fi
+fi
+
+# Auto-detect the C++ standard library headers in the sysroot.
+# The version directory (e.g., 11.5.0) varies by toolchain.
+cxx_flags=""
+for ver_dir in "$X86_64_SYSROOT/include/c++"/*/; do
+    ver_dir="${ver_dir%/}"
+    cxx_flags="-isystem $ver_dir -isystem $ver_dir/x86_64-linux-musl"
+    break
+done
+
+MUSL_ARCH=x86_64 MUSL_SYSROOT="$X86_64_SYSROOT" exec "$REALGXX" "$@" -specs "$script_dir/musl-gcc.specs" $cxx_flags

--- a/build_support/underhill_cross/x86_64-underhill-musl-g++
+++ b/build_support/underhill_cross/x86_64-underhill-musl-g++
@@ -14,13 +14,29 @@ if [ -z "$REALGXX" ]; then
     fi
 fi
 
+if [ -z "$X86_64_SYSROOT" ]; then
+    echo "error: X86_64_SYSROOT is not set" >&2
+    exit 1
+fi
+
 # Auto-detect the C++ standard library headers in the sysroot.
 # The version directory (e.g., 11.5.0) varies by toolchain.
-cxx_flags=""
-for ver_dir in "$X86_64_SYSROOT/include/c++"/*/; do
-    ver_dir="${ver_dir%/}"
-    cxx_flags="-isystem $ver_dir -isystem $ver_dir/x86_64-linux-musl"
-    break
+ver_dir=""
+for candidate in "$X86_64_SYSROOT/include/c++"/*/; do
+    candidate="${candidate%/}"
+    if [ -d "$candidate" ]; then
+        ver_dir="$candidate"
+        break
+    fi
 done
 
-MUSL_ARCH=x86_64 MUSL_SYSROOT="$X86_64_SYSROOT" exec "$REALGXX" "$@" -specs "$script_dir/musl-gcc.specs" $cxx_flags
+if [ -z "$ver_dir" ]; then
+    echo "error: could not find C++ headers under $X86_64_SYSROOT/include/c++" >&2
+    exit 1
+fi
+
+MUSL_ARCH=x86_64 MUSL_SYSROOT="$X86_64_SYSROOT" exec "$REALGXX" \
+    "$@" \
+    -specs "$script_dir/musl-gcc.specs" \
+    -isystem "$ver_dir" \
+    -isystem "$ver_dir/x86_64-linux-musl"

--- a/shell.nix
+++ b/shell.nix
@@ -177,14 +177,18 @@ in pkgs.mkShell {
     ${if hostArch == "x86_64" then ''
     # On x64 host: native x64 + cross aarch64
     ln -sf ${nativeGcc}/bin/gcc $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-gcc
+    ln -sf ${nativeGcc}/bin/g++ $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-g++
     ln -sf ${pkgs.binutils}/bin/objcopy $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-objcopy
     ln -sf ${aarch64CrossGcc}/bin/aarch64-unknown-linux-gnu-gcc $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-gcc
+    ln -sf ${aarch64CrossGcc}/bin/aarch64-unknown-linux-gnu-g++ $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-g++
     ln -sf ${aarch64CrossGcc}/bin/aarch64-unknown-linux-gnu-objcopy $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-objcopy
     '' else ''
     # On aarch64 host: native aarch64 + cross x64
     ln -sf ${nativeGcc}/bin/gcc $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-gcc
+    ln -sf ${nativeGcc}/bin/g++ $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-g++
     ln -sf ${pkgs.binutils}/bin/objcopy $NIX_CC_WRAPPER_DIR/aarch64-linux-gnu-objcopy
     ln -sf ${x64CrossGcc}/bin/x86_64-unknown-linux-gnu-gcc $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-gcc
+    ln -sf ${x64CrossGcc}/bin/x86_64-unknown-linux-gnu-g++ $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-g++
     ln -sf ${x64CrossGcc}/bin/x86_64-unknown-linux-gnu-objcopy $NIX_CC_WRAPPER_DIR/x86_64-linux-gnu-objcopy
     ''}
     export PATH="$NIX_CC_WRAPPER_DIR:$PATH"


### PR DESCRIPTION
The existing cross-compilation setup only had C compiler wrappers
(`*-underhill-musl-gcc`). When cc-rs needed to compile `.cxx` files, it fell
back to using that gcc wrapper as the C++ compiler, which failed because:

1. gcc doesn't search C++ standard library headers (`<cassert>`, `<cstdint>`, etc.)
2. The `musl-gcc.specs` file uses `-nostdinc`, stripping all system include
   paths — so even g++ can't find its C++ headers unless they're explicitly
   added back via `-isystem`

This PR adds matching g++ wrappers for both x86_64 and aarch64 that invoke g++
with the same musl specs, plus `-isystem` flags pointing at the sysroot's C++
headers. The C++ header version directory is auto-detected via shell glob rather
than hardcoded.

### Changes

- **`build_support/underhill_cross/{x86_64,aarch64}-underhill-musl-g++`** — new g++
  wrappers mirroring the existing gcc wrapper pattern
- **`.cargo/config.toml`** — added `CXX_*` env vars for all 4 musl targets so
  cc-rs discovers the wrappers
- **`shell.nix`** — added g++ symlinks alongside the existing gcc symlinks