### PR TITLE
virtio: improve inspect output

### DIFF
--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -254,7 +254,7 @@ impl<'a> PeekedWork<'a> {
 pub struct VirtioQueue {
     #[inspect(flatten)]
     core: QueueCoreGetWork,
-    #[inspect(skip)]
+    #[inspect(flatten)]
     complete: QueueCoreCompleteWork,
     #[inspect(skip)]
     notify_guest: Interrupt,

--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -96,10 +96,11 @@ enum QueueGetWorkInner {
     Packed(#[inspect(flatten)] PackedQueueGetWork),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Inspect)]
+#[inspect(tag = "type")]
 enum QueueCompleteWorkInner {
-    Split(SplitQueueCompleteWork),
-    Packed(PackedQueueCompleteWork),
+    Split(#[inspect(flatten)] SplitQueueCompleteWork),
+    Packed(#[inspect(flatten)] PackedQueueCompleteWork),
 }
 
 #[derive(Debug, Copy, Clone, Default, inspect::Inspect)]
@@ -381,8 +382,9 @@ impl QueueCoreGetWork {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Inspect)]
 pub struct QueueCoreCompleteWork {
+    #[inspect(flatten)]
     inner: QueueCompleteWorkInner,
 }
 

--- a/vm/devices/virtio/virtio/src/queue/packed.rs
+++ b/vm/devices/virtio/virtio/src/queue/packed.rs
@@ -38,6 +38,7 @@ impl PackedQueueCompletionContext {
 }
 
 #[derive(Debug, Inspect)]
+#[inspect(extra = "Self::inspect_extra")]
 pub(crate) struct PackedQueueGetWork {
     #[inspect(skip)]
     queue_desc: GuestMemory,
@@ -50,6 +51,14 @@ pub(crate) struct PackedQueueGetWork {
 }
 
 impl PackedQueueGetWork {
+    fn inspect_extra(&self, resp: &mut inspect::Response<'_>) {
+        if let Ok(event) = self.device_event.read_plain::<PackedEventSuppression>(0) {
+            resp.field("device_event_flags", event.flags());
+            resp.field("device_event_offset", event.offset());
+            resp.field("device_event_wrap", event.wrap());
+        }
+    }
+
     pub fn new(
         _features: VirtioDeviceFeatures,
         mem: GuestMemory,
@@ -149,9 +158,12 @@ impl PackedQueueGetWork {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Inspect)]
+#[inspect(extra = "Self::inspect_extra")]
 pub(crate) struct PackedQueueCompleteWork {
+    #[inspect(skip)]
     queue_desc: GuestMemory,
+    #[inspect(skip)]
     driver_event: GuestMemory,
     queue_size: u16,
     next_index: u16,
@@ -160,6 +172,14 @@ pub(crate) struct PackedQueueCompleteWork {
 }
 
 impl PackedQueueCompleteWork {
+    fn inspect_extra(&self, resp: &mut inspect::Response<'_>) {
+        if let Ok(event) = self.driver_event.read_plain::<PackedEventSuppression>(0) {
+            resp.field("driver_event_flags", event.flags());
+            resp.field("driver_event_offset", event.offset());
+            resp.field("driver_event_wrap", event.wrap());
+        }
+    }
+
     pub fn new(
         features: VirtioDeviceFeatures,
         mem: GuestMemory,

--- a/vm/devices/virtio/virtio/src/queue/split.rs
+++ b/vm/devices/virtio/virtio/src/queue/split.rs
@@ -169,9 +169,12 @@ impl SplitQueueGetWork {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Inspect)]
+#[inspect(extra = "Self::inspect_extra")]
 pub(crate) struct SplitQueueCompleteWork {
+    #[inspect(skip)]
     queue_avail: GuestMemory,
+    #[inspect(skip)]
     queue_used: GuestMemory,
     queue_size: u16,
     last_used_index: u16,
@@ -179,6 +182,14 @@ pub(crate) struct SplitQueueCompleteWork {
 }
 
 impl SplitQueueCompleteWork {
+    fn inspect_extra(&self, resp: &mut inspect::Response<'_>) {
+        if self.use_ring_event_index {
+            resp.field("used_event", self.get_used_event().ok());
+        } else {
+            resp.field("available_flags", self.get_available_flags().ok());
+        }
+    }
+
     pub fn new(
         features: VirtioDeviceFeatures,
         mem: GuestMemory,

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -28,7 +28,7 @@ use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 use task_control::AsyncRun;
-use task_control::InspectTask;
+use task_control::InspectTaskMut;
 use task_control::StopTask;
 use task_control::TaskControl;
 use unicycle::FuturesUnordered;
@@ -54,7 +54,7 @@ const MAX_IO_DEPTH: usize = 64;
 /// The virtio-blk device.
 #[derive(InspectMut)]
 pub struct VirtioBlkDevice {
-    #[inspect(flatten)]
+    #[inspect(flatten, mut)]
     worker: TaskControl<BlkWorker, BlkQueueState>,
     #[inspect(skip)]
     driver: VmTaskDriver,
@@ -70,17 +70,17 @@ pub struct VirtioBlkDevice {
 /// live here (not in `BlkQueueState`) so they survive when the
 /// task is stopped — they're drained in `poll_disable()` before
 /// the queue state is removed.
-#[derive(Inspect)]
+#[derive(InspectMut)]
 struct BlkWorker {
     disk: Disk,
     read_only: bool,
-    #[inspect(flatten)]
     stats: WorkerStats,
-    #[inspect(skip)]
+    #[inspect(with = "FuturesUnordered::len")]
     ios: FuturesUnordered<Pin<Box<dyn Future<Output = IoCompletion> + Send>>>,
 }
 
 /// Transient queue state, created in `enable()` and removed in `poll_disable()`.
+#[derive(InspectMut)]
 struct BlkQueueState {
     queue: VirtioQueue,
     memory: GuestMemory,
@@ -96,9 +96,9 @@ struct WorkerStats {
     errors: Counter,
 }
 
-impl InspectTask<BlkQueueState> for BlkWorker {
-    fn inspect(&self, req: inspect::Request<'_>, _state: Option<&BlkQueueState>) {
-        Inspect::inspect(self, req);
+impl InspectTaskMut<BlkQueueState> for BlkWorker {
+    fn inspect_mut(&mut self, req: inspect::Request<'_>, state: Option<&mut BlkQueueState>) {
+        req.respond().merge(self).merge(state);
     }
 }
 

--- a/vm/devices/virtio/virtio_console/src/lib.rs
+++ b/vm/devices/virtio/virtio_console/src/lib.rs
@@ -67,7 +67,7 @@ use vmcore::vm_task::VmTaskDriverSource;
 pub struct VirtioConsoleDevice {
     driver: VmTaskDriver,
     config: VirtioConsoleConfig,
-    #[inspect(skip)]
+    #[inspect(mut)]
     worker: TaskControl<ConsoleWorker, ConsoleWorkerState>,
 }
 

--- a/vm/devices/virtio/virtio_spec/src/lib.rs
+++ b/vm/devices/virtio/virtio_spec/src/lib.rs
@@ -235,6 +235,7 @@ pub mod queue {
     use super::u32_le;
     use super::u64_le;
     use bitfield_struct::bitfield;
+    use inspect::Inspect;
 
     use zerocopy::FromBytes;
     use zerocopy::Immutable;
@@ -283,6 +284,7 @@ pub mod queue {
     pub const AVAIL_OFFSET_RING: u64 = 4;
     pub const AVAIL_ELEMENT_SIZE: u64 = size_of::<u16>() as u64;
 
+    #[derive(Inspect)]
     #[bitfield(u16)]
     pub struct AvailableFlags {
         pub no_interrupt: bool,
@@ -360,7 +362,7 @@ pub mod queue {
     /// virtqueues.
     ///
     /// Reference: virtio spec §2.8.10, "Event Suppression Structure Layout".
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Inspect)]
     #[repr(u8)]
     pub enum EventSuppressionFlags {
         /// `RING_EVENT_FLAGS_ENABLE` (0x0) — events are enabled; the device/driver


### PR DESCRIPTION
Add more queue state and ensure virtio-console and virtio-blk are inspecting everything they should.