### PR TITLE
openvmm_entry: split REPL from VM control into separate modules

### DIFF
--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -2203,8 +2203,9 @@ async fn run_control(driver: &DefaultDriver, mesh: VmmMesh, opt: Options) -> any
     };
 
     // Spawn the VmController as a task.
-    let controller_task = driver.spawn("vm-controller", 
-        controller.run(vm_controller_recv, vm_controller_event_send, notify_recv)
+    let controller_task = driver.spawn(
+        "vm-controller",
+        controller.run(vm_controller_recv, vm_controller_event_send, notify_recv),
     );
 
     // Run the REPL with shareable resources.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -11,10 +11,12 @@ mod cli_args;
 mod crash_dump;
 mod kvp;
 mod meshworker;
+mod repl;
 mod serial_io;
 mod storage_builder;
 mod tracing_init;
 mod ttrpc;
+mod vm_controller;
 
 // `pub` so that the missing_docs warning fires for options without
 // documentation.
@@ -25,8 +27,6 @@ use crate::cli_args::SecureBootTemplateCli;
 use anyhow::Context;
 use anyhow::bail;
 use chipset_resources::battery::HostBatteryUpdate;
-use clap::CommandFactory;
-use clap::FromArgMatches;
 use clap::Parser;
 use cli_args::DiskCliKind;
 use cli_args::EfiDiagnosticsLogLevelCli;
@@ -49,32 +49,21 @@ use framebuffer::FRAMEBUFFER_SIZE;
 use framebuffer::FramebufferAccess;
 use futures::AsyncReadExt;
 use futures::AsyncWrite;
-use futures::AsyncWriteExt;
-use futures::FutureExt;
 use futures::StreamExt;
 use futures::executor::block_on;
 use futures::io::AllowStdIo;
-use futures_concurrency::stream::Merge;
 use gdma_resources::GdmaDeviceHandle;
 use gdma_resources::VportDefinition;
-use get_resources::ged::GuestServicingFlags;
 use guid::Guid;
 use input_core::MultiplexedInputHandle;
 use inspect::InspectMut;
-use inspect::InspectionBuilder;
 use io::Read;
 use memory_range::MemoryRange;
 use mesh::CancelContext;
 use mesh::CellUpdater;
-use mesh::error::RemoteError;
-use mesh::rpc::Rpc;
-use mesh::rpc::RpcError;
 use mesh::rpc::RpcSend;
-use mesh_worker::WorkerEvent;
-use mesh_worker::WorkerHandle;
 use meshworker::VmmMesh;
 use net_backend_resources::mac_address::MacAddress;
-use nvme_resources::NamespaceDefinition;
 use nvme_resources::NvmeControllerRequest;
 use openvmm_defs::config::Config;
 use openvmm_defs::config::DEFAULT_MMIO_GAPS_AARCH64;
@@ -99,7 +88,6 @@ use openvmm_defs::config::VmbusConfig;
 use openvmm_defs::config::VpciDeviceConfig;
 use openvmm_defs::config::Vtl2BaseAddressType;
 use openvmm_defs::config::Vtl2Config;
-use openvmm_defs::rpc::PulseSaveRestoreError;
 use openvmm_defs::rpc::VmRpc;
 use openvmm_defs::worker::VM_WORKER;
 use openvmm_defs::worker::VmWorkerParameters;
@@ -110,9 +98,6 @@ use pal_async::DefaultPool;
 use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
-use pal_async::timer::PolledTimer;
-use scsidisk_resources::SimpleScsiDiskHandle;
-use scsidisk_resources::SimpleScsiDvdHandle;
 use serial_16550_resources::ComPort;
 use serial_core::resources::DisconnectedSerialBackendHandle;
 use sparse_mmap::alloc_shared_memory;
@@ -127,17 +112,12 @@ use std::io::Write;
 use std::net::TcpListener;
 use std::path::Path;
 use std::path::PathBuf;
-use std::pin::pin;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use std::time::Instant;
 use storvsp_resources::ScsiControllerRequest;
-use storvsp_resources::ScsiDeviceAndPath;
-use storvsp_resources::ScsiPath;
 use tpm_resources::TpmDeviceHandle;
 use tpm_resources::TpmRegisterLayout;
-use tracing_helpers::AnyhowValueExt;
 use uidevices_resources::SynthKeyboardHandle;
 use uidevices_resources::SynthMouseHandle;
 use uidevices_resources::SynthVideoHandle;
@@ -212,164 +192,6 @@ struct VmResources {
     vtl2_settings: Option<vtl2_settings_proto::Vtl2Settings>,
     #[cfg(windows)]
     switch_ports: Vec<vmswitch::kernel::SwitchPort>,
-}
-
-impl VmResources {
-    /// Modify the cached VTL2 settings and send them to OpenHCL via the GED.
-    ///
-    /// This follows the same pattern as petri's `modify_vtl2_settings`: the cache
-    /// is modified locally, then the entire settings are sent to OpenHCL.
-    async fn modify_vtl2_settings(
-        &mut self,
-        f: impl FnOnce(&mut vtl2_settings_proto::Vtl2Settings),
-    ) -> anyhow::Result<()> {
-        let mut settings_copy = self
-            .vtl2_settings
-            .clone()
-            .context("vtl2 settings not configured")?;
-
-        f(&mut settings_copy);
-
-        let ged_rpc = self.ged_rpc.as_ref().context("no GED configured")?;
-
-        ged_rpc
-            .call_failable(
-                get_resources::ged::GuestEmulationRequest::ModifyVtl2Settings,
-                prost::Message::encode_to_vec(&settings_copy),
-            )
-            .await?;
-
-        // Settings successfully applied, update our cache
-        self.vtl2_settings = Some(settings_copy);
-        Ok(())
-    }
-
-    /// Add a VTL0 SCSI LUN backed by a VTL2 storage device.
-    ///
-    /// This modifies the VTL2 settings to add a new LUN to the specified SCSI controller,
-    /// backed by the given VTL2 device (NVMe namespace or SCSI disk).
-    async fn add_vtl0_scsi_disk(
-        &mut self,
-        controller_guid: Guid,
-        lun: u32,
-        device_type: vtl2_settings_proto::physical_device::DeviceType,
-        device_path: Guid,
-        sub_device_path: u32,
-    ) -> anyhow::Result<()> {
-        let mut not_found = false;
-        self.modify_vtl2_settings(|settings| {
-            let dynamic = settings.dynamic.get_or_insert_with(Default::default);
-
-            // Find the SCSI controller, bail out if not found (we can't create new controllers at runtime)
-            let scsi_controller = dynamic.storage_controllers.iter_mut().find(|c| {
-                c.instance_id == controller_guid.to_string()
-                    && c.protocol
-                        == vtl2_settings_proto::storage_controller::StorageProtocol::Scsi as i32
-            });
-
-            let Some(scsi_controller) = scsi_controller else {
-                not_found = true;
-                return;
-            };
-
-            // Add the LUN backed by the VTL2 storage device. If the LUN exists already, UH will reject the settings
-            scsi_controller.luns.push(vtl2_settings_proto::Lun {
-                location: lun,
-                device_id: Guid::new_random().to_string(),
-                vendor_id: "OpenVMM".to_string(),
-                product_id: "Disk".to_string(),
-                product_revision_level: "1.0".to_string(),
-                serial_number: "0".to_string(),
-                model_number: "1".to_string(),
-                physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
-                    r#type: vtl2_settings_proto::physical_devices::BackingType::Single.into(),
-                    device: Some(vtl2_settings_proto::PhysicalDevice {
-                        device_type: device_type.into(),
-                        device_path: device_path.to_string(),
-                        sub_device_path,
-                    }),
-                    devices: Vec::new(),
-                }),
-                is_dvd: false,
-                ..Default::default()
-            });
-        })
-        .await?;
-
-        if not_found {
-            anyhow::bail!("SCSI controller {} not found", controller_guid);
-        }
-        Ok(())
-    }
-
-    /// Remove a VTL0 SCSI LUN.
-    ///
-    /// This modifies the VTL2 settings to remove a LUN from the specified SCSI controller.
-    async fn remove_vtl0_scsi_disk(
-        &mut self,
-        controller_guid: Guid,
-        lun: u32,
-    ) -> anyhow::Result<()> {
-        self.modify_vtl2_settings(|settings| {
-            let dynamic = settings.dynamic.as_mut();
-            if let Some(dynamic) = dynamic {
-                // Find the SCSI controller
-                if let Some(scsi_controller) = dynamic.storage_controllers.iter_mut().find(|c| {
-                    c.instance_id == controller_guid.to_string()
-                        && c.protocol
-                            == vtl2_settings_proto::storage_controller::StorageProtocol::Scsi as i32
-                }) {
-                    // Remove the LUN
-                    scsi_controller.luns.retain(|l| l.location != lun);
-                }
-            }
-        })
-        .await
-    }
-
-    /// Find and remove a VTL0 SCSI LUN backed by a specific NVMe namespace.
-    ///
-    /// Returns the LUN number that was removed, or None if no matching LUN was found.
-    async fn remove_vtl0_scsi_disk_by_nvme_nsid(
-        &mut self,
-        controller_guid: Guid,
-        nvme_controller_guid: Guid,
-        nsid: u32,
-    ) -> anyhow::Result<Option<u32>> {
-        let mut removed_lun = None;
-        self.modify_vtl2_settings(|settings| {
-            let dynamic = settings.dynamic.as_mut();
-            if let Some(dynamic) = dynamic {
-                // Find the SCSI controller
-                if let Some(scsi_controller) = dynamic.storage_controllers.iter_mut().find(|c| {
-                    c.instance_id == controller_guid.to_string()
-                        && c.protocol
-                            == vtl2_settings_proto::storage_controller::StorageProtocol::Scsi as i32
-                }) {
-                    // Find and remove the LUN backed by this NVMe namespace
-                    let nvme_controller_str = nvme_controller_guid.to_string();
-                    scsi_controller.luns.retain(|l| {
-                        let dominated_by_nsid = l.physical_devices.as_ref().is_some_and(|pd| {
-                            pd.device.as_ref().is_some_and(|d| {
-                                d.device_type
-                                    == vtl2_settings_proto::physical_device::DeviceType::Nvme as i32
-                                    && d.device_path == nvme_controller_str
-                                    && d.sub_device_path == nsid
-                            })
-                        });
-                        if dominated_by_nsid {
-                            removed_lun = Some(l.location);
-                            false // Remove this LUN
-                        } else {
-                            true // Keep this LUN
-                        }
-                    });
-                }
-            }
-        })
-        .await?;
-        Ok(removed_lun)
-    }
 }
 
 struct ConsoleState<'a> {
@@ -1779,7 +1601,7 @@ async fn vm_config_from_command_line(
 }
 
 /// Gets the terminal to use for externally launched console windows.
-fn openvmm_terminal_app() -> Option<PathBuf> {
+pub(crate) fn openvmm_terminal_app() -> Option<PathBuf> {
     std::env::var_os("OPENVMM_TERM")
         .or_else(|| std::env::var_os("HVLITE_TERM"))
         .map(Into::into)
@@ -2093,12 +1915,12 @@ fn disk_open_inner(
 }
 
 /// Get the system page size.
-fn system_page_size() -> u32 {
+pub(crate) fn system_page_size() -> u32 {
     sparse_mmap::SparseMapping::page_size() as u32
 }
 
 /// The guest architecture string, derived from the compile-time `guest_arch` cfg.
-const GUEST_ARCH: &str = if cfg!(guest_arch = "x86_64") {
+pub(crate) const GUEST_ARCH: &str = if cfg!(guest_arch = "x86_64") {
     "x86_64"
 } else {
     "aarch64"
@@ -2149,65 +1971,6 @@ fn prepare_snapshot_restore(
         .context("failed to decode saved state from snapshot")?;
 
     Ok((shared_memory_fd, state_msg))
-}
-
-/// Save a VM snapshot to the given directory.
-///
-/// Pauses the VM, saves device state, fsyncs the memory backing file,
-/// and writes the snapshot directory. The VM remains paused after this
-/// call — resuming would corrupt the snapshot.
-async fn save_snapshot(
-    vm_rpc: &mesh::Sender<VmRpc>,
-    opt: &Options,
-    dir: &Path,
-) -> anyhow::Result<()> {
-    let memory_file_path = opt
-        .memory_backing_file
-        .as_ref()
-        .context("save-snapshot requires --memory-backing-file")?;
-
-    // Pause the VM.
-    vm_rpc
-        .call(VmRpc::Pause, ())
-        .await
-        .context("failed to pause VM")?;
-
-    // Get device state via existing VmRpc::Save.
-    let saved_state_msg = vm_rpc
-        .call_failable(VmRpc::Save, ())
-        .await
-        .context("failed to save state")?;
-
-    // Serialize the ProtobufMessage to bytes for writing to disk.
-    let saved_state_bytes = mesh::payload::encode(saved_state_msg);
-
-    // Fsync the memory backing file.
-    let memory_file = fs_err::File::open(memory_file_path)?;
-    memory_file
-        .sync_all()
-        .context("failed to fsync memory backing file")?;
-
-    // Build manifest.
-    let manifest = openvmm_helpers::snapshot::SnapshotManifest {
-        version: openvmm_helpers::snapshot::MANIFEST_VERSION,
-        created_at: std::time::SystemTime::now().into(),
-        openvmm_version: env!("CARGO_PKG_VERSION").to_string(),
-        memory_size_bytes: opt.memory,
-        vp_count: opt.processors,
-        page_size: system_page_size(),
-        architecture: GUEST_ARCH.to_string(),
-    };
-
-    // Write snapshot directory.
-    openvmm_helpers::snapshot::write_snapshot(
-        dir,
-        &manifest,
-        &saved_state_bytes,
-        memory_file_path,
-    )?;
-
-    // VM stays paused. Do NOT resume.
-    Ok(())
 }
 
 fn do_main(pidfile_path: &mut Option<PathBuf>) -> anyhow::Result<()> {
@@ -2274,325 +2037,8 @@ fn do_main(pidfile_path: &mut Option<PathBuf>) -> anyhow::Result<()> {
 
     DefaultPool::run_with(async |driver| {
         let mesh = VmmMesh::new(&driver, opt.single_process)?;
-        let result = run_control(&driver, &mesh, opt).await;
-        mesh.shutdown().await;
-        result
+        run_control(&driver, mesh, opt).await
     })
-}
-
-fn maybe_with_radix_u64(s: &str) -> Result<u64, String> {
-    let (radix, prefix_len) = if s.starts_with("0x") || s.starts_with("0X") {
-        (16, 2)
-    } else if s.starts_with("0o") || s.starts_with("0O") {
-        (8, 2)
-    } else if s.starts_with("0b") || s.starts_with("0B") {
-        (2, 2)
-    } else {
-        (10, 0)
-    };
-
-    u64::from_str_radix(&s[prefix_len..], radix).map_err(|e| format!("{e}"))
-}
-
-#[derive(Parser)]
-#[clap(
-    name = "openvmm",
-    disable_help_flag = true,
-    disable_version_flag = true,
-    no_binary_name = true,
-    help_template("{subcommands}")
-)]
-enum InteractiveCommand {
-    /// Restart the VM worker (experimental).
-    ///
-    /// This restarts the VM worker while preserving state.
-    #[clap(visible_alias = "R")]
-    Restart,
-
-    /// Inject an NMI.
-    #[clap(visible_alias = "n")]
-    Nmi,
-
-    /// Pause the VM.
-    #[clap(visible_alias = "p")]
-    Pause,
-
-    /// Resume the VM.
-    #[clap(visible_alias = "r")]
-    Resume,
-
-    /// Save a snapshot to a directory (requires --memory-backing-file).
-    #[clap(visible_alias = "snap")]
-    SaveSnapshot {
-        /// Directory to write the snapshot to.
-        dir: PathBuf,
-    },
-
-    /// Do a pulsed save restore (pause, save, reset, restore, resume) to the VM.
-    #[clap(visible_alias = "psr")]
-    PulseSaveRestore,
-
-    /// Schedule a pulsed save restore (pause, save, reset, restore, resume) to the VM.
-    #[clap(visible_alias = "spsr")]
-    SchedulePulseSaveRestore {
-        /// The interval between pulse save restore operations in seconds.
-        /// None or 0 means any previous scheduled pulse save restores will be cleared.
-        interval: Option<u64>,
-    },
-
-    /// Hot add a disk to the VTL0 guest.
-    #[clap(visible_alias = "d")]
-    AddDisk {
-        #[clap(long = "ro")]
-        read_only: bool,
-        #[clap(long = "dvd")]
-        is_dvd: bool,
-        #[clap(long, default_value_t)]
-        target: u8,
-        #[clap(long, default_value_t)]
-        path: u8,
-        #[clap(long, default_value_t)]
-        lun: u8,
-        #[clap(long)]
-        ram: Option<u64>,
-        file_path: Option<PathBuf>,
-    },
-
-    /// Hot remove a disk from the VTL0 guest.
-    #[clap(visible_alias = "D")]
-    RmDisk {
-        #[clap(long)]
-        target: u8,
-        #[clap(long)]
-        path: u8,
-        #[clap(long)]
-        lun: u8,
-    },
-
-    /// Manage VTL2 settings (storage controllers, NICs exposed to VTL0).
-    #[clap(subcommand)]
-    Vtl2Settings(Vtl2SettingsCommand),
-
-    /// Hot add an NVMe namespace to VTL2, and optionally to VTL0.
-    AddNvmeNs {
-        #[clap(long = "ro")]
-        read_only: bool,
-        /// The namespace ID.
-        #[clap(long)]
-        nsid: u32,
-        /// Create a RAM-backed namespace of the specified size in bytes.
-        #[clap(long)]
-        ram: Option<u64>,
-        /// Path to a file to use as the backing store.
-        file_path: Option<PathBuf>,
-        /// Also expose this namespace to VTL0 via VTL2 settings as a SCSI disk
-        /// with the specified LUN number.
-        #[clap(long)]
-        vtl0_lun: Option<u32>,
-    },
-
-    /// Hot remove an NVMe namespace from VTL2.
-    RmNvmeNs {
-        /// The namespace ID to remove.
-        #[clap(long)]
-        nsid: u32,
-        /// Also remove the VTL0 SCSI disk backed by this namespace.
-        #[clap(long)]
-        vtl0: bool,
-    },
-
-    /// Inspect program state.
-    #[clap(visible_alias = "x")]
-    Inspect {
-        /// Enumerate state recursively.
-        #[clap(short, long)]
-        recursive: bool,
-        /// The recursive depth limit.
-        #[clap(short, long, requires("recursive"))]
-        limit: Option<usize>,
-        /// Target the paravisor.
-        #[clap(short = 'v', long)]
-        paravisor: bool,
-        /// The element path to inspect.
-        element: Option<String>,
-        /// Update the path with a new value.
-        #[clap(short, long, conflicts_with("recursive"))]
-        update: Option<String>,
-    },
-
-    /// Restart the VNC worker.
-    #[clap(visible_alias = "V")]
-    RestartVnc,
-
-    /// Start an hvsocket terminal window.
-    #[clap(visible_alias = "v")]
-    Hvsock {
-        /// the terminal emulator to run (defaults to conhost.exe or xterm)
-        #[clap(short, long)]
-        term: Option<PathBuf>,
-        /// the vsock port to connect to
-        port: u32,
-    },
-
-    /// Quit the program.
-    #[clap(visible_alias = "q")]
-    Quit,
-
-    /// Write input to the VM console.
-    ///
-    /// This will write each input parameter to the console's associated serial
-    /// port, separated by spaces.
-    #[clap(visible_alias = "i")]
-    Input { data: Vec<String> },
-
-    /// Switch to input mode.
-    ///
-    /// Once in input mode, Ctrl-Q returns to command mode.
-    #[clap(visible_alias = "I")]
-    InputMode,
-
-    /// Reset the VM.
-    Reset,
-
-    /// Send a request to the VM to shut it down.
-    Shutdown {
-        /// Reboot the VM instead of powering it off.
-        #[clap(long, short = 'r')]
-        reboot: bool,
-        /// Hibernate the VM instead of powering it off.
-        #[clap(long, short = 'h', conflicts_with = "reboot")]
-        hibernate: bool,
-        /// Tell the guest to force the power state transition.
-        #[clap(long, short = 'f')]
-        force: bool,
-    },
-
-    /// Clears the current halt condition, resuming the VPs if the VM is
-    /// running.
-    #[clap(visible_alias = "ch")]
-    ClearHalt,
-
-    /// Update the image in VTL2.
-    ServiceVtl2 {
-        /// Just restart the user-mode paravisor process, not the full
-        /// firmware.
-        #[clap(long, short = 'u')]
-        user_mode_only: bool,
-        /// The path to the new IGVM file. If missing, use the originally
-        /// configured path.
-        #[clap(long, conflicts_with("user_mode_only"))]
-        igvm: Option<PathBuf>,
-        /// Enable keepalive when servicing VTL2 devices.
-        /// Default is `true`.
-        #[clap(long, short = 'n', default_missing_value = "true")]
-        nvme_keepalive: bool,
-        /// Enable keepalive when servicing VTL2 devices.
-        /// Default is `false`.
-        #[clap(long)]
-        mana_keepalive: bool,
-    },
-
-    /// Read guest memory
-    ReadMemory {
-        /// Guest physical address to start at.
-        #[clap(value_parser=maybe_with_radix_u64)]
-        gpa: u64,
-        /// How many bytes to dump.
-        #[clap(value_parser=maybe_with_radix_u64)]
-        size: u64,
-        /// File to save the data to. If omitted,
-        /// the data will be presented as a hex dump.
-        #[clap(long, short = 'f')]
-        file: Option<PathBuf>,
-    },
-
-    /// Write guest memory
-    WriteMemory {
-        /// Guest physical address to start at
-        #[clap(value_parser=maybe_with_radix_u64)]
-        gpa: u64,
-        /// Hex string encoding data, with no `0x` radix.
-        /// If omitted, the source file must be specified.
-        hex: Option<String>,
-        /// File to write the data from.
-        #[clap(long, short = 'f')]
-        file: Option<PathBuf>,
-    },
-
-    /// Inject an artificial panic into OpenVMM
-    Panic,
-
-    /// Use KVP to interact with the guest.
-    Kvp(kvp::KvpCommand),
-}
-
-/// Subcommands for managing VTL2 settings.
-#[derive(clap::Subcommand)]
-enum Vtl2SettingsCommand {
-    /// Show the current VTL2 settings.
-    Show,
-
-    /// Add a SCSI disk to VTL0 backed by a VTL2 storage device.
-    ///
-    /// The backing device can be either a VTL2 NVMe namespace or a VTL2 SCSI disk.
-    AddScsiDisk {
-        /// The VTL0 SCSI controller instance ID (GUID). Defaults to the standard
-        /// OpenVMM VTL0 SCSI instance.
-        #[clap(long)]
-        controller: Option<String>,
-        /// The SCSI LUN to expose to VTL0.
-        #[clap(long)]
-        lun: u32,
-        /// The backing VTL2 NVMe namespace ID.
-        #[clap(
-            long,
-            conflicts_with = "backing_scsi_lun",
-            required_unless_present = "backing_scsi_lun"
-        )]
-        backing_nvme_nsid: Option<u32>,
-        /// The backing VTL2 SCSI LUN.
-        #[clap(
-            long,
-            conflicts_with = "backing_nvme_nsid",
-            required_unless_present = "backing_nvme_nsid"
-        )]
-        backing_scsi_lun: Option<u32>,
-    },
-
-    /// Remove a SCSI disk from VTL0.
-    RmScsiDisk {
-        /// The SCSI controller instance ID (GUID). Defaults to the standard
-        /// OpenVMM VTL0 SCSI instance.
-        #[clap(long)]
-        controller: Option<String>,
-        /// The SCSI LUN to remove.
-        #[clap(long)]
-        lun: u32,
-    },
-}
-
-struct CommandParser {
-    app: clap::Command,
-}
-
-impl CommandParser {
-    fn new() -> Self {
-        // Update the help template for each subcommand.
-        let mut app = InteractiveCommand::command();
-        for sc in app.get_subcommands_mut() {
-            *sc = sc
-                .clone()
-                .help_template("{about-with-newline}\n{usage-heading}\n    {usage}\n\n{all-args}");
-        }
-        Self { app }
-    }
-
-    fn parse(&mut self, line: &str) -> clap::error::Result<InteractiveCommand> {
-        let args = shell_words::split(line)
-            .map_err(|err| self.app.error(clap::error::ErrorKind::ValueValidation, err))?;
-        let matches = self.app.try_get_matches_from_mut(args)?;
-        InteractiveCommand::from_arg_matches(&matches).map_err(|err| err.format(&mut self.app))
-    }
 }
 
 fn new_hvsock_service_id(port: u32) -> Guid {
@@ -2604,8 +2050,8 @@ fn new_hvsock_service_id(port: u32) -> Guid {
     }
 }
 
-async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> anyhow::Result<()> {
-    let (mut vm_config, mut resources) = vm_config_from_command_line(driver, mesh, &opt).await?;
+async fn run_control(driver: &DefaultDriver, mesh: VmmMesh, opt: Options) -> anyhow::Result<()> {
+    let (mut vm_config, mut resources) = vm_config_from_command_line(driver, &mesh, &opt).await?;
 
     let mut vnc_worker = None;
     if opt.gfx || opt.vnc {
@@ -2675,7 +2121,7 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
     // spin up the VM
     let (vm_rpc, rpc_recv) = mesh::channel();
     let (notify_send, notify_recv) = mesh::channel();
-    let mut vm_worker = {
+    let vm_worker = {
         let vm_host = mesh.make_host("vm", opt.log_file.clone()).await?;
 
         let (shared_memory, saved_state) = if let Some(snapshot_dir) = &opt.restore_snapshot {
@@ -2730,1086 +2176,59 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
         },
     ));
 
-    let mut diag_inspector = DiagInspector::new(driver.clone(), paravisor_diag.clone());
-
-    let (console_command_send, console_command_recv) = mesh::channel();
-    let (inspect_completion_engine_send, inspect_completion_engine_recv) = mesh::channel();
-
-    let mut console_in = resources.console_in.take();
-    thread::Builder::new()
-        .name("stdio-thread".to_string())
-        .spawn(move || {
-            // install panic hook to restore cooked terminal (linux)
-            #[cfg(unix)]
-            if io::stderr().is_terminal() {
-                term::revert_terminal_on_panic()
-            }
-
-            let mut rl = rustyline::Editor::<
-                interactive_console::OpenvmmRustylineEditor,
-                rustyline::history::FileHistory,
-            >::with_config(
-                rustyline::Config::builder()
-                    .completion_type(rustyline::CompletionType::List)
-                    .build(),
-            )
-            .unwrap();
-
-            rl.set_helper(Some(interactive_console::OpenvmmRustylineEditor {
-                openvmm_inspect_req: Arc::new(inspect_completion_engine_send),
-            }));
-
-            let history_file = {
-                const HISTORY_FILE: &str = ".openvmm_history";
-
-                // using a `None` to kick off the `.or()` chain in order to make
-                // it a bit easier to visually inspect the fallback chain.
-                let history_folder = None
-                    .or_else(dirs::state_dir)
-                    .or_else(dirs::data_local_dir)
-                    .map(|path| path.join("openvmm"));
-
-                if let Some(history_folder) = history_folder {
-                    if let Err(err) = std::fs::create_dir_all(&history_folder) {
-                        tracing::warn!(
-                            error = &err as &dyn std::error::Error,
-                            "could not create directory: {}",
-                            history_folder.display()
-                        )
-                    }
-
-                    Some(history_folder.join(HISTORY_FILE))
-                } else {
-                    None
-                }
-            };
-
-            if let Some(history_file) = &history_file {
-                tracing::info!("restoring history from {}", history_file.display());
-                if rl.load_history(history_file).is_err() {
-                    tracing::info!("could not find existing {}", history_file.display());
-                }
-            }
-
-            // Enable Ctrl-Backspace to delete the current word.
-            rl.bind_sequence(
-                rustyline::KeyEvent::new('\x08', rustyline::Modifiers::CTRL),
-                rustyline::Cmd::Kill(rustyline::Movement::BackwardWord(1, rustyline::Word::Emacs)),
-            );
-
-            let mut parser = CommandParser::new();
-
-            let mut stdin = io::stdin();
-            loop {
-                // Raw console text until Ctrl-Q.
-                term::set_raw_console(true).expect("failed to set raw console mode");
-
-                if let Some(input) = console_in.as_mut() {
-                    let mut buf = [0; 32];
-                    loop {
-                        let n = stdin.read(&mut buf).unwrap();
-                        let mut b = &buf[..n];
-                        let stop = if let Some(ctrlq) = b.iter().position(|x| *x == 0x11) {
-                            b = &b[..ctrlq];
-                            true
-                        } else {
-                            false
-                        };
-                        block_on(input.as_mut().write_all(b)).expect("BUGBUG");
-                        if stop {
-                            break;
-                        }
-                    }
-                }
-
-                term::set_raw_console(false).expect("failed to set raw console mode");
-
-                loop {
-                    let line = rl.readline("openvmm> ");
-                    if line.is_err() {
-                        break;
-                    }
-                    let line = line.unwrap();
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    if let Err(err) = rl.add_history_entry(&line) {
-                        tracing::warn!(
-                            err = &err as &dyn std::error::Error,
-                            "error adding to .openvmm_history"
-                        )
-                    }
-
-                    match parser.parse(trimmed) {
-                        Ok(cmd) => match cmd {
-                            InteractiveCommand::Input { data } => {
-                                let mut data = data.join(" ");
-                                data.push('\n');
-                                if let Some(input) = console_in.as_mut() {
-                                    block_on(input.write_all(data.as_bytes())).expect("BUGBUG");
-                                }
-                            }
-                            InteractiveCommand::InputMode => break,
-                            cmd => {
-                                // Send the command to the main thread for processing.
-                                let (processing_done_send, processing_done_recv) =
-                                    mesh::oneshot::<()>();
-                                console_command_send.send((cmd, processing_done_send));
-                                let _ = block_on(processing_done_recv);
-                            }
-                        },
-                        Err(err) => {
-                            err.print().unwrap();
-                        }
-                    }
-
-                    if let Some(history_file) = &history_file {
-                        rl.append_history(history_file).unwrap();
-                    }
-                }
-            }
-        })
-        .unwrap();
-
-    let mut state_change_task = None::<Task<Result<StateChange, RpcError>>>;
-    let mut pulse_save_restore_interval: Option<Duration> = None;
-    let mut pending_shutdown = None;
-    let mut snapshot_saved = false;
-
-    enum StateChange {
-        Pause(bool),
-        Resume(bool),
-        Reset(Result<(), RemoteError>),
-        PulseSaveRestore(Result<(), PulseSaveRestoreError>),
-        ServiceVtl2(anyhow::Result<Duration>),
-    }
-
-    enum Event {
-        Command((InteractiveCommand, mesh::OneshotSender<()>)),
-        InspectRequestFromCompletionEngine(
-            (InspectTarget, String, mesh::OneshotSender<inspect::Node>),
-        ),
-        Quit,
-        Halt(vmm_core_defs::HaltReason),
-        PulseSaveRestore,
-        Worker(WorkerEvent),
-        VncWorker(WorkerEvent),
-        StateChange(Result<StateChange, RpcError>),
-        ShutdownResult(Result<hyperv_ic_resources::shutdown::ShutdownResult, RpcError>),
-    }
-
-    let mut console_command_recv = console_command_recv
-        .map(Event::Command)
-        .chain(futures::stream::repeat_with(|| Event::Quit));
-
-    let mut notify_recv = notify_recv.map(Event::Halt);
-
-    let mut inspect_completion_engine_recv =
-        inspect_completion_engine_recv.map(Event::InspectRequestFromCompletionEngine);
-
-    let mut quit = false;
-    loop {
-        let event = {
-            let pulse_save_restore = pin!(async {
-                match pulse_save_restore_interval {
-                    Some(wait) => {
-                        PolledTimer::new(driver).sleep(wait).await;
-                        Event::PulseSaveRestore
-                    }
-                    None => pending().await,
-                }
-            });
-
-            let vm = (&mut vm_worker).map(Event::Worker);
-            let vnc = futures::stream::iter(vnc_worker.as_mut())
-                .flatten()
-                .map(Event::VncWorker);
-            let change = futures::stream::iter(state_change_task.as_mut().map(|x| x.into_stream()))
-                .flatten()
-                .map(Event::StateChange);
-            let shutdown = pin!(async {
-                if let Some(s) = &mut pending_shutdown {
-                    Event::ShutdownResult(s.await)
-                } else {
-                    pending().await
-                }
-            });
-
-            (
-                &mut console_command_recv,
-                &mut inspect_completion_engine_recv,
-                &mut notify_recv,
-                pulse_save_restore.into_stream(),
-                vm,
-                vnc,
-                change,
-                shutdown.into_stream(),
-            )
-                .merge()
-                .next()
-                .await
-                .unwrap()
-        };
-
-        let (cmd, _processing_done_send) = match event {
-            Event::Command(message) => message,
-            Event::InspectRequestFromCompletionEngine((vtl, path, res)) => {
-                let mut inspection =
-                    InspectionBuilder::new(&path)
-                        .depth(Some(1))
-                        .inspect(inspect_obj(
-                            vtl,
-                            mesh,
-                            &vm_worker,
-                            vnc_worker.as_ref(),
-                            gdb_worker.as_ref(),
-                            &mut diag_inspector,
-                        ));
-                let _ = CancelContext::new()
-                    .with_timeout(Duration::from_secs(1))
-                    .until_cancelled(inspection.resolve())
-                    .await;
-
-                let node = inspection.results();
-                res.send(node);
-                continue;
-            }
-            Event::Quit => break,
-            Event::Halt(reason) => {
-                tracing::info!(?reason, "guest halted");
-                continue;
-            }
-            Event::PulseSaveRestore => {
-                vm_rpc.call(VmRpc::PulseSaveRestore, ()).await??;
-                continue;
-            }
-            Event::Worker(event) => {
-                match event {
-                    WorkerEvent::Stopped => {
-                        if quit {
-                            tracing::info!("vm stopped");
-                        } else {
-                            tracing::error!("vm worker unexpectedly stopped");
-                        }
-                        break;
-                    }
-                    WorkerEvent::Failed(err) => {
-                        tracing::error!(error = &err as &dyn std::error::Error, "vm worker failed");
-                        break;
-                    }
-                    WorkerEvent::RestartFailed(err) => {
-                        tracing::error!(
-                            error = &err as &dyn std::error::Error,
-                            "vm worker restart failed"
-                        );
-                    }
-                    WorkerEvent::Started => {
-                        tracing::info!("vm worker restarted");
-                    }
-                }
-                continue;
-            }
-            Event::VncWorker(event) => {
-                match event {
-                    WorkerEvent::Stopped => tracing::error!("vnc unexpectedly stopped"),
-                    WorkerEvent::Failed(err) => {
-                        tracing::error!(
-                            error = &err as &dyn std::error::Error,
-                            "vnc worker failed"
-                        );
-                    }
-                    WorkerEvent::RestartFailed(err) => {
-                        tracing::error!(
-                            error = &err as &dyn std::error::Error,
-                            "vnc worker restart failed"
-                        );
-                    }
-                    WorkerEvent::Started => {
-                        tracing::info!("vnc worker restarted");
-                    }
-                }
-                continue;
-            }
-            Event::StateChange(r) => {
-                match r {
-                    Ok(sc) => match sc {
-                        StateChange::Pause(success) => {
-                            if success {
-                                tracing::info!("pause complete");
-                            } else {
-                                tracing::warn!("already paused");
-                            }
-                        }
-                        StateChange::Resume(success) => {
-                            if success {
-                                tracing::info!("resumed complete");
-                            } else {
-                                tracing::warn!("already running");
-                            }
-                        }
-                        StateChange::Reset(r) => match r {
-                            Ok(()) => tracing::info!("reset complete"),
-                            Err(err) => tracing::error!(
-                                error = &err as &dyn std::error::Error,
-                                "reset failed"
-                            ),
-                        },
-                        StateChange::PulseSaveRestore(r) => match r {
-                            Ok(()) => tracing::info!("pulse save/restore complete"),
-                            Err(err) => tracing::error!(
-                                error = &err as &dyn std::error::Error,
-                                "pulse save/restore failed"
-                            ),
-                        },
-                        StateChange::ServiceVtl2(r) => match r {
-                            Ok(dur) => {
-                                tracing::info!(
-                                    duration = dur.as_millis() as i64,
-                                    "vtl2 servicing complete"
-                                )
-                            }
-                            Err(err) => tracing::error!(
-                                error = err.as_ref() as &dyn std::error::Error,
-                                "vtl2 servicing failed"
-                            ),
-                        },
-                    },
-                    Err(err) => {
-                        tracing::error!(
-                            error = &err as &dyn std::error::Error,
-                            "communication failure during state change"
-                        );
-                    }
-                }
-                state_change_task = None;
-                continue;
-            }
-            Event::ShutdownResult(r) => {
-                match r {
-                    Ok(r) => match r {
-                        hyperv_ic_resources::shutdown::ShutdownResult::Ok => {
-                            tracing::info!("shutdown initiated");
-                        }
-                        hyperv_ic_resources::shutdown::ShutdownResult::NotReady => {
-                            tracing::error!("shutdown ic not ready");
-                        }
-                        hyperv_ic_resources::shutdown::ShutdownResult::AlreadyInProgress => {
-                            tracing::error!("shutdown already in progress");
-                        }
-                        hyperv_ic_resources::shutdown::ShutdownResult::Failed(hr) => {
-                            tracing::error!("shutdown failed with error code {hr:#x}");
-                        }
-                    },
-                    Err(err) => {
-                        tracing::error!(
-                            error = &err as &dyn std::error::Error,
-                            "communication failure during shutdown"
-                        );
-                    }
-                }
-                pending_shutdown = None;
-                continue;
-            }
-        };
-
-        fn inspect_obj<'a>(
-            target: InspectTarget,
-            mesh: &'a VmmMesh,
-            vm_worker: &'a WorkerHandle,
-            vnc_worker: Option<&'a WorkerHandle>,
-            gdb_worker: Option<&'a WorkerHandle>,
-            diag_inspector: &'a mut DiagInspector,
-        ) -> impl 'a + InspectMut {
-            inspect::adhoc_mut(move |req| match target {
-                InspectTarget::Host => {
-                    let mut resp = req.respond();
-                    resp.field("mesh", mesh)
-                        .field("vm", vm_worker)
-                        .field("vnc", vnc_worker)
-                        .field("gdb", gdb_worker);
-                }
-                InspectTarget::Paravisor => {
-                    diag_inspector.inspect_mut(req);
-                }
-            })
-        }
-
-        fn state_change<U: 'static + Send>(
-            driver: impl Spawn,
-            vm_rpc: &mesh::Sender<VmRpc>,
-            state_change_task: &mut Option<Task<Result<StateChange, RpcError>>>,
-            f: impl FnOnce(Rpc<(), U>) -> VmRpc,
-            g: impl FnOnce(U) -> StateChange + 'static + Send,
-        ) {
-            if state_change_task.is_some() {
-                tracing::error!("state change already in progress");
-            } else {
-                let rpc = vm_rpc.call(f, ());
-                *state_change_task =
-                    Some(driver.spawn("state-change", async move { Ok(g(rpc.await?)) }));
-            }
-        }
-
-        match cmd {
-            InteractiveCommand::Panic => {
-                panic!("injected panic")
-            }
-            InteractiveCommand::Restart => {
-                // create a new host process
-                let vm_host = mesh.make_host("vm", opt.log_file.clone()).await?;
-
-                vm_worker.restart(&vm_host);
-            }
-            InteractiveCommand::Pause => {
-                state_change(
-                    driver,
-                    &vm_rpc,
-                    &mut state_change_task,
-                    VmRpc::Pause,
-                    StateChange::Pause,
-                );
-            }
-            InteractiveCommand::Resume => {
-                if snapshot_saved {
-                    eprintln!(
-                        "error: cannot resume after snapshot save — resuming would corrupt the snapshot. Use 'shutdown' to exit."
-                    );
-                } else {
-                    state_change(
-                        driver,
-                        &vm_rpc,
-                        &mut state_change_task,
-                        VmRpc::Resume,
-                        StateChange::Resume,
-                    );
-                }
-            }
-            InteractiveCommand::Reset => {
-                state_change(
-                    driver,
-                    &vm_rpc,
-                    &mut state_change_task,
-                    VmRpc::Reset,
-                    StateChange::Reset,
-                );
-            }
-            InteractiveCommand::SaveSnapshot { dir } => {
-                match save_snapshot(&vm_rpc, &opt, &dir).await {
-                    Ok(()) => {
-                        snapshot_saved = true;
-                        tracing::info!(
-                            dir = %dir.display(),
-                            "snapshot saved; VM is paused. \
-                             Resume is blocked to prevent snapshot corruption. \
-                             Use 'shutdown' to exit."
-                        );
-                    }
-                    Err(err) => {
-                        eprintln!("error: save-snapshot failed: {err:#}");
-                    }
-                }
-            }
-            InteractiveCommand::PulseSaveRestore => {
-                state_change(
-                    driver,
-                    &vm_rpc,
-                    &mut state_change_task,
-                    VmRpc::PulseSaveRestore,
-                    StateChange::PulseSaveRestore,
-                );
-            }
-            InteractiveCommand::SchedulePulseSaveRestore { interval } => {
-                pulse_save_restore_interval = match interval {
-                    Some(seconds) if seconds != 0 => Some(Duration::from_secs(seconds)),
-                    _ => {
-                        // Treat None and 0 seconds as do not perform scheduled pulse save restores anymore.
-                        None
-                    }
-                }
-            }
-            InteractiveCommand::Shutdown {
-                reboot,
-                hibernate,
-                force,
-            } => {
-                if pending_shutdown.is_some() {
-                    println!("shutdown already in progress");
-                } else if let Some(ic) = &resources.shutdown_ic {
-                    let params = hyperv_ic_resources::shutdown::ShutdownParams {
-                        shutdown_type: if hibernate {
-                            hyperv_ic_resources::shutdown::ShutdownType::Hibernate
-                        } else if reboot {
-                            hyperv_ic_resources::shutdown::ShutdownType::Reboot
-                        } else {
-                            hyperv_ic_resources::shutdown::ShutdownType::PowerOff
-                        },
-                        force,
-                    };
-                    pending_shutdown =
-                        Some(ic.call(hyperv_ic_resources::shutdown::ShutdownRpc::Shutdown, params));
-                } else {
-                    println!("no shutdown ic configured");
-                }
-            }
-            InteractiveCommand::Nmi => {
-                let _ = vm_rpc.call(VmRpc::Nmi, 0).await;
-            }
-            InteractiveCommand::ClearHalt => {
-                vm_rpc.call(VmRpc::ClearHalt, ()).await.ok();
-            }
-            InteractiveCommand::AddDisk {
-                read_only,
-                target,
-                path,
-                lun,
-                ram,
-                file_path,
-                is_dvd,
-            } => {
-                let action = async {
-                    let scsi = resources.scsi_rpc.as_ref().context("no scsi controller")?;
-                    let disk_type = match ram {
-                        None => {
-                            let path = file_path.context("no filename passed")?;
-                            open_disk_type(path.as_ref(), read_only)
-                                .with_context(|| format!("failed to open {}", path.display()))?
-                        }
-                        Some(size) => {
-                            Resource::new(disk_backend_resources::LayeredDiskHandle::single_layer(
-                                RamDiskLayerHandle {
-                                    len: Some(size),
-                                    sector_size: None,
-                                },
-                            ))
-                        }
-                    };
-
-                    let device = if is_dvd {
-                        SimpleScsiDvdHandle {
-                            media: Some(disk_type),
-                            requests: None,
-                        }
-                        .into_resource()
-                    } else {
-                        SimpleScsiDiskHandle {
-                            disk: disk_type,
-                            read_only,
-                            parameters: Default::default(),
-                        }
-                        .into_resource()
-                    };
-
-                    let cfg = ScsiDeviceAndPath {
-                        path: ScsiPath { path, target, lun },
-                        device,
-                    };
-
-                    scsi.call_failable(ScsiControllerRequest::AddDevice, cfg)
-                        .await?;
-
-                    anyhow::Result::<_>::Ok(())
-                };
-
-                if let Err(error) = action.await {
-                    tracing::error!(error = error.as_error(), "error adding disk")
-                }
-            }
-            InteractiveCommand::RmDisk { target, path, lun } => {
-                let action = async {
-                    let scsi = resources.scsi_rpc.as_ref().context("no scsi controller")?;
-                    scsi.call_failable(
-                        ScsiControllerRequest::RemoveDevice,
-                        ScsiPath { target, path, lun },
-                    )
-                    .await?;
-                    anyhow::Ok(())
-                };
-
-                if let Err(error) = action.await {
-                    tracing::error!(error = error.as_error(), "error removing disk")
-                }
-            }
-            InteractiveCommand::Vtl2Settings(cmd) => {
-                if resources.vtl2_settings.is_none() {
-                    eprintln!("error: no VTL2 settings (not running with VTL2?)");
-                    continue;
-                }
-                let action = async {
-                    match cmd {
-                        Vtl2SettingsCommand::Show => {
-                            let settings = resources.vtl2_settings.as_ref().unwrap();
-                            println!("{:#?}", settings);
-                        }
-                        Vtl2SettingsCommand::AddScsiDisk {
-                            controller,
-                            lun,
-                            backing_nvme_nsid,
-                            backing_scsi_lun,
-                        } => {
-                            // Determine the backing device type and path
-                            let (device_type, device_path, sub_device_path) = match (
-                                backing_nvme_nsid,
-                                backing_scsi_lun,
-                            ) {
-                                (Some(nsid), None) => (
-                                    vtl2_settings_proto::physical_device::DeviceType::Nvme,
-                                    storage_builder::NVME_VTL2_INSTANCE_ID,
-                                    nsid,
-                                ),
-                                (None, Some(scsi_lun)) => (
-                                    vtl2_settings_proto::physical_device::DeviceType::Vscsi,
-                                    storage_builder::SCSI_VTL2_INSTANCE_ID,
-                                    scsi_lun,
-                                ),
-                                (Some(_), Some(_)) => {
-                                    anyhow::bail!(
-                                        "can't specify both --backing-nvme-nsid and --backing-scsi-lun"
-                                    );
-                                }
-                                (None, None) => {
-                                    anyhow::bail!(
-                                        "must specify either --backing-nvme-nsid or --backing-scsi-lun"
-                                    );
-                                }
-                            };
-
-                            // Default to the standard OpenVMM VTL0 SCSI instance
-                            let controller_guid = controller
-                                .map(|s| s.parse())
-                                .transpose()
-                                .context("invalid controller GUID")?
-                                .unwrap_or(storage_builder::UNDERHILL_VTL0_SCSI_INSTANCE);
-
-                            resources
-                                .add_vtl0_scsi_disk(
-                                    controller_guid,
-                                    lun,
-                                    device_type,
-                                    device_path,
-                                    sub_device_path,
-                                )
-                                .await?;
-
-                            let backing_desc = if backing_nvme_nsid.is_some() {
-                                format!("nvme_nsid={}", sub_device_path)
-                            } else {
-                                format!("scsi_lun={}", sub_device_path)
-                            };
-                            println!(
-                                "Added VTL0 SCSI disk: controller={}, lun={}, backing={}",
-                                controller_guid, lun, backing_desc
-                            );
-                        }
-                        Vtl2SettingsCommand::RmScsiDisk { controller, lun } => {
-                            // Default to the standard OpenVMM VTL0 SCSI instance
-                            let controller_guid = controller
-                                .map(|s| s.parse())
-                                .transpose()
-                                .context("invalid controller GUID")?
-                                .unwrap_or(storage_builder::UNDERHILL_VTL0_SCSI_INSTANCE);
-
-                            resources
-                                .remove_vtl0_scsi_disk(controller_guid, lun)
-                                .await?;
-
-                            println!(
-                                "Removed VTL0 SCSI disk: controller={}, lun={}",
-                                controller_guid, lun
-                            );
-                        }
-                    }
-                    anyhow::Ok(())
-                };
-
-                if let Err(error) = action.await {
-                    eprintln!("error: {}", error);
-                }
-            }
-            InteractiveCommand::AddNvmeNs {
-                read_only,
-                nsid,
-                ram,
-                file_path,
-                vtl0_lun,
-            } => {
-                if resources.vtl2_settings.is_none() {
-                    eprintln!("error: add-nvme-ns requires --vtl2 mode");
-                    continue;
-                }
-                let action = async {
-                    let nvme = resources
-                        .nvme_vtl2_rpc
-                        .as_ref()
-                        .context("no vtl2 nvme controller")?;
-                    let disk_type = match (ram, file_path) {
-                        (None, Some(path)) => open_disk_type(path.as_ref(), read_only)
-                            .with_context(|| format!("failed to open {}", path.display()))?,
-                        (Some(size), None) => {
-                            Resource::new(disk_backend_resources::LayeredDiskHandle::single_layer(
-                                RamDiskLayerHandle {
-                                    len: Some(size),
-                                    sector_size: None,
-                                },
-                            ))
-                        }
-                        (None, None) => {
-                            anyhow::bail!("must specify either file path or --ram");
-                        }
-                        (Some(_), Some(_)) => {
-                            anyhow::bail!("cannot specify both file path and --ram");
-                        }
-                    };
-
-                    let ns = NamespaceDefinition {
-                        nsid,
-                        read_only,
-                        disk: disk_type,
-                    };
-
-                    nvme.call_failable(NvmeControllerRequest::AddNamespace, ns)
-                        .await?;
-                    println!("Added namespace {}", nsid);
-
-                    // If --vtl0-lun was specified, add a SCSI disk to VTL0 backed by the NVMe namespace
-                    if let Some(lun) = vtl0_lun {
-                        resources
-                            .add_vtl0_scsi_disk(
-                                storage_builder::UNDERHILL_VTL0_SCSI_INSTANCE,
-                                lun,
-                                vtl2_settings_proto::physical_device::DeviceType::Nvme,
-                                storage_builder::NVME_VTL2_INSTANCE_ID,
-                                nsid,
-                            )
-                            .await?;
-                        println!("Exposed namespace {} to VTL0 as SCSI lun={}", nsid, lun);
-                    }
-
-                    Ok(())
-                };
-
-                if let Err(error) = action.await {
-                    eprintln!("error adding nvme namespace: {}", error);
-                }
-            }
-            InteractiveCommand::RmNvmeNs { nsid, vtl0 } => {
-                if resources.vtl2_settings.is_none() {
-                    eprintln!("error: rm-nvme-ns requires --vtl2 mode");
-                    continue;
-                }
-                let action = async {
-                    // If --vtl0 was specified, find and remove the SCSI disk backed by this namespace
-                    if vtl0 {
-                        let removed_lun = resources
-                            .remove_vtl0_scsi_disk_by_nvme_nsid(
-                                storage_builder::UNDERHILL_VTL0_SCSI_INSTANCE,
-                                storage_builder::NVME_VTL2_INSTANCE_ID,
-                                nsid,
-                            )
-                            .await?;
-                        if let Some(lun) = removed_lun {
-                            println!("Removed VTL0 SCSI lun={}", lun);
-                        } else {
-                            println!("No VTL0 SCSI disk found backed by NVMe nsid={}", nsid);
-                        }
-                    }
-
-                    let nvme = resources
-                        .nvme_vtl2_rpc
-                        .as_ref()
-                        .context("no vtl2 nvme controller")?;
-                    nvme.call_failable(NvmeControllerRequest::RemoveNamespace, nsid)
-                        .await?;
-                    println!("Removed NVMe namespace {}", nsid);
-                    anyhow::Ok(())
-                };
-
-                if let Err(error) = action.await {
-                    eprintln!("error removing nvme namespace: {}", error);
-                }
-            }
-            InteractiveCommand::Inspect {
-                recursive,
-                limit,
-                paravisor,
-                element,
-                update,
-            } => {
-                let obj = inspect_obj(
-                    if paravisor {
-                        InspectTarget::Paravisor
-                    } else {
-                        InspectTarget::Host
-                    },
-                    mesh,
-                    &vm_worker,
-                    vnc_worker.as_ref(),
-                    gdb_worker.as_ref(),
-                    &mut diag_inspector,
-                );
-
-                if let Some(value) = update {
-                    let Some(element) = element else {
-                        anyhow::bail!("must provide element for update")
-                    };
-
-                    let value = async {
-                        let update = inspect::update(&element, &value, obj);
-                        let value = CancelContext::new()
-                            .with_timeout(Duration::from_secs(1))
-                            .until_cancelled(update)
-                            .await??;
-                        anyhow::Ok(value)
-                    }
-                    .await;
-                    match value {
-                        Ok(node) => match &node.kind {
-                            inspect::ValueKind::String(s) => println!("{s}"),
-                            _ => println!("{:#}", node),
-                        },
-                        Err(err) => println!("error: {:#}", err),
-                    }
-                } else {
-                    let element = element.unwrap_or_default();
-                    let depth = if recursive { limit } else { Some(0) };
-                    let node = async {
-                        let mut inspection =
-                            InspectionBuilder::new(&element).depth(depth).inspect(obj);
-                        let _ = CancelContext::new()
-                            .with_timeout(Duration::from_secs(1))
-                            .until_cancelled(inspection.resolve())
-                            .await;
-                        inspection.results()
-                    }
-                    .await;
-
-                    println!("{:#}", node);
-                }
-            }
-            InteractiveCommand::RestartVnc => {
-                if let Some(vnc) = &mut vnc_worker {
-                    let action = async {
-                        let vnc_host = mesh
-                            .make_host("vnc", None)
-                            .await
-                            .context("spawning vnc process failed")?;
-
-                        vnc.restart(&vnc_host);
-                        anyhow::Result::<_>::Ok(())
-                    };
-
-                    if let Err(error) = action.await {
-                        eprintln!("error: {}", error);
-                    }
-                } else {
-                    eprintln!("ERROR: no VNC server running");
-                }
-            }
-            InteractiveCommand::Hvsock { term, port } => {
-                let vm_rpc = &vm_rpc;
-                let action = async || {
-                    let service_id = new_hvsock_service_id(port);
-                    let socket = vm_rpc
-                        .call_failable(
-                            VmRpc::ConnectHvsock,
-                            (
-                                CancelContext::new().with_timeout(Duration::from_secs(2)),
-                                service_id,
-                                DeviceVtl::Vtl0,
-                            ),
-                        )
-                        .await?;
-                    let socket = PolledSocket::new(driver, socket)?;
-                    let mut console = console_relay::Console::new(
-                        driver.clone(),
-                        term.or_else(openvmm_terminal_app).as_deref(),
-                        Some(ConsoleLaunchOptions {
-                            window_title: Some(format!("HVSock{} [OpenVMM]", port)),
-                        }),
-                    )?;
-                    driver
-                        .spawn("console-relay", async move { console.relay(socket).await })
-                        .detach();
-                    anyhow::Result::<_>::Ok(())
-                };
-
-                if let Err(error) = (action)().await {
-                    eprintln!("error: {}", error);
-                }
-            }
-            InteractiveCommand::ServiceVtl2 {
-                user_mode_only,
-                igvm,
-                mana_keepalive,
-                nvme_keepalive,
-            } => {
-                let paravisor_diag = paravisor_diag.clone();
-                let vm_rpc = vm_rpc.clone();
-                let igvm = igvm.or_else(|| opt.igvm.clone());
-                let ged_rpc = resources.ged_rpc.clone();
-                let r = async move {
-                    let start;
-                    if user_mode_only {
-                        start = Instant::now();
-                        paravisor_diag.restart().await?;
-                    } else {
-                        let path = igvm.context("no igvm file loaded")?;
-                        let file = fs_err::File::open(path)?;
-                        start = Instant::now();
-                        openvmm_helpers::underhill::save_underhill(
-                            &vm_rpc,
-                            ged_rpc.as_ref().context("no GED")?,
-                            GuestServicingFlags {
-                                nvme_keepalive,
-                                mana_keepalive,
-                            },
-                            file.into(),
-                        )
-                        .await?;
-                        openvmm_helpers::underhill::restore_underhill(
-                            &vm_rpc,
-                            ged_rpc.as_ref().context("no GED")?,
-                        )
-                        .await?;
-                    }
-                    let end = Instant::now();
-                    Ok(end - start)
-                }
-                .map(|r| Ok(StateChange::ServiceVtl2(r)));
-                if state_change_task.is_some() {
-                    tracing::error!("state change already in progress");
-                } else {
-                    state_change_task = Some(driver.spawn("state-change", r));
-                }
-            }
-            InteractiveCommand::Quit => {
-                tracing::info!("quitting");
-                // Work around the detached SCSI task holding up worker stop.
-                // TODO: Fix the underlying bug
-                resources.scsi_rpc = None;
-                resources.nvme_vtl2_rpc = None;
-
-                vm_worker.stop();
-                quit = true;
-            }
-            InteractiveCommand::ReadMemory { gpa, size, file } => {
-                let size = size as usize;
-                let data = vm_rpc.call(VmRpc::ReadMemory, (gpa, size)).await?;
-
-                match data {
-                    Ok(bytes) => {
-                        if let Some(file) = file {
-                            if let Err(err) = fs_err::write(file, bytes) {
-                                eprintln!("error: {err:?}");
-                            }
-                        } else {
-                            let width = 16;
-                            let show_ascii = true;
-
-                            let mut dump = String::new();
-                            for (i, chunk) in bytes.chunks(width).enumerate() {
-                                let hex_part: Vec<String> =
-                                    chunk.iter().map(|byte| format!("{:02x}", byte)).collect();
-                                let hex_line = hex_part.join(" ");
-
-                                if show_ascii {
-                                    let ascii_part: String = chunk
-                                        .iter()
-                                        .map(|&byte| {
-                                            if byte.is_ascii_graphic() || byte == b' ' {
-                                                byte as char
-                                            } else {
-                                                '.'
-                                            }
-                                        })
-                                        .collect();
-                                    dump.push_str(&format!(
-                                        "{:04x}: {:<width$}  {}\n",
-                                        i * width,
-                                        hex_line,
-                                        ascii_part,
-                                        width = width * 3 - 1
-                                    ));
-                                } else {
-                                    dump.push_str(&format!("{:04x}: {}\n", i * width, hex_line));
-                                }
-                            }
-
-                            println!("{dump}");
-                        }
-                    }
-                    Err(err) => {
-                        eprintln!("error: {err:?}");
-                    }
-                }
-            }
-            InteractiveCommand::WriteMemory { gpa, hex, file } => {
-                if hex.is_some() == file.is_some() {
-                    eprintln!("error: either path to the file or the hex string must be specified");
-                    continue;
-                }
-
-                let data = if let Some(file) = file {
-                    let data = fs_err::read(file);
-                    match data {
-                        Ok(data) => data,
-                        Err(err) => {
-                            eprintln!("error: {err:?}");
-                            continue;
-                        }
-                    }
-                } else if let Some(hex) = hex {
-                    if hex.len() & 1 != 0 {
-                        eprintln!(
-                            "error: expected even number of hex digits (2 hex digits per byte)"
-                        );
-                        continue;
-                    }
-                    let data: Result<Vec<u8>, String> = (0..hex.len())
-                        .step_by(2)
-                        .map(|i| {
-                            u8::from_str_radix(&hex[i..i + 2], 16).map_err(|e| {
-                                format!("invalid hex character at position {}: {}", i, e)
-                            })
-                        })
-                        .collect();
-
-                    match data {
-                        Ok(data) => data,
-                        Err(err) => {
-                            eprintln!("error: {err}");
-                            continue;
-                        }
-                    }
-                } else {
-                    unreachable!();
-                };
-
-                if data.is_empty() {
-                    eprintln!("error: no data to write");
-                    continue;
-                }
-
-                if let Err(err) = vm_rpc.call(VmRpc::WriteMemory, (gpa, data)).await? {
-                    eprintln!("error: {err:?}");
-                }
-            }
-            InteractiveCommand::Kvp(command) => {
-                let Some(kvp) = &resources.kvp_ic else {
-                    eprintln!("error: no kvp ic configured");
-                    continue;
-                };
-                if let Err(err) = kvp::handle_kvp(kvp, command).await {
-                    eprintln!("error: {err:#}");
-                }
-            }
-            InteractiveCommand::Input { .. } | InteractiveCommand::InputMode => unreachable!(),
-        }
-    }
-
-    vm_worker.stop();
-    vm_worker.join().await?;
-    Ok(())
+    let diag_inspector = DiagInspector::new(driver.clone(), paravisor_diag.clone());
+
+    // Create channels between the REPL and VmController.
+    let (vm_controller_send, vm_controller_recv) = mesh::channel();
+    let (vm_controller_event_send, vm_controller_event_recv) = mesh::channel();
+
+    let has_vtl2 = resources.vtl2_settings.is_some();
+
+    // Build the VmController with exclusive resources.
+    let controller = vm_controller::VmController {
+        mesh,
+        vm_worker,
+        vnc_worker,
+        gdb_worker,
+        diag_inspector,
+        vtl2_settings: resources.vtl2_settings,
+        ged_rpc: resources.ged_rpc.clone(),
+        vm_rpc: vm_rpc.clone(),
+        paravisor_diag,
+        igvm_path: opt.igvm.clone(),
+        memory_backing_file: opt.memory_backing_file.clone(),
+        memory: opt.memory,
+        processors: opt.processors,
+        log_file: opt.log_file.clone(),
+    };
+
+    // Spawn the VmController as a task.
+    let controller_task = driver.spawn("vm-controller", 
+        controller.run(vm_controller_recv, vm_controller_event_send, notify_recv)
+    );
+
+    // Run the REPL with shareable resources.
+    let repl_result = repl::run_repl(
+        driver,
+        repl::ReplResources {
+            vm_rpc,
+            vm_controller: vm_controller_send,
+            vm_controller_events: vm_controller_event_recv,
+            scsi_rpc: resources.scsi_rpc,
+            nvme_vtl2_rpc: resources.nvme_vtl2_rpc,
+            shutdown_ic: resources.shutdown_ic,
+            kvp_ic: resources.kvp_ic,
+            console_in: resources.console_in,
+            has_vtl2,
+        },
+    )
+    .await;
+
+    // Wait for the controller task to finish (it stops the VM worker and
+    // shuts down the mesh).
+    controller_task.await;
+
+    repl_result
 }
 
 struct DiagDialer {
@@ -3846,7 +2265,7 @@ impl mesh_rpc::client::Dial for DiagDialer {
 ///
 /// This also caches the TTRPC connection to the guest so that only the first
 /// inspect request has to wait for the connection to be established.
-pub struct DiagInspector(DiagInspectorInner);
+pub(crate) struct DiagInspector(DiagInspectorInner);
 
 enum DiagInspectorInner {
     NotStarted(DefaultDriver, Arc<diag_client::DiagClient>),
@@ -3918,169 +2337,5 @@ impl DiagInspector {
 impl InspectMut for DiagInspector {
     fn inspect_mut(&mut self, req: inspect::Request<'_>) {
         self.start().send(req.defer());
-    }
-}
-
-enum InspectTarget {
-    Host,
-    Paravisor,
-}
-
-mod interactive_console {
-    use super::InteractiveCommand;
-    use rustyline::Helper;
-    use rustyline::Highlighter;
-    use rustyline::Hinter;
-    use rustyline::Validator;
-
-    #[derive(Helper, Highlighter, Hinter, Validator)]
-    pub(crate) struct OpenvmmRustylineEditor {
-        pub openvmm_inspect_req: std::sync::Arc<
-            mesh::Sender<(
-                super::InspectTarget,
-                String,
-                mesh::OneshotSender<inspect::Node>,
-            )>,
-        >,
-    }
-
-    impl rustyline::completion::Completer for OpenvmmRustylineEditor {
-        type Candidate = String;
-
-        fn complete(
-            &self,
-            line: &str,
-            pos: usize,
-            _ctx: &rustyline::Context<'_>,
-        ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
-            let Ok(cmd) = shell_words::split(line) else {
-                return Ok((0, Vec::with_capacity(0)));
-            };
-
-            let completions = futures::executor::block_on(
-                clap_dyn_complete::Complete {
-                    cmd,
-                    raw: Some(line.into()),
-                    position: Some(pos),
-                }
-                .generate_completions::<InteractiveCommand>(None, self),
-            );
-
-            let pos_from_end = {
-                let line = line.chars().take(pos).collect::<String>();
-
-                let trailing_ws = line.len() - line.trim_end().len();
-
-                if trailing_ws > 0 {
-                    line.len() - trailing_ws + 1 // +1 for the space
-                } else {
-                    let last_word = shell_words::split(&line)
-                        .unwrap_or_default()
-                        .last()
-                        .cloned()
-                        .unwrap_or_default();
-
-                    line.len() - last_word.len()
-                }
-            };
-
-            Ok((pos_from_end, completions))
-        }
-    }
-
-    impl clap_dyn_complete::CustomCompleterFactory for &OpenvmmRustylineEditor {
-        type CustomCompleter = OpenvmmComplete;
-        async fn build(&self, _ctx: &clap_dyn_complete::RootCtx<'_>) -> Self::CustomCompleter {
-            OpenvmmComplete {
-                openvmm_inspect_req: self.openvmm_inspect_req.clone(),
-            }
-        }
-    }
-
-    pub struct OpenvmmComplete {
-        openvmm_inspect_req: std::sync::Arc<
-            mesh::Sender<(
-                super::InspectTarget,
-                String,
-                mesh::OneshotSender<inspect::Node>,
-            )>,
-        >,
-    }
-
-    impl clap_dyn_complete::CustomCompleter for OpenvmmComplete {
-        async fn complete(
-            &self,
-            ctx: &clap_dyn_complete::RootCtx<'_>,
-            subcommand_path: &[&str],
-            arg_id: &str,
-        ) -> Vec<String> {
-            match (subcommand_path, arg_id) {
-                (["openvmm", "inspect"], "element") => {
-                    let on_error = vec!["failed/to/connect".into()];
-
-                    let (parent_path, to_complete) = (ctx.to_complete)
-                        .rsplit_once('/')
-                        .unwrap_or(("", ctx.to_complete));
-
-                    let node = {
-                        let paravisor = {
-                            let raw_arg = ctx
-                                .matches
-                                .subcommand()
-                                .unwrap()
-                                .1
-                                .get_one::<String>("paravisor")
-                                .map(|x| x.as_str())
-                                .unwrap_or_default();
-                            raw_arg == "true"
-                        };
-
-                        let (tx, rx) = mesh::oneshot();
-                        self.openvmm_inspect_req.send((
-                            if paravisor {
-                                super::InspectTarget::Paravisor
-                            } else {
-                                super::InspectTarget::Host
-                            },
-                            parent_path.to_owned(),
-                            tx,
-                        ));
-                        let Ok(node) = rx.await else {
-                            return on_error;
-                        };
-
-                        node
-                    };
-
-                    let mut completions = Vec::new();
-
-                    if let inspect::Node::Dir(dir) = node {
-                        for entry in dir {
-                            if entry.name.starts_with(to_complete) {
-                                if parent_path.is_empty() {
-                                    completions.push(format!("{}/", entry.name))
-                                } else {
-                                    completions.push(format!(
-                                        "{}/{}{}",
-                                        parent_path,
-                                        entry.name,
-                                        if matches!(entry.node, inspect::Node::Dir(..)) {
-                                            "/"
-                                        } else {
-                                            ""
-                                        }
-                                    ))
-                                }
-                            }
-                        }
-                    } else {
-                        return on_error;
-                    }
-
-                    completions
-                }
-                _ => Vec::new(),
-            }
-        }
     }
 }

--- a/openvmm/openvmm_entry/src/repl.rs
+++ b/openvmm/openvmm_entry/src/repl.rs
@@ -1,0 +1,1585 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Interactive REPL (Read-Eval-Print Loop) for openvmm.
+//!
+//! This module handles user input, command parsing, and dispatching. Commands
+//! that operate on shareable resources (e.g., `Sender<VmRpc>`) are executed
+//! directly. Commands that need exclusive resources (worker handles,
+//! DiagInspector, vtl2_settings) are dispatched via `Sender<VmControllerRpc>`.
+
+use crate::kvp;
+use crate::storage_builder;
+use crate::vm_controller::AddVtl0ScsiDiskParams;
+use crate::vm_controller::InspectTarget;
+use crate::vm_controller::RemoveVtl0ScsiDiskByNvmeNsidParams;
+use crate::vm_controller::RemoveVtl0ScsiDiskParams;
+use crate::vm_controller::ServiceVtl2Params;
+use crate::vm_controller::VmControllerEvent;
+use crate::vm_controller::VmControllerRpc;
+use anyhow::Context;
+use clap::CommandFactory;
+use clap::FromArgMatches;
+use clap::Parser;
+use console_relay::ConsoleLaunchOptions;
+use disk_backend_resources::layer::RamDiskLayerHandle;
+use futures::AsyncWrite;
+use futures::AsyncWriteExt;
+use futures::FutureExt;
+use futures::StreamExt;
+use futures::executor::block_on;
+use futures_concurrency::stream::Merge;
+use inspect::InspectionBuilder;
+use mesh::CancelContext;
+use mesh::error::RemoteError;
+use mesh::rpc::Rpc;
+use mesh::rpc::RpcError;
+use mesh::rpc::RpcSend;
+use nvme_resources::NamespaceDefinition;
+use nvme_resources::NvmeControllerRequest;
+use openvmm_defs::config::DeviceVtl;
+use openvmm_defs::rpc::PulseSaveRestoreError;
+use openvmm_defs::rpc::VmRpc;
+use pal_async::DefaultDriver;
+use pal_async::socket::PolledSocket;
+use pal_async::task::Spawn;
+use pal_async::task::Task;
+use pal_async::timer::PolledTimer;
+use scsidisk_resources::SimpleScsiDiskHandle;
+use scsidisk_resources::SimpleScsiDvdHandle;
+use std::future::pending;
+use std::io;
+#[cfg(unix)]
+use std::io::IsTerminal;
+use std::io::Read;
+use std::path::PathBuf;
+use std::pin::pin;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use storvsp_resources::ScsiControllerRequest;
+use storvsp_resources::ScsiDeviceAndPath;
+use storvsp_resources::ScsiPath;
+use tracing_helpers::AnyhowValueExt;
+use vm_resource::IntoResource;
+use vm_resource::Resource;
+
+fn maybe_with_radix_u64(s: &str) -> Result<u64, String> {
+    let (radix, prefix_len) = if s.starts_with("0x") || s.starts_with("0X") {
+        (16, 2)
+    } else if s.starts_with("0o") || s.starts_with("0O") {
+        (8, 2)
+    } else if s.starts_with("0b") || s.starts_with("0B") {
+        (2, 2)
+    } else {
+        (10, 0)
+    };
+
+    u64::from_str_radix(&s[prefix_len..], radix).map_err(|e| format!("{e}"))
+}
+
+#[derive(Parser)]
+#[clap(
+    name = "openvmm",
+    disable_help_flag = true,
+    disable_version_flag = true,
+    no_binary_name = true,
+    help_template("{subcommands}")
+)]
+enum InteractiveCommand {
+    /// Restart the VM worker (experimental).
+    ///
+    /// This restarts the VM worker while preserving state.
+    #[clap(visible_alias = "R")]
+    Restart,
+
+    /// Inject an NMI.
+    #[clap(visible_alias = "n")]
+    Nmi,
+
+    /// Pause the VM.
+    #[clap(visible_alias = "p")]
+    Pause,
+
+    /// Resume the VM.
+    #[clap(visible_alias = "r")]
+    Resume,
+
+    /// Save a snapshot to a directory (requires --memory-backing-file).
+    #[clap(visible_alias = "snap")]
+    SaveSnapshot {
+        /// Directory to write the snapshot to.
+        dir: PathBuf,
+    },
+
+    /// Do a pulsed save restore (pause, save, reset, restore, resume) to the VM.
+    #[clap(visible_alias = "psr")]
+    PulseSaveRestore,
+
+    /// Schedule a pulsed save restore (pause, save, reset, restore, resume) to the VM.
+    #[clap(visible_alias = "spsr")]
+    SchedulePulseSaveRestore {
+        /// The interval between pulse save restore operations in seconds.
+        /// None or 0 means any previous scheduled pulse save restores will be cleared.
+        interval: Option<u64>,
+    },
+
+    /// Hot add a disk to the VTL0 guest.
+    #[clap(visible_alias = "d")]
+    AddDisk {
+        #[clap(long = "ro")]
+        read_only: bool,
+        #[clap(long = "dvd")]
+        is_dvd: bool,
+        #[clap(long, default_value_t)]
+        target: u8,
+        #[clap(long, default_value_t)]
+        path: u8,
+        #[clap(long, default_value_t)]
+        lun: u8,
+        #[clap(long)]
+        ram: Option<u64>,
+        file_path: Option<PathBuf>,
+    },
+
+    /// Hot remove a disk from the VTL0 guest.
+    #[clap(visible_alias = "D")]
+    RmDisk {
+        #[clap(long)]
+        target: u8,
+        #[clap(long)]
+        path: u8,
+        #[clap(long)]
+        lun: u8,
+    },
+
+    /// Manage VTL2 settings (storage controllers, NICs exposed to VTL0).
+    #[clap(subcommand)]
+    Vtl2Settings(Vtl2SettingsCommand),
+
+    /// Hot add an NVMe namespace to VTL2, and optionally to VTL0.
+    AddNvmeNs {
+        #[clap(long = "ro")]
+        read_only: bool,
+        /// The namespace ID.
+        #[clap(long)]
+        nsid: u32,
+        /// Create a RAM-backed namespace of the specified size in bytes.
+        #[clap(long)]
+        ram: Option<u64>,
+        /// Path to a file to use as the backing store.
+        file_path: Option<PathBuf>,
+        /// Also expose this namespace to VTL0 via VTL2 settings as a SCSI disk
+        /// with the specified LUN number.
+        #[clap(long)]
+        vtl0_lun: Option<u32>,
+    },
+
+    /// Hot remove an NVMe namespace from VTL2.
+    RmNvmeNs {
+        /// The namespace ID to remove.
+        #[clap(long)]
+        nsid: u32,
+        /// Also remove the VTL0 SCSI disk backed by this namespace.
+        #[clap(long)]
+        vtl0: bool,
+    },
+
+    /// Inspect program state.
+    #[clap(visible_alias = "x")]
+    Inspect {
+        /// Enumerate state recursively.
+        #[clap(short, long)]
+        recursive: bool,
+        /// The recursive depth limit.
+        #[clap(short, long, requires("recursive"))]
+        limit: Option<usize>,
+        /// Target the paravisor.
+        #[clap(short = 'v', long)]
+        paravisor: bool,
+        /// The element path to inspect.
+        element: Option<String>,
+        /// Update the path with a new value.
+        #[clap(short, long, conflicts_with("recursive"))]
+        update: Option<String>,
+    },
+
+    /// Restart the VNC worker.
+    #[clap(visible_alias = "V")]
+    RestartVnc,
+
+    /// Start an hvsocket terminal window.
+    #[clap(visible_alias = "v")]
+    Hvsock {
+        /// the terminal emulator to run (defaults to conhost.exe or xterm)
+        #[clap(short, long)]
+        term: Option<PathBuf>,
+        /// the vsock port to connect to
+        port: u32,
+    },
+
+    /// Quit the program.
+    #[clap(visible_alias = "q")]
+    Quit,
+
+    /// Write input to the VM console.
+    ///
+    /// This will write each input parameter to the console's associated serial
+    /// port, separated by spaces.
+    #[clap(visible_alias = "i")]
+    Input { data: Vec<String> },
+
+    /// Switch to input mode.
+    ///
+    /// Once in input mode, Ctrl-Q returns to command mode.
+    #[clap(visible_alias = "I")]
+    InputMode,
+
+    /// Reset the VM.
+    Reset,
+
+    /// Send a request to the VM to shut it down.
+    Shutdown {
+        /// Reboot the VM instead of powering it off.
+        #[clap(long, short = 'r')]
+        reboot: bool,
+        /// Hibernate the VM instead of powering it off.
+        #[clap(long, short = 'h', conflicts_with = "reboot")]
+        hibernate: bool,
+        /// Tell the guest to force the power state transition.
+        #[clap(long, short = 'f')]
+        force: bool,
+    },
+
+    /// Clears the current halt condition, resuming the VPs if the VM is
+    /// running.
+    #[clap(visible_alias = "ch")]
+    ClearHalt,
+
+    /// Update the image in VTL2.
+    ServiceVtl2 {
+        /// Just restart the user-mode paravisor process, not the full
+        /// firmware.
+        #[clap(long, short = 'u')]
+        user_mode_only: bool,
+        /// The path to the new IGVM file. If missing, use the originally
+        /// configured path.
+        #[clap(long, conflicts_with("user_mode_only"))]
+        igvm: Option<PathBuf>,
+        /// Enable keepalive when servicing VTL2 devices.
+        /// Default is `true`.
+        #[clap(long, short = 'n', default_missing_value = "true")]
+        nvme_keepalive: bool,
+        /// Enable keepalive when servicing VTL2 devices.
+        /// Default is `false`.
+        #[clap(long)]
+        mana_keepalive: bool,
+    },
+
+    /// Read guest memory
+    ReadMemory {
+        /// Guest physical address to start at.
+        #[clap(value_parser=maybe_with_radix_u64)]
+        gpa: u64,
+        /// How many bytes to dump.
+        #[clap(value_parser=maybe_with_radix_u64)]
+        size: u64,
+        /// File to save the data to. If omitted,
+        /// the data will be presented as a hex dump.
+        #[clap(long, short = 'f')]
+        file: Option<PathBuf>,
+    },
+
+    /// Write guest memory
+    WriteMemory {
+        /// Guest physical address to start at
+        #[clap(value_parser=maybe_with_radix_u64)]
+        gpa: u64,
+        /// Hex string encoding data, with no `0x` radix.
+        /// If omitted, the source file must be specified.
+        hex: Option<String>,
+        /// File to write the data from.
+        #[clap(long, short = 'f')]
+        file: Option<PathBuf>,
+    },
+
+    /// Inject an artificial panic into OpenVMM
+    Panic,
+
+    /// Use KVP to interact with the guest.
+    Kvp(kvp::KvpCommand),
+}
+
+/// Subcommands for managing VTL2 settings.
+#[derive(clap::Subcommand)]
+enum Vtl2SettingsCommand {
+    /// Show the current VTL2 settings.
+    Show,
+
+    /// Add a SCSI disk to VTL0 backed by a VTL2 storage device.
+    ///
+    /// The backing device can be either a VTL2 NVMe namespace or a VTL2 SCSI disk.
+    AddScsiDisk {
+        /// The VTL0 SCSI controller instance ID (GUID). Defaults to the standard
+        /// OpenVMM VTL0 SCSI instance.
+        #[clap(long)]
+        controller: Option<String>,
+        /// The SCSI LUN to expose to VTL0.
+        #[clap(long)]
+        lun: u32,
+        /// The backing VTL2 NVMe namespace ID.
+        #[clap(
+            long,
+            conflicts_with = "backing_scsi_lun",
+            required_unless_present = "backing_scsi_lun"
+        )]
+        backing_nvme_nsid: Option<u32>,
+        /// The backing VTL2 SCSI LUN.
+        #[clap(
+            long,
+            conflicts_with = "backing_nvme_nsid",
+            required_unless_present = "backing_nvme_nsid"
+        )]
+        backing_scsi_lun: Option<u32>,
+    },
+
+    /// Remove a SCSI disk from VTL0.
+    RmScsiDisk {
+        /// The SCSI controller instance ID (GUID). Defaults to the standard
+        /// OpenVMM VTL0 SCSI instance.
+        #[clap(long)]
+        controller: Option<String>,
+        /// The SCSI LUN to remove.
+        #[clap(long)]
+        lun: u32,
+    },
+}
+
+struct CommandParser {
+    app: clap::Command,
+}
+
+impl CommandParser {
+    fn new() -> Self {
+        // Update the help template for each subcommand.
+        let mut app = InteractiveCommand::command();
+        for sc in app.get_subcommands_mut() {
+            *sc = sc
+                .clone()
+                .help_template("{about-with-newline}\n{usage-heading}\n    {usage}\n\n{all-args}");
+        }
+        Self { app }
+    }
+
+    fn parse(&mut self, line: &str) -> clap::error::Result<InteractiveCommand> {
+        let args = shell_words::split(line)
+            .map_err(|err| self.app.error(clap::error::ErrorKind::ValueValidation, err))?;
+        let matches = self.app.try_get_matches_from_mut(args)?;
+        InteractiveCommand::from_arg_matches(&matches).map_err(|err| err.format(&mut self.app))
+    }
+}
+
+/// Resources shared with the REPL (cloneable senders and handles).
+pub(crate) struct ReplResources {
+    pub vm_rpc: mesh::Sender<VmRpc>,
+    pub vm_controller: mesh::Sender<VmControllerRpc>,
+    pub vm_controller_events: mesh::Receiver<VmControllerEvent>,
+    pub scsi_rpc: Option<mesh::Sender<ScsiControllerRequest>>,
+    pub nvme_vtl2_rpc: Option<mesh::Sender<NvmeControllerRequest>>,
+    pub shutdown_ic: Option<mesh::Sender<hyperv_ic_resources::shutdown::ShutdownRpc>>,
+    pub kvp_ic: Option<mesh::Sender<hyperv_ic_resources::kvp::KvpConnectRpc>>,
+    pub console_in: Option<Box<dyn AsyncWrite + Send + Unpin>>,
+    pub has_vtl2: bool,
+}
+
+/// Run the interactive REPL.
+pub(crate) async fn run_repl(
+    driver: &DefaultDriver,
+    resources: ReplResources,
+) -> anyhow::Result<()> {
+    let ReplResources {
+        vm_rpc,
+        vm_controller,
+        mut vm_controller_events,
+        mut scsi_rpc,
+        mut nvme_vtl2_rpc,
+        shutdown_ic,
+        kvp_ic,
+        console_in,
+        has_vtl2,
+    } = resources;
+
+    let (console_command_send, console_command_recv) = mesh::channel();
+    let (inspect_completion_engine_send, inspect_completion_engine_recv) = mesh::channel();
+
+    let mut console_in = console_in;
+    thread::Builder::new()
+        .name("stdio-thread".to_string())
+        .spawn(move || {
+            // install panic hook to restore cooked terminal (linux)
+            #[cfg(unix)]
+            if io::stderr().is_terminal() {
+                term::revert_terminal_on_panic()
+            }
+
+            let mut rl = rustyline::Editor::<
+                OpenvmmRustylineEditor,
+                rustyline::history::FileHistory,
+            >::with_config(
+                rustyline::Config::builder()
+                    .completion_type(rustyline::CompletionType::List)
+                    .build(),
+            )
+            .unwrap();
+
+            rl.set_helper(Some(OpenvmmRustylineEditor {
+                openvmm_inspect_req: Arc::new(inspect_completion_engine_send),
+            }));
+
+            let history_file = {
+                const HISTORY_FILE: &str = ".openvmm_history";
+
+                let history_folder = None
+                    .or_else(dirs::state_dir)
+                    .or_else(dirs::data_local_dir)
+                    .map(|path| path.join("openvmm"));
+
+                if let Some(history_folder) = history_folder {
+                    if let Err(err) = std::fs::create_dir_all(&history_folder) {
+                        tracing::warn!(
+                            error = &err as &dyn std::error::Error,
+                            "could not create directory: {}",
+                            history_folder.display()
+                        )
+                    }
+
+                    Some(history_folder.join(HISTORY_FILE))
+                } else {
+                    None
+                }
+            };
+
+            if let Some(history_file) = &history_file {
+                tracing::info!("restoring history from {}", history_file.display());
+                if rl.load_history(history_file).is_err() {
+                    tracing::info!("could not find existing {}", history_file.display());
+                }
+            }
+
+            // Enable Ctrl-Backspace to delete the current word.
+            rl.bind_sequence(
+                rustyline::KeyEvent::new('\x08', rustyline::Modifiers::CTRL),
+                rustyline::Cmd::Kill(rustyline::Movement::BackwardWord(1, rustyline::Word::Emacs)),
+            );
+
+            let mut parser = CommandParser::new();
+
+            let mut stdin = io::stdin();
+            loop {
+                // Raw console text until Ctrl-Q.
+                term::set_raw_console(true).expect("failed to set raw console mode");
+
+                if let Some(input) = console_in.as_mut() {
+                    let mut buf = [0; 32];
+                    loop {
+                        let n = stdin.read(&mut buf).unwrap();
+                        let mut b = &buf[..n];
+                        let stop = if let Some(ctrlq) = b.iter().position(|x| *x == 0x11) {
+                            b = &b[..ctrlq];
+                            true
+                        } else {
+                            false
+                        };
+                        block_on(input.as_mut().write_all(b)).expect("BUGBUG");
+                        if stop {
+                            break;
+                        }
+                    }
+                }
+
+                term::set_raw_console(false).expect("failed to set raw console mode");
+
+                loop {
+                    let line = rl.readline("openvmm> ");
+                    if line.is_err() {
+                        break;
+                    }
+                    let line = line.unwrap();
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if let Err(err) = rl.add_history_entry(&line) {
+                        tracing::warn!(
+                            err = &err as &dyn std::error::Error,
+                            "error adding to .openvmm_history"
+                        )
+                    }
+
+                    match parser.parse(trimmed) {
+                        Ok(cmd) => match cmd {
+                            InteractiveCommand::Input { data } => {
+                                let mut data = data.join(" ");
+                                data.push('\n');
+                                if let Some(input) = console_in.as_mut() {
+                                    block_on(input.write_all(data.as_bytes())).expect("BUGBUG");
+                                }
+                            }
+                            InteractiveCommand::InputMode => break,
+                            cmd => {
+                                // Send the command to the main thread for processing.
+                                let (processing_done_send, processing_done_recv) =
+                                    mesh::oneshot::<()>();
+                                console_command_send.send((cmd, processing_done_send));
+                                let _ = block_on(processing_done_recv);
+                            }
+                        },
+                        Err(err) => {
+                            err.print().unwrap();
+                        }
+                    }
+
+                    if let Some(history_file) = &history_file {
+                        rl.append_history(history_file).unwrap();
+                    }
+                }
+            }
+        })
+        .unwrap();
+
+    let mut state_change_task = None::<Task<Result<StateChange, RpcError>>>;
+    let mut pulse_save_restore_interval: Option<Duration> = None;
+    let mut pending_shutdown = None;
+    let mut snapshot_saved = false;
+
+    enum StateChange {
+        Pause(bool),
+        Resume(bool),
+        Reset(Result<(), RemoteError>),
+        PulseSaveRestore(Result<(), PulseSaveRestoreError>),
+        ServiceVtl2(anyhow::Result<Duration>),
+    }
+
+    enum Event {
+        Command((InteractiveCommand, mesh::OneshotSender<()>)),
+        InspectRequestFromCompletionEngine(
+            (InspectTarget, String, mesh::OneshotSender<inspect::Node>),
+        ),
+        Quit,
+        PulseSaveRestore,
+        StateChange(Result<StateChange, RpcError>),
+        ShutdownResult(Result<hyperv_ic_resources::shutdown::ShutdownResult, RpcError>),
+        Controller(VmControllerEvent),
+    }
+
+    let mut console_command_recv = console_command_recv
+        .map(Event::Command)
+        .chain(futures::stream::repeat_with(|| Event::Quit));
+
+    let mut inspect_completion_engine_recv =
+        inspect_completion_engine_recv.map(Event::InspectRequestFromCompletionEngine);
+
+    loop {
+        let event = {
+            let pulse_save_restore = pin!(async {
+                match pulse_save_restore_interval {
+                    Some(wait) => {
+                        PolledTimer::new(driver).sleep(wait).await;
+                        Event::PulseSaveRestore
+                    }
+                    None => pending().await,
+                }
+            });
+
+            let change = futures::stream::iter(state_change_task.as_mut().map(|x| x.into_stream()))
+                .flatten()
+                .map(Event::StateChange);
+            let shutdown = pin!(async {
+                if let Some(s) = &mut pending_shutdown {
+                    Event::ShutdownResult(s.await)
+                } else {
+                    pending().await
+                }
+            });
+            let controller_events = (&mut vm_controller_events).map(Event::Controller);
+
+            (
+                &mut console_command_recv,
+                &mut inspect_completion_engine_recv,
+                pulse_save_restore.into_stream(),
+                change,
+                shutdown.into_stream(),
+                controller_events,
+            )
+                .merge()
+                .next()
+                .await
+                .unwrap()
+        };
+
+        let (cmd, _processing_done_send) = match event {
+            Event::Command(message) => message,
+            Event::InspectRequestFromCompletionEngine((target, path, res)) => {
+                let depth = Some(1);
+                let element = if path.is_empty() { None } else { Some(path) };
+                let deferred = {
+                    let element_ref = element.as_deref().unwrap_or("");
+                    let mut inspection = InspectionBuilder::new(element_ref).depth(depth).inspect(
+                        inspect::adhoc_mut(|req| {
+                            vm_controller.send(VmControllerRpc::Inspect(target, req.defer()));
+                        }),
+                    );
+                    let _ = CancelContext::new()
+                        .with_timeout(Duration::from_secs(1))
+                        .until_cancelled(inspection.resolve())
+                        .await;
+                    inspection.results()
+                };
+                res.send(deferred);
+                continue;
+            }
+            Event::Quit => break,
+            Event::PulseSaveRestore => {
+                vm_rpc.call(VmRpc::PulseSaveRestore, ()).await??;
+                continue;
+            }
+            Event::StateChange(r) => {
+                match r {
+                    Ok(sc) => match sc {
+                        StateChange::Pause(success) => {
+                            if success {
+                                tracing::info!("pause complete");
+                            } else {
+                                tracing::warn!("already paused");
+                            }
+                        }
+                        StateChange::Resume(success) => {
+                            if success {
+                                tracing::info!("resumed complete");
+                            } else {
+                                tracing::warn!("already running");
+                            }
+                        }
+                        StateChange::Reset(r) => match r {
+                            Ok(()) => tracing::info!("reset complete"),
+                            Err(err) => tracing::error!(
+                                error = &err as &dyn std::error::Error,
+                                "reset failed"
+                            ),
+                        },
+                        StateChange::PulseSaveRestore(r) => match r {
+                            Ok(()) => tracing::info!("pulse save/restore complete"),
+                            Err(err) => tracing::error!(
+                                error = &err as &dyn std::error::Error,
+                                "pulse save/restore failed"
+                            ),
+                        },
+                        StateChange::ServiceVtl2(r) => match r {
+                            Ok(dur) => {
+                                tracing::info!(
+                                    duration = dur.as_millis() as i64,
+                                    "vtl2 servicing complete"
+                                )
+                            }
+                            Err(err) => tracing::error!(
+                                error = err.as_ref() as &dyn std::error::Error,
+                                "vtl2 servicing failed"
+                            ),
+                        },
+                    },
+                    Err(err) => {
+                        tracing::error!(
+                            error = &err as &dyn std::error::Error,
+                            "communication failure during state change"
+                        );
+                    }
+                }
+                state_change_task = None;
+                continue;
+            }
+            Event::ShutdownResult(r) => {
+                match r {
+                    Ok(r) => match r {
+                        hyperv_ic_resources::shutdown::ShutdownResult::Ok => {
+                            tracing::info!("shutdown initiated");
+                        }
+                        hyperv_ic_resources::shutdown::ShutdownResult::NotReady => {
+                            tracing::error!("shutdown ic not ready");
+                        }
+                        hyperv_ic_resources::shutdown::ShutdownResult::AlreadyInProgress => {
+                            tracing::error!("shutdown already in progress");
+                        }
+                        hyperv_ic_resources::shutdown::ShutdownResult::Failed(hr) => {
+                            tracing::error!("shutdown failed with error code {hr:#x}");
+                        }
+                    },
+                    Err(err) => {
+                        tracing::error!(
+                            error = &err as &dyn std::error::Error,
+                            "communication failure during shutdown"
+                        );
+                    }
+                }
+                pending_shutdown = None;
+                continue;
+            }
+            Event::Controller(event) => {
+                match event {
+                    VmControllerEvent::WorkerStopped { error } => {
+                        if let Some(err) = &error {
+                            tracing::error!(error = err.as_str(), "vm worker stopped");
+                        }
+                        break;
+                    }
+                    VmControllerEvent::VncWorkerStopped { .. } => {
+                        // VNC stopped but VM is still running, continue.
+                    }
+                    VmControllerEvent::GuestHalt(reason) => {
+                        tracing::info!(reason = reason.as_str(), "guest halted");
+                    }
+                }
+                continue;
+            }
+        };
+
+        fn state_change<U: 'static + Send>(
+            driver: impl Spawn,
+            vm_rpc: &mesh::Sender<VmRpc>,
+            state_change_task: &mut Option<Task<Result<StateChange, RpcError>>>,
+            f: impl FnOnce(Rpc<(), U>) -> VmRpc,
+            g: impl FnOnce(U) -> StateChange + 'static + Send,
+        ) {
+            if state_change_task.is_some() {
+                tracing::error!("state change already in progress");
+            } else {
+                let rpc = vm_rpc.call(f, ());
+                *state_change_task =
+                    Some(driver.spawn("state-change", async move { Ok(g(rpc.await?)) }));
+            }
+        }
+
+        match cmd {
+            InteractiveCommand::Panic => {
+                panic!("injected panic")
+            }
+            InteractiveCommand::Restart => {
+                match vm_controller
+                    .call(VmControllerRpc::Restart, ())
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .and_then(|r| Ok(r?))
+                {
+                    Ok(()) => {}
+                    Err(err) => {
+                        eprintln!("error: {err:#}");
+                    }
+                }
+            }
+            InteractiveCommand::Pause => {
+                state_change(
+                    driver,
+                    &vm_rpc,
+                    &mut state_change_task,
+                    VmRpc::Pause,
+                    StateChange::Pause,
+                );
+            }
+            InteractiveCommand::Resume => {
+                if snapshot_saved {
+                    eprintln!(
+                        "error: cannot resume after snapshot save — resuming would corrupt the snapshot. Use 'shutdown' to exit."
+                    );
+                } else {
+                    state_change(
+                        driver,
+                        &vm_rpc,
+                        &mut state_change_task,
+                        VmRpc::Resume,
+                        StateChange::Resume,
+                    );
+                }
+            }
+            InteractiveCommand::Reset => {
+                state_change(
+                    driver,
+                    &vm_rpc,
+                    &mut state_change_task,
+                    VmRpc::Reset,
+                    StateChange::Reset,
+                );
+            }
+            InteractiveCommand::SaveSnapshot { dir } => {
+                match vm_controller
+                    .call(
+                        VmControllerRpc::SaveSnapshot,
+                        dir.to_string_lossy().into_owned(),
+                    )
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .and_then(|r| Ok(r?))
+                {
+                    Ok(()) => {
+                        snapshot_saved = true;
+                        tracing::info!(
+                            dir = %dir.display(),
+                            "snapshot saved; VM is paused. \
+                             Resume is blocked to prevent snapshot corruption. \
+                             Use 'shutdown' to exit."
+                        );
+                    }
+                    Err(err) => {
+                        eprintln!("error: save-snapshot failed: {err:#}");
+                    }
+                }
+            }
+            InteractiveCommand::PulseSaveRestore => {
+                state_change(
+                    driver,
+                    &vm_rpc,
+                    &mut state_change_task,
+                    VmRpc::PulseSaveRestore,
+                    StateChange::PulseSaveRestore,
+                );
+            }
+            InteractiveCommand::SchedulePulseSaveRestore { interval } => {
+                pulse_save_restore_interval = match interval {
+                    Some(seconds) if seconds != 0 => Some(Duration::from_secs(seconds)),
+                    _ => None,
+                }
+            }
+            InteractiveCommand::Shutdown {
+                reboot,
+                hibernate,
+                force,
+            } => {
+                if pending_shutdown.is_some() {
+                    println!("shutdown already in progress");
+                } else if let Some(ic) = &shutdown_ic {
+                    let params = hyperv_ic_resources::shutdown::ShutdownParams {
+                        shutdown_type: if hibernate {
+                            hyperv_ic_resources::shutdown::ShutdownType::Hibernate
+                        } else if reboot {
+                            hyperv_ic_resources::shutdown::ShutdownType::Reboot
+                        } else {
+                            hyperv_ic_resources::shutdown::ShutdownType::PowerOff
+                        },
+                        force,
+                    };
+                    pending_shutdown =
+                        Some(ic.call(hyperv_ic_resources::shutdown::ShutdownRpc::Shutdown, params));
+                } else {
+                    println!("no shutdown ic configured");
+                }
+            }
+            InteractiveCommand::Nmi => {
+                let _ = vm_rpc.call(VmRpc::Nmi, 0).await;
+            }
+            InteractiveCommand::ClearHalt => {
+                vm_rpc.call(VmRpc::ClearHalt, ()).await.ok();
+            }
+            InteractiveCommand::AddDisk {
+                read_only,
+                target,
+                path,
+                lun,
+                ram,
+                file_path,
+                is_dvd,
+            } => {
+                let action = async {
+                    let scsi = scsi_rpc.as_ref().context("no scsi controller")?;
+                    let disk_type = match ram {
+                        None => {
+                            let path = file_path.context("no filename passed")?;
+                            openvmm_helpers::disk::open_disk_type(path.as_ref(), read_only)
+                                .with_context(|| format!("failed to open {}", path.display()))?
+                        }
+                        Some(size) => {
+                            Resource::new(disk_backend_resources::LayeredDiskHandle::single_layer(
+                                RamDiskLayerHandle {
+                                    len: Some(size),
+                                    sector_size: None,
+                                },
+                            ))
+                        }
+                    };
+
+                    let device = if is_dvd {
+                        SimpleScsiDvdHandle {
+                            media: Some(disk_type),
+                            requests: None,
+                        }
+                        .into_resource()
+                    } else {
+                        SimpleScsiDiskHandle {
+                            disk: disk_type,
+                            read_only,
+                            parameters: Default::default(),
+                        }
+                        .into_resource()
+                    };
+
+                    let cfg = ScsiDeviceAndPath {
+                        path: ScsiPath { path, target, lun },
+                        device,
+                    };
+
+                    scsi.call_failable(ScsiControllerRequest::AddDevice, cfg)
+                        .await?;
+
+                    anyhow::Result::<_>::Ok(())
+                };
+
+                if let Err(error) = action.await {
+                    tracing::error!(error = error.as_error(), "error adding disk")
+                }
+            }
+            InteractiveCommand::RmDisk { target, path, lun } => {
+                let action = async {
+                    let scsi = scsi_rpc.as_ref().context("no scsi controller")?;
+                    scsi.call_failable(
+                        ScsiControllerRequest::RemoveDevice,
+                        ScsiPath { target, path, lun },
+                    )
+                    .await?;
+                    anyhow::Ok(())
+                };
+
+                if let Err(error) = action.await {
+                    tracing::error!(error = error.as_error(), "error removing disk")
+                }
+            }
+            InteractiveCommand::Vtl2Settings(cmd) => {
+                if !has_vtl2 {
+                    eprintln!("error: no VTL2 settings (not running with VTL2?)");
+                    continue;
+                }
+                let action = async {
+                    match cmd {
+                        Vtl2SettingsCommand::Show => {
+                            let encoded = vm_controller
+                                .call(VmControllerRpc::GetVtl2Settings, ())
+                                .await
+                                .map_err(anyhow::Error::from)?;
+                            if let Some(bytes) = encoded {
+                                let settings: vtl2_settings_proto::Vtl2Settings =
+                                    prost::Message::decode(bytes.as_slice())
+                                        .context("failed to decode vtl2 settings")?;
+                                println!("{:#?}", settings);
+                            } else {
+                                println!("(no VTL2 settings)");
+                            }
+                        }
+                        Vtl2SettingsCommand::AddScsiDisk {
+                            controller,
+                            lun,
+                            backing_nvme_nsid,
+                            backing_scsi_lun,
+                        } => {
+                            let (device_type, device_path, sub_device_path) = match (
+                                backing_nvme_nsid,
+                                backing_scsi_lun,
+                            ) {
+                                (Some(nsid), None) => (
+                                    vtl2_settings_proto::physical_device::DeviceType::Nvme,
+                                    storage_builder::NVME_VTL2_INSTANCE_ID,
+                                    nsid,
+                                ),
+                                (None, Some(scsi_lun)) => (
+                                    vtl2_settings_proto::physical_device::DeviceType::Vscsi,
+                                    storage_builder::SCSI_VTL2_INSTANCE_ID,
+                                    scsi_lun,
+                                ),
+                                (Some(_), Some(_)) => {
+                                    anyhow::bail!(
+                                        "can't specify both --backing-nvme-nsid and --backing-scsi-lun"
+                                    );
+                                }
+                                (None, None) => {
+                                    anyhow::bail!(
+                                        "must specify either --backing-nvme-nsid or --backing-scsi-lun"
+                                    );
+                                }
+                            };
+
+                            let controller_guid = controller
+                                .map(|s| s.parse())
+                                .transpose()
+                                .context("invalid controller GUID")?
+                                .unwrap_or(storage_builder::UNDERHILL_VTL0_SCSI_INSTANCE);
+
+                            vm_controller
+                                .call(
+                                    VmControllerRpc::AddVtl0ScsiDisk,
+                                    AddVtl0ScsiDiskParams {
+                                        controller_guid,
+                                        lun,
+                                        device_type: device_type as i32,
+                                        device_path,
+                                        sub_device_path,
+                                    },
+                                )
+                                .await
+                                .map_err(anyhow::Error::from)?
+                                .map_err(anyhow::Error::from)?;
+
+                            let backing_desc = if backing_nvme_nsid.is_some() {
+                                format!("nvme_nsid={}", sub_device_path)
+                            } else {
+                                format!("scsi_lun={}", sub_device_path)
+                            };
+                            println!(
+                                "Added VTL0 SCSI disk: controller={}, lun={}, backing={}",
+                                controller_guid, lun, backing_desc
+                            );
+                        }
+                        Vtl2SettingsCommand::RmScsiDisk { controller, lun } => {
+                            let controller_guid = controller
+                                .map(|s| s.parse())
+                                .transpose()
+                                .context("invalid controller GUID")?
+                                .unwrap_or(storage_builder::UNDERHILL_VTL0_SCSI_INSTANCE);
+
+                            vm_controller
+                                .call(
+                                    VmControllerRpc::RemoveVtl0ScsiDisk,
+                                    RemoveVtl0ScsiDiskParams {
+                                        controller_guid,
+                                        lun,
+                                    },
+                                )
+                                .await
+                                .map_err(anyhow::Error::from)?
+                                .map_err(anyhow::Error::from)?;
+
+                            println!(
+                                "Removed VTL0 SCSI disk: controller={}, lun={}",
+                                controller_guid, lun
+                            );
+                        }
+                    }
+                    anyhow::Ok(())
+                };
+
+                if let Err(error) = action.await {
+                    eprintln!("error: {}", error);
+                }
+            }
+            InteractiveCommand::AddNvmeNs {
+                read_only,
+                nsid,
+                ram,
+                file_path,
+                vtl0_lun,
+            } => {
+                if !has_vtl2 {
+                    eprintln!("error: add-nvme-ns requires --vtl2 mode");
+                    continue;
+                }
+                let action = async {
+                    let nvme = nvme_vtl2_rpc.as_ref().context("no vtl2 nvme controller")?;
+                    let disk_type = match (ram, file_path) {
+                        (None, Some(path)) => {
+                            openvmm_helpers::disk::open_disk_type(path.as_ref(), read_only)
+                                .with_context(|| format!("failed to open {}", path.display()))?
+                        }
+                        (Some(size), None) => {
+                            Resource::new(disk_backend_resources::LayeredDiskHandle::single_layer(
+                                RamDiskLayerHandle {
+                                    len: Some(size),
+                                    sector_size: None,
+                                },
+                            ))
+                        }
+                        (None, None) => {
+                            anyhow::bail!("must specify either file path or --ram");
+                        }
+                        (Some(_), Some(_)) => {
+                            anyhow::bail!("cannot specify both file path and --ram");
+                        }
+                    };
+
+                    let ns = NamespaceDefinition {
+                        nsid,
+                        read_only,
+                        disk: disk_type,
+                    };
+
+                    nvme.call_failable(NvmeControllerRequest::AddNamespace, ns)
+                        .await?;
+                    println!("Added namespace {}", nsid);
+
+                    if let Some(lun) = vtl0_lun {
+                        vm_controller
+                            .call(
+                                VmControllerRpc::AddVtl0ScsiDisk,
+                                AddVtl0ScsiDiskParams {
+                                    controller_guid: storage_builder::UNDERHILL_VTL0_SCSI_INSTANCE,
+                                    lun,
+                                    device_type:
+                                        vtl2_settings_proto::physical_device::DeviceType::Nvme
+                                            as i32,
+                                    device_path: storage_builder::NVME_VTL2_INSTANCE_ID,
+                                    sub_device_path: nsid,
+                                },
+                            )
+                            .await
+                            .map_err(anyhow::Error::from)?
+                            .map_err(anyhow::Error::from)?;
+                        println!("Exposed namespace {} to VTL0 as SCSI lun={}", nsid, lun);
+                    }
+
+                    Ok(())
+                };
+
+                if let Err(error) = action.await {
+                    eprintln!("error adding nvme namespace: {}", error);
+                }
+            }
+            InteractiveCommand::RmNvmeNs { nsid, vtl0 } => {
+                if !has_vtl2 {
+                    eprintln!("error: rm-nvme-ns requires --vtl2 mode");
+                    continue;
+                }
+                let action = async {
+                    if vtl0 {
+                        let removed_lun = vm_controller
+                            .call(
+                                VmControllerRpc::RemoveVtl0ScsiDiskByNvmeNsid,
+                                RemoveVtl0ScsiDiskByNvmeNsidParams {
+                                    controller_guid: storage_builder::UNDERHILL_VTL0_SCSI_INSTANCE,
+                                    nvme_controller_guid: storage_builder::NVME_VTL2_INSTANCE_ID,
+                                    nsid,
+                                },
+                            )
+                            .await
+                            .map_err(anyhow::Error::from)?
+                            .map_err(anyhow::Error::from)?;
+                        if let Some(lun) = removed_lun {
+                            println!("Removed VTL0 SCSI lun={}", lun);
+                        } else {
+                            println!("No VTL0 SCSI disk found backed by NVMe nsid={}", nsid);
+                        }
+                    }
+
+                    let nvme = nvme_vtl2_rpc.as_ref().context("no vtl2 nvme controller")?;
+                    nvme.call_failable(NvmeControllerRequest::RemoveNamespace, nsid)
+                        .await?;
+                    println!("Removed NVMe namespace {}", nsid);
+                    anyhow::Ok(())
+                };
+
+                if let Err(error) = action.await {
+                    eprintln!("error removing nvme namespace: {}", error);
+                }
+            }
+            InteractiveCommand::Inspect {
+                recursive,
+                limit,
+                paravisor,
+                element,
+                update,
+            } => {
+                let target = if paravisor {
+                    InspectTarget::Paravisor
+                } else {
+                    InspectTarget::Host
+                };
+
+                let obj = inspect::adhoc_mut(|req| {
+                    vm_controller.send(VmControllerRpc::Inspect(target, req.defer()));
+                });
+
+                if let Some(value) = update {
+                    let Some(element) = element else {
+                        eprintln!("error: must provide element for update");
+                        continue;
+                    };
+
+                    let value = async {
+                        let update = inspect::update(&element, &value, obj);
+                        let value = CancelContext::new()
+                            .with_timeout(Duration::from_secs(1))
+                            .until_cancelled(update)
+                            .await??;
+                        anyhow::Ok(value)
+                    }
+                    .await;
+                    match value {
+                        Ok(node) => match &node.kind {
+                            inspect::ValueKind::String(s) => println!("{s}"),
+                            _ => println!("{:#}", node),
+                        },
+                        Err(err) => println!("error: {:#}", err),
+                    }
+                } else {
+                    let element = element.unwrap_or_default();
+                    let depth = if recursive { limit } else { Some(0) };
+                    let node = async {
+                        let mut inspection =
+                            InspectionBuilder::new(&element).depth(depth).inspect(obj);
+                        let _ = CancelContext::new()
+                            .with_timeout(Duration::from_secs(1))
+                            .until_cancelled(inspection.resolve())
+                            .await;
+                        inspection.results()
+                    }
+                    .await;
+
+                    println!("{:#}", node);
+                }
+            }
+            InteractiveCommand::RestartVnc => {
+                match vm_controller
+                    .call(VmControllerRpc::RestartVnc, ())
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .and_then(|r| Ok(r?))
+                {
+                    Ok(()) => {}
+                    Err(err) => {
+                        eprintln!("error: {err:#}");
+                    }
+                }
+            }
+            InteractiveCommand::Hvsock { term, port } => {
+                let vm_rpc = &vm_rpc;
+                let action = async || {
+                    let service_id = crate::new_hvsock_service_id(port);
+                    let socket = vm_rpc
+                        .call_failable(
+                            VmRpc::ConnectHvsock,
+                            (
+                                CancelContext::new().with_timeout(Duration::from_secs(2)),
+                                service_id,
+                                DeviceVtl::Vtl0,
+                            ),
+                        )
+                        .await?;
+                    let socket = PolledSocket::new(driver, socket)?;
+                    let mut console = console_relay::Console::new(
+                        driver.clone(),
+                        term.or_else(crate::openvmm_terminal_app).as_deref(),
+                        Some(ConsoleLaunchOptions {
+                            window_title: Some(format!("HVSock{} [OpenVMM]", port)),
+                        }),
+                    )?;
+                    driver
+                        .spawn("console-relay", async move { console.relay(socket).await })
+                        .detach();
+                    anyhow::Result::<_>::Ok(())
+                };
+
+                if let Err(error) = (action)().await {
+                    eprintln!("error: {}", error);
+                }
+            }
+            InteractiveCommand::ServiceVtl2 {
+                user_mode_only,
+                igvm,
+                mana_keepalive,
+                nvme_keepalive,
+            } => {
+                let vm_controller = vm_controller.clone();
+                let r = async move {
+                    let millis = vm_controller
+                        .call(
+                            VmControllerRpc::ServiceVtl2,
+                            ServiceVtl2Params {
+                                user_mode_only,
+                                igvm: igvm.map(|p| p.to_string_lossy().into_owned()),
+                                nvme_keepalive,
+                                mana_keepalive,
+                            },
+                        )
+                        .await??;
+                    Ok(Duration::from_millis(millis))
+                }
+                .map(|r| Ok(StateChange::ServiceVtl2(r)));
+                if state_change_task.is_some() {
+                    tracing::error!("state change already in progress");
+                } else {
+                    state_change_task = Some(driver.spawn("state-change", r));
+                }
+            }
+            InteractiveCommand::Quit => {
+                tracing::info!("quitting");
+                // Work around the detached SCSI task holding up worker stop.
+                // TODO: Fix the underlying bug
+                drop(scsi_rpc.take());
+                drop(nvme_vtl2_rpc.take());
+                vm_controller.send(VmControllerRpc::Quit);
+            }
+            InteractiveCommand::ReadMemory { gpa, size, file } => {
+                let size = size as usize;
+                let data = vm_rpc.call(VmRpc::ReadMemory, (gpa, size)).await?;
+
+                match data {
+                    Ok(bytes) => {
+                        if let Some(file) = file {
+                            if let Err(err) = fs_err::write(file, bytes) {
+                                eprintln!("error: {err:?}");
+                            }
+                        } else {
+                            let width = 16;
+                            let show_ascii = true;
+
+                            let mut dump = String::new();
+                            for (i, chunk) in bytes.chunks(width).enumerate() {
+                                let hex_part: Vec<String> =
+                                    chunk.iter().map(|byte| format!("{:02x}", byte)).collect();
+                                let hex_line = hex_part.join(" ");
+
+                                if show_ascii {
+                                    let ascii_part: String = chunk
+                                        .iter()
+                                        .map(|&byte| {
+                                            if byte.is_ascii_graphic() || byte == b' ' {
+                                                byte as char
+                                            } else {
+                                                '.'
+                                            }
+                                        })
+                                        .collect();
+                                    std::fmt::Write::write_fmt(
+                                        &mut dump,
+                                        format_args!(
+                                            "{:04x}: {:<width$}  {}\n",
+                                            i * width,
+                                            hex_line,
+                                            ascii_part,
+                                            width = width * 3 - 1
+                                        ),
+                                    )
+                                    .unwrap();
+                                } else {
+                                    std::fmt::Write::write_fmt(
+                                        &mut dump,
+                                        format_args!("{:04x}: {}\n", i * width, hex_line),
+                                    )
+                                    .unwrap();
+                                }
+                            }
+
+                            println!("{dump}");
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("error: {err:?}");
+                    }
+                }
+            }
+            InteractiveCommand::WriteMemory { gpa, hex, file } => {
+                if hex.is_some() == file.is_some() {
+                    eprintln!("error: either path to the file or the hex string must be specified");
+                    continue;
+                }
+
+                let data = if let Some(file) = file {
+                    let data = fs_err::read(file);
+                    match data {
+                        Ok(data) => data,
+                        Err(err) => {
+                            eprintln!("error: {err:?}");
+                            continue;
+                        }
+                    }
+                } else if let Some(hex) = hex {
+                    if hex.len() & 1 != 0 {
+                        eprintln!(
+                            "error: expected even number of hex digits (2 hex digits per byte)"
+                        );
+                        continue;
+                    }
+                    let data: Result<Vec<u8>, String> = (0..hex.len())
+                        .step_by(2)
+                        .map(|i| {
+                            u8::from_str_radix(&hex[i..i + 2], 16).map_err(|e| {
+                                format!("invalid hex character at position {}: {}", i, e)
+                            })
+                        })
+                        .collect();
+
+                    match data {
+                        Ok(data) => data,
+                        Err(err) => {
+                            eprintln!("error: {err}");
+                            continue;
+                        }
+                    }
+                } else {
+                    unreachable!();
+                };
+
+                if data.is_empty() {
+                    eprintln!("error: no data to write");
+                    continue;
+                }
+
+                if let Err(err) = vm_rpc.call(VmRpc::WriteMemory, (gpa, data)).await? {
+                    eprintln!("error: {err:?}");
+                }
+            }
+            InteractiveCommand::Kvp(command) => {
+                let Some(kvp) = &kvp_ic else {
+                    eprintln!("error: no kvp ic configured");
+                    continue;
+                };
+                if let Err(err) = kvp::handle_kvp(kvp, command).await {
+                    eprintln!("error: {err:#}");
+                }
+            }
+            InteractiveCommand::Input { .. } | InteractiveCommand::InputMode => unreachable!(),
+        }
+    }
+
+    Ok(())
+}
+
+// -- Rustyline helpers --
+
+use rustyline::Helper;
+use rustyline::Highlighter;
+use rustyline::Hinter;
+use rustyline::Validator;
+
+#[derive(Helper, Highlighter, Hinter, Validator)]
+struct OpenvmmRustylineEditor {
+    openvmm_inspect_req:
+        Arc<mesh::Sender<(InspectTarget, String, mesh::OneshotSender<inspect::Node>)>>,
+}
+
+impl rustyline::completion::Completer for OpenvmmRustylineEditor {
+    type Candidate = String;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &rustyline::Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        let Ok(cmd) = shell_words::split(line) else {
+            return Ok((0, Vec::with_capacity(0)));
+        };
+
+        let completions = block_on(
+            clap_dyn_complete::Complete {
+                cmd,
+                raw: Some(line.into()),
+                position: Some(pos),
+            }
+            .generate_completions::<InteractiveCommand>(None, self),
+        );
+
+        let pos_from_end = {
+            let line = line.chars().take(pos).collect::<String>();
+
+            let trailing_ws = line.len() - line.trim_end().len();
+
+            if trailing_ws > 0 {
+                line.len() - trailing_ws + 1
+            } else {
+                let last_word = shell_words::split(&line)
+                    .unwrap_or_default()
+                    .last()
+                    .cloned()
+                    .unwrap_or_default();
+
+                line.len() - last_word.len()
+            }
+        };
+
+        Ok((pos_from_end, completions))
+    }
+}
+
+impl clap_dyn_complete::CustomCompleterFactory for &OpenvmmRustylineEditor {
+    type CustomCompleter = OpenvmmComplete;
+    async fn build(&self, _ctx: &clap_dyn_complete::RootCtx<'_>) -> Self::CustomCompleter {
+        OpenvmmComplete {
+            openvmm_inspect_req: self.openvmm_inspect_req.clone(),
+        }
+    }
+}
+
+struct OpenvmmComplete {
+    openvmm_inspect_req:
+        Arc<mesh::Sender<(InspectTarget, String, mesh::OneshotSender<inspect::Node>)>>,
+}
+
+impl clap_dyn_complete::CustomCompleter for OpenvmmComplete {
+    async fn complete(
+        &self,
+        ctx: &clap_dyn_complete::RootCtx<'_>,
+        subcommand_path: &[&str],
+        arg_id: &str,
+    ) -> Vec<String> {
+        match (subcommand_path, arg_id) {
+            (["openvmm", "inspect"], "element") => {
+                let on_error = vec!["failed/to/connect".into()];
+
+                let (parent_path, to_complete) = (ctx.to_complete)
+                    .rsplit_once('/')
+                    .unwrap_or(("", ctx.to_complete));
+
+                let node = {
+                    let paravisor = {
+                        let raw_arg = ctx
+                            .matches
+                            .subcommand()
+                            .unwrap()
+                            .1
+                            .get_one::<String>("paravisor")
+                            .map(|x| x.as_str())
+                            .unwrap_or_default();
+                        raw_arg == "true"
+                    };
+
+                    let (tx, rx) = mesh::oneshot();
+                    self.openvmm_inspect_req.send((
+                        if paravisor {
+                            InspectTarget::Paravisor
+                        } else {
+                            InspectTarget::Host
+                        },
+                        parent_path.to_owned(),
+                        tx,
+                    ));
+                    let Ok(node) = rx.await else {
+                        return on_error;
+                    };
+
+                    node
+                };
+
+                let mut completions = Vec::new();
+
+                if let inspect::Node::Dir(dir) = node {
+                    for entry in dir {
+                        if entry.name.starts_with(to_complete) {
+                            if parent_path.is_empty() {
+                                completions.push(format!("{}/", entry.name))
+                            } else {
+                                completions.push(format!(
+                                    "{}/{}{}",
+                                    parent_path,
+                                    entry.name,
+                                    if matches!(entry.node, inspect::Node::Dir(..)) {
+                                        "/"
+                                    } else {
+                                        ""
+                                    }
+                                ))
+                            }
+                        }
+                    }
+                } else {
+                    return on_error;
+                }
+
+                completions
+            }
+            _ => Vec::new(),
+        }
+    }
+}

--- a/openvmm/openvmm_entry/src/vm_controller.rs
+++ b/openvmm/openvmm_entry/src/vm_controller.rs
@@ -1,0 +1,563 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! VM controller task that owns exclusive resources (worker handles,
+//! DiagInspector, vtl2_settings) and exposes them to the REPL via mesh RPC.
+
+use crate::DiagInspector;
+use crate::meshworker::VmmMesh;
+use anyhow::Context;
+use futures::FutureExt;
+use futures::StreamExt;
+use futures_concurrency::stream::Merge;
+use get_resources::ged::GuestServicingFlags;
+use guid::Guid;
+use inspect::InspectMut;
+use mesh::rpc::Rpc;
+use mesh::rpc::RpcSend;
+use mesh_worker::WorkerEvent;
+use mesh_worker::WorkerHandle;
+use openvmm_defs::rpc::VmRpc;
+use std::path::Path;
+use std::path::PathBuf;
+use std::pin::pin;
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Inspection target: host-side workers or the paravisor.
+#[derive(Clone, Copy, mesh::MeshPayload)]
+pub enum InspectTarget {
+    Host,
+    Paravisor,
+}
+
+/// RPC enum for operations requiring exclusive resources.
+///
+/// All variants derive `MeshPayload` so the boundary is cross-process
+/// remotable in the future.
+#[derive(mesh::MeshPayload)]
+pub enum VmControllerRpc {
+    /// Restart the VM worker.
+    Restart(Rpc<(), Result<(), mesh::error::RemoteError>>),
+    /// Restart the VNC worker.
+    RestartVnc(Rpc<(), Result<(), mesh::error::RemoteError>>),
+    /// Deferred inspection (commands and tab-completion).
+    Inspect(InspectTarget, inspect::Deferred),
+    /// Query current VTL2 settings (returned as protobuf-encoded bytes).
+    GetVtl2Settings(Rpc<(), Option<Vec<u8>>>),
+    /// Add a VTL0 SCSI disk backed by a VTL2 storage device.
+    AddVtl0ScsiDisk(Rpc<AddVtl0ScsiDiskParams, Result<(), mesh::error::RemoteError>>),
+    /// Remove a VTL0 SCSI disk.
+    RemoveVtl0ScsiDisk(Rpc<RemoveVtl0ScsiDiskParams, Result<(), mesh::error::RemoteError>>),
+    /// Remove a VTL0 SCSI disk by NVMe namespace ID.
+    RemoveVtl0ScsiDiskByNvmeNsid(
+        Rpc<RemoveVtl0ScsiDiskByNvmeNsidParams, Result<Option<u32>, mesh::error::RemoteError>>,
+    ),
+    /// Save a VM snapshot to a directory.
+    SaveSnapshot(Rpc<String, Result<(), mesh::error::RemoteError>>),
+    /// Service (update) the VTL2 firmware.
+    ServiceVtl2(Rpc<ServiceVtl2Params, Result<u64, mesh::error::RemoteError>>),
+    /// Stop the VM and quit.
+    Quit,
+}
+
+#[derive(mesh::MeshPayload)]
+pub struct AddVtl0ScsiDiskParams {
+    pub controller_guid: Guid,
+    pub lun: u32,
+    pub device_type: i32,
+    pub device_path: Guid,
+    pub sub_device_path: u32,
+}
+
+#[derive(mesh::MeshPayload)]
+pub struct RemoveVtl0ScsiDiskParams {
+    pub controller_guid: Guid,
+    pub lun: u32,
+}
+
+#[derive(mesh::MeshPayload)]
+pub struct RemoveVtl0ScsiDiskByNvmeNsidParams {
+    pub controller_guid: Guid,
+    pub nvme_controller_guid: Guid,
+    pub nsid: u32,
+}
+
+#[derive(mesh::MeshPayload)]
+pub struct ServiceVtl2Params {
+    pub user_mode_only: bool,
+    pub igvm: Option<String>,
+    pub nvme_keepalive: bool,
+    pub mana_keepalive: bool,
+}
+
+/// Events sent from the VmController to the REPL.
+#[derive(mesh::MeshPayload)]
+pub enum VmControllerEvent {
+    /// The VM worker stopped (normally or with error).
+    WorkerStopped { error: Option<String> },
+    /// The VNC worker stopped or failed.
+    VncWorkerStopped { error: Option<String> },
+    /// The guest halted.
+    GuestHalt(String),
+}
+
+/// Owns exclusive VM resources and services RPCs from the REPL.
+pub struct VmController {
+    pub(crate) mesh: VmmMesh,
+    pub(crate) vm_worker: WorkerHandle,
+    pub(crate) vnc_worker: Option<WorkerHandle>,
+    pub(crate) gdb_worker: Option<WorkerHandle>,
+    pub(crate) diag_inspector: DiagInspector,
+    pub(crate) vtl2_settings: Option<vtl2_settings_proto::Vtl2Settings>,
+    pub(crate) ged_rpc: Option<mesh::Sender<get_resources::ged::GuestEmulationRequest>>,
+    pub(crate) vm_rpc: mesh::Sender<VmRpc>,
+    pub(crate) paravisor_diag: Arc<diag_client::DiagClient>,
+    pub(crate) igvm_path: Option<PathBuf>,
+    pub(crate) memory_backing_file: Option<PathBuf>,
+    pub(crate) memory: u64,
+    pub(crate) processors: u32,
+    pub(crate) log_file: Option<PathBuf>,
+}
+
+impl VmController {
+    /// Run the controller, processing RPCs and worker events until the VM
+    /// stops or the REPL sends Quit.
+    pub async fn run(
+        mut self,
+        mut rpc_recv: mesh::Receiver<VmControllerRpc>,
+        event_send: mesh::Sender<VmControllerEvent>,
+        mut notify_recv: mesh::Receiver<vmm_core_defs::HaltReason>,
+    ) {
+        enum Event {
+            Rpc(VmControllerRpc),
+            RpcClosed,
+            Worker(WorkerEvent),
+            VncWorker(WorkerEvent),
+            Halt(vmm_core_defs::HaltReason),
+        }
+
+        let mut quit = false;
+        loop {
+            let event = {
+                let rpc = pin!(async {
+                    match rpc_recv.next().await {
+                        Some(msg) => Event::Rpc(msg),
+                        None => Event::RpcClosed,
+                    }
+                });
+                let vm = (&mut self.vm_worker).map(Event::Worker);
+                let vnc = futures::stream::iter(self.vnc_worker.as_mut())
+                    .flatten()
+                    .map(Event::VncWorker);
+                let halt = (&mut notify_recv).map(Event::Halt);
+
+                (rpc.into_stream(), vm, vnc, halt)
+                    .merge()
+                    .next()
+                    .await
+                    .unwrap()
+            };
+
+            match event {
+                Event::Rpc(rpc) => {
+                    self.handle_rpc(rpc, &mut quit).await;
+                }
+                Event::RpcClosed => {
+                    // REPL disconnected. Stop the VM.
+                    tracing::info!("REPL disconnected, stopping VM");
+                    self.vm_worker.stop();
+                    quit = true;
+                }
+                Event::Worker(event) => match event {
+                    WorkerEvent::Stopped => {
+                        if quit {
+                            tracing::info!("vm stopped");
+                        } else {
+                            tracing::error!("vm worker unexpectedly stopped");
+                        }
+                        event_send.send(VmControllerEvent::WorkerStopped { error: None });
+                        break;
+                    }
+                    WorkerEvent::Failed(err) => {
+                        tracing::error!(error = &err as &dyn std::error::Error, "vm worker failed");
+                        event_send.send(VmControllerEvent::WorkerStopped {
+                            error: Some(format!("{err:#}")),
+                        });
+                        break;
+                    }
+                    WorkerEvent::RestartFailed(err) => {
+                        tracing::error!(
+                            error = &err as &dyn std::error::Error,
+                            "vm worker restart failed"
+                        );
+                    }
+                    WorkerEvent::Started => {
+                        tracing::info!("vm worker restarted");
+                    }
+                },
+                Event::VncWorker(event) => match event {
+                    WorkerEvent::Stopped => {
+                        tracing::error!("vnc unexpectedly stopped");
+                        event_send.send(VmControllerEvent::VncWorkerStopped { error: None });
+                    }
+                    WorkerEvent::Failed(err) => {
+                        tracing::error!(
+                            error = &err as &dyn std::error::Error,
+                            "vnc worker failed"
+                        );
+                        event_send.send(VmControllerEvent::VncWorkerStopped {
+                            error: Some(format!("{err:#}")),
+                        });
+                    }
+                    WorkerEvent::RestartFailed(err) => {
+                        tracing::error!(
+                            error = &err as &dyn std::error::Error,
+                            "vnc worker restart failed"
+                        );
+                    }
+                    WorkerEvent::Started => {
+                        tracing::info!("vnc worker restarted");
+                    }
+                },
+                Event::Halt(reason) => {
+                    tracing::info!(?reason, "guest halted");
+                    event_send.send(VmControllerEvent::GuestHalt(format!("{reason:?}")));
+                }
+            }
+        }
+
+        // Ensure all workers are cleaned up before shutting down the mesh.
+        self.vm_worker.stop();
+        if let Err(err) = self.vm_worker.join().await {
+            tracing::error!(
+                error = err.as_ref() as &dyn std::error::Error,
+                "vm worker join failed"
+            );
+        }
+
+        if let Some(mut vnc) = self.vnc_worker.take() {
+            vnc.stop();
+            if let Err(err) = vnc.join().await {
+                tracing::error!(
+                    error = err.as_ref() as &dyn std::error::Error,
+                    "vnc worker join failed"
+                );
+            }
+        }
+
+        if let Some(mut gdb) = self.gdb_worker.take() {
+            gdb.stop();
+            if let Err(err) = gdb.join().await {
+                tracing::error!(
+                    error = err.as_ref() as &dyn std::error::Error,
+                    "gdb worker join failed"
+                );
+            }
+        }
+
+        self.mesh.shutdown().await;
+    }
+
+    async fn handle_rpc(&mut self, rpc: VmControllerRpc, quit: &mut bool) {
+        match rpc {
+            VmControllerRpc::Restart(req) => {
+                let result = self.handle_restart().await;
+                req.complete(result.map_err(mesh::error::RemoteError::new));
+            }
+            VmControllerRpc::RestartVnc(req) => {
+                let result = self.handle_restart_vnc().await;
+                req.complete(result.map_err(mesh::error::RemoteError::new));
+            }
+            VmControllerRpc::Inspect(target, deferred) => {
+                self.handle_inspect(target, deferred);
+            }
+            VmControllerRpc::GetVtl2Settings(req) => {
+                let bytes = self
+                    .vtl2_settings
+                    .as_ref()
+                    .map(prost::Message::encode_to_vec);
+                req.complete(bytes);
+            }
+            VmControllerRpc::AddVtl0ScsiDisk(req) => {
+                let (params, req) = req.split();
+                let result = self.handle_add_vtl0_scsi_disk(params).await;
+                req.complete(result.map_err(mesh::error::RemoteError::new));
+            }
+            VmControllerRpc::RemoveVtl0ScsiDisk(req) => {
+                let (params, req) = req.split();
+                let result = self.handle_remove_vtl0_scsi_disk(params).await;
+                req.complete(result.map_err(mesh::error::RemoteError::new));
+            }
+            VmControllerRpc::RemoveVtl0ScsiDiskByNvmeNsid(req) => {
+                let (params, req) = req.split();
+                let result = self.handle_remove_vtl0_scsi_disk_by_nvme_nsid(params).await;
+                req.complete(result.map_err(mesh::error::RemoteError::new));
+            }
+            VmControllerRpc::SaveSnapshot(req) => {
+                let (dir, req) = req.split();
+                let result = self.handle_save_snapshot(Path::new(&dir)).await;
+                req.complete(result.map_err(mesh::error::RemoteError::new));
+            }
+            VmControllerRpc::ServiceVtl2(req) => {
+                let (params, req) = req.split();
+                let result = self.handle_service_vtl2(params).await;
+                req.complete(result.map_err(mesh::error::RemoteError::new));
+            }
+            VmControllerRpc::Quit => {
+                tracing::info!("quitting");
+                self.vm_worker.stop();
+                *quit = true;
+            }
+        }
+    }
+
+    async fn handle_restart(&mut self) -> anyhow::Result<()> {
+        let vm_host = self
+            .mesh
+            .make_host("vm", self.log_file.clone())
+            .await
+            .context("spawning vm process failed")?;
+        self.vm_worker.restart(&vm_host);
+        Ok(())
+    }
+
+    async fn handle_restart_vnc(&mut self) -> anyhow::Result<()> {
+        if let Some(vnc) = &mut self.vnc_worker {
+            let vnc_host = self
+                .mesh
+                .make_host("vnc", None)
+                .await
+                .context("spawning vnc process failed")?;
+            vnc.restart(&vnc_host);
+            Ok(())
+        } else {
+            anyhow::bail!("no VNC server running")
+        }
+    }
+
+    fn handle_inspect(&mut self, target: InspectTarget, deferred: inspect::Deferred) {
+        let obj = inspect::adhoc_mut(|req| match target {
+            InspectTarget::Host => {
+                let mut resp = req.respond();
+                resp.field("mesh", &self.mesh)
+                    .field("vm", &self.vm_worker)
+                    .field("vnc", self.vnc_worker.as_ref())
+                    .field("gdb", self.gdb_worker.as_ref());
+            }
+            InspectTarget::Paravisor => {
+                self.diag_inspector.inspect_mut(req);
+            }
+        });
+        deferred.inspect(obj);
+    }
+
+    async fn handle_save_snapshot(&self, dir: &Path) -> anyhow::Result<()> {
+        let memory_file_path = self
+            .memory_backing_file
+            .as_ref()
+            .context("save-snapshot requires --memory-backing-file")?;
+
+        // Pause the VM.
+        self.vm_rpc
+            .call(VmRpc::Pause, ())
+            .await
+            .context("failed to pause VM")?;
+
+        // Get device state via existing VmRpc::Save.
+        let saved_state_msg = self
+            .vm_rpc
+            .call_failable(VmRpc::Save, ())
+            .await
+            .context("failed to save state")?;
+
+        // Serialize the ProtobufMessage to bytes for writing to disk.
+        let saved_state_bytes = mesh::payload::encode(saved_state_msg);
+
+        // Fsync the memory backing file.
+        let memory_file = fs_err::File::open(memory_file_path)?;
+        memory_file
+            .sync_all()
+            .context("failed to fsync memory backing file")?;
+
+        // Build manifest.
+        let manifest = openvmm_helpers::snapshot::SnapshotManifest {
+            version: openvmm_helpers::snapshot::MANIFEST_VERSION,
+            created_at: std::time::SystemTime::now().into(),
+            openvmm_version: env!("CARGO_PKG_VERSION").to_string(),
+            memory_size_bytes: self.memory,
+            vp_count: self.processors,
+            page_size: crate::system_page_size(),
+            architecture: crate::GUEST_ARCH.to_string(),
+        };
+
+        // Write snapshot directory.
+        openvmm_helpers::snapshot::write_snapshot(
+            dir,
+            &manifest,
+            &saved_state_bytes,
+            memory_file_path,
+        )?;
+
+        // VM stays paused. Do NOT resume.
+        Ok(())
+    }
+
+    async fn handle_service_vtl2(&self, params: ServiceVtl2Params) -> anyhow::Result<u64> {
+        let start;
+        if params.user_mode_only {
+            start = Instant::now();
+            self.paravisor_diag.restart().await?;
+        } else {
+            let igvm = params
+                .igvm
+                .map(PathBuf::from)
+                .or_else(|| self.igvm_path.clone())
+                .context("no igvm file loaded")?;
+            let file = fs_err::File::open(igvm)?;
+            start = Instant::now();
+            let ged_rpc = self.ged_rpc.as_ref().context("no GED")?;
+            openvmm_helpers::underhill::save_underhill(
+                &self.vm_rpc,
+                ged_rpc,
+                GuestServicingFlags {
+                    nvme_keepalive: params.nvme_keepalive,
+                    mana_keepalive: params.mana_keepalive,
+                },
+                file.into(),
+            )
+            .await?;
+            openvmm_helpers::underhill::restore_underhill(&self.vm_rpc, ged_rpc).await?;
+        }
+        let elapsed = Instant::now() - start;
+        Ok(elapsed.as_millis() as u64)
+    }
+
+    async fn modify_vtl2_settings(
+        &mut self,
+        f: impl FnOnce(&mut vtl2_settings_proto::Vtl2Settings),
+    ) -> anyhow::Result<()> {
+        let mut settings_copy = self
+            .vtl2_settings
+            .clone()
+            .context("vtl2 settings not configured")?;
+
+        f(&mut settings_copy);
+
+        let ged_rpc = self.ged_rpc.as_ref().context("no GED configured")?;
+
+        ged_rpc
+            .call_failable(
+                get_resources::ged::GuestEmulationRequest::ModifyVtl2Settings,
+                prost::Message::encode_to_vec(&settings_copy),
+            )
+            .await?;
+
+        self.vtl2_settings = Some(settings_copy);
+        Ok(())
+    }
+
+    async fn handle_add_vtl0_scsi_disk(
+        &mut self,
+        params: AddVtl0ScsiDiskParams,
+    ) -> anyhow::Result<()> {
+        let mut not_found = false;
+        self.modify_vtl2_settings(|settings| {
+            let dynamic = settings.dynamic.get_or_insert_with(Default::default);
+
+            let scsi_controller = dynamic.storage_controllers.iter_mut().find(|c| {
+                c.instance_id == params.controller_guid.to_string()
+                    && c.protocol
+                        == vtl2_settings_proto::storage_controller::StorageProtocol::Scsi as i32
+            });
+
+            let Some(scsi_controller) = scsi_controller else {
+                not_found = true;
+                return;
+            };
+
+            scsi_controller.luns.push(vtl2_settings_proto::Lun {
+                location: params.lun,
+                device_id: Guid::new_random().to_string(),
+                vendor_id: "OpenVMM".to_string(),
+                product_id: "Disk".to_string(),
+                product_revision_level: "1.0".to_string(),
+                serial_number: "0".to_string(),
+                model_number: "1".to_string(),
+                physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
+                    r#type: vtl2_settings_proto::physical_devices::BackingType::Single.into(),
+                    device: Some(vtl2_settings_proto::PhysicalDevice {
+                        device_type: params.device_type,
+                        device_path: params.device_path.to_string(),
+                        sub_device_path: params.sub_device_path,
+                    }),
+                    devices: Vec::new(),
+                }),
+                is_dvd: false,
+                ..Default::default()
+            });
+        })
+        .await?;
+
+        if not_found {
+            anyhow::bail!("SCSI controller {} not found", params.controller_guid);
+        }
+        Ok(())
+    }
+
+    async fn handle_remove_vtl0_scsi_disk(
+        &mut self,
+        params: RemoveVtl0ScsiDiskParams,
+    ) -> anyhow::Result<()> {
+        self.modify_vtl2_settings(|settings| {
+            let dynamic = settings.dynamic.as_mut();
+            if let Some(dynamic) = dynamic {
+                if let Some(scsi_controller) = dynamic.storage_controllers.iter_mut().find(|c| {
+                    c.instance_id == params.controller_guid.to_string()
+                        && c.protocol
+                            == vtl2_settings_proto::storage_controller::StorageProtocol::Scsi as i32
+                }) {
+                    scsi_controller.luns.retain(|l| l.location != params.lun);
+                }
+            }
+        })
+        .await
+    }
+
+    async fn handle_remove_vtl0_scsi_disk_by_nvme_nsid(
+        &mut self,
+        params: RemoveVtl0ScsiDiskByNvmeNsidParams,
+    ) -> anyhow::Result<Option<u32>> {
+        let mut removed_lun = None;
+        self.modify_vtl2_settings(|settings| {
+            let dynamic = settings.dynamic.as_mut();
+            if let Some(dynamic) = dynamic {
+                if let Some(scsi_controller) = dynamic.storage_controllers.iter_mut().find(|c| {
+                    c.instance_id == params.controller_guid.to_string()
+                        && c.protocol
+                            == vtl2_settings_proto::storage_controller::StorageProtocol::Scsi as i32
+                }) {
+                    let nvme_controller_str = params.nvme_controller_guid.to_string();
+                    scsi_controller.luns.retain(|l| {
+                        let dominated_by_nsid = l.physical_devices.as_ref().is_some_and(|pd| {
+                            pd.device.as_ref().is_some_and(|d| {
+                                d.device_type
+                                    == vtl2_settings_proto::physical_device::DeviceType::Nvme as i32
+                                    && d.device_path == nvme_controller_str
+                                    && d.sub_device_path == params.nsid
+                            })
+                        });
+                        if dominated_by_nsid {
+                            removed_lun = Some(l.location);
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                }
+            }
+        })
+        .await?;
+        Ok(removed_lun)
+    }
+}


### PR DESCRIPTION
Separate the interactive REPL from the VM lifecycle management by introducing a VmController task and moving the REPL to its own module.

Previously, run_control() interleaved two concerns: owning exclusive VM resources (worker handles, DiagInspector, vtl2_settings, snapshot config) and running the interactive command loop. This made it impossible to reuse either piece independently—e.g., attaching a REPL to an already- running VM started via ttrpc, or replacing the REPL with a different control interface.

The VmController task owns all exclusive resources and exposes them through a mesh RPC channel (VmControllerRpc). The REPL holds cloneable Sender handles for direct VM interaction (pause/resume/reset, SCSI hot-plug, etc.) and routes operations needing exclusive access through the controller. All RPC types derive MeshPayload, so this boundary can later become cross-process without further changes.

The VmController runs as a spawned task (not a stack future), enabled by moving VmmMesh ownership into it. This also makes mesh shutdown the controller's responsibility, which is a better fit since it knows when all workers have been cleaned up.

This is a stepping stone toward unifying the CLI and ttrpc entry paths behind a shared VM control interface, and toward supporting dynamic REPL attach/detach on running VMs.