### PR TITLE
virtio_spec: replace VirtioDeviceFeatures Vec<u32> with u64 bitfield

### DIFF
--- a/openvmm_vhost/vhost_user_backend/src/lib.rs
+++ b/openvmm_vhost/vhost_user_backend/src/lib.rs
@@ -164,9 +164,12 @@ impl VhostUserDeviceServer {
 
         match code {
             VhostUserRequestCode::GET_FEATURES => {
-                let mut features = features_to_u64(&traits.device_features);
-                features |= VHOST_USER_F_PROTOCOL_FEATURES;
-                let reply_payload = VhostUserU64Msg { value: features };
+                let features = traits
+                    .device_features
+                    .with_vhost_user_protocol_features(true);
+                let reply_payload = VhostUserU64Msg {
+                    value: features.into_bits(),
+                };
                 send_reply(socket, hdr, reply_payload.as_bytes(), &[]).await?;
             }
 
@@ -177,10 +180,10 @@ impl VhostUserDeviceServer {
                 // VHOST_F_LOG_ALL may be toggled). We don't currently support
                 // any features that require restarting queues on change, so
                 // just storing the new value is correct.
-                // Mask out VHOST_USER_F_PROTOCOL_FEATURES — it's a
+                // Mask out the vhost-user protocol features bit — it's a
                 // vhost-user control bit, not a virtio device feature.
-                state.negotiated_features =
-                    features_from_u64(msg.value & !VHOST_USER_F_PROTOCOL_FEATURES);
+                state.negotiated_features = VirtioDeviceFeatures::from_bits(msg.value)
+                    .with_vhost_user_protocol_features(false);
                 maybe_ack(socket, hdr, state).await?
             }
 
@@ -360,7 +363,7 @@ impl VhostUserDeviceServer {
                 // For packed ring, pack both avail and used state into
                 // the reply (avail in low 16, used in high 16). For split
                 // ring, only the avail index matters.
-                let num = if state.negotiated_features.bank1().ring_packed() {
+                let num = if state.negotiated_features.ring_packed() {
                     (queue_state.avail_index as u32) | ((queue_state.used_index as u32) << 16)
                 } else {
                     queue_state.avail_index as u32
@@ -418,8 +421,7 @@ impl VhostUserDeviceServer {
                                 q.try_activate(self.guest_memory.clone())
                             {
                                 // Split raw_base into QueueState based on ring type.
-                                let queue_state = if state.negotiated_features.bank1().ring_packed()
-                                {
+                                let queue_state = if state.negotiated_features.ring_packed() {
                                     // Packed: low 16 = avail state, high 16 = used state.
                                     QueueState {
                                         avail_index: raw_base as u16,
@@ -694,22 +696,6 @@ fn parse_payload<T: FromBytes>(payload: &[u8]) -> anyhow::Result<T> {
         })
 }
 
-/// Convert a u64 to VirtioDeviceFeatures (bank0 = low 32 bits, bank1 = high 32 bits).
-// TODO: VirtioDeviceFeatures should just be a u64-based enum/bitfield instead
-// of a Vec<u32> bank model. The spec's bank-indexed transport registers don't
-// require the in-memory representation to match, and every VMM (QEMU, CH,
-// Linux) uses a flat u64. That would eliminate these helpers entirely.
-fn features_from_u64(value: u64) -> VirtioDeviceFeatures {
-    VirtioDeviceFeatures::new()
-        .with_bank(0, value as u32)
-        .with_bank(1, (value >> 32) as u32)
-}
-
-/// Convert VirtioDeviceFeatures to a u64 (bank0 = low 32 bits, bank1 = high 32 bits).
-fn features_to_u64(features: &VirtioDeviceFeatures) -> u64 {
-    features.bank(0) as u64 | ((features.bank(1) as u64) << 32)
-}
-
 /// Create a `pal_event::Event` from an `OwnedFd`.
 ///
 /// The fd should be an eventfd. On Linux, `pal_event::Event` wraps an eventfd.
@@ -856,13 +842,15 @@ mod tests {
             let reply = send_and_recv(&frontend, VhostUserRequestCode::GET_FEATURES, &[]).await;
             let features_msg = VhostUserU64Msg::read_from_bytes(&reply).unwrap();
             assert!(
-                features_msg.value & VHOST_USER_F_PROTOCOL_FEATURES != 0,
+                VirtioDeviceFeatures::from_bits(features_msg.value).vhost_user_protocol_features(),
                 "should advertise PROTOCOL_FEATURES"
             );
 
             // SET_FEATURES (must include PROTOCOL_FEATURES bit)
             let set_features = VhostUserU64Msg {
-                value: VHOST_USER_F_PROTOCOL_FEATURES,
+                value: VirtioDeviceFeatures::new()
+                    .with_vhost_user_protocol_features(true)
+                    .into_bits(),
             };
             send_msg(
                 &frontend,
@@ -950,11 +938,13 @@ mod tests {
         // GET_FEATURES
         let reply = send_and_recv(frontend, VhostUserRequestCode::GET_FEATURES, &[]).await;
         let features_msg = VhostUserU64Msg::read_from_bytes(&reply).unwrap();
-        assert!(features_msg.value & VHOST_USER_F_PROTOCOL_FEATURES != 0);
+        assert!(VirtioDeviceFeatures::from_bits(features_msg.value).vhost_user_protocol_features());
 
         // SET_FEATURES
         let set_features = VhostUserU64Msg {
-            value: VHOST_USER_F_PROTOCOL_FEATURES,
+            value: VirtioDeviceFeatures::new()
+                .with_vhost_user_protocol_features(true)
+                .into_bits(),
         };
         send_msg(
             frontend,

--- a/vm/devices/virtio/vhost_user_frontend/src/lib.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/lib.rs
@@ -71,8 +71,8 @@ pub struct VhostUserFrontend {
     /// reads are served locally and `VHOST_USER_PROTOCOL_F_CONFIG` is
     /// not negotiated with the backend.
     config_space: Option<Vec<u8>>,
-    /// Raw feature bits from GET_FEATURES (used to mask guest features).
-    device_features_raw: u64,
+    /// Device feature bits from GET_FEATURES (used to mask guest features).
+    device_features_raw: VirtioDeviceFeatures,
     guest_features_sent: bool,
     /// Whether packed ring (VIRTIO_F_RING_PACKED) is active. Set when
     /// guest-negotiated features are sent to the backend.
@@ -130,11 +130,13 @@ impl VhostUserFrontend {
         config_space: Option<Vec<u8>>,
     ) -> anyhow::Result<Self> {
         // 1. GET_FEATURES
-        let device_features_raw = send_get_u64(&socket, VhostUserRequestCode::GET_FEATURES).await?;
-        tracing::trace!(features = %format!("0x{device_features_raw:x}"), "GET_FEATURES");
+        let device_features_raw = VirtioDeviceFeatures::from_bits(
+            send_get_u64(&socket, VhostUserRequestCode::GET_FEATURES).await?,
+        );
+        tracing::trace!(features = %format!("0x{:x}", device_features_raw.into_bits()), "GET_FEATURES");
 
         // 2. Negotiate protocol features (only if the backend advertises them).
-        let negotiated_proto = if device_features_raw & VHOST_USER_F_PROTOCOL_FEATURES != 0 {
+        let negotiated_proto = if device_features_raw.vhost_user_protocol_features() {
             let proto_features_raw =
                 send_get_u64(&socket, VhostUserRequestCode::GET_PROTOCOL_FEATURES).await?;
             let wanted = VhostUserProtocolFeatures::new()
@@ -170,8 +172,7 @@ impl VhostUserFrontend {
         tracing::trace!(max_queues, "GET_QUEUE_NUM");
 
         // Build DeviceTraits from the wire features.
-        let device_features =
-            features_from_u64(device_features_raw & !(VHOST_USER_F_PROTOCOL_FEATURES));
+        let device_features = device_features_raw.with_vhost_user_protocol_features(false);
 
         // Determine the config register length.
         //
@@ -300,31 +301,29 @@ impl VirtioDevice for VhostUserFrontend {
         // first queue is started.  The backend needs this to know which
         // features are active.
         if !self.guest_features_sent {
-            let guest_bits = features.bank(0) as u64 | ((features.bank(1) as u64) << 32);
             // Mask to only include features the backend actually advertised.
             // The VMM transport may add features (e.g., RING_PACKED) that
             // the backend doesn't support. Always include PROTOCOL_FEATURES
             // if it was negotiated — backends (e.g., virtiofsd) treat its
             // absence in SET_FEATURES as de-negotiation.
-            let masked_bits =
-                (guest_bits & self.device_features_raw) | VHOST_USER_F_PROTOCOL_FEATURES;
+            let negotiated = VirtioDeviceFeatures::from_bits(
+                features.into_bits() & self.device_features_raw.into_bits(),
+            );
+            let on_wire = negotiated.with_vhost_user_protocol_features(true);
             tracing::trace!(
                 idx,
-                features = %format!("0x{masked_bits:x}"),
+                features = %format!("0x{:x}", on_wire.into_bits()),
                 "SET_FEATURES (guest-negotiated)",
             );
             send_set_u64(
                 &self.socket,
                 VhostUserRequestCode::SET_FEATURES,
-                masked_bits,
+                on_wire.into_bits(),
                 self.reply_ack(),
             )
             .await?;
             self.guest_features_sent = true;
-            // Determine the effective ring format from the actually-
-            // negotiated features (intersection of guest and backend).
-            let negotiated = features_from_u64(masked_bits);
-            self.packed_ring = negotiated.bank1().ring_packed();
+            self.packed_ring = negotiated.ring_packed();
         }
 
         let packed_ring = self.packed_ring;
@@ -933,17 +932,6 @@ async fn send_set_config(
     Ok(())
 }
 
-/// Convert a u64 to VirtioDeviceFeatures.
-// TODO: VirtioDeviceFeatures should just be a u64-based enum/bitfield instead
-// of a Vec<u32> bank model. The spec's bank-indexed transport registers don't
-// require the in-memory representation to match, and every VMM (QEMU, CH,
-// Linux) uses a flat u64. That would eliminate these helpers entirely.
-fn features_from_u64(value: u64) -> VirtioDeviceFeatures {
-    VirtioDeviceFeatures::new()
-        .with_bank(0, value as u32)
-        .with_bank(1, (value >> 32) as u32)
-}
-
 /// Read a little-endian `u32` from config bytes, zero-padding any trailing
 /// bytes when the read overlaps the end of the slice.
 fn read_config_u32(config: &[u8], offset: usize) -> u32 {
@@ -1377,9 +1365,7 @@ mod tests {
 
     impl SaveRestoreMockDevice {
         fn new(packed_ring: bool, stop_avail: u16, stop_used: u16) -> Self {
-            use virtio::spec::VirtioDeviceFeaturesBank1;
-            let features = VirtioDeviceFeatures::new()
-                .with_bank1(VirtioDeviceFeaturesBank1::new().with_ring_packed(packed_ring));
+            let features = VirtioDeviceFeatures::new().with_ring_packed(packed_ring);
             Self {
                 traits: DeviceTraits {
                     device_id: VirtioDeviceType::BLK,
@@ -1492,9 +1478,7 @@ mod tests {
             setup_frontend_backend_with_device(&driver, device).await;
 
         // Features must include packed ring so the frontend knows.
-        use virtio::spec::VirtioDeviceFeaturesBank1;
-        let features = VirtioDeviceFeatures::new()
-            .with_bank1(VirtioDeviceFeaturesBank1::new().with_ring_packed(true));
+        let features = VirtioDeviceFeatures::new().with_ring_packed(true);
         let resources =
             dummy_queue_resources(Interrupt::from_event(Event::new()), guest_memory.clone());
         frontend

--- a/vm/devices/virtio/vhost_user_protocol/src/protocol.rs
+++ b/vm/devices/virtio/vhost_user_protocol/src/protocol.rs
@@ -22,9 +22,6 @@ pub const VHOST_USER_FLAG_REPLY: u32 = 0x4;
 /// Header flag: the frontend requests a reply to this message.
 pub const VHOST_USER_FLAG_NEED_REPLY: u32 = 0x8;
 
-/// Feature bit indicating vhost-user protocol features are available.
-pub const VHOST_USER_F_PROTOCOL_FEATURES: u64 = 1 << 30;
-
 /// SET_VRING_KICK/CALL/ERR: bit 8 means "no fd".
 pub const VHOST_USER_VRING_NOFD_MASK: u64 = 1 << 8;
 /// Index bits for SET_VRING_KICK/CALL/ERR.

--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -118,7 +118,6 @@ pub struct QueueParams {
 pub(crate) struct QueueCoreGetWork {
     queue_desc: GuestMemory,
     queue_size: u16,
-    #[inspect(skip)]
     features: VirtioDeviceFeatures,
     mem: GuestMemory,
     #[inspect(flatten)]
@@ -147,19 +146,19 @@ impl QueueCoreGetWork {
         let initial_avail = initial_state.map(|s| s.avail_index);
         // Split queues require power-of-2 sizes (virtio spec §2.7.1).
         // Packed queues do not (§2.8.10.1).
-        if !features.bank1().ring_packed() && !params.size.is_power_of_two() {
+        if !features.ring_packed() && !params.size.is_power_of_two() {
             return Err(QueueError::InvalidQueueSize(params.size));
         }
         let queue_desc = mem
             .subrange(params.desc_addr, descriptor_offset(params.size), true)
             .map_err(QueueError::Memory)?;
-        let inner = if features.bank1().ring_packed() {
+        let inner = if features.ring_packed() {
             let (index, wrap) = match initial_avail {
                 Some(v) => (v & 0x7FFF, (v >> 15) != 0),
                 None => (0, true),
             };
             QueueGetWorkInner::Packed(PackedQueueGetWork::new(
-                features.clone(),
+                features,
                 mem.clone(),
                 params,
                 index,
@@ -168,7 +167,7 @@ impl QueueCoreGetWork {
         } else {
             let index = initial_avail.unwrap_or(0);
             QueueGetWorkInner::Split(SplitQueueGetWork::new(
-                features.clone(),
+                features,
                 mem.clone(),
                 params,
                 index,
@@ -312,11 +311,7 @@ impl QueueCoreGetWork {
 
     fn reader(&mut self, descriptor_index: u16) -> DescriptorReader<'_> {
         DescriptorReader {
-            chain: DescriptorChain::new(
-                self,
-                self.features.bank0().ring_indirect_desc(),
-                descriptor_index,
-            ),
+            chain: DescriptorChain::new(self, self.features.ring_indirect_desc(), descriptor_index),
         }
     }
 
@@ -394,13 +389,13 @@ impl QueueCoreCompleteWork {
         initial_state: Option<QueueState>,
     ) -> Result<Self, QueueError> {
         let initial_used = initial_state.map(|s| s.used_index);
-        let inner = if features.bank1().ring_packed() {
+        let inner = if features.ring_packed() {
             let (index, wrap) = match initial_used {
                 Some(v) => (v & 0x7FFF, (v >> 15) != 0),
                 None => (0, true),
             };
             QueueCompleteWorkInner::Packed(PackedQueueCompleteWork::new(
-                features.clone(),
+                features,
                 mem.clone(),
                 params,
                 index,
@@ -409,7 +404,7 @@ impl QueueCoreCompleteWork {
         } else {
             let index = initial_used.unwrap_or(0);
             QueueCompleteWorkInner::Split(SplitQueueCompleteWork::new(
-                features.clone(),
+                features,
                 mem.clone(),
                 params,
                 index,
@@ -450,9 +445,8 @@ pub(crate) fn new_queue(
     params: QueueParams,
     initial_state: Option<QueueState>,
 ) -> Result<(QueueCoreGetWork, QueueCoreCompleteWork), QueueError> {
-    let get_work = QueueCoreGetWork::new(features.clone(), mem.clone(), params, initial_state)?;
-    let complete_work =
-        QueueCoreCompleteWork::new(features.clone(), mem.clone(), params, initial_state)?;
+    let get_work = QueueCoreGetWork::new(features, mem.clone(), params, initial_state)?;
+    let complete_work = QueueCoreCompleteWork::new(features, mem.clone(), params, initial_state)?;
     Ok((get_work, complete_work))
 }
 

--- a/vm/devices/virtio/virtio/src/queue/packed.rs
+++ b/vm/devices/virtio/virtio/src/queue/packed.rs
@@ -183,7 +183,7 @@ impl PackedQueueCompleteWork {
             queue_size: params.size,
             next_index: initial_index,
             wrapped_bit: initial_wrap,
-            use_event_index: features.bank0().ring_event_idx(),
+            use_event_index: features.ring_event_idx(),
         })
     }
 

--- a/vm/devices/virtio/virtio/src/queue/split.rs
+++ b/vm/devices/virtio/virtio/src/queue/split.rs
@@ -61,7 +61,7 @@ impl SplitQueueGetWork {
             queue_size: params.size,
             last_avail_index: initial_avail_index,
             cached_avail_index: initial_avail_index,
-            use_ring_event_index: features.bank0().ring_event_idx(),
+            use_ring_event_index: features.ring_event_idx(),
         })
     }
 
@@ -208,7 +208,7 @@ impl SplitQueueCompleteWork {
             queue_used,
             queue_size: params.size,
             last_used_index: initial_used_index,
-            use_ring_event_index: features.bank0().ring_event_idx(),
+            use_ring_event_index: features.ring_event_idx(),
         })
     }
 

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -1297,7 +1297,7 @@ impl VirtioDevice for TestDevice {
 
         let queue_event = PolledWait::new(&self.driver, resources.event).unwrap();
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory,
             resources.notify,
@@ -2567,7 +2567,7 @@ async fn verify_device_queue_simple_inner(
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: features.clone(),
+                device_features: features,
                 max_queues: 1,
                 device_register_length: 0,
                 ..Default::default()
@@ -2656,7 +2656,7 @@ async fn verify_device_multi_queue_inner(
             &driver_source,
             DeviceTraits {
                 device_id: VirtioDeviceType::CONSOLE,
-                device_features: features.clone(),
+                device_features: features,
                 max_queues: num_queues + 1,
                 device_register_length: 0,
                 ..Default::default()

--- a/vm/devices/virtio/virtio/src/transport/core.rs
+++ b/vm/devices/virtio/virtio/src/transport/core.rs
@@ -70,11 +70,9 @@ pub(crate) struct VirtioTransportCore {
     #[inspect(skip)]
     pub _device_task: Task<()>,
     pub state: TransportState,
-    #[inspect(skip)]
     pub device_feature: VirtioDeviceFeatures,
     #[inspect(hex)]
     pub device_feature_select: u32,
-    #[inspect(skip)]
     pub driver_feature: VirtioDeviceFeatures,
     #[inspect(hex)]
     pub driver_feature_select: u32,
@@ -123,10 +121,7 @@ impl VirtioTransportCore {
             })
             .collect::<std::io::Result<Vec<_>>>()?;
 
-        let device_feature = traits
-            .device_features
-            .clone()
-            .with_bank1(traits.device_features.bank1().with_version_1(true));
+        let device_feature = traits.device_features.with_version_1(true);
         let supports_save_restore = device.supports_save_restore();
 
         let (sender, receiver) = mesh::channel();
@@ -438,9 +433,7 @@ impl VirtioTransportCore {
         }
         Ok(super::saved_state::state::CommonSavedState {
             device_status: self.device_status.into(),
-            driver_feature_banks: (0..self.device_feature.len())
-                .map(|i| self.driver_feature.bank(i))
-                .collect(),
+            driver_feature_banks: (0..2usize).map(|i| self.driver_feature.bank(i)).collect(),
             device_feature_select: self.device_feature_select,
             driver_feature_select: self.driver_feature_select,
             queue_select: self.queue_select,

--- a/vm/devices/virtio/virtio/src/transport/core.rs
+++ b/vm/devices/virtio/virtio/src/transport/core.rs
@@ -306,7 +306,7 @@ impl VirtioTransportCore {
         if !self.device_status.driver_ok() && new_status.driver_ok() {
             self.install_doorbells(ops);
 
-            let features = self.driver_feature.clone();
+            let features = self.driver_feature;
             let queues: Vec<_> = self
                 .queues
                 .iter()
@@ -354,7 +354,7 @@ impl VirtioTransportCore {
     /// `ChangeDeviceState::start()` implementation.
     pub fn start(&mut self, ops: &mut dyn TransportOps) {
         if self.device_status.driver_ok() {
-            let features = self.driver_feature.clone();
+            let features = self.driver_feature;
             let mut queues = Vec::new();
             for (i, qd) in self.queues.iter_mut().enumerate() {
                 if !qd.params.enable {

--- a/vm/devices/virtio/virtio/src/transport/mmio.rs
+++ b/vm/devices/virtio/virtio/src/transport/mmio.rs
@@ -230,7 +230,7 @@ impl VirtioMmioDevice {
             VirtioMmioRegister::DEVICE_FEATURES_SEL => self.core.device_feature_select = val,
             VirtioMmioRegister::DRIVER_FEATURES => {
                 let bank = self.core.driver_feature_select as usize;
-                if !features_locked && bank < self.core.device_feature.len() {
+                if !features_locked && bank < 2 {
                     self.core
                         .driver_feature
                         .set_bank(bank, val & self.core.device_feature.bank(bank));

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -380,7 +380,7 @@ impl VirtioPciDevice {
             VirtioPciCommonCfg::DRIVER_FEATURE_SELECT => self.core.driver_feature_select = val,
             VirtioPciCommonCfg::DRIVER_FEATURE => {
                 let bank = self.core.driver_feature_select as usize;
-                if !features_locked && bank < self.core.device_feature.len() {
+                if !features_locked && bank < 2 {
                     self.core
                         .driver_feature
                         .set_bank(bank, val & self.core.device_feature.bank(bank));

--- a/vm/devices/virtio/virtio/src/transport/saved_state.rs
+++ b/vm/devices/virtio/virtio/src/transport/saved_state.rs
@@ -88,11 +88,11 @@ pub(crate) fn validate_restore(
 ) -> Result<(), RestoreError> {
     // Validate feature banks.
     let saved_banks = &common.driver_feature_banks;
-    if saved_banks.len() > device_features.len() {
+    if saved_banks.len() > 2 {
         return Err(RestoreError::InvalidSavedState(
             VirtioRestoreError::TooManyFeatureBanks {
                 saved: saved_banks.len(),
-                device: device_features.len(),
+                device: 2,
             }
             .into(),
         ));

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -43,7 +43,6 @@ use virtio::regions::DataRegion;
 use virtio::regions::data_regions;
 use virtio::regions::try_build_gpn_list;
 use virtio::spec::VirtioDeviceFeatures;
-use virtio::spec::VirtioDeviceFeaturesBank0;
 use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
 use zerocopy::FromZeros;
@@ -312,13 +311,10 @@ impl VirtioDevice for VirtioBlkDevice {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::BLK,
             device_features: VirtioDeviceFeatures::new()
-                .with_bank0(
-                    VirtioDeviceFeaturesBank0::new()
-                        .with_device_specific(features)
-                        .with_ring_event_idx(true)
-                        .with_ring_indirect_desc(true),
-                )
-                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
+                .with_device_specific_low(features)
+                .with_ring_event_idx(true)
+                .with_ring_indirect_desc(true)
+                .with_ring_packed(true),
             max_queues: 1,
             // Config space is 60 bytes (size_of minus 4 bytes of struct padding).
             device_register_length: (size_of::<VirtioBlkConfig>() - 4) as u32,
@@ -365,7 +361,7 @@ impl VirtioDevice for VirtioBlkDevice {
             .context("failed to create queue event")?;
 
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory.clone(),
             resources.notify,

--- a/vm/devices/virtio/virtio_console/src/lib.rs
+++ b/vm/devices/virtio/virtio_console/src/lib.rs
@@ -85,13 +85,10 @@ impl VirtioConsoleDevice {
 impl VirtioDevice for VirtioConsoleDevice {
     fn traits(&self) -> DeviceTraits {
         let features = VirtioDeviceFeatures::new()
-            .with_bank0(
-                virtio::spec::VirtioDeviceFeaturesBank0::new()
-                    .with_device_specific(1 << VIRTIO_CONSOLE_F_SIZE)
-                    .with_ring_event_idx(true)
-                    .with_ring_indirect_desc(true),
-            )
-            .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true));
+            .with_device_specific_low(1 << VIRTIO_CONSOLE_F_SIZE)
+            .with_ring_event_idx(true)
+            .with_ring_indirect_desc(true)
+            .with_ring_packed(true);
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::CONSOLE,
             device_features: features,
@@ -118,7 +115,7 @@ impl VirtioDevice for VirtioConsoleDevice {
     ) -> anyhow::Result<()> {
         let guest_memory = resources.guest_memory.clone();
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory,
             resources.notify,

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -269,12 +269,10 @@ impl VirtioDevice for Device {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::NET,
             device_features: VirtioDeviceFeatures::new()
-                .with_bank0(
-                    virtio::spec::VirtioDeviceFeaturesBank0::from_bits(features_bank0.into_bits())
-                        .with_ring_event_idx(true)
-                        .with_ring_indirect_desc(true),
-                )
-                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
+                .with_device_specific_low(features_bank0.into_bits())
+                .with_ring_event_idx(true)
+                .with_ring_indirect_desc(true)
+                .with_ring_packed(true),
             max_queues: 2 * self.registers.max_virtqueue_pairs,
             device_register_length: size_of::<NetConfig>() as u32,
             shared_memory: DeviceTraitsSharedMemory { id: 0, size: 0 },
@@ -314,7 +312,7 @@ impl VirtioDevice for Device {
         let queue_event = PolledWait::new(&self.adapter.driver, resources.event)
             .context("failed creating queue event")?;
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory,
             resources.notify,

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -74,13 +74,10 @@ impl VirtioDevice for VirtioPlan9Device {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::P9,
             device_features: VirtioDeviceFeatures::new()
-                .with_bank0(
-                    virtio::spec::VirtioDeviceFeaturesBank0::new()
-                        .with_device_specific(VIRTIO_9P_F_MOUNT_TAG)
-                        .with_ring_event_idx(true)
-                        .with_ring_indirect_desc(true),
-                )
-                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
+                .with_device_specific_low(VIRTIO_9P_F_MOUNT_TAG)
+                .with_ring_event_idx(true)
+                .with_ring_indirect_desc(true)
+                .with_ring_packed(true),
             max_queues: 1,
             device_register_length: self.tag.len() as u32,
             ..Default::default()
@@ -119,7 +116,7 @@ impl VirtioDevice for VirtioPlan9Device {
         let queue_event = PolledWait::new(&self.driver, resources.event)
             .context("failed to create polled wait")?;
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory.clone(),
             resources.notify,

--- a/vm/devices/virtio/virtio_pmem/src/lib.rs
+++ b/vm/devices/virtio/virtio_pmem/src/lib.rs
@@ -70,12 +70,9 @@ impl VirtioDevice for Device {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::PMEM,
             device_features: VirtioDeviceFeatures::new()
-                .with_bank0(
-                    virtio::spec::VirtioDeviceFeaturesBank0::new()
-                        .with_ring_event_idx(true)
-                        .with_ring_indirect_desc(true),
-                )
-                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
+                .with_ring_event_idx(true)
+                .with_ring_indirect_desc(true)
+                .with_ring_packed(true),
             max_queues: 1,
             device_register_length: size_of::<PmemConfig>() as u32,
             shared_memory: DeviceTraitsSharedMemory {
@@ -116,7 +113,7 @@ impl VirtioDevice for Device {
         let queue_event = PolledWait::new(&self.driver, resources.event)
             .context("failed to create polled wait")?;
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory.clone(),
             resources.notify,

--- a/vm/devices/virtio/virtio_rng/src/lib.rs
+++ b/vm/devices/virtio/virtio_rng/src/lib.rs
@@ -56,12 +56,9 @@ impl VirtioDevice for VirtioRngDevice {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::RNG,
             device_features: VirtioDeviceFeatures::new()
-                .with_bank0(
-                    virtio::spec::VirtioDeviceFeaturesBank0::new()
-                        .with_ring_event_idx(true)
-                        .with_ring_indirect_desc(true),
-                )
-                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
+                .with_ring_event_idx(true)
+                .with_ring_indirect_desc(true)
+                .with_ring_packed(true),
             max_queues: 1,
             device_register_length: 0,
             shared_memory: DeviceTraitsSharedMemory::default(),
@@ -86,7 +83,7 @@ impl VirtioDevice for VirtioRngDevice {
         let queue_event = PolledWait::new(&self.driver, resources.event)
             .context("failed to create polled wait")?;
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory.clone(),
             resources.notify,

--- a/vm/devices/virtio/virtio_spec/src/lib.rs
+++ b/vm/devices/virtio/virtio_spec/src/lib.rs
@@ -27,87 +27,62 @@ mod packed_nums {
     pub type u64_le = zerocopy::U64<zerocopy::LittleEndian>;
 }
 
-#[bitfield(u32)]
-#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
-pub struct VirtioDeviceFeaturesBank0 {
+#[derive(Inspect)]
+#[bitfield(u64)]
+pub struct VirtioDeviceFeatures {
+    // Bank 0 (bits 0-31)
     #[bits(24)]
-    pub device_specific: u32,
+    pub device_specific_low: u32,
     #[bits(4)]
     _reserved1: u8,
-    pub ring_indirect_desc: bool, // VIRTIO_F_INDIRECT_DESC
-    pub ring_event_idx: bool,     // VIRTIO_F_EVENT_IDX
+    pub ring_indirect_desc: bool, // VIRTIO_F_INDIRECT_DESC (bit 28)
+    pub ring_event_idx: bool,     // VIRTIO_F_EVENT_IDX (bit 29)
     #[bits(2)]
     _reserved2: u8,
-}
-
-#[bitfield(u32)]
-#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
-pub struct VirtioDeviceFeaturesBank1 {
-    pub version_1: bool,         // VIRTIO_F_VERSION_1
-    pub access_platform: bool,   // VIRTIO_F_ACCESS_PLATFORM
-    pub ring_packed: bool,       // VIRTIO_F_RING_PACKED
-    pub in_order: bool,          // VIRTIO_F_IN_ORDER
-    pub order_platform: bool,    // VIRTIO_F_ORDER_PLATFORM
-    pub sriov: bool,             // VIRTIO_F_SR_IOV
-    pub notification_data: bool, // VIRTIO_F_NOTIFICATION_DATA
-    pub notif_config_data: bool, // VIRTIO_F_NOTIF_CONFIG_DATA
-    pub ring_reset: bool,        // VIRTIO_F_RING_RESET
-    pub admin_vq: bool,          // VIRTIO_F_ADMIN_VQ
+    // Bank 1 (bits 32-63)
+    pub version_1: bool,         // VIRTIO_F_VERSION_1 (bit 32)
+    pub access_platform: bool,   // VIRTIO_F_ACCESS_PLATFORM (bit 33)
+    pub ring_packed: bool,       // VIRTIO_F_RING_PACKED (bit 34)
+    pub in_order: bool,          // VIRTIO_F_IN_ORDER (bit 35)
+    pub order_platform: bool,    // VIRTIO_F_ORDER_PLATFORM (bit 36)
+    pub sriov: bool,             // VIRTIO_F_SR_IOV (bit 37)
+    pub notification_data: bool, // VIRTIO_F_NOTIFICATION_DATA (bit 38)
+    pub notif_config_data: bool, // VIRTIO_F_NOTIF_CONFIG_DATA (bit 39)
+    pub ring_reset: bool,        // VIRTIO_F_RING_RESET (bit 40)
+    pub admin_vq: bool,          // VIRTIO_F_ADMIN_VQ (bit 41)
     pub device_specific_bit_42: bool,
-    pub suspend: bool, // VIRTIO_F_SUSPEND
+    pub suspend: bool, // VIRTIO_F_SUSPEND (bit 43)
     #[bits(7)]
-    _reserved: u8,
+    _reserved3: u8,
     #[bits(13)]
-    pub device_specific: u16,
+    pub device_specific_high: u16,
 }
 
-#[derive(Debug, Clone)]
-pub struct VirtioDeviceFeatures(Vec<u32>);
 impl VirtioDeviceFeatures {
-    pub fn new() -> Self {
-        Self(Vec::with_capacity(2))
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn set_bank(&mut self, index: usize, val: u32) {
-        if self.0.len() <= index {
-            self.0.resize(index + 1, 0);
+    /// Get a 32-bit bank by index (0 = low, 1 = high) for transport register
+    /// reads. Returns 0 for out-of-range indices.
+    pub fn bank(&self, index: usize) -> u32 {
+        match index {
+            0 => self.into_bits() as u32,
+            1 => (self.into_bits() >> 32) as u32,
+            _ => 0,
         }
-        self.0[index] = val;
     }
 
+    /// Set a 32-bit bank by index for transport register writes.
+    pub fn set_bank(&mut self, index: usize, val: u32) {
+        let bits = self.into_bits();
+        *self = Self::from_bits(match index {
+            0 => (bits & !0xFFFF_FFFF) | val as u64,
+            1 => (bits & 0xFFFF_FFFF) | (val as u64) << 32,
+            _ => return,
+        });
+    }
+
+    /// Builder method to set a 32-bit bank by index.
     pub fn with_bank(mut self, index: usize, val: u32) -> Self {
         self.set_bank(index, val);
         self
-    }
-
-    pub fn with_bank0(self, bank0: VirtioDeviceFeaturesBank0) -> Self {
-        self.with_bank(0, bank0.into_bits())
-    }
-
-    pub fn with_bank1(self, bank1: VirtioDeviceFeaturesBank1) -> Self {
-        self.with_bank(1, bank1.into_bits())
-    }
-
-    pub fn bank(&self, index: usize) -> u32 {
-        self.0.get(index).map_or(0, |x| *x)
-    }
-
-    pub fn bank0(&self) -> VirtioDeviceFeaturesBank0 {
-        VirtioDeviceFeaturesBank0::from_bits(self.bank(0))
-    }
-
-    pub fn bank1(&self) -> VirtioDeviceFeaturesBank1 {
-        VirtioDeviceFeaturesBank1::from_bits(self.bank(1))
-    }
-}
-
-impl Default for VirtioDeviceFeatures {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/vm/devices/virtio/virtio_spec/src/lib.rs
+++ b/vm/devices/virtio/virtio_spec/src/lib.rs
@@ -37,8 +37,8 @@ pub struct VirtioDeviceFeatures {
     _reserved1: u8,
     pub ring_indirect_desc: bool, // VIRTIO_F_INDIRECT_DESC (bit 28)
     pub ring_event_idx: bool,     // VIRTIO_F_EVENT_IDX (bit 29)
-    #[bits(2)]
-    _reserved2: u8,
+    pub vhost_user_protocol_features: bool, // VHOST_USER_F_PROTOCOL_FEATURES (bit 30)
+    _reserved2: bool,
     // Bank 1 (bits 32-63)
     pub version_1: bool,         // VIRTIO_F_VERSION_1 (bit 32)
     pub access_platform: bool,   // VIRTIO_F_ACCESS_PLATFORM (bit 33)

--- a/vm/devices/virtio/virtio_vsock/src/lib.rs
+++ b/vm/devices/virtio/virtio_vsock/src/lib.rs
@@ -118,9 +118,8 @@ impl VirtioDevice for VirtioVsockDevice {
             .with_no_implied_stream(true);
         DeviceTraits {
             device_id: VirtioDeviceType::VSOCK,
-            device_features: VirtioDeviceFeatures::new().with_bank0(
-                virtio::spec::VirtioDeviceFeaturesBank0::from_bits(features_bank0.into_bits()),
-            ),
+            device_features: VirtioDeviceFeatures::new()
+                .with_device_specific_low(features_bank0.into_bits()),
             max_queues: QUEUE_COUNT.try_into().unwrap(),
             device_register_length: size_of::<VsockConfig>() as u32,
             ..Default::default()
@@ -176,7 +175,7 @@ impl VirtioDevice for VirtioVsockDevice {
             .context("failed to create queue event")?;
 
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory.clone(),
             resources.notify,

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -101,12 +101,9 @@ impl VirtioDevice for VirtioFsDevice {
         DeviceTraits {
             device_id: virtio::spec::VirtioDeviceType::FS,
             device_features: VirtioDeviceFeatures::new()
-                .with_bank0(
-                    virtio::spec::VirtioDeviceFeaturesBank0::new()
-                        .with_ring_event_idx(true)
-                        .with_ring_indirect_desc(true),
-                )
-                .with_bank1(virtio::spec::VirtioDeviceFeaturesBank1::new().with_ring_packed(true)),
+                .with_ring_event_idx(true)
+                .with_ring_indirect_desc(true)
+                .with_ring_packed(true),
             max_queues: 2,
             device_register_length: self.config.as_bytes().len() as u32,
             shared_memory: DeviceTraitsSharedMemory {
@@ -159,7 +156,7 @@ impl VirtioDevice for VirtioFsDevice {
         let queue_event = PolledWait::new(&self.driver, resources.event)
             .context("failed to create polled wait")?;
         let queue = VirtioQueue::new(
-            features.clone(),
+            *features,
             resources.params,
             resources.guest_memory.clone(),
             resources.notify,


### PR DESCRIPTION
Collapse VirtioDeviceFeatures, VirtioDeviceFeaturesBank0, and VirtioDeviceFeaturesBank1 into a single #[bitfield(u64)] struct. No real implementation supports more than 64 bits of features, so the Vec<u32> was unnecessary overhead.

The type is now Copy (no heap allocation), and device code can access feature flags directly (e.g. features.ring_packed()) instead of going through bank accessor methods.

Transport-level bank()/set_bank() methods are preserved for the register read/write paths that operate on 32-bit banks.