### PR TITLE
Repo: Enable linting against allow attributes, with exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -672,6 +672,7 @@ unsafe_op_in_unsafe_fn = "forbid"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)'] }
 
 [workspace.lints.clippy]
+allow_attributes = "warn"
 dbg_macro = "warn"
 debug_assert_with_mut_call = "warn"
 filter_map_next = "warn"

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -1856,25 +1856,23 @@ pub mod steps {
             ado_var: Cow<'static, str>,
         }
 
-        #[allow(non_upper_case_globals)]
         impl AdoRuntimeVar {
             /// `build.SourceBranch`
             ///
             /// NOTE: Includes the full branch ref (ex: `refs/heads/main`) so
             /// unlike `build.SourceBranchName`, a branch like `user/foo/bar`
             /// won't be stripped to just `bar`
-            pub const BUILD__SOURCE_BRANCH: AdoRuntimeVar =
-                AdoRuntimeVar::new("build.SourceBranch");
+            pub const BUILD_SOURCE_BRANCH: AdoRuntimeVar = AdoRuntimeVar::new("build.SourceBranch");
 
             /// `build.BuildNumber`
-            pub const BUILD__BUILD_NUMBER: AdoRuntimeVar = AdoRuntimeVar::new("build.BuildNumber");
+            pub const BUILD_BUILD_NUMBER: AdoRuntimeVar = AdoRuntimeVar::new("build.BuildNumber");
 
             /// `System.AccessToken`
-            pub const SYSTEM__ACCESS_TOKEN: AdoRuntimeVar =
+            pub const SYSTEM_ACCESS_TOKEN: AdoRuntimeVar =
                 AdoRuntimeVar::new_secret("System.AccessToken");
 
             /// `System.System.JobAttempt`
-            pub const SYSTEM__JOB_ATTEMPT: AdoRuntimeVar =
+            pub const SYSTEM_JOB_ATTEMPT: AdoRuntimeVar =
                 AdoRuntimeVar::new_secret("System.JobAttempt");
         }
 

--- a/flowey/flowey_lib_common/src/publish_test_results.rs
+++ b/flowey/flowey_lib_common/src/publish_test_results.rs
@@ -180,7 +180,7 @@ impl FlowNode for Node {
                                             - publish: $({path_var})
                                               artifact: {artifact_name}-$({})
                                             "#,
-                                            AdoRuntimeVar::SYSTEM__JOB_ATTEMPT.as_raw_var_name()
+                                            AdoRuntimeVar::SYSTEM_JOB_ATTEMPT.as_raw_var_name()
                                         )
                                     }
                                 },

--- a/openhcl/azure_profiler_proto/src/lib.rs
+++ b/openhcl/azure_profiler_proto/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
+#![expect(clippy::allow_attributes)]
 
 // Crates used by generated code. Reference them explicitly to ensure that
 // automated tools do not remove them.

--- a/openhcl/diag_proto/src/lib.rs
+++ b/openhcl/diag_proto/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
+#![expect(clippy::allow_attributes)]
 
 // Crates used by generated code. Reference them explicitly to ensure that
 // automated tools do not remove them.

--- a/openhcl/underhill_core/src/vp.rs
+++ b/openhcl/underhill_core/src/vp.rs
@@ -135,7 +135,6 @@ impl VpSpawner {
         saved_state: Option<vmcore::save_restore::SavedStateBlob>,
         control: Option<&mut IdleControl>,
     ) -> Option<vmcore::save_restore::SavedStateBlob> {
-        #[allow(unreachable_patterns)]
         let r = match self.isolation {
             virt::IsolationType::None | virt::IsolationType::Vbs => {
                 self.run_backed_vp::<virt_mshv_vtl::HypervisorBacked>(saved_state, control)
@@ -151,6 +150,8 @@ impl VpSpawner {
                 self.run_backed_vp::<virt_mshv_vtl::TdxBacked>(saved_state, control)
                     .await
             }
+            #[expect(clippy::allow_attributes)]
+            #[allow(unreachable_patterns)]
             _ => unimplemented!(),
         };
         match r {

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2464,6 +2464,8 @@ impl LoadedVmInner {
                 };
                 super::vm_loaders::igvm::load_igvm(params)?
             }
+
+            #[expect(clippy::allow_attributes)]
             #[allow(unreachable_patterns)]
             _ => anyhow::bail!("load mode not supported on this platform"),
         };
@@ -3006,7 +3008,7 @@ impl LoadedVm {
             automatic_guest_reset: self.inner.automatic_guest_reset,
             efi_diagnostics_log_level: Default::default(),
         };
-        #[allow(unreachable_code, reason = "TODO")]
+        #[expect(unreachable_code, reason = "TODO")]
         RestartState {
             manifest,
             running: self.running,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -113,6 +113,7 @@ impl Worker for TtrpcWorker {
                 RpcTransport::Ttrpc => ResolvedTransport::Ttrpc,
                 #[cfg(feature = "grpc")]
                 RpcTransport::Grpc => ResolvedTransport::Grpc,
+                #[expect(clippy::allow_attributes)]
                 #[allow(unreachable_patterns)]
                 transport => bail!("unsupported transport {transport}"),
             },

--- a/openvmm/openvmm_ttrpc_vmservice/src/lib.rs
+++ b/openvmm/openvmm_ttrpc_vmservice/src/lib.rs
@@ -6,6 +6,7 @@
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
 #![expect(clippy::enum_variant_names, clippy::large_enum_variant)]
+#![expect(clippy::allow_attributes)]
 
 // Crates used by generated code. Reference them explicitly to ensure that
 // automated tools do not remove them.

--- a/support/inspect_proto/src/lib.rs
+++ b/support/inspect_proto/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
+#![expect(clippy::allow_attributes)]
 
 // Crates used by generated code. Reference them explicitly to ensure that
 // automated tools do not remove them.

--- a/support/mesh/mesh_protobuf/src/prost.rs
+++ b/support/mesh/mesh_protobuf/src/prost.rs
@@ -47,6 +47,7 @@ mod tests {
     use crate::SerializedMessage;
     use alloc::string::ToString;
 
+    #[expect(clippy::allow_attributes)]
     mod items {
         // Crates used by generated code. Reference them explicitly to ensure that
         // automated tools do not remove them.

--- a/support/mesh/mesh_remote/src/unix_common.rs
+++ b/support/mesh/mesh_remote/src/unix_common.rs
@@ -29,13 +29,11 @@ const MAX_FDS_PER_MSG: usize = 64;
 
 /// Sends a packet, including the specified file descriptors. May fail with
 /// ErrorKind::WouldBlock.
-#[cfg_attr(
-    target_env = "gnu",
-    expect(
-        clippy::needless_update,
-        clippy::useless_conversion,
-        reason = "libc::cmsghdr has different type defs on gnu vs musl"
-    )
+#[expect(clippy::allow_attributes)]
+#[allow(
+    clippy::needless_update,
+    clippy::useless_conversion,
+    reason = "libc::cmsghdr has different type defs on gnu vs musl"
 )]
 pub(crate) fn try_send(
     fd: BorrowedFd<'_>,

--- a/support/mesh/mesh_remote/src/unix_common.rs
+++ b/support/mesh/mesh_remote/src/unix_common.rs
@@ -29,10 +29,13 @@ const MAX_FDS_PER_MSG: usize = 64;
 
 /// Sends a packet, including the specified file descriptors. May fail with
 /// ErrorKind::WouldBlock.
-#[allow(
-    clippy::needless_update,
-    clippy::useless_conversion,
-    reason = "libc::cmsghdr has different type defs on different platforms"
+#[cfg_attr(
+    target_env = "gnu",
+    expect(
+        clippy::needless_update,
+        clippy::useless_conversion,
+        reason = "libc::cmsghdr has different type defs on gnu vs musl"
+    )
 )]
 pub(crate) fn try_send(
     fd: BorrowedFd<'_>,
@@ -132,7 +135,6 @@ pub(crate) fn try_recv(
         // SAFETY: cmsg_ptr is valid per CMSG_FIRSTHDR/CMSG_NXTHDR contract.
         let cmsg = unsafe { &*cmsg_ptr };
         if cmsg.cmsg_level == libc::SOL_SOCKET && cmsg.cmsg_type == libc::SCM_RIGHTS {
-            #[allow(clippy::unnecessary_cast)] // cmsg_len is u32 on musl and usize on gnu.
             let data_len = cmsg.cmsg_len as usize - size_of::<libc::cmsghdr>();
             let fd_count = data_len / size_of::<RawFd>();
             // SAFETY: CMSG_DATA returns a pointer to the cmsg payload, which

--- a/support/mesh/mesh_rpc/examples/rust-server.rs
+++ b/support/mesh/mesh_rpc/examples/rust-server.rs
@@ -9,6 +9,7 @@ use futures::executor::block_on;
 use pal_async::local::block_with_io;
 use unix_socket::UnixListener;
 
+#[expect(clippy::allow_attributes)]
 mod items {
     // Generated types use these crates, reference them here to ensure they are
     // not removed by automated tooling.

--- a/support/mesh/mesh_rpc/fuzz/fuzz_mesh_ttrpc_server.rs
+++ b/support/mesh/mesh_rpc/fuzz/fuzz_mesh_ttrpc_server.rs
@@ -15,7 +15,12 @@ use unix_socket::UnixStream;
 use xtask_fuzz::fuzz_eprintln;
 use xtask_fuzz::fuzz_target;
 
-include!(concat!(env!("OUT_DIR"), "/proto.rs"));
+#[expect(clippy::allow_attributes)]
+mod proto {
+    include!(concat!(env!("OUT_DIR"), "/proto.rs"));
+}
+
+use proto::*;
 
 fn do_fuzz(input: &[u8]) {
     fuzz_eprintln!("{input:X?}");

--- a/support/mesh/mesh_rpc/src/server.rs
+++ b/support/mesh/mesh_rpc/src/server.rs
@@ -623,6 +623,7 @@ mod tests {
     use pal_async::socket::PolledSocket;
     use test_with_tracing::test;
 
+    #[expect(clippy::allow_attributes)]
     mod items {
         include!(concat!(env!("OUT_DIR"), "/ttrpc.example.v1.rs"));
     }

--- a/support/mesh/mesh_rpc/src/service.rs
+++ b/support/mesh/mesh_rpc/src/service.rs
@@ -18,6 +18,7 @@ use mesh::payload::protobuf::MessageSizer;
 use mesh::payload::protobuf::MessageWriter;
 use mesh::resource::Resource;
 
+#[expect(clippy::allow_attributes)]
 mod grpc {
     // Generated types use these crates, reference them here to ensure they are
     // not removed by automated tooling.

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -151,6 +151,7 @@ fn choose_hypervisor() -> anyhow::Result<HypervisorOpt> {
         return Ok(HypervisorOpt::Hvf);
     }
 
+    #[expect(clippy::allow_attributes)]
     #[allow(unreachable_code, reason = "unreachable on some targets")]
     {
         anyhow::bail!("no hypervisor available");

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
@@ -19,7 +19,8 @@ use uefi_specs::uefi::common::EfiStatus;
 pub trait NvramServicesExt {
     /// Get a variable identified by `name` (as a Rust string) + `vendor`,
     /// returning the variable's attributes and data.
-    #[allow(dead_code)]
+    #[expect(clippy::allow_attributes)]
+    #[allow(dead_code, reason = "helpful to have for debugging")]
     async fn get_variable(
         &mut self,
         vendor: Guid,
@@ -28,7 +29,6 @@ pub trait NvramServicesExt {
 
     /// Get a variable identified by `name` (as a UCS-2 string) + `vendor`,
     /// returning the variable's attributes and data.
-    #[allow(dead_code)]
     async fn get_variable_ucs2(
         &mut self,
         vendor: Guid,

--- a/vm/devices/firmware/uefi_specs/src/lib.rs
+++ b/vm/devices/firmware/uefi_specs/src/lib.rs
@@ -17,6 +17,7 @@
 // `const`ants instead of runtime methods...
 macro_rules! defn_nvram_var {
     ($varname:ident = ($guid:expr, $name:literal)) => {
+        #[expect(clippy::allow_attributes)]
         #[allow(non_snake_case)]
         pub fn $varname() -> (Guid, &'static ucs2::Ucs2LeSlice) {
             use ucs2::Ucs2LeSlice;

--- a/vm/devices/get/vtl2_settings_proto/src/lib.rs
+++ b/vm/devices/get/vtl2_settings_proto/src/lib.rs
@@ -7,6 +7,7 @@
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
 #![expect(unused_qualifications)] // pbjson-build doesn't use ::fully::qualified::paths.
+#![expect(clippy::allow_attributes)] // both crates generate allows
 
 // These crates are referenced by the generated code. Reference them
 // explicitly here so that they are not removed by automated tools (xtask

--- a/vm/devices/net/net_consomme/consomme/src/ndp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/ndp.rs
@@ -290,8 +290,6 @@ impl<T: Client> Access<'_, T> {
                 HardwareAddress::Ethernet(eth_addr) => {
                     eth_addr == self.inner.state.params.client_mac
                 }
-                #[allow(unreachable_patterns)]
-                _ => false,
             })
             .unwrap_or(false);
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/registers.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/registers.rs
@@ -71,12 +71,14 @@ pub(crate) struct Bar0<T: Inspect>(#[inspect(flatten)] pub T);
 
 macro_rules! reg32 {
     ($get:ident, $set:ident, $reg:ident, $ty:ty) => {
+        #[expect(clippy::allow_attributes)]
         #[allow(dead_code)]
         pub fn $get(&self) -> $ty {
             let r = <$ty>::from(self.0.read_u32(spec::Register::$reg.0 as usize));
             tracing::trace!(r = ?r, reg = stringify!($reg), "Read register");
             r
         }
+        #[expect(clippy::allow_attributes)]
         #[allow(dead_code)]
         pub fn $set(&self, v: $ty) {
             tracing::trace!(v = ?v, reg = stringify!($reg), "Writing register");
@@ -87,12 +89,14 @@ macro_rules! reg32 {
 
 macro_rules! reg64 {
     ($get:ident, $set:ident, $reg:ident, $ty:ty) => {
+        #[expect(clippy::allow_attributes)]
         #[allow(dead_code)]
         pub fn $get(&self) -> $ty {
             let r = <$ty>::from(self.0.read_u64(spec::Register::$reg.0 as usize));
             tracing::trace!(r = ?r, reg = stringify!($reg), "Read register");
             r
         }
+        #[expect(clippy::allow_attributes)]
         #[allow(dead_code)]
         pub fn $set(&self, v: $ty) {
             tracing::trace!(v = ?v, reg = stringify!($reg), "Writing register");

--- a/vm/devices/support/fs/plan9/src/protocol/macros.rs
+++ b/vm/devices/support/fs/plan9/src/protocol/macros.rs
@@ -9,6 +9,7 @@ macro_rules! p9_message_struct {
             // 1. Some operations (e.g. Twrite) need it to access additional data.
             // 2. It allows the lifetime 'a to be there unconditionally; otherwise, only some
             //    messages would need it and the macro can't easily filter on that.
+            #[expect(clippy::allow_attributes)]
             #[allow(dead_code)]
             pub struct $name<'a> {
                 pub reader: super::SliceReader<'a>,

--- a/vm/devices/tdisp_proto/src/lib.rs
+++ b/vm/devices/tdisp_proto/src/lib.rs
@@ -9,6 +9,7 @@
     unused_qualifications,
     reason = "generated code contains fully qualified paths"
 )]
+#![expect(clippy::allow_attributes)]
 
 // Crates used by generated code. Reference them explicitly to ensure that
 // automated tools do not remove them.

--- a/vm/devices/tpm/tpm_guest_tests/src/tpm.rs
+++ b/vm/devices/tpm/tpm_guest_tests/src/tpm.rs
@@ -333,15 +333,14 @@ mod windows {
         pub const TBS_COMMAND_PRIORITY_NORMAL: u32 = 100;
 
         /// Allow non-snake / camel case naming that matches the Windows SDK for FFI correctness.
-        #[allow(non_snake_case)]
+        #[expect(non_snake_case)]
         #[repr(C)]
         pub union TBS_CONTEXT_PARAMS2_FLAGS {
             pub asUINT32: u32, // bit 0: requestRaw, bit 1: includeTpm12, bit 2: includeTpm20
         }
 
         #[repr(C)]
-        #[allow(non_camel_case_types)]
-        #[allow(non_snake_case)]
+        #[expect(non_snake_case)]
         pub struct TBS_CONTEXT_PARAMS2 {
             pub version: u32, // must be TPM_VERSION_20 for PARAMS2
             pub Anonymous: TBS_CONTEXT_PARAMS2_FLAGS,

--- a/vm/devices/uidevices/src/video/protocol.rs
+++ b/vm/devices/uidevices/src/video/protocol.rs
@@ -42,7 +42,7 @@ pub const MAX_DIRTY_REGIONS: u8 = 255;
 
 macro_rules! packed {
     ($wrap:ident, $prim:ident, $count:literal) => {
-        #[allow(non_camel_case_types)]
+        #[expect(non_camel_case_types)]
         #[repr(transparent)]
         #[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
         pub struct $wrap([u8; $count]);

--- a/vm/devices/virtio/vhost_user_protocol/src/socket.rs
+++ b/vm/devices/virtio/vhost_user_protocol/src/socket.rs
@@ -238,10 +238,13 @@ fn build_remaining_iov<'a>(original: &'a [IoSlice<'a>], skip: usize) -> Vec<IoSl
 }
 
 /// Send data with optional file descriptors via sendmsg. May return WouldBlock.
-#[allow(
-    clippy::needless_update,
-    clippy::useless_conversion,
-    reason = "libc cmsghdr field types and as-conversions differ between musl and glibc"
+#[cfg_attr(
+    target_env = "gnu",
+    expect(
+        clippy::needless_update,
+        clippy::useless_conversion,
+        reason = "libc::cmsghdr has different type defs on gnu vs musl"
+    )
 )]
 fn try_send(socket: &UnixStream, msg: &[IoSlice<'_>], fds: &[RawFd]) -> io::Result<usize> {
     assert!(
@@ -334,10 +337,6 @@ fn try_recv(
             && cmsg.hdr.cmsg_level == libc::SOL_SOCKET
             && cmsg.hdr.cmsg_type == libc::SCM_RIGHTS
         {
-            #[allow(
-                clippy::unnecessary_cast,
-                reason = "cmsg_len type differs between musl and glibc"
-            )]
             let fd_count = ((cmsg.hdr.cmsg_len as usize).saturating_sub(size_of_val(&cmsg.hdr))
                 / size_of::<RawFd>())
             .min(VHOST_USER_MAX_FDS);
@@ -355,10 +354,6 @@ fn try_recv(
             // Unexpected ancillary data type — no SCM_RIGHTS fds to close.
             return Err(io::ErrorKind::InvalidData.into());
         }
-        #[allow(
-            clippy::unnecessary_cast,
-            reason = "cmsg_len type differs between musl and glibc"
-        )]
         let fd_count = ((cmsg.hdr.cmsg_len as usize).saturating_sub(size_of_val(&cmsg.hdr))
             / size_of::<RawFd>())
         .min(VHOST_USER_MAX_FDS);

--- a/vm/devices/virtio/vhost_user_protocol/src/socket.rs
+++ b/vm/devices/virtio/vhost_user_protocol/src/socket.rs
@@ -298,12 +298,10 @@ fn try_send(socket: &UnixStream, msg: &[IoSlice<'_>], fds: &[RawFd]) -> io::Resu
 /// Always provides a cmsg buffer so that any file descriptors sent by the peer
 /// are properly received and closed, even when the caller doesn't expect them.
 /// This prevents fd leaks from misbehaving or malicious peers.
-#[cfg_attr(
-    target_env = "gnu",
-    expect(
-        clippy::unnecessary_cast,
-        reason = "libc::cmsghdr has different type defs on gnu vs musl"
-    )
+#[expect(clippy::allow_attributes)]
+#[allow(
+    clippy::useless_conversion,
+    reason = "libc::cmsghdr has different type defs on gnu vs musl"
 )]
 fn try_recv(
     socket: &UnixStream,

--- a/vm/devices/virtio/vhost_user_protocol/src/socket.rs
+++ b/vm/devices/virtio/vhost_user_protocol/src/socket.rs
@@ -300,7 +300,7 @@ fn try_send(socket: &UnixStream, msg: &[IoSlice<'_>], fds: &[RawFd]) -> io::Resu
 /// This prevents fd leaks from misbehaving or malicious peers.
 #[expect(clippy::allow_attributes)]
 #[allow(
-    clippy::unnecessary_cast
+    clippy::unnecessary_cast,
     reason = "libc::cmsghdr has different type defs on gnu vs musl"
 )]
 fn try_recv(

--- a/vm/devices/virtio/vhost_user_protocol/src/socket.rs
+++ b/vm/devices/virtio/vhost_user_protocol/src/socket.rs
@@ -298,6 +298,13 @@ fn try_send(socket: &UnixStream, msg: &[IoSlice<'_>], fds: &[RawFd]) -> io::Resu
 /// Always provides a cmsg buffer so that any file descriptors sent by the peer
 /// are properly received and closed, even when the caller doesn't expect them.
 /// This prevents fd leaks from misbehaving or malicious peers.
+#[cfg_attr(
+    target_env = "gnu",
+    expect(
+        clippy::unnecessary_cast,
+        reason = "libc::cmsghdr has different type defs on gnu vs musl"
+    )
+)]
 fn try_recv(
     socket: &UnixStream,
     buf: &mut [u8],

--- a/vm/devices/virtio/vhost_user_protocol/src/socket.rs
+++ b/vm/devices/virtio/vhost_user_protocol/src/socket.rs
@@ -300,7 +300,7 @@ fn try_send(socket: &UnixStream, msg: &[IoSlice<'_>], fds: &[RawFd]) -> io::Resu
 /// This prevents fd leaks from misbehaving or malicious peers.
 #[expect(clippy::allow_attributes)]
 #[allow(
-    clippy::useless_conversion,
+    clippy::unnecessary_cast
     reason = "libc::cmsghdr has different type defs on gnu vs musl"
 )]
 fn try_recv(

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -1874,11 +1874,11 @@ pub fn extract_helper<T: RegisterName>(_: T, value: &abi::WHV_REGISTER_VALUE) ->
 #[macro_export]
 macro_rules! set_registers {
     ($vp:expr, [$(($name:expr, $value:expr)),+ $(,)? ] $(,)? ) => {
+        #[expect(clippy::allow_attributes)]
+        #[allow(unused_parens)]
         {
             let names = [$($crate::RegisterName::as_abi(&($name))),+];
-            #[allow(unused_parens)]
             let values = [$($crate::inject_helper(($name), &($value))),+];
-            #[allow(unused_parens)]
             ($vp).set_registers(&names, &values)
         }
     }
@@ -1892,6 +1892,7 @@ macro_rules! get_registers {
             let mut values = [$($crate::get_registers!(@def $name)),+];
             ($vp).get_registers(&names, &mut values).map(|_| {
                 let mut vs = &values[..];
+                #[expect(clippy::allow_attributes)]
                 #[allow(unused_assignments)]
                 ($({
                     let n = $name;

--- a/vm/whp/src/partition_prop.rs
+++ b/vm/whp/src/partition_prop.rs
@@ -17,6 +17,7 @@ pub trait AssociatedType {
 macro_rules! pp {
     ($($(#[$attr:meta])* ($internal_name:ident, $code:ident, $ty:ty),)*) => {
         $(
+            #[expect(clippy::allow_attributes)]
             #[allow(dead_code)]
             $(#[$attr])*
             pub struct $internal_name;

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -459,7 +459,7 @@ pub trait Processor: InspectMut {
     ///
     /// The default implementation panics. Backends that support
     /// [`ResetPartition`] must override this.
-    #[allow(unreachable_code)]
+    #[expect(unreachable_code)]
     fn reset(&mut self) -> Result<(), impl std::error::Error + Send + Sync + 'static> {
         Ok::<(), Infallible>(unimplemented!(
             "Processor::reset not implemented for this backend"
@@ -473,7 +473,7 @@ pub trait Processor: InspectMut {
     ///
     /// The default implementation panics. Backends that support
     /// [`ScrubVtl`] must override this.
-    #[allow(unreachable_code)]
+    #[expect(unreachable_code)]
     fn scrub(&mut self, _vtl: Vtl) -> Result<(), impl std::error::Error + Send + Sync + 'static> {
         Ok::<(), Infallible>(unimplemented!(
             "Processor::scrub not implemented for this backend"

--- a/vmm_core/virt/src/state.rs
+++ b/vmm_core/virt/src/state.rs
@@ -63,6 +63,7 @@ mod macros {
             $(($field_num:literal, $id:expr, $get:ident, $set:ident, $ty:ty $(,)?)),* $(,)?
         ) => {
             #[doc = $doc]
+            #[expect(clippy::allow_attributes)]
             pub trait $trait {
                 type Error: 'static + std::error::Error + Send + Sync;
 

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -974,7 +974,6 @@ pub struct ArcMutexIsaDmaChannel {
 }
 
 impl ArcMutexIsaDmaChannel {
-    #[allow(dead_code)] // use is feature dependent
     pub fn new(dma: Arc<CloseableMutex<dma::DmaController>>, channel_num: u8) -> Self {
         Self { dma, channel_num }
     }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -41,17 +41,14 @@ use petri::vtl2_settings::ControllerType;
 use petri::vtl2_settings::Vtl2LunBuilder;
 use petri::vtl2_settings::Vtl2StorageBackingDeviceBuilder;
 use petri::vtl2_settings::Vtl2StorageControllerBuilder;
-#[allow(unused_imports)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_LINUX_DIRECT_TEST_X64;
-#[allow(unused_imports)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_RELEASE_LINUX_DIRECT_X64;
-#[allow(unused_imports)]
+#[cfg(windows)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_RELEASE_STANDARD_AARCH64;
-#[allow(unused_imports)]
+#[cfg(windows)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_RELEASE_STANDARD_X64;
-#[allow(unused_imports)]
+#[cfg(windows)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_AARCH64;
-#[allow(unused_imports)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64;
 use pipette_client::PipetteClient;
 use pipette_client::process::Child;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
@@ -15,9 +15,8 @@ use petri_artifacts_vmm_test::artifacts::guest_tools::TPM_GUEST_TESTS_LINUX_X64;
 use petri_artifacts_vmm_test::artifacts::guest_tools::TPM_GUEST_TESTS_WINDOWS_X64;
 #[cfg(windows)]
 use petri_artifacts_vmm_test::artifacts::host_tools::TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64;
-#[allow(unused_imports)]
+#[cfg(windows)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_AARCH64;
-#[allow(unused_imports)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64;
 use petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_16K_TPM;
 use pipette_client::PipetteClient;


### PR DESCRIPTION
By manually allowing allows in the few places they're needed (macro-generated code, complex match statements) we can finally turn this warning on globally. Especially relevant recently because AI really likes to generate allows instead of expects. Closes #300.