### PR TITLE
ci: fix ImageOverride in ADO pool demands

### DIFF
--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -25,7 +25,7 @@ jobs:
   displayName: quick check [fmt, clippy x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -210,7 +210,7 @@ jobs:
   displayName: build openhcl (mi-secure) [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -469,7 +469,7 @@ jobs:
   displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -673,7 +673,7 @@ jobs:
   displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -870,7 +870,7 @@ jobs:
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -1099,7 +1099,7 @@ jobs:
   displayName: build openhcl [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -1448,7 +1448,7 @@ jobs:
   displayName: build openhcl [aarch64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -1706,7 +1706,7 @@ jobs:
   displayName: build artifacts [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -2019,7 +2019,7 @@ jobs:
   displayName: build artifacts [aarch64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -2280,7 +2280,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -2572,7 +2572,7 @@ jobs:
   displayName: run vmm-tests [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -2799,7 +2799,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -3070,7 +3070,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -3340,7 +3340,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -3610,7 +3610,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [x64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -3811,7 +3811,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4098,7 +4098,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4295,7 +4295,7 @@ jobs:
   displayName: xtask fmt (windows)
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0

--- a/flowey/flowey_hvlite/src/pipelines_shared/ado_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/ado_pools.rs
@@ -11,7 +11,7 @@ pub const INTEL_POOL: &str = "openvmm-ado-intel-centralus";
 fn intel_pool_with_image(image: &str) -> AdoPool {
     AdoPool {
         name: INTEL_POOL.into(),
-        demands: vec![format!("1ES.ImageOverride -equals {image}")],
+        demands: vec![format!("ImageOverride -equals {image}")],
     }
 }
 


### PR DESCRIPTION
The override for selecting a specific 1ES image is different for ADO and Github

This has been tested against the mirror, and unblocks breaks in the build there