### PR TITLE
nvme_driver: Log pci device id when creating new queues (#2906)

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1311,9 +1311,10 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             }
         }
 
+        let pci_id = self.device.id().to_owned();
         let issuer = match self
             .create_io_queue(state, cpu)
-            .instrument(info_span!("create_nvme_io_queue", cpu))
+            .instrument(info_span!("create_nvme_io_queue", cpu, pci_id = ?pci_id))
             .await
         {
             Ok(issuer) => issuer,


### PR DESCRIPTION
Clean cherry pick of PR #2906

Minor change. Came across this issue when debugging a case with several queues. 

P.S. Had to do some type gymnastics to avoid the immutable reference borrow (string being sent to the info span)
