### PR TITLE
ci: add Linux MSHV VMM tests job

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3449,8 +3449,7 @@ jobs:
     steps:
     - run: |
         set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        sudo tdnf install -y gcc
         curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -33,7 +33,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -43,7 +43,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -51,7 +51,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -189,7 +189,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -199,7 +199,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -207,7 +207,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -360,7 +360,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -370,7 +370,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -378,7 +378,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -601,7 +601,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -611,7 +611,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -619,7 +619,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -878,7 +878,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -888,7 +888,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -896,7 +896,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1146,7 +1146,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1156,7 +1156,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1164,7 +1164,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1387,7 +1387,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1397,7 +1397,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1405,7 +1405,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1644,7 +1644,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1654,7 +1654,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1662,7 +1662,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -2980,7 +2980,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2990,7 +2990,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -2998,7 +2998,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3450,7 +3450,7 @@ jobs:
     - run: |
         set -x
         sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3460,7 +3460,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3468,7 +3468,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3751,7 +3751,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3761,7 +3761,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3769,7 +3769,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4049,7 +4049,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4059,7 +4059,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4067,7 +4067,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4138,9 +4138,12 @@ jobs:
       run: flowey e 23 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
+      run: flowey e 23 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
       run: |-
-        flowey e 23 flowey_lib_common::install_rust 1
-        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 23 flowey_lib_common::install_rust 2
+        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4163,7 +4166,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4173,7 +4176,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4181,7 +4184,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4888,7 +4891,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4898,7 +4901,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4906,7 +4909,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5206,7 +5209,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5216,7 +5219,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5224,7 +5227,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5425,7 +5428,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5435,7 +5438,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5443,7 +5446,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5751,7 +5754,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5761,7 +5764,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5769,7 +5772,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6092,7 +6095,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6102,7 +6105,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6110,7 +6113,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6489,7 +6492,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6499,7 +6502,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6507,7 +6510,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6880,7 +6883,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6890,7 +6893,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6898,7 +6901,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -2797,8 +2797,6 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
@@ -2808,6 +2806,8 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -6554,10 +6554,6 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -6671,12 +6667,12 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
         flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
@@ -6691,7 +6687,7 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6700,7 +6696,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -6753,51 +6749,9 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: copying openhcl build to publish dir
-      run: |-
-        flowey e 8 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 15
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 16
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
         flowey e 8 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build openvmm
+    - name: cargo build openvmm_hcl
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 6
@@ -6806,11 +6760,27 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::build_openvmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: |-
+        flowey e 8 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 5
         flowey e 8 flowey_lib_hvlite::run_cargo_build 11
@@ -6819,24 +6789,12 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 8 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3449,7 +3449,7 @@ jobs:
     steps:
     - run: |
         set -x
-        sudo tdnf install -y gcc
+        sudo tdnf install -y gcc glibc-devel
         curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3324,7 +3324,7 @@ jobs:
     - name: setting up vmm_tests env
       run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
-    - name: ensure /dev/kvm is accessible
+    - name: ensure hypervisor device is accessible
       run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3447,21 +3447,70 @@ jobs:
     - job9
     if: github.event.pull_request.draft == false
     steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-9,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9/flowey
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
         echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
@@ -3576,7 +3625,7 @@ jobs:
     - name: setting up vmm_tests env
       run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
-    - name: ensure /dev/kvm is accessible
+    - name: ensure hypervisor device is accessible
       run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3180,7 +3180,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-linux]
+    name: run vmm-tests [x64-linux-amd]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3399,9 +3399,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmm-tests-logs
+        name: x64-linux-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3415,9 +3415,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmm-tests-junit-xml
+        name: x64-linux-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -3432,7 +3432,7 @@ jobs:
       run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-linux-mshv]
+    name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
@@ -3699,9 +3699,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-mshv-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-mshv-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3715,9 +3715,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-mshv-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-mshv-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -33,7 +33,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -43,7 +43,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -51,7 +51,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -189,7 +189,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -199,7 +199,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -207,7 +207,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -360,7 +360,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -370,7 +370,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -378,7 +378,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -601,7 +601,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -611,7 +611,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -619,7 +619,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -878,7 +878,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -888,7 +888,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -896,7 +896,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1146,7 +1146,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1156,7 +1156,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1164,7 +1164,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1387,7 +1387,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1397,7 +1397,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1405,7 +1405,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1644,7 +1644,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1654,7 +1654,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1662,7 +1662,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -2980,7 +2980,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2990,7 +2990,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -2998,7 +2998,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3432,6 +3432,258 @@ jobs:
       run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
+    name: run vmm-tests [x64-linux-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job5
+    - job7
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-9,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9/flowey
+
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 21 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 8
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 10
+        flowey e 21 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 21 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 4
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 6
+        flowey e 21 flowey_lib_common::download_gh_cli 1
+        flowey v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 21 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 21 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure /dev/kvm is accessible
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 21 flowey_lib_common::git_checkout 0
+        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 21 flowey_lib_common::git_checkout 3
+        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_common::publish_test_results 4
+        flowey e 21 flowey_lib_common::publish_test_results 5
+        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-mshv-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-mshv-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 21 flowey_lib_common::publish_test_results 0
+        flowey e 21 flowey_lib_common::publish_test_results 1
+        flowey e 21 flowey_lib_common::publish_test_results 2
+        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-mshv-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-mshv-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 21 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 21 flowey_lib_common::cache 11
+      shell: bash
+  job22:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -3451,7 +3703,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3461,7 +3713,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3469,7 +3721,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3512,35 +3764,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 21 'verbose' update
+        cat <<'EOF' | flowey.exe v 22 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 21 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 22 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3550,17 +3802,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3572,35 +3824,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 21 flowey_lib_common::git_checkout 3
-        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3610,31 +3862,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 10
-        flowey.exe e 21 flowey_lib_common::download_gh_release 1
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3644,63 +3896,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -3711,12 +3963,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 21 flowey_lib_common::publish_test_results 0
-        flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -3726,18 +3978,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 21 flowey_lib_common::cache 3
+      run: flowey.exe e 22 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 21 flowey_lib_common::cache 7
+      run: flowey.exe e 22 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
+      run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
-  job22:
+  job23:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -3749,7 +4001,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3759,7 +4011,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3767,124 +4019,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 22 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 22 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 22 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 22 flowey_lib_common::install_rust 2
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job23:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3928,25 +4063,139 @@ jobs:
         cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 23 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: |-
+        flowey e 23 flowey_lib_common::install_rust 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 23 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job24:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 24 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 24 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 24 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3956,31 +4205,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_gh_release 1
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 23 flowey_lib_common::install_rust 0
+      run: flowey e 24 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 23 flowey_lib_common::install_rust 1
+      run: flowey e 24 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 23 flowey_lib_common::install_rust 2
-        flowey e 23 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 24 flowey_lib_common::install_rust 2
+        flowey e 24 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3992,172 +4241,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 23 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 24 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 23 flowey_lib_common::resolve_protoc 0
-        flowey e 23 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 24 flowey_lib_common::resolve_protoc 0
+        flowey e 24 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 24 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 24 flowey_lib_common::run_cargo_build 3
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 23 flowey_lib_hvlite::build_sidecar 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 24 flowey_lib_hvlite::build_sidecar 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 1
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 24 flowey_lib_common::run_cargo_build 1
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 24 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 3
+        flowey e 24 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 23 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 24 flowey_lib_common::run_cargo_build 2
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 24 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 23 flowey_lib_hvlite::init_cross_build 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 24 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 24 flowey_lib_common::run_cargo_build 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 24 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 24 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 23 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 24 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 23 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 24 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 3
+      run: flowey e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -4171,18 +4420,18 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job24:
+  job25:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job23
+    - job24
     - job5
     - job7
     - job9
@@ -4204,39 +4453,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 25 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 25 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 25 flowey_lib_common::cache 0
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4246,17 +4495,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 25 flowey_lib_common::cache 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_common::git_checkout 0
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4268,38 +4517,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_lib_common::git_checkout 3
+        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 25 flowey_lib_common::cache 8
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4309,31 +4558,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 25 flowey_lib_common::cache 10
+        flowey.exe e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 25 flowey_lib_common::cache 4
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4343,63 +4592,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 25 flowey_lib_common::cache 6
+        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 25 flowey_lib_common::publish_test_results 4
+        flowey.exe e 25 flowey_lib_common::publish_test_results 5
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4410,12 +4659,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_common::publish_test_results 0
+        flowey.exe e 25 flowey_lib_common::publish_test_results 1
+        flowey.exe e 25 flowey_lib_common::publish_test_results 2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4425,18 +4674,18 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 25 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job26:
     name: publish vmgstool
     runs-on: ubuntu-latest
     permissions:
@@ -4461,6 +4710,7 @@ jobs:
     - job22
     - job23
     - job24
+    - job25
     - job3
     - job4
     - job5
@@ -4486,25 +4736,25 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 25 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 25 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 25 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 26 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 26 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 26 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      run: flowey e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4514,31 +4764,31 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_gh_cli 1
+        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
       run: |-
-        flowey e 25 flowey_lib_common::use_gh_cli 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 26 flowey_lib_common::use_gh_cli 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey e 26 flowey_core::pipeline::artifact::resolve 2
       shell: bash
     - name: enumerate vmgstool release files
-      run: flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
+      run: flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4550,29 +4800,29 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: get current commit
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
       shell: bash
     - name: get cargo crate version
       run: |-
-        flowey e 25 flowey_lib_common::get_cargo_crate_version 0
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
+        flowey e 26 flowey_lib_common::get_cargo_crate_version 0
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
+        flowey e 26 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
       shell: bash
     - name: publish github releases
-      run: flowey e 25 flowey_lib_common::publish_gh_release 0
+      run: flowey e 26 flowey_lib_common::publish_gh_release 0
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 3
+      run: flowey e 26 flowey_lib_common::cache 3
       shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
@@ -4590,7 +4840,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4600,7 +4850,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4608,7 +4858,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4908,7 +5158,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4918,7 +5168,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4926,7 +5176,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5127,7 +5377,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5137,7 +5387,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5145,7 +5395,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5453,7 +5703,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5463,7 +5713,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5471,7 +5721,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5794,7 +6044,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5804,7 +6054,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5812,7 +6062,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6191,7 +6441,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6201,7 +6451,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6209,7 +6459,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -6540,7 +6790,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -6550,7 +6800,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -6558,7 +6808,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -2797,6 +2797,10 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
@@ -2804,10 +2808,6 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3180,7 +3180,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-linux-amd]
+    name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3399,9 +3399,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-vmm-tests-logs
+        name: x64-linux-amd-kvm-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3415,9 +3415,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-vmm-tests-junit-xml
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -3489,7 +3489,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -3518,22 +3518,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 21 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey e 21 flowey_core::pipeline::artifact::resolve 7
         flowey e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey e 21 flowey_core::pipeline::artifact::resolve 0
         flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
         flowey e 21 flowey_core::pipeline::artifact::resolve 6
         flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -6551,6 +6551,10 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -6664,12 +6668,12 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_common::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
         flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
@@ -6684,7 +6688,7 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6693,7 +6697,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 8
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -6746,9 +6750,51 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: |-
+        flowey e 8 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 15
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 16
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 6
@@ -6757,27 +6803,11 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: copying openhcl build to publish dir
-      run: |-
-        flowey e 8 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
         flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build openvmm_vhost
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 5
         flowey e 8 flowey_lib_hvlite::run_cargo_build 11
@@ -6786,12 +6816,24 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 8 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
@@ -6900,10 +6942,16 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 9 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
@@ -6922,22 +6970,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 9 flowey_lib_common::cache 4
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::cache 6
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
@@ -6957,7 +7005,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar5
         flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -6965,7 +7013,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -6988,18 +7036,18 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 17
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 11
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 18
         flowey e 9 flowey_lib_hvlite::build_sidecar 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 2
@@ -7027,12 +7075,12 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
         flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 1
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
@@ -7187,9 +7235,51 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: |-
+        flowey e 9 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::build_pipette 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 8
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 19
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 12
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 20
+        flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 2
         flowey e 9 flowey_lib_hvlite::run_cargo_build 6
@@ -7198,41 +7288,81 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
-    - name: copying openhcl build to publish dir
+    - name: cargo build openvmm_vhost
       run: |-
-        flowey e 9 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 9 flowey_lib_hvlite::build_pipette 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 3
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
+        flowey e 9 flowey_lib_common::download_cargo_nextest 0
+        flowey e 9 flowey_lib_common::download_cargo_nextest 1
+        flowey e 9 flowey_lib_common::download_cargo_nextest 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 3
       shell: bash
-    - name: split debug symbols
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
-        flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 9 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 9 flowey_lib_common::install_cargo_nextest 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 9 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
@@ -7244,6 +7374,12 @@ jobs:
       with:
         name: x64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-baseline
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -3401,7 +3401,7 @@ jobs:
     steps:
     - run: |
         set -x
-        sudo tdnf install -y gcc
+        sudo tdnf install -y gcc glibc-devel
         curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -2742,8 +2742,6 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
@@ -2753,6 +2751,8 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -6162,10 +6162,6 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -6277,12 +6273,12 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
         flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
@@ -6297,7 +6293,7 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6306,7 +6302,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -6359,48 +6355,22 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::build_openvmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
@@ -6409,24 +6379,12 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -2745,6 +2745,10 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
@@ -2752,10 +2756,6 @@ jobs:
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3130,7 +3130,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-linux-amd]
+    name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3350,9 +3350,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-vmm-tests-logs
+        name: x64-linux-amd-kvm-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3366,9 +3366,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-vmm-tests-junit-xml
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -3441,7 +3441,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -3470,22 +3470,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 21 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey e 21 flowey_core::pipeline::artifact::resolve 7
         flowey e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey e 21 flowey_core::pipeline::artifact::resolve 0
         flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
         flowey e 21 flowey_core::pipeline::artifact::resolve 6
         flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -6162,6 +6162,10 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -6273,12 +6277,12 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
         flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
@@ -6293,7 +6297,7 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6302,7 +6306,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -6355,22 +6359,48 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_common::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
         flowey e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build openvmm_vhost
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
@@ -6379,12 +6409,24 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
@@ -6445,10 +6487,16 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
@@ -6465,22 +6513,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 9 flowey_lib_common::cache 4
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::cache 6
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
@@ -6500,7 +6548,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar5
         flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -6508,7 +6556,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -6531,18 +6579,18 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
         flowey e 9 flowey_lib_hvlite::build_sidecar 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 2
@@ -6570,12 +6618,12 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
         flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
@@ -6730,36 +6778,118 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 9 flowey_lib_hvlite::build_pipette 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_hvlite::build_pipette 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 17
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 11
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 18
         flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 3
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 9 flowey_lib_common::download_cargo_nextest 0
+        flowey e 9 flowey_lib_common::download_cargo_nextest 1
+        flowey e 9 flowey_lib_common::download_cargo_nextest 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 9 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 9 flowey_lib_common::install_cargo_nextest 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 9 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
@@ -6771,6 +6901,12 @@ jobs:
       with:
         name: x64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -3401,8 +3401,7 @@ jobs:
     steps:
     - run: |
         set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        sudo tdnf install -y gcc
         curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -21,9 +21,6 @@ on:
     - reopened
     - ready_for_review
     - labeled
-    paths-ignore:
-    - Guide/**
-    - petri/logview/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -44,7 +41,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -54,7 +51,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -62,7 +59,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -241,7 +238,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -251,7 +248,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -259,7 +256,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -403,7 +400,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -413,7 +410,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -421,7 +418,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1086,7 +1083,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1096,7 +1093,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1104,7 +1101,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1329,7 +1326,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1339,7 +1336,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1347,7 +1344,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1588,7 +1585,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1598,7 +1595,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1606,7 +1603,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -2930,7 +2927,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2940,7 +2937,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -2948,7 +2945,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3402,7 +3399,7 @@ jobs:
     - run: |
         set -x
         sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3412,7 +3409,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3420,7 +3417,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3704,7 +3701,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3714,7 +3711,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3722,7 +3719,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4049,9 +4046,12 @@ jobs:
       run: flowey e 23 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
+      run: flowey e 23 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
       run: |-
-        flowey e 23 flowey_lib_common::install_rust 1
-        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 23 flowey_lib_common::install_rust 2
+        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4621,7 +4621,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4631,7 +4631,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4639,7 +4639,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4941,7 +4941,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4951,7 +4951,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4959,7 +4959,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5162,7 +5162,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5172,7 +5172,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5180,7 +5180,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -21,6 +21,9 @@ on:
     - reopened
     - ready_for_review
     - labeled
+    paths-ignore:
+    - Guide/**
+    - petri/logview/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -41,7 +44,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -51,7 +54,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -59,7 +62,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -238,7 +241,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -248,7 +251,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -256,7 +259,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -400,7 +403,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -410,7 +413,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -418,7 +421,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1083,7 +1086,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1093,7 +1096,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1101,7 +1104,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1326,7 +1329,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1336,7 +1339,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1344,7 +1347,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1585,7 +1588,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1595,7 +1598,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1603,7 +1606,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -2927,7 +2930,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2937,7 +2940,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -2945,7 +2948,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3380,6 +3383,259 @@ jobs:
       run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
+    name: run vmm-tests [x64-linux-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job5
+    - job7
+    - job9
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 21 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 8
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 10
+        flowey e 21 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 21 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 4
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 6
+        flowey e 21 flowey_lib_common::download_gh_cli 1
+        flowey v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 21 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 21 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure /dev/kvm is accessible
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 21 flowey_lib_common::git_checkout 0
+        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 21 flowey_lib_common::git_checkout 3
+        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_common::publish_test_results 4
+        flowey e 21 flowey_lib_common::publish_test_results 5
+        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-mshv-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-mshv-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 21 flowey_lib_common::publish_test_results 0
+        flowey e 21 flowey_lib_common::publish_test_results 1
+        flowey e 21 flowey_lib_common::publish_test_results 2
+        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-mshv-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-mshv-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 21 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 21 flowey_lib_common::cache 11
+      shell: bash
+  job22:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -3400,7 +3656,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3410,7 +3666,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3418,7 +3674,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3461,35 +3717,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 21 'verbose' update
+        cat <<'EOF' | flowey.exe v 22 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 21 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 22 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3499,17 +3755,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3521,35 +3777,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 21 flowey_lib_common::git_checkout 3
-        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3559,31 +3815,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 10
-        flowey.exe e 21 flowey_lib_common::download_gh_release 1
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3593,63 +3849,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -3660,12 +3916,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 21 flowey_lib_common::publish_test_results 0
-        flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -3675,95 +3931,20 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 21 flowey_lib_common::cache 3
+      run: flowey.exe e 22 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 21 flowey_lib_common::cache 7
+      run: flowey.exe e 22 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
-      shell: bash
-  job22:
-    name: test flowey local backend
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 22 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 22 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 22 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 22 flowey_lib_common::install_rust 2
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    name: test flowey local backend
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -3793,25 +3974,97 @@ jobs:
         cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 23 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: |-
+        flowey e 23 flowey_lib_common::install_rust 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 23 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job24:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 24 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 24 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 24 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3821,31 +4074,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_gh_release 1
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 23 flowey_lib_common::install_rust 0
+      run: flowey e 24 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 23 flowey_lib_common::install_rust 1
+      run: flowey e 24 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 23 flowey_lib_common::install_rust 2
-        flowey e 23 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 24 flowey_lib_common::install_rust 2
+        flowey e 24 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3857,172 +4110,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 23 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 24 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 23 flowey_lib_common::resolve_protoc 0
-        flowey e 23 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 24 flowey_lib_common::resolve_protoc 0
+        flowey e 24 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 24 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 24 flowey_lib_common::run_cargo_build 3
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 23 flowey_lib_hvlite::build_sidecar 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 24 flowey_lib_hvlite::build_sidecar 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 1
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 24 flowey_lib_common::run_cargo_build 1
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 24 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 3
+        flowey e 24 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 24 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 23 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 24 flowey_lib_common::run_cargo_build 2
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 24 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 23 flowey_lib_hvlite::init_cross_build 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 24 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 24 flowey_lib_common::run_cargo_build 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 24 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 24 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 24 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 24 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 24 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 24 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 23 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 24 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 24 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 24 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 23 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 24 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 3
+      run: flowey e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -4036,19 +4289,19 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job24:
+  job25:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job23
+    - job24
     - job5
     - job7
     - job9
@@ -4070,39 +4323,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 25 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 25 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 25 flowey_lib_common::cache 0
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4112,17 +4365,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 25 flowey_lib_common::cache 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_common::git_checkout 0
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4134,38 +4387,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_lib_common::git_checkout 3
+        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 25 flowey_lib_common::cache 8
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4175,31 +4428,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 25 flowey_lib_common::cache 10
+        flowey.exe e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 25 flowey_lib_common::cache 4
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4209,63 +4462,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 25 flowey_lib_common::cache 6
+        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 25 flowey_lib_common::publish_test_results 4
+        flowey.exe e 25 flowey_lib_common::publish_test_results 5
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4276,12 +4529,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_common::publish_test_results 0
+        flowey.exe e 25 flowey_lib_common::publish_test_results 1
+        flowey.exe e 25 flowey_lib_common::publish_test_results 2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4291,16 +4544,16 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 25 flowey_lib_common::cache 11
       shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
@@ -4320,7 +4573,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4330,7 +4583,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4338,7 +4591,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4640,7 +4893,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4650,7 +4903,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4658,7 +4911,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4861,7 +5114,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4871,7 +5124,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4879,7 +5132,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -3275,7 +3275,7 @@ jobs:
     - name: setting up vmm_tests env
       run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
-    - name: ensure /dev/kvm is accessible
+    - name: ensure hypervisor device is accessible
       run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3399,21 +3399,70 @@ jobs:
     - job9
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
         echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
@@ -3528,7 +3577,7 @@ jobs:
     - name: setting up vmm_tests env
       run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
-    - name: ensure /dev/kvm is accessible
+    - name: ensure hypervisor device is accessible
       run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -3130,7 +3130,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-linux]
+    name: run vmm-tests [x64-linux-amd]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3350,9 +3350,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmm-tests-logs
+        name: x64-linux-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3366,9 +3366,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmm-tests-junit-xml
+        name: x64-linux-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -3383,7 +3383,7 @@ jobs:
       run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-linux-mshv]
+    name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
@@ -3651,9 +3651,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-mshv-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-mshv-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3667,9 +3667,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-mshv-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-mshv-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -20,6 +20,9 @@ on:
     - synchronize
     - reopened
     - ready_for_review
+    paths-ignore:
+    - Guide/**
+    - petri/logview/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -40,7 +43,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -50,7 +53,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -58,7 +61,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -237,7 +240,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -247,7 +250,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -255,7 +258,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -966,7 +969,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -976,7 +979,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -984,7 +987,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1645,7 +1648,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1655,7 +1658,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1663,7 +1666,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1884,7 +1887,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1894,7 +1897,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1902,7 +1905,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -2139,7 +2142,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2149,7 +2152,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -2157,7 +2160,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -2945,7 +2948,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2955,7 +2958,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -2963,7 +2966,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3934,6 +3937,259 @@ jobs:
       run: flowey e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
+    name: run vmm-tests [x64-linux-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job10
+    - job5
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 23 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 23 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 8
+        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 10
+        flowey e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 4
+        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 6
+        flowey e 23 flowey_lib_common::download_gh_cli 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure /dev/kvm is accessible
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 0
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 5
+        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-mshv-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-mshv-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 23 flowey_lib_common::publish_test_results 0
+        flowey e 23 flowey_lib_common::publish_test_results 1
+        flowey e 23 flowey_lib_common::publish_test_results 2
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-mshv-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-mshv-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 23 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 23 flowey_lib_common::cache 11
+      shell: bash
+  job24:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -3954,7 +4210,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3964,7 +4220,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3972,7 +4228,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4015,35 +4271,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 23 'verbose' update
+        cat <<'EOF' | flowey.exe v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 23 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 23 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 24 flowey_lib_common::cache 0
+        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4053,17 +4309,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 23 flowey_lib_common::cache 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 24 flowey_lib_common::cache 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_common::git_checkout 0
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4075,35 +4331,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 23 flowey_lib_common::git_checkout 3
-        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 24 flowey_lib_common::git_checkout 3
+        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 24 flowey_lib_common::cache 8
+        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4113,31 +4369,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 23 flowey_lib_common::cache 10
-        flowey.exe e 23 flowey_lib_common::download_gh_release 1
+        flowey.exe e 24 flowey_lib_common::cache 10
+        flowey.exe e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 24 flowey_lib_common::cache 4
+        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4147,63 +4403,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 23 flowey_lib_common::cache 6
-        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 24 flowey_lib_common::cache 6
+        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe e 23 flowey_lib_common::publish_test_results 5
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 24 flowey_lib_common::publish_test_results 4
+        flowey.exe e 24 flowey_lib_common::publish_test_results 5
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4214,12 +4470,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 23 flowey_lib_common::publish_test_results 0
-        flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe e 23 flowey_lib_common::publish_test_results 2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 24 flowey_lib_common::publish_test_results 0
+        flowey.exe e 24 flowey_lib_common::publish_test_results 1
+        flowey.exe e 24 flowey_lib_common::publish_test_results 2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4229,95 +4485,20 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 23 flowey_lib_common::cache 3
+      run: flowey.exe e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 23 flowey_lib_common::cache 7
+      run: flowey.exe e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 23 flowey_lib_common::cache 11
-      shell: bash
-  job24:
-    name: test flowey local backend
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 24 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 24 flowey_lib_common::git_checkout 3
-        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 24 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 24 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 24 flowey_lib_common::install_rust 2
-        flowey v 24 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 24 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey.exe e 24 flowey_lib_common::cache 11
       shell: bash
   job25:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    name: test flowey local backend
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -4347,25 +4528,97 @@ jobs:
         cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 25 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: |-
+        flowey e 25 flowey_lib_common::install_rust 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job26:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 26 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 25 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 25 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_release 0
+      run: flowey e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4375,31 +4628,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_gh_release 1
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 25 flowey_lib_common::install_rust 0
+      run: flowey e 26 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 25 flowey_lib_common::install_rust 1
+      run: flowey e 26 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 25 flowey_lib_common::install_rust 2
-        flowey e 25 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 26 flowey_lib_common::install_rust 2
+        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4411,172 +4664,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 25 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 25 flowey_lib_common::resolve_protoc 0
-        flowey e 25 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 26 flowey_lib_common::resolve_protoc 0
+        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 25 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 25 flowey_lib_hvlite::init_cross_build 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 25 flowey_lib_common::run_cargo_build 3
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 26 flowey_lib_common::run_cargo_build 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 25 flowey_lib_hvlite::build_sidecar 0
-        flowey e 25 flowey_lib_hvlite::init_cross_build 1
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 26 flowey_lib_hvlite::build_sidecar 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 25 flowey_lib_common::run_cargo_build 1
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 26 flowey_lib_common::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 25 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 25 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 25 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 25 flowey_lib_hvlite::init_cross_build 3
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 25 flowey_lib_common::run_cargo_build 2
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 25 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 26 flowey_lib_common::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 25 flowey_lib_hvlite::init_cross_build 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 26 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 25 flowey_lib_common::run_cargo_build 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 26 flowey_lib_common::run_cargo_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 25 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 25 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 25 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 25 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 25 flowey_lib_common::cache 3
+      run: flowey e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -4590,20 +4843,20 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job26:
+  job27:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
     - job10
-    - job25
+    - job26
     - job5
     - job7
     if: github.event.pull_request.draft == false
@@ -4624,39 +4877,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 26 'verbose' update
+        cat <<'EOF' | flowey.exe v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 26 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 26 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 26 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 26 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 26 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 27 flowey_lib_common::cache 0
+        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4666,17 +4919,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 27 flowey_lib_common::cache 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_common::git_checkout 0
+        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4688,38 +4941,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 27 flowey_lib_common::git_checkout 3
+        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 27 flowey_lib_common::cache 8
+        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4729,31 +4982,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 10
-        flowey.exe e 26 flowey_lib_common::download_gh_release 1
+        flowey.exe e 27 flowey_lib_common::cache 10
+        flowey.exe e 27 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 27 flowey_lib_common::cache 4
+        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4763,63 +5016,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 6
-        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 27 flowey_lib_common::cache 6
+        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 27 flowey_lib_common::publish_test_results 4
+        flowey.exe e 27 flowey_lib_common::publish_test_results 5
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4830,12 +5083,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 26 flowey_lib_common::publish_test_results 0
-        flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 27 flowey_lib_common::publish_test_results 0
+        flowey.exe e 27 flowey_lib_common::publish_test_results 1
+        flowey.exe e 27 flowey_lib_common::publish_test_results 2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4845,18 +5098,18 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 26 flowey_lib_common::cache 3
+      run: flowey.exe e 27 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 26 flowey_lib_common::cache 7
+      run: flowey.exe e 27 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 26 flowey_lib_common::cache 11
+      run: flowey.exe e 27 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job28:
     name: openvmm checkin gates
     runs-on: ubuntu-latest
     permissions:
@@ -4883,6 +5136,7 @@ jobs:
     - job24
     - job25
     - job26
+    - job27
     - job3
     - job4
     - job5
@@ -4910,15 +5164,15 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 27 'verbose' update
+        cat <<'EOF' | flowey v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: Check if any jobs failed
-      run: flowey e 27 flowey_lib_hvlite::_jobs::all_good_job 0
+      run: flowey e 28 flowey_lib_hvlite::_jobs::all_good_job 0
       shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
@@ -4938,7 +5192,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4948,7 +5202,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4956,7 +5210,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5258,7 +5512,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5268,7 +5522,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5276,7 +5530,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5479,7 +5733,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5489,7 +5743,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5497,7 +5751,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
+        ./rustup-init.exe -y --default-toolchain=1.94.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3684,7 +3684,7 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-linux]
+    name: run vmm-tests [x64-linux-amd]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3904,9 +3904,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmm-tests-logs
+        name: x64-linux-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3920,9 +3920,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmm-tests-junit-xml
+        name: x64-linux-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -3937,7 +3937,7 @@ jobs:
       run: flowey e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-linux-mshv]
+    name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
@@ -4205,9 +4205,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-mshv-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-mshv-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4221,9 +4221,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-mshv-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-mshv-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3955,8 +3955,7 @@ jobs:
     steps:
     - run: |
         set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        sudo tdnf install -y gcc
         curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3829,7 +3829,7 @@ jobs:
     - name: setting up vmm_tests env
       run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
-    - name: ensure /dev/kvm is accessible
+    - name: ensure hypervisor device is accessible
       run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3953,21 +3953,70 @@ jobs:
     - job7
     if: github.event.pull_request.draft == false
     steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.94.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
         echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
@@ -4082,7 +4131,7 @@ jobs:
     - name: setting up vmm_tests env
       run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
-    - name: ensure /dev/kvm is accessible
+    - name: ensure hypervisor device is accessible
       run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -20,9 +20,6 @@ on:
     - synchronize
     - reopened
     - ready_for_review
-    paths-ignore:
-    - Guide/**
-    - petri/logview/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -43,7 +40,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -53,7 +50,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -61,7 +58,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -240,7 +237,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -250,7 +247,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -258,7 +255,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1063,7 +1060,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1073,7 +1070,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1081,7 +1078,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1742,7 +1739,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1752,7 +1749,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1760,7 +1757,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -1981,7 +1978,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1991,7 +1988,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -1999,7 +1996,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -2236,7 +2233,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2246,7 +2243,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -2254,7 +2251,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -3042,7 +3039,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3052,7 +3049,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -3060,7 +3057,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4050,7 +4047,7 @@ jobs:
     - run: |
         set -x
         sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4060,7 +4057,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4068,7 +4065,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4352,7 +4349,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4362,7 +4359,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -4370,7 +4367,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -4697,9 +4694,12 @@ jobs:
       run: flowey e 25 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
+      run: flowey e 25 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
       run: |-
-        flowey e 25 flowey_lib_common::install_rust 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::install_rust 2
+        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5334,7 +5334,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5344,7 +5344,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5352,7 +5352,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5654,7 +5654,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5664,7 +5664,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5672,7 +5672,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
@@ -5875,7 +5875,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5885,7 +5885,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
@@ -5893,7 +5893,7 @@ jobs:
     - run: |
         set -x
         curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.94.0
+        ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -420,10 +420,16 @@ jobs:
         cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 10 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 10 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 10 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
@@ -440,22 +446,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 10 flowey_lib_common::cache 4
+        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::cache 6
         flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
@@ -475,7 +481,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar5
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -483,7 +489,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -506,18 +512,18 @@ jobs:
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 14
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 10 flowey_lib_common::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 10
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 16
         flowey e 10 flowey_lib_hvlite::build_sidecar 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
@@ -545,12 +551,12 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
         flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
@@ -705,36 +711,118 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 4
+        flowey e 10 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 10 flowey_lib_hvlite::build_pipette 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
         flowey e 10 flowey_lib_common::run_cargo_build 5
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 10 flowey_lib_hvlite::build_pipette 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 7
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 17
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 11
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 18
         flowey e 10 flowey_lib_hvlite::build_tmk_vmm 0
         flowey e 10 flowey_core::pipeline::artifact::publish 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: cargo build openvmm
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_hvlite::build_openvmm 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 2
+        flowey e 10 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 3
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 10 flowey_lib_common::download_cargo_nextest 0
+        flowey e 10 flowey_lib_common::download_cargo_nextest 1
+        flowey e 10 flowey_lib_common::download_cargo_nextest 2
+        flowey e 10 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 10 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 10 flowey_lib_common::install_cargo_nextest 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 10 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 10 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
@@ -746,6 +834,12 @@ jobs:
       with:
         name: x64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -3516,6 +3610,10 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
@@ -3523,10 +3621,6 @@ jobs:
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3684,7 +3778,7 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-linux-amd]
+    name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3904,9 +3998,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-vmm-tests-logs
+        name: x64-linux-amd-kvm-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3920,9 +4014,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-vmm-tests-junit-xml
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -3995,7 +4089,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -4024,22 +4118,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 23 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey e 23 flowey_core::pipeline::artifact::resolve 7
         flowey e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 0
         flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
         flowey e 23 flowey_core::pipeline::artifact::resolve 6
         flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -6781,6 +6875,10 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -6892,12 +6990,12 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
         flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
@@ -6912,7 +7010,7 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6921,7 +7019,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -6974,22 +7072,48 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_common::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
         flowey e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build openvmm_vhost
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
@@ -6998,12 +7122,24 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3607,8 +3607,6 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
@@ -3618,6 +3616,8 @@ jobs:
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -6875,10 +6875,6 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -6990,12 +6986,12 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
         flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
@@ -7010,7 +7006,7 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7019,7 +7015,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -7072,48 +7068,22 @@ jobs:
     - name: copying OpenHCL igvm extras to artifact dir
       run: |-
         flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::build_openvmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
@@ -7122,24 +7092,12 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3955,7 +3955,7 @@ jobs:
     steps:
     - run: |
         set -x
-        sudo tdnf install -y gcc
+        sudo tdnf install -y gcc glibc-devel
         curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1564,10 +1564,6 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 8 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -1667,12 +1663,12 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
     displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_hcl 0
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: cargo build openvmm_hcl
@@ -1687,7 +1683,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_initrd 1
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
     displayName: building openhcl initrd
   - bash: |-
       set -e
@@ -1696,7 +1692,7 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -1749,67 +1745,35 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::copy_to_artifact_dir 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
     displayName: copying OpenHCL igvm extras to artifact dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 11
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
     displayName: cargo build pipette
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 12
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_pipette 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 13
-    displayName: cargo build tmk_vmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 14
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 2
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 4
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build openvmm_vhost
+    displayName: cargo build tmk_vmm
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 4
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
-    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
-    artifact: aarch64-linux-musl-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
-    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-    artifact: aarch64-linux-musl-openvmm_vhost
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette
     displayName: 🌼📦 Publish aarch64-linux-musl-pipette
     artifact: aarch64-linux-musl-pipette

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1131,10 +1131,16 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 9 'verbose' update
       ${{ parameters.verbose }}
       EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-pipette"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-tmk_vmm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
@@ -1148,22 +1154,22 @@ jobs:
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar2)
-      path: $(floweyvar1)
+      key: $(floweyvar4)
+      path: $(floweyvar3)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
@@ -1179,14 +1185,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar5
       $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar3)
+    persistCredentials: $(floweyvar5)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -1206,18 +1212,18 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 13
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 14
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 11
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 15
     displayName: cargo build sidecar
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 7
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 12
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 10
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 16
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_sidecar 0
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 2
@@ -1244,12 +1250,12 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
     displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 8
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_hcl 0
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
     displayName: cargo build openvmm_hcl
@@ -1403,41 +1409,119 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::copy_to_artifact_dir 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
     displayName: copying OpenHCL igvm extras to artifact dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 11
     displayName: cargo build pipette
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 8
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_pipette 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 13
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 17
     displayName: cargo build tmk_vmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 8
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 14
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 11
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 18
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_tmk_vmm 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 6
+    displayName: cargo build openvmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
+    displayName: cargo build openvmm_vhost
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 3
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar2)
+      path: $(floweyvar1)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 2
+    displayName: report $CARGO_HOME
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
+    displayName: installing cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
+    displayName: build + archive 'vmm_tests' nextests
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm
+    artifact: x64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    artifact: x64-linux-musl-openvmm_vhost
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette
     displayName: 🌼📦 Publish x64-linux-musl-pipette
     artifact: x64-linux-musl-pipette
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm
     displayName: 🌼📦 Publish x64-linux-musl-tmk_vmm
     artifact: x64-linux-musl-tmk_vmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive
+    displayName: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+    artifact: x64-linux-musl-vmm-tests-archive
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
     displayName: 🌼📦 Publish x64-openhcl-igvm
     artifact: x64-openhcl-igvm
@@ -1480,6 +1564,10 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 8 'verbose' update
       ${{ parameters.verbose }}
       EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -1579,12 +1667,12 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
     displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_hcl 0
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: cargo build openvmm_hcl
@@ -1599,7 +1687,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_initrd 1
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
     displayName: building openhcl initrd
   - bash: |-
       set -e
@@ -1608,7 +1696,7 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 7
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -1661,35 +1749,67 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::copy_to_artifact_dir 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
     displayName: copying OpenHCL igvm extras to artifact dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 11
     displayName: cargo build pipette
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_pipette 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 13
+    displayName: cargo build tmk_vmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 14
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
+    displayName: cargo build openvmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 2
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 4
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build tmk_vmm
+    displayName: cargo build openvmm_vhost
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 4
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 3
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
+    artifact: aarch64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+    artifact: aarch64-linux-musl-openvmm_vhost
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette
     displayName: 🌼📦 Publish aarch64-linux-musl-pipette
     artifact: aarch64-linux-musl-pipette
@@ -2569,7 +2689,7 @@ jobs:
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
 - job: job15
-  displayName: run vmm-tests [x64-linux-amd]
+  displayName: run vmm-tests [x64-linux-amd-kvm]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64-256gb
@@ -2781,8 +2901,8 @@ jobs:
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-linux-amd-vmm-tests
-    displayName: 'publish test results: x64-linux-amd-vmm-tests (JUnit XML)'
+      testRunTitle: x64-linux-amd-kvm-vmm-tests
+    displayName: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -37,7 +37,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -45,7 +45,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.94.0
+      ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -883,7 +883,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -891,7 +891,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.94.0
+      ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -2413,7 +2413,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -2421,7 +2421,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.94.0
+      ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -3743,7 +3743,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -3751,7 +3751,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.94.0
+      ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -3944,7 +3944,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -3952,7 +3952,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.94.0
+      ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -4231,7 +4231,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -4239,7 +4239,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.94.0
+      ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -4428,7 +4428,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -4436,7 +4436,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.94.0
+      ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -2569,7 +2569,7 @@ jobs:
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
 - job: job15
-  displayName: run vmm-tests [x64-linux]
+  displayName: run vmm-tests [x64-linux-amd]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64-256gb
@@ -2781,8 +2781,8 @@ jobs:
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-linux-vmm-tests
-    displayName: 'publish test results: x64-linux-vmm-tests (JUnit XML)'
+      testRunTitle: x64-linux-amd-vmm-tests
+    displayName: 'publish test results: x64-linux-amd-vmm-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -37,7 +37,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -45,7 +45,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
+      ./rustup-init.exe -y --default-toolchain=1.94.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -883,7 +883,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -891,7 +891,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
+      ./rustup-init.exe -y --default-toolchain=1.94.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -2293,7 +2293,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -2301,7 +2301,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
+      ./rustup-init.exe -y --default-toolchain=1.94.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -2657,7 +2657,7 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-    displayName: ensure /dev/kvm is accessible
+    displayName: ensure hypervisor device is accessible
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
@@ -3623,7 +3623,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -3631,7 +3631,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
+      ./rustup-init.exe -y --default-toolchain=1.94.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -3824,7 +3824,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -3832,7 +3832,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
+      ./rustup-init.exe -y --default-toolchain=1.94.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -4111,7 +4111,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -4119,7 +4119,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
+      ./rustup-init.exe -y --default-toolchain=1.94.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)
@@ -4308,7 +4308,7 @@ jobs:
       set -x
       i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
       sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.94.0 -y
       . "$HOME/.cargo/env"
       echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -4316,7 +4316,7 @@ jobs:
   - bash: |
       set -x
       curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
+      ./rustup-init.exe -y --default-toolchain=1.94.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: rustup (Windows X64)

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -23,6 +23,7 @@ use flowey_core::node::FlowArch;
 use flowey_core::node::FlowBackend;
 use flowey_core::node::FlowPlatform;
 use flowey_core::node::FlowPlatformKind;
+use flowey_core::node::FlowPlatformLinuxDistro;
 use flowey_core::node::NodeHandle;
 use flowey_core::node::user_facing::GhPermission;
 use flowey_core::node::user_facing::GhPermissionValue;
@@ -197,7 +198,21 @@ pub fn github_yaml(
                             }
                         },
                     )
-                    .replace("{{FLOWEY_OUTDIR}}", &format!("{RUNNER_TEMP}/{flowey_path}"));
+                    .replace("{{FLOWEY_OUTDIR}}", &format!("{RUNNER_TEMP}/{flowey_path}"))
+                    .replace(
+                        "{{LINUX_INSTALL_DEPS}}",
+                        match platform {
+                            FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux) => {
+                                "sudo tdnf install -y gcc"
+                            }
+                            FlowPlatform::Linux(FlowPlatformLinuxDistro::Fedora) => {
+                                "sudo dnf install -y gcc"
+                            }
+                            _ => {
+                                "i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let \"i=i+1\"; sleep 1; done;\n    sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y"
+                            }
+                        },
+                    );
 
                 let bootstrap_steps: serde_yaml::Sequence =
                     serde_yaml::from_str(&gh_bootstrap_template)

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -203,7 +203,7 @@ pub fn github_yaml(
                         "{{LINUX_INSTALL_DEPS}}",
                         match platform {
                             FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux) => {
-                                "sudo tdnf install -y gcc"
+                                "sudo tdnf install -y gcc glibc-devel"
                             }
                             FlowPlatform::Linux(FlowPlatformLinuxDistro::Fedora) => {
                                 "sudo dnf install -y gcc"

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1097,6 +1097,12 @@ impl IntoPipeline for CheckinGatesCli {
             .map_err(|missing| {
                 anyhow::anyhow!("missing required windows-amd-snp vmm_tests artifact: {missing}")
             })?;
+        let vmm_tests_artifacts_linux_mshv_x86 = vmm_tests_artifacts_linux_x86
+            .clone()
+            .finish()
+            .map_err(|missing| {
+                anyhow::anyhow!("missing required linux-mshv vmm_tests artifact: {missing}")
+            })?;
         let vmm_tests_artifacts_linux_x86 =
             vmm_tests_artifacts_linux_x86.finish().map_err(|missing| {
                 anyhow::anyhow!("missing required linux vmm_tests artifact: {missing}")
@@ -1272,6 +1278,18 @@ impl IntoPipeline for CheckinGatesCli {
                 needs_prep_run: false,
             },
             VmmTestJobParams {
+                platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                arch: FlowArch::X86_64,
+                gh_pool: crate::pipelines_shared::gh_pools::linux_mshv_1es(),
+                label: "x64-linux-mshv",
+                target: CommonTriple::X86_64_LINUX_GNU,
+                resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_mshv_x86,
+                // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
+                nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
+                test_artifacts: standard_x64_test_artifacts.clone(),
+                needs_prep_run: false,
+            },
+            VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::Aarch64,
                 gh_pool: crate::pipelines_shared::gh_pools::windows_arm_self_hosted_baremetal(),
@@ -1289,11 +1307,12 @@ impl IntoPipeline for CheckinGatesCli {
                 needs_prep_run: false,
             },
         ] {
-            // Skip ARM64/CVM jobs entirely for ADO backend (no native ARM64/CVM pools in ADO)
+            // Skip ARM64/CVM/MSHV jobs entirely for ADO backend (no native ARM64/CVM/MSHV pools in ADO)
             if matches!(backend_hint, PipelineBackendHint::Ado) {
                 if matches!(arch, FlowArch::Aarch64)
                     || label.contains("tdx")
                     || label.contains("snp")
+                    || label.contains("mshv")
                 {
                     continue;
                 }
@@ -1603,7 +1622,7 @@ mod vmm_tests_artifact_builders {
     pub type ResolveVmmTestsDepArtifacts =
         Box<dyn Fn(&mut PipelineJobCtx<'_>) -> VmmTestsDepArtifacts>;
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct VmmTestsArtifactsBuilderLinuxX86 {
         // windows build machine
         pub use_pipette_windows: Option<UseTypedArtifact<PipetteOutput>>,

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1269,7 +1269,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
                 gh_pool: crate::pipelines_shared::gh_pools::linux_1es(),
-                label: "x64-linux",
+                label: "x64-linux-amd-kvm",
                 target: CommonTriple::X86_64_LINUX_GNU,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_x86,
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
@@ -1281,7 +1281,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux),
                 arch: FlowArch::X86_64,
                 gh_pool: crate::pipelines_shared::gh_pools::linux_mshv_1es(),
-                label: "x64-linux-mshv",
+                label: "x64-linux-intel-mshv",
                 target: CommonTriple::X86_64_LINUX_GNU,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_mshv_x86,
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1278,7 +1278,7 @@ impl IntoPipeline for CheckinGatesCli {
                 needs_prep_run: false,
             },
             VmmTestJobParams {
-                platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux),
                 arch: FlowArch::X86_64,
                 gh_pool: crate::pipelines_shared::gh_pools::linux_mshv_1es(),
                 label: "x64-linux-mshv",
@@ -1336,19 +1336,24 @@ impl IntoPipeline for CheckinGatesCli {
                 .new_job(platform, arch, format!("run vmm-tests [{label}]"))
                 .gh_set_pool(gh_pool);
 
-            // Only add ADO pool for x86_64 jobs (ARM not supported in ADO org)
+            // Only add ADO pool for x86_64 jobs that have a matching ADO pool
             if matches!(arch, FlowArch::X86_64) {
-                vmm_tests_run_job = vmm_tests_run_job.ado_set_pool(match platform {
-                    FlowPlatform::Windows => {
-                        crate::pipelines_shared::ado_pools::default_x86_pool(FlowPlatform::Windows)
-                    }
+                let ado_pool = match platform {
+                    FlowPlatform::Windows => Some(
+                        crate::pipelines_shared::ado_pools::default_x86_pool(FlowPlatform::Windows),
+                    ),
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu) => {
-                        crate::pipelines_shared::ado_pools::default_x86_pool(FlowPlatform::Linux(
-                            FlowPlatformLinuxDistro::Ubuntu,
+                        Some(crate::pipelines_shared::ado_pools::default_x86_pool(
+                            FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                         ))
                     }
+                    // No ADO pool for AzureLinux (MSHV jobs are GH-only)
+                    FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux) => None,
                     _ => anyhow::bail!("unsupported platform"),
-                });
+                };
+                if let Some(pool) = ado_pool {
+                    vmm_tests_run_job = vmm_tests_run_job.ado_set_pool(pool);
+                }
             }
 
             vmm_tests_run_job = vmm_tests_run_job.dep_on(|ctx| {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -759,10 +759,16 @@ impl IntoPipeline for CheckinGatesCli {
             // Also build openvmm and openvmm_vhost for musl on this job,
             // alongside pipette and tmk_vmm. This enables running VMM tests
             // on Azure Linux (MSHV) runners which have an older glibc.
-            let (pub_openvmm_musl, use_openvmm_musl) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm"));
+            // Only needed for x86_64 (the MSHV test job is x64-only).
+            let (pub_openvmm_musl, use_openvmm_musl) = matches!(arch, CommonArch::X86_64)
+                .then(|| pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm")))
+                .unzip();
             let (pub_openvmm_vhost_musl, use_openvmm_vhost_musl) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm_vhost"));
+                matches!(arch, CommonArch::X86_64)
+                    .then(|| {
+                        pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm_vhost"))
+                    })
+                    .unzip();
 
             // skim off interesting artifacts required by the VMM tests job
             match arch {
@@ -777,9 +783,10 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
                         Some(use_tmk_vmm.clone());
                     // musl artifacts for MSHV test job
-                    vmm_tests_artifacts_linux_musl_x86.use_openvmm = Some(use_openvmm_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_openvmm =
+                        Some(use_openvmm_musl.clone().unwrap());
                     vmm_tests_artifacts_linux_musl_x86.use_openvmm_vhost =
-                        Some(use_openvmm_vhost_musl.clone());
+                        Some(use_openvmm_vhost_musl.clone().unwrap());
                     vmm_tests_artifacts_linux_musl_x86.use_pipette_linux_musl =
                         Some(use_pipette_linux_musl.clone());
                     vmm_tests_artifacts_linux_musl_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
@@ -861,31 +868,37 @@ impl IntoPipeline for CheckinGatesCli {
                     profile: CommonProfile::from_release(release),
                     unstable_whp: false,
                     tmk_vmm: ctx.publish_typed_artifact(pub_tmk_vmm),
-                })
-                .dep_on(|ctx| flowey_lib_hvlite::build_openvmm::Request {
-                    params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxMusl,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm].into(),
-                    },
-                    openvmm: ctx.publish_typed_artifact(pub_openvmm_musl),
-                })
-                .dep_on(|ctx| flowey_lib_hvlite::build_openvmm_vhost::Request {
-                    params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxMusl,
-                        },
-                        profile: CommonProfile::from_release(release),
-                    },
-                    openvmm_vhost: ctx.publish_typed_artifact(pub_openvmm_vhost_musl),
                 });
 
-            // Build musl VMM tests archive on the OpenHCL x86 job
-            if matches!(arch, CommonArch::X86_64) {
+            // Build musl openvmm, openvmm_vhost, and VMM tests archive on the
+            // OpenHCL x86 job only (the MSHV test job is x64-only).
+            if let (Some(pub_openvmm_musl), Some(pub_openvmm_vhost_musl)) =
+                (pub_openvmm_musl, pub_openvmm_vhost_musl)
+            {
+                job = job
+                    .dep_on(|ctx| flowey_lib_hvlite::build_openvmm::Request {
+                        params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxMusl,
+                            },
+                            profile: CommonProfile::from_release(release),
+                            features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
+                                .into(),
+                        },
+                        openvmm: ctx.publish_typed_artifact(pub_openvmm_musl),
+                    })
+                    .dep_on(|ctx| flowey_lib_hvlite::build_openvmm_vhost::Request {
+                        params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxMusl,
+                            },
+                            profile: CommonProfile::from_release(release),
+                        },
+                        openvmm_vhost: ctx.publish_typed_artifact(pub_openvmm_vhost_musl),
+                    });
+
                 let pub_vmm_tests_archive_linux_musl_x86 =
                     pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
                 job = job.dep_on(|ctx| flowey_lib_hvlite::build_nextest_vmm_tests::Request {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -186,6 +186,8 @@ impl IntoPipeline for CheckinGatesCli {
         // initialize the various VMM tests nextest archive artifacts
         let (pub_vmm_tests_archive_linux_x86, use_vmm_tests_archive_linux_x86) =
             pipeline.new_typed_artifact("x64-linux-vmm-tests-archive");
+        let (pub_vmm_tests_archive_linux_musl_x86, use_vmm_tests_archive_linux_musl_x86) =
+            pipeline.new_typed_artifact("x64-linux-musl-vmm-tests-archive");
         let (pub_vmm_tests_archive_windows_x86, use_vmm_tests_archive_windows_x86) =
             pipeline.new_typed_artifact("x64-windows-vmm-tests-archive");
         let (pub_vmm_tests_archive_windows_aarch64, use_vmm_tests_archive_windows_aarch64) =
@@ -194,6 +196,7 @@ impl IntoPipeline for CheckinGatesCli {
         // wrap each publish handle in an option, so downstream code can
         // `.take()` the handle when emitting the corresponding job
         let mut pub_vmm_tests_archive_linux_x86 = Some(pub_vmm_tests_archive_linux_x86);
+        let mut pub_vmm_tests_archive_linux_musl_x86 = Some(pub_vmm_tests_archive_linux_musl_x86);
         let mut pub_vmm_tests_archive_windows_x86 = Some(pub_vmm_tests_archive_windows_x86);
         let mut pub_vmm_tests_archive_windows_aarch64 = Some(pub_vmm_tests_archive_windows_aarch64);
 
@@ -201,6 +204,8 @@ impl IntoPipeline for CheckinGatesCli {
         // are used to "skim off" various artifacts that the VMM test jobs
         // require.
         let mut vmm_tests_artifacts_linux_x86 =
+            vmm_tests_artifact_builders::VmmTestsArtifactsBuilderLinuxX86::default();
+        let mut vmm_tests_artifacts_linux_musl_x86 =
             vmm_tests_artifact_builders::VmmTestsArtifactsBuilderLinuxX86::default();
         let mut vmm_tests_artifacts_windows_x86 =
             vmm_tests_artifact_builders::VmmTestsArtifactsBuilderWindowsX86::default();
@@ -336,6 +341,8 @@ impl IntoPipeline for CheckinGatesCli {
             match arch {
                 CommonArch::X86_64 => {
                     vmm_tests_artifacts_linux_x86.use_pipette_windows =
+                        Some(use_pipette_windows.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_pipette_windows =
                         Some(use_pipette_windows.clone());
                     vmm_tests_artifacts_windows_x86.use_openvmm = Some(use_openvmm.clone());
                     vmm_tests_artifacts_windows_x86.use_pipette_windows =
@@ -585,6 +592,10 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_linux_x86.use_tmks = Some(use_tmks.clone());
                     vmm_tests_artifacts_windows_x86.use_tpm_guest_tests_linux =
                         Some(use_tpm_guest_tests.clone());
+                    // arch-neutral artifacts for musl MSHV test job
+                    vmm_tests_artifacts_linux_musl_x86.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_tmks = Some(use_tmks.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_guest_test_uefi =
@@ -745,6 +756,14 @@ impl IntoPipeline for CheckinGatesCli {
             let (pub_tmk_vmm, use_tmk_vmm) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-tmk_vmm"));
 
+            // Also build openvmm and openvmm_vhost for musl on this job,
+            // alongside pipette and tmk_vmm. This enables running VMM tests
+            // on Azure Linux (MSHV) runners which have an older glibc.
+            let (pub_openvmm_musl, use_openvmm_musl) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm"));
+            let (pub_openvmm_vhost_musl, use_openvmm_vhost_musl) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm_vhost"));
+
             // skim off interesting artifacts required by the VMM tests job
             match arch {
                 CommonArch::X86_64 => {
@@ -757,6 +776,13 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_linux_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
                     vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
                         Some(use_tmk_vmm.clone());
+                    // musl artifacts for MSHV test job
+                    vmm_tests_artifacts_linux_musl_x86.use_openvmm = Some(use_openvmm_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_openvmm_vhost =
+                        Some(use_openvmm_vhost_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_openhcl_igvm_files =
@@ -784,7 +810,7 @@ impl IntoPipeline for CheckinGatesCli {
             };
 
             let build_openhcl_job_tag = |arch_tag| format!("build openhcl [{arch_tag}-linux]");
-            let job = pipeline
+            let mut job = pipeline
                 .new_job(
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                     FlowArch::X86_64,
@@ -835,7 +861,41 @@ impl IntoPipeline for CheckinGatesCli {
                     profile: CommonProfile::from_release(release),
                     unstable_whp: false,
                     tmk_vmm: ctx.publish_typed_artifact(pub_tmk_vmm),
+                })
+                .dep_on(|ctx| flowey_lib_hvlite::build_openvmm::Request {
+                    params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxMusl,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm].into(),
+                    },
+                    openvmm: ctx.publish_typed_artifact(pub_openvmm_musl),
+                })
+                .dep_on(|ctx| flowey_lib_hvlite::build_openvmm_vhost::Request {
+                    params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxMusl,
+                        },
+                        profile: CommonProfile::from_release(release),
+                    },
+                    openvmm_vhost: ctx.publish_typed_artifact(pub_openvmm_vhost_musl),
                 });
+
+            // Build musl VMM tests archive on the OpenHCL x86 job
+            if matches!(arch, CommonArch::X86_64) {
+                let pub_vmm_tests_archive_linux_musl_x86 =
+                    pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
+                job = job.dep_on(|ctx| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
+                    target: CommonTriple::X86_64_LINUX_MUSL.as_triple(),
+                    profile: CommonProfile::from_release(release),
+                    build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
+                        ctx.publish_typed_artifact(pub_vmm_tests_archive_linux_musl_x86),
+                    ),
+                });
+            }
 
             all_jobs.push(job.finish());
 
@@ -1097,11 +1157,10 @@ impl IntoPipeline for CheckinGatesCli {
             .map_err(|missing| {
                 anyhow::anyhow!("missing required windows-amd-snp vmm_tests artifact: {missing}")
             })?;
-        let vmm_tests_artifacts_linux_mshv_x86 = vmm_tests_artifacts_linux_x86
-            .clone()
+        let vmm_tests_artifacts_linux_mshv_x86 = vmm_tests_artifacts_linux_musl_x86
             .finish()
             .map_err(|missing| {
-                anyhow::anyhow!("missing required linux-mshv vmm_tests artifact: {missing}")
+                anyhow::anyhow!("missing required linux-mshv (musl) vmm_tests artifact: {missing}")
             })?;
         let vmm_tests_artifacts_linux_x86 =
             vmm_tests_artifacts_linux_x86.finish().map_err(|missing| {
@@ -1282,7 +1341,7 @@ impl IntoPipeline for CheckinGatesCli {
                 arch: FlowArch::X86_64,
                 gh_pool: crate::pipelines_shared::gh_pools::linux_mshv_1es(),
                 label: "x64-linux-intel-mshv",
-                target: CommonTriple::X86_64_LINUX_GNU,
+                target: CommonTriple::X86_64_LINUX_MUSL,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_mshv_x86,
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
@@ -1328,6 +1387,7 @@ impl IntoPipeline for CheckinGatesCli {
             let use_vmm_tests_archive = match target {
                 CommonTriple::X86_64_WINDOWS_MSVC => &use_vmm_tests_archive_windows_x86,
                 CommonTriple::X86_64_LINUX_GNU => &use_vmm_tests_archive_linux_x86,
+                CommonTriple::X86_64_LINUX_MUSL => &use_vmm_tests_archive_linux_musl_x86,
                 CommonTriple::AARCH64_WINDOWS_MSVC => &use_vmm_tests_archive_windows_aarch64,
                 _ => unreachable!(),
             };

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
@@ -13,13 +13,11 @@
 #### Flowey Build Dependencies
 
 # On Linux, install gcc and rust to build flowey.
-# The apt-get retries below avoid failures in CI that can be
-# intermittently caused by other processes temporarily holding
-# the necessary dpkg or apt locks.
+# The package install commands are replaced at pipeline generation time
+# with the appropriate commands for the target distro.
 - run: |
     set -x
-    i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-    sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+    {{LINUX_INSTALL_DEPS}}
     curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain={{RUSTUP_TOOLCHAIN}} -y
     . "$HOME/.cargo/env"
     echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -45,6 +45,14 @@ pub fn linux_1es() -> GhRunner {
     ])
 }
 
+pub fn linux_mshv_1es() -> GhRunner {
+    GhRunner::SelfHosted(vec![
+        "self-hosted".to_string(),
+        "1ES.Pool=openvmm-gh-intel-westus3".to_string(),
+        "1ES.ImageOverride=azurelinux3-amd64-dom0".to_string(),
+    ])
+}
+
 pub fn gh_hosted_x64_windows() -> GhRunner {
     GhRunner::GhHosted(GhRunnerOsLabel::WindowsLatest)
 }

--- a/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
@@ -67,9 +67,16 @@ impl SimpleFlowNode for Node {
             && matches!(ctx.platform(), FlowPlatform::Linux(_))
         {
             pre_run_deps.push({
-                ctx.emit_rust_step("ensure /dev/kvm is accessible", |_| {
+                ctx.emit_rust_step("ensure hypervisor device is accessible", |_| {
                     |rt| {
-                        flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/kvm").run()?;
+                        // Make whichever hypervisor device exists accessible.
+                        // KVM machines have /dev/kvm, MSHV machines have /dev/mshv.
+                        if Path::new("/dev/kvm").exists() {
+                            flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/kvm").run()?;
+                        }
+                        if Path::new("/dev/mshv").exists() {
+                            flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/mshv").run()?;
+                        }
                         Ok(())
                     }
                 })


### PR DESCRIPTION
OpenVMM supports running on /dev/mshv in addition to /dev/kvm, but CI only exercises the KVM path on Linux today. Add a new VMM tests job that runs on Azure Linux 3 dom0 machines with MSHV available, using the same test suite and filter as the existing Linux KVM job. The hypervisor backend is auto-detected at runtime, so the same test binaries will use MSHV on these runners.

The new job uses the azurelinux3-amd64-dom0 image in the openvmm-gh-intel-westus3 1ES pool.