### PR TITLE
virt_kvm: add GICv2 support for Raspberry Pi 5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5470,7 +5470,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",
+ "fs-err",
  "hypervisor_resources",
+ "kvm",
  "openvmm_core",
  "virt_hvf",
  "virt_kvm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5472,7 +5472,6 @@ dependencies = [
  "build_rs_guest_arch",
  "fs-err",
  "hypervisor_resources",
- "kvm",
  "openvmm_core",
  "virt_hvf",
  "virt_kvm",

--- a/Guide/src/reference/devices/firmware/linux_direct.md
+++ b/Guide/src/reference/devices/firmware/linux_direct.md
@@ -54,9 +54,10 @@ OpenVMM synthesizes a minimal set of EFI structures in guest memory:
    and an RT Properties entry that advertises no runtime services.
 2. **EFI Memory Map** — describes the EFI metadata region, ACPI tables, and
    conventional RAM.
-3. **ACPI Tables** — FADT (with `HW_REDUCED_ACPI`), MADT (GICv3
-   redistributors, distributor, optional v2m MSI frame), GTDT (virtual timer),
-   DSDT (VMBus, serial UARTs), and optionally MCFG/SSDT for PCIe.
+3. **ACPI Tables** — FADT (with `HW_REDUCED_ACPI`), MADT (GIC distributor, GICv3
+   redistributors or GICv2 CPU interfaces, optional v2m MSI frame), GTDT
+   (virtual timer), DSDT (VMBus, serial UARTs), and optionally MCFG/SSDT for
+   PCIe.
 
 A **stub device tree** is then built. Unlike a full device tree, it contains
 no hardware nodes — no CPUs, GIC, timer, or devices. Its only purpose is a

--- a/openhcl/bootloader_fdt_parser/src/lib.rs
+++ b/openhcl/bootloader_fdt_parser/src/lib.rs
@@ -533,11 +533,15 @@ fn parse_gic(node: &Node<'_>) -> anyhow::Result<Aarch64PlatformConfig> {
 
     Ok(Aarch64PlatformConfig {
         gic_distributor_base: reg[0],
-        gic_redistributors_base: reg[2],
+        // The OpenHCL paravisor boot path always receives a GICv3 layout.
+        gic_version: vm_topology::processor::aarch64::GicVersion::V3 {
+            redistributors_base: reg[2],
+        },
         gic_v2m: None,
         pmu_gsiv: None,
         // TODO: parse from the DT timer node instead of hardcoding.
         virt_timer_ppi: 20,
+        gic_nr_irqs: 992,
     })
 }
 
@@ -826,16 +830,21 @@ mod tests {
             let p_redist_stride = root_builder.add_string("redistributor-stride")?;
             let p_interrupt_controller = root_builder.add_string("interrupt-controller")?;
             let p_phandle = root_builder.add_string("phandle")?;
+            let gic_redist_base = match gic.gic_version {
+                vm_topology::processor::aarch64::GicVersion::V3 {
+                    redistributors_base,
+                } => redistributors_base,
+                vm_topology::processor::aarch64::GicVersion::V2 { cpu_interface_base } => {
+                    cpu_interface_base
+                }
+            };
             let name = format!("intc@{}", gic.gic_distributor_base);
             root_builder = root_builder
                 .start_node(name.as_ref())?
                 .add_str(p_compatible, "arm,gic-v3")?
                 .add_u32(p_redist_regions, 1)?
                 .add_u64(p_redist_stride, 0)?
-                .add_u64_array(
-                    p_reg,
-                    &[gic.gic_distributor_base, 0, gic.gic_redistributors_base, 0],
-                )?
+                .add_u64_array(p_reg, &[gic.gic_distributor_base, 0, gic_redist_base, 0])?
                 .add_u32(p_address_cells, 2)?
                 .add_u32(p_size_cells, 2)?
                 .add_u32(p_interrupt_cells, 3)?
@@ -1066,10 +1075,13 @@ mod tests {
             vtl0_alias_map: Some(1 << 48),
             gic: Some(Aarch64PlatformConfig {
                 gic_distributor_base: 0x10000,
-                gic_redistributors_base: 0x20000,
+                gic_version: vm_topology::processor::aarch64::GicVersion::V3 {
+                    redistributors_base: 0x20000,
+                },
                 gic_v2m: None,
                 pmu_gsiv: Some(0x17),
                 virt_timer_ppi: 20,
+                gic_nr_irqs: 992,
             }),
             accepted_ranges: vec![
                 MemoryRange::new(0x10000..0x20000),

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -80,6 +80,8 @@ pub enum Error {
     #[cfg(guest_arch = "x86_64")]
     #[error("acpi tables require at least two mmio ranges")]
     UnsupportedMmio,
+    #[error("expected GICv3 topology")]
+    ExpectedGicV3,
 }
 
 pub const PV_CONFIG_BASE_PAGE: u64 = if cfg!(guest_arch = "x86_64") {
@@ -685,9 +687,18 @@ pub fn write_uefi_config(
 
     #[cfg(guest_arch = "aarch64")]
     {
+        use vm_topology::processor::arch::GicVersion;
+
+        let GicVersion::V3 {
+            redistributors_base,
+        } = processor_topology.gic_version()
+        else {
+            return Err(Error::ExpectedGicV3);
+        };
+
         cfg.add(&config::Gic {
             gic_distributor_base: processor_topology.gic_distributor_base(),
-            gic_redistributors_base: processor_topology.gic_redistributors_base(),
+            gic_redistributors_base: redistributors_base,
         });
     }
 

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -80,6 +80,7 @@ pub enum Error {
     #[cfg(guest_arch = "x86_64")]
     #[error("acpi tables require at least two mmio ranges")]
     UnsupportedMmio,
+    #[cfg(guest_arch = "aarch64")]
     #[error("expected GICv3 topology")]
     ExpectedGicV3,
 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1304,7 +1304,15 @@ fn new_aarch64_topology(
 ) -> anyhow::Result<ProcessorTopology<vm_topology::processor::aarch64::Aarch64Topology>> {
     // TODO SMP: Query the MT property from the host topology somehow. Device Tree
     // doesn't specify that.
-    let gic_redistributors_base = gic.gic_redistributors_base;
+
+    use vm_topology::processor::arch::GicVersion;
+    let GicVersion::V3 {
+        redistributors_base,
+    } = gic.gic_version
+    else {
+        anyhow::bail!("expected GICv3 topology");
+    };
+
     TopologyBuilder::new_aarch64(gic)
         .vps_per_socket(cpus.len() as u32)
         .build_with_vp_info(cpus.iter().enumerate().map(|(vp_index, cpu)| {
@@ -1319,8 +1327,9 @@ fn new_aarch64_topology(
                     vnode: cpu.vnode,
                 },
                 mpidr,
-                gicr: gic_redistributors_base
-                    + vp_index as u64 * aarch64defs::GIC_REDISTRIBUTOR_SIZE,
+                gicr: Some(
+                    redistributors_base + vp_index as u64 * aarch64defs::GIC_REDISTRIBUTOR_SIZE,
+                ),
                 pmu_gsiv: gic.pmu_gsiv,
             }
         }))

--- a/openvmm/hypervisor_resources/src/lib.rs
+++ b/openvmm/hypervisor_resources/src/lib.rs
@@ -27,8 +27,15 @@ impl ResourceKind for HypervisorKind {
 }
 
 /// Handle for the KVM hypervisor backend.
+///
+/// Contains the open `/dev/kvm` file descriptor so that it can be probed
+/// early and reused when creating the partition.
 #[derive(MeshPayload)]
-pub struct KvmHandle;
+pub struct KvmHandle {
+    /// An open `/dev/kvm` file descriptor, open with read and write
+    /// permissions.
+    pub kvm: std::fs::File,
+}
 
 impl ResourceId<HypervisorKind> for KvmHandle {
     const ID: &'static str = "kvm";

--- a/openvmm/openvmm_core/src/hypervisor_backend.rs
+++ b/openvmm/openvmm_core/src/hypervisor_backend.rs
@@ -72,11 +72,11 @@ impl ResolvedHypervisorBackend {
         Self(Box::new(move |driver_source, cfg, shared_memory| {
             Box::pin(async move {
                 let mut hv = hypervisor;
-                let platform_gsiv = virt::Hypervisor::platform_gsiv(&hv);
+                let platform_info = virt::Hypervisor::platform_info(&hv);
                 InitializedVm::new_with_hypervisor(
                     driver_source,
                     &mut hv,
-                    platform_gsiv,
+                    platform_info,
                     cfg,
                     shared_memory,
                 )

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -492,6 +492,7 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
     }
 }
 
+#[cfg(guest_arch = "aarch64")]
 impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
     fn to_topology(
         &self,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -110,9 +110,7 @@ use vm_topology::pcie::PcieHostBridge;
 use vm_topology::processor::ArchTopology;
 use vm_topology::processor::ProcessorTopology;
 use vm_topology::processor::TopologyBuilder;
-use vm_topology::processor::aarch64::Aarch64PlatformConfig;
 use vm_topology::processor::aarch64::Aarch64Topology;
-use vm_topology::processor::aarch64::GicV2mInfo;
 use vm_topology::processor::aarch64::GicVersion;
 use vm_topology::processor::x86::X86Topology;
 use vmbus_channel::channel::VmbusDevice;
@@ -498,6 +496,9 @@ impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
         &self,
         platform_info: &virt::PlatformInfo,
     ) -> anyhow::Result<ProcessorTopology<Aarch64Topology>> {
+        use vm_topology::processor::aarch64::Aarch64PlatformConfig;
+        use vm_topology::processor::aarch64::GicV2mInfo;
+
         let arch = match &self.arch {
             None => Default::default(),
             Some(ArchTopologyConfig::Aarch64(arch)) => arch.clone(),

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -113,6 +113,7 @@ use vm_topology::processor::TopologyBuilder;
 use vm_topology::processor::aarch64::Aarch64PlatformConfig;
 use vm_topology::processor::aarch64::Aarch64Topology;
 use vm_topology::processor::aarch64::GicV2mInfo;
+use vm_topology::processor::aarch64::GicVersion;
 use vm_topology::processor::x86::X86Topology;
 use vmbus_channel::channel::VmbusDevice;
 use vmbus_server::HvsockRelayChannel;
@@ -396,7 +397,10 @@ pub(crate) struct InitializedVm {
 }
 
 trait BuildTopology<T: ArchTopology + Inspect> {
-    fn to_topology(&self, platform_gsiv: Option<u32>) -> anyhow::Result<ProcessorTopology<T>>;
+    fn to_topology(
+        &self,
+        platform_info: &virt::PlatformInfo,
+    ) -> anyhow::Result<ProcessorTopology<T>>;
 }
 
 trait ExtractTopologyConfig {
@@ -427,7 +431,7 @@ impl ExtractTopologyConfig for ProcessorTopology<X86Topology> {
 impl BuildTopology<X86Topology> for ProcessorTopologyConfig {
     fn to_topology(
         &self,
-        _platform_gsiv: Option<u32>,
+        _platform_info: &virt::PlatformInfo,
     ) -> anyhow::Result<ProcessorTopology<X86Topology>> {
         use vm_topology::processor::x86::X2ApicState;
 
@@ -465,9 +469,19 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
             vps_per_socket: Some(self.reserved_vps_per_socket()),
             enable_smt: Some(self.smt_enabled()),
             arch: Some(ArchTopologyConfig::Aarch64(Aarch64TopologyConfig {
-                gic_config: Some(GicConfig {
-                    gic_distributor_base: self.gic_distributor_base(),
-                    gic_redistributors_base: self.gic_redistributors_base(),
+                gic_config: Some(match self.gic_version() {
+                    GicVersion::V3 {
+                        redistributors_base,
+                    } => GicConfig::V3(Some(openvmm_defs::config::GicV3Config {
+                        gic_distributor_base: self.gic_distributor_base(),
+                        gic_redistributors_base: redistributors_base,
+                    })),
+                    GicVersion::V2 { cpu_interface_base } => {
+                        GicConfig::V2(Some(openvmm_defs::config::GicV2Config {
+                            gic_distributor_base: self.gic_distributor_base(),
+                            cpu_interface_base,
+                        }))
+                    }
                 }),
                 pmu_gsiv: match self.pmu_gsiv() {
                     Some(gsiv) => PmuGsivConfig::Gsiv(gsiv),
@@ -481,7 +495,7 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
 impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
     fn to_topology(
         &self,
-        platform_gsiv: Option<u32>,
+        platform_info: &virt::PlatformInfo,
     ) -> anyhow::Result<ProcessorTopology<Aarch64Topology>> {
         let arch = match &self.arch {
             None => Default::default(),
@@ -496,7 +510,7 @@ impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
         let pmu_gsiv = match arch.pmu_gsiv {
             PmuGsivConfig::Disabled => None,
             PmuGsivConfig::Gsiv(gsiv) => Some(gsiv),
-            PmuGsivConfig::Platform => platform_gsiv,
+            PmuGsivConfig::Platform => platform_info.platform_gsiv,
         };
 
         // TODO: When this value is supported on all platforms, we should change
@@ -506,22 +520,69 @@ impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
             tracing::warn!("PMU GSIV is not set");
         }
 
-        let platform = if let Some(gic_config) = &arch.gic_config {
-            Aarch64PlatformConfig {
-                gic_distributor_base: gic_config.gic_distributor_base,
-                gic_redistributors_base: gic_config.gic_redistributors_base,
-                gic_v2m,
-                pmu_gsiv,
-                virt_timer_ppi: openvmm_defs::config::DEFAULT_VIRT_TIMER_PPI,
+        let (gic_distributor_base, gic_version) = match &arch.gic_config {
+            Some(GicConfig::V3(config)) => {
+                let dist = config
+                    .as_ref()
+                    .map(|c| c.gic_distributor_base)
+                    .unwrap_or(openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE);
+                let redist = config
+                    .as_ref()
+                    .map(|c| c.gic_redistributors_base)
+                    .unwrap_or(openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE);
+                (
+                    dist,
+                    GicVersion::V3 {
+                        redistributors_base: redist,
+                    },
+                )
             }
-        } else {
-            Aarch64PlatformConfig {
-                gic_distributor_base: openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE,
-                gic_redistributors_base: openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE,
-                gic_v2m,
-                pmu_gsiv,
-                virt_timer_ppi: openvmm_defs::config::DEFAULT_VIRT_TIMER_PPI,
+            Some(GicConfig::V2(config)) => {
+                let dist = config
+                    .as_ref()
+                    .map(|c| c.gic_distributor_base)
+                    .unwrap_or(openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE);
+                let cpu_if = config
+                    .as_ref()
+                    .map(|c| c.cpu_interface_base)
+                    .unwrap_or(openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE);
+                (
+                    dist,
+                    GicVersion::V2 {
+                        cpu_interface_base: cpu_if,
+                    },
+                )
             }
+            None => {
+                // No explicit GIC config — use the hypervisor's detected version
+                // with default addresses.
+                let dist = openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE;
+                let second = openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE;
+                if platform_info.supports_gic_v3 {
+                    (
+                        dist,
+                        GicVersion::V3 {
+                            redistributors_base: second,
+                        },
+                    )
+                } else {
+                    (
+                        dist,
+                        GicVersion::V2 {
+                            cpu_interface_base: second,
+                        },
+                    )
+                }
+            }
+        };
+
+        let platform = Aarch64PlatformConfig {
+            gic_distributor_base,
+            gic_version,
+            gic_v2m,
+            pmu_gsiv,
+            virt_timer_ppi: openvmm_defs::config::DEFAULT_VIRT_TIMER_PPI,
+            gic_nr_irqs: openvmm_defs::config::DEFAULT_GIC_NR_IRQS,
         };
 
         let mut builder = TopologyBuilder::new_aarch64(platform);
@@ -695,7 +756,7 @@ impl InitializedVm {
     pub(crate) async fn new_with_hypervisor<P, H>(
         driver_source: VmTaskDriverSource,
         hypervisor: &mut H,
-        platform_gsiv: Option<u32>,
+        platform_info: virt::PlatformInfo,
         cfg: Manifest,
         shared_memory: Option<SharedMemoryBacking>,
     ) -> anyhow::Result<Self>
@@ -743,7 +804,7 @@ impl InitializedVm {
             None
         };
 
-        let processor_topology = cfg.processor_topology.to_topology(platform_gsiv)?;
+        let processor_topology = cfg.processor_topology.to_topology(&platform_info)?;
 
         let proto = hypervisor
             .new_partition(virt::ProtoPartitionConfig {

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -161,18 +161,29 @@ fn build_dt(
 
     let num_cpus = processor_topology.vps().len();
 
+    use vm_topology::processor::aarch64::GicVersion;
+
     let gic_dist_base: u64 = processor_topology.gic_distributor_base();
     let gic_dist_size: u64 = aarch64defs::GIC_DISTRIBUTOR_SIZE;
-    let gic_redist_base: u64 = processor_topology.gic_redistributors_base();
-    let gic_redist_size: u64 = aarch64defs::GIC_REDISTRIBUTOR_SIZE * num_cpus as u64;
+    let (gic_second_base, gic_second_size) = match processor_topology.gic_version() {
+        GicVersion::V3 {
+            redistributors_base,
+        } => (
+            redistributors_base,
+            aarch64defs::GIC_REDISTRIBUTOR_SIZE * num_cpus as u64,
+        ),
+        GicVersion::V2 { cpu_interface_base } => {
+            (cpu_interface_base, aarch64defs::GIC_V2_CPU_INTERFACE_SIZE)
+        }
+    };
 
     // With the default values, that will overlap with the GIC distributor range
     // if the number of VPs goes above `2048`. That is more than enough for the time being,
     // both for the Linux and the Windows guests. The debug assert below is for the time
     // when custom values are used.
     debug_assert!(
-        !(gic_dist_base..gic_dist_base + gic_dist_size).contains(&gic_redist_base)
-            && !(gic_redist_base..gic_redist_base + gic_redist_size).contains(&gic_dist_base)
+        !(gic_dist_base..gic_dist_base + gic_dist_size).contains(&gic_second_base)
+            && !(gic_second_base..gic_second_base + gic_second_size).contains(&gic_dist_base)
     );
 
     let mut buffer = vec![0u8; 0x200000];
@@ -295,19 +306,24 @@ fn build_dt(
         .add_u32(p_phandle, PHANDLE_APB_PCLK)?
         .end_node()?;
 
-    // ARM64 Generic Interrupt Controller aka GIC, v3.
-    // The GICv3 node has a v2m child for SPI-based MSIs (PCIe).
+    // ARM64 Generic Interrupt Controller.
+    // GICv3 uses "arm,gic-v3"; GICv2 uses "arm,cortex-a15-gic".
+    // Both versions can have a v2m child for SPI-based MSIs (PCIe).
     let v2m_info = processor_topology.gic_v2m();
-    let gicv3 = root_builder
+    let gic_compatible = match processor_topology.gic_version() {
+        GicVersion::V3 { .. } => "arm,gic-v3",
+        GicVersion::V2 { .. } => "arm,cortex-a15-gic",
+    };
+    let gic_node = root_builder
         .start_node(format!("intc@{gic_dist_base:x}").as_str())?
-        .add_str(p_compatible, "arm,gic-v3")?
+        .add_str(p_compatible, gic_compatible)?
         .add_u64_array(
             p_reg,
             &[
                 gic_dist_base,
                 gic_dist_size,
-                gic_redist_base,
-                gic_redist_size,
+                gic_second_base,
+                gic_second_size,
             ],
         )?
         .add_u32(p_address_cells, 2)?
@@ -317,7 +333,7 @@ fn build_dt(
         .add_u32(p_phandle, PHANDLE_GIC)?
         .add_null(p_ranges)?;
     root_builder = if let Some(v2m) = v2m_info {
-        gicv3
+        gic_node
             .start_node(format!("v2m@{:x}", v2m.frame_base).as_str())?
             .add_str(p_compatible, "arm,gic-v2m-frame")?
             .add_null(p_msi_controller)?
@@ -331,7 +347,7 @@ fn build_dt(
             .end_node()?
             .end_node()?
     } else {
-        gicv3.end_node()?
+        gic_node.end_node()?
     };
 
     // ARM64 Architectural Timer.

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -164,7 +164,10 @@ fn build_dt(
     use vm_topology::processor::aarch64::GicVersion;
 
     let gic_dist_base: u64 = processor_topology.gic_distributor_base();
-    let gic_dist_size: u64 = aarch64defs::GIC_DISTRIBUTOR_SIZE;
+    let gic_dist_size: u64 = match processor_topology.gic_version() {
+        GicVersion::V3 { .. } => aarch64defs::GIC_DISTRIBUTOR_SIZE,
+        GicVersion::V2 { .. } => aarch64defs::GIC_V2_DISTRIBUTOR_SIZE,
+    };
     let (gic_second_base, gic_second_size) = match processor_topology.gic_version() {
         GicVersion::V3 {
             redistributors_base,

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -152,10 +152,20 @@ pub fn load_uefi(
     .add(&flags);
 
     #[cfg(guest_arch = "aarch64")]
-    cfg.add(&config::Gic {
-        gic_distributor_base: processor_topology.gic_distributor_base(),
-        gic_redistributors_base: processor_topology.gic_redistributors_base(),
-    });
+    {
+        let gic_redistributors_base = match processor_topology.gic_version() {
+            vm_topology::processor::aarch64::GicVersion::V3 {
+                redistributors_base,
+            } => redistributors_base,
+            vm_topology::processor::aarch64::GicVersion::V2 { cpu_interface_base } => {
+                cpu_interface_base
+            }
+        };
+        cfg.add(&config::Gic {
+            gic_distributor_base: processor_topology.gic_distributor_base(),
+            gic_redistributors_base,
+        });
+    }
 
     if let Some(mcfg) = mcfg {
         cfg.add_raw(config::BlobStructureType::Mcfg, mcfg);

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -25,6 +25,9 @@ pub enum Error {
     Loader(#[source] loader::uefi::Error),
     #[error("UEFI requires at least two MMIO ranges")]
     UnsupportedMmio,
+    #[cfg(guest_arch = "aarch64")]
+    #[error("UEFI boot with GICv2 is not supported")]
+    GicV2NotSupported,
 }
 
 pub struct UefiLoadSettings {
@@ -153,17 +156,17 @@ pub fn load_uefi(
 
     #[cfg(guest_arch = "aarch64")]
     {
-        let gic_redistributors_base = match processor_topology.gic_version() {
+        let redistributors_base = match processor_topology.gic_version() {
             vm_topology::processor::aarch64::GicVersion::V3 {
                 redistributors_base,
             } => redistributors_base,
-            vm_topology::processor::aarch64::GicVersion::V2 { cpu_interface_base } => {
-                cpu_interface_base
+            vm_topology::processor::aarch64::GicVersion::V2 { .. } => {
+                return Err(Error::GicV2NotSupported);
             }
         };
         cfg.add(&config::Gic {
             gic_distributor_base: processor_topology.gic_distributor_base(),
-            gic_redistributors_base,
+            gic_redistributors_base: redistributors_base,
         });
     }
 

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -113,6 +113,11 @@ pub const DEFAULT_GIC_V2M_SPI_COUNT: u32 = 64;
 /// This is the EL1 virtual timer interrupt used across Hyper-V, KVM, and HVF.
 pub const DEFAULT_VIRT_TIMER_PPI: u32 = 20;
 
+/// Default total number of GIC interrupts (SGIs + PPIs + SPIs).
+/// Must satisfy KVM constraints: 64 <= n <= 1023, multiple of 32.
+/// 992 = 31 × 32 is the largest valid value.
+pub const DEFAULT_GIC_NR_IRQS: u32 = 992;
+
 /// Default VMBus PPI (GIC INTID). PPI 2 = INTID 16 + 2 = 18.
 pub const DEFAULT_VMBUS_PPI: u32 = 18;
 
@@ -288,8 +293,28 @@ pub struct Aarch64TopologyConfig {
     pub pmu_gsiv: PmuGsivConfig,
 }
 
+/// GIC configuration for the virtual machine.
+///
+/// The variant selects the GIC version. `None` inner config means use
+/// defaults for that version's addresses.
 #[derive(Debug, Protobuf, Clone)]
-pub struct GicConfig {
+pub enum GicConfig {
+    /// GICv2 with optional address overrides.
+    V2(Option<GicV2Config>),
+    /// GICv3 with optional address overrides.
+    V3(Option<GicV3Config>),
+}
+
+/// GICv2-specific address configuration.
+#[derive(Debug, Protobuf, Clone)]
+pub struct GicV2Config {
+    pub gic_distributor_base: u64,
+    pub cpu_interface_base: u64,
+}
+
+/// GICv3-specific address configuration.
+#[derive(Debug, Protobuf, Clone)]
+pub struct GicV3Config {
     pub gic_distributor_base: u64,
     pub gic_redistributors_base: u64,
 }

--- a/openvmm/openvmm_hypervisors/Cargo.toml
+++ b/openvmm/openvmm_hypervisors/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 virt_mshv = ["dep:virt_mshv"]
 
 # Enable building with KVM support.
-virt_kvm = ["dep:virt_kvm", "dep:kvm"]
+virt_kvm = ["dep:virt_kvm"]
 
 # Enable building with WHP support.
 virt_whp = ["dep:virt_whp"]
@@ -27,7 +27,6 @@ openvmm_core.workspace = true
 vm_resource.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-kvm = { workspace = true, optional = true }
 virt_kvm = { workspace = true, optional = true }
 virt_mshv = { workspace = true, optional = true }
 

--- a/openvmm/openvmm_hypervisors/Cargo.toml
+++ b/openvmm/openvmm_hypervisors/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 virt_mshv = ["dep:virt_mshv"]
 
 # Enable building with KVM support.
-virt_kvm = ["dep:virt_kvm"]
+virt_kvm = ["dep:virt_kvm", "dep:kvm"]
 
 # Enable building with WHP support.
 virt_whp = ["dep:virt_whp"]
@@ -21,11 +21,13 @@ virt_hvf = ["dep:virt_hvf"]
 
 [dependencies]
 anyhow.workspace = true
+fs-err.workspace = true
 hypervisor_resources.workspace = true
 openvmm_core.workspace = true
 vm_resource.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+kvm = { workspace = true, optional = true }
 virt_kvm = { workspace = true, optional = true }
 virt_mshv = { workspace = true, optional = true }
 

--- a/openvmm/openvmm_hypervisors/src/kvm.rs
+++ b/openvmm/openvmm_hypervisors/src/kvm.rs
@@ -8,6 +8,7 @@
 use hypervisor_resources::HypervisorKind;
 use hypervisor_resources::KvmHandle;
 use openvmm_core::hypervisor_backend::ResolvedHypervisorBackend;
+use vm_resource::IntoResource;
 use vm_resource::Resource;
 
 /// KVM probe for auto-detection.
@@ -19,7 +20,16 @@ impl hypervisor_resources::HypervisorProbe for KvmProbe {
     }
 
     fn try_new_resource(&self) -> anyhow::Result<Option<Resource<HypervisorKind>>> {
-        Ok(virt_kvm::is_available()?.then(|| Resource::new(KvmHandle)))
+        let kvm = match fs_err::File::options()
+            .read(true)
+            .write(true)
+            .open("/dev/kvm")
+        {
+            Ok(kvm) => kvm,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+        Ok(Some(KvmHandle { kvm: kvm.into() }.into_resource()))
     }
 }
 
@@ -28,10 +38,13 @@ pub struct KvmResolver;
 
 impl vm_resource::ResolveResource<HypervisorKind, KvmHandle> for KvmResolver {
     type Output = ResolvedHypervisorBackend;
-    type Error = std::convert::Infallible;
+    type Error = virt_kvm::KvmError;
 
-    fn resolve(&self, _resource: KvmHandle, _input: ()) -> Result<Self::Output, Self::Error> {
-        Ok(ResolvedHypervisorBackend::new(virt_kvm::Kvm))
+    fn resolve(&self, resource: KvmHandle, _input: ()) -> Result<Self::Output, Self::Error> {
+        let kvm = resource.kvm;
+        Ok(ResolvedHypervisorBackend::new(virt_kvm::Kvm::from_kvm(
+            kvm,
+        )?))
     }
 }
 

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -109,7 +109,7 @@ async fn do_main(driver: DefaultDriver) -> anyhow::Result<()> {
         state
             .for_each_test(async |state, test| match hv {
                 #[cfg(target_os = "linux")]
-                HypervisorOpt::Kvm => state.run_host_vmm(virt_kvm::Kvm, test).await,
+                HypervisorOpt::Kvm => state.run_host_vmm(virt_kvm::Kvm::new()?, test).await,
                 #[cfg(all(target_os = "linux", guest_arch = "x86_64"))]
                 HypervisorOpt::Mshv => state.run_host_vmm(virt_mshv::LinuxMshv, test).await,
                 #[cfg(target_os = "linux")]

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -62,10 +62,13 @@ impl CommonState {
         let processor_topology =
             TopologyBuilder::new_aarch64(vm_topology::processor::arch::Aarch64PlatformConfig {
                 gic_distributor_base: 0xff000000,
-                gic_redistributors_base: 0xff020000,
+                gic_version: vm_topology::processor::aarch64::GicVersion::V3 {
+                    redistributors_base: 0xff020000,
+                },
                 gic_v2m: None,
                 pmu_gsiv: None,
                 virt_timer_ppi: 20, // DEFAULT_VIRT_TIMER_PPI
+                gic_nr_irqs: 256,
             })
             .build(1)
             .context("failed to build processor topology")?;

--- a/vm/aarch64/aarch64defs/src/lib.rs
+++ b/vm/aarch64/aarch64defs/src/lib.rs
@@ -840,6 +840,10 @@ pub const GIC_REDISTRIBUTOR_FRAME_SIZE: u64 = 0x1_0000;
 pub const GIC_SGI_FRAME_SIZE: u64 = 0x1_0000;
 pub const GIC_REDISTRIBUTOR_SIZE: u64 = GIC_REDISTRIBUTOR_FRAME_SIZE + GIC_SGI_FRAME_SIZE;
 
+// GICv2 sizes.
+pub const GIC_V2_DISTRIBUTOR_SIZE: u64 = 0x1000;
+pub const GIC_V2_CPU_INTERFACE_SIZE: u64 = 0x2000;
+
 open_enum! {
     pub enum SystemReset2Code: u32 {
         WARM_RESET = 0,

--- a/vm/acpi_spec/src/madt.rs
+++ b/vm/acpi_spec/src/madt.rs
@@ -297,20 +297,13 @@ pub struct MadtGicc {
 const_assert_eq!(size_of::<MadtGicc>(), 80);
 
 impl MadtGicc {
-    pub fn new(
-        acpi_processor_uid: u32,
-        mpidr: u64,
-        gicr: u64,
-        performance_monitoring_gsiv: u32,
-    ) -> Self {
+    pub fn new(acpi_processor_uid: u32, mpidr: u64) -> Self {
         Self {
             typ: MadtType::GICC,
             length: size_of::<Self>() as u8,
             flags: u32::from(MadtGiccFlags::new().with_enabled(true)).into(),
             acpi_processor_uid: acpi_processor_uid.into(),
             mpidr: mpidr.into(),
-            gicr_base_address: gicr.into(),
-            performance_monitoring_gsiv: performance_monitoring_gsiv.into(),
             ..Self::new_zeroed()
         }
     }

--- a/vm/kvm/src/lib.rs
+++ b/vm/kvm/src/lib.rs
@@ -187,6 +187,8 @@ pub enum Error {
     CreateDevice(#[source] nix::Error),
     #[error("SetDeviceAttr")]
     SetDeviceAttr(#[source] nix::Error),
+    #[error("CheckExtension")]
+    CheckExtension(#[source] nix::Error),
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -645,6 +647,25 @@ impl Partition {
             ioctl::kvm_create_device(self.vm.as_raw_fd(), &mut device)?;
             Ok(Device(File::from_raw_fd(device.fd as i32)))
         }
+    }
+
+    /// Tests whether a device type can be created without actually creating it.
+    ///
+    /// Uses `KVM_CREATE_DEVICE_TEST` to probe support. Unlike
+    /// [`create_device`](Self::create_device), this does not wrap any fd.
+    pub fn test_create_device(&self, ty: u32) -> nix::Result<()> {
+        // SAFETY: With KVM_CREATE_DEVICE_TEST the kernel only checks
+        // whether the device type is supported and does not populate
+        // `device.fd`.
+        unsafe {
+            let mut device = kvm_create_device {
+                type_: ty,
+                fd: 0,
+                flags: KVM_CREATE_DEVICE_TEST,
+            };
+            ioctl::kvm_create_device(self.vm.as_raw_fd(), &mut device)?;
+        }
+        Ok(())
     }
 
     /// Gets the current kvmclock value.

--- a/vm/kvm/src/lib.rs
+++ b/vm/kvm/src/lib.rs
@@ -309,6 +309,18 @@ impl AsFd for Kvm {
     }
 }
 
+impl From<File> for Kvm {
+    fn from(fd: File) -> Self {
+        Self(fd)
+    }
+}
+
+impl From<Kvm> for File {
+    fn from(kvm: Kvm) -> Self {
+        kvm.0
+    }
+}
+
 #[repr(C)]
 #[cfg(target_arch = "x86_64")]
 struct Cpuid {

--- a/vm/vmcore/vm_topology/src/processor.rs
+++ b/vm/vmcore/vm_topology/src/processor.rs
@@ -97,6 +97,9 @@ pub enum InvalidTopology {
     /// The GIC interrupt count is invalid.
     #[error("gic_nr_irqs {0} must be 64..=992 and a multiple of 32")]
     InvalidGicNrIrqs(u32),
+    /// GICv2 supports at most 8 CPUs.
+    #[error("GICv2 supports at most 8 CPUs, but {0} were requested")]
+    TooManyCpusForGicV2(u32),
     /// Failed to query the topology information from Device Tree.
     #[error("failed to query memory topology from device tree")]
     StdIoError(#[source] std::io::Error),

--- a/vm/vmcore/vm_topology/src/processor.rs
+++ b/vm/vmcore/vm_topology/src/processor.rs
@@ -94,6 +94,9 @@ pub enum InvalidTopology {
     /// A PPI INTID is not in the valid range (16..32).
     #[error("PPI INTID {0} is not in the valid range 16..32")]
     InvalidPpiIntid(u32),
+    /// The GIC interrupt count is invalid.
+    #[error("gic_nr_irqs {0} must be 64..=992 and a multiple of 32")]
+    InvalidGicNrIrqs(u32),
     /// Failed to query the topology information from Device Tree.
     #[error("failed to query memory topology from device tree")]
     StdIoError(#[source] std::io::Error),

--- a/vm/vmcore/vm_topology/src/processor/aarch64.rs
+++ b/vm/vmcore/vm_topology/src/processor/aarch64.rs
@@ -158,7 +158,7 @@ impl TopologyBuilder<Aarch64Topology> {
             }
         }
         let nr = self.arch.platform.gic_nr_irqs;
-        if nr < 64 || nr > 992 || nr % 32 != 0 {
+        if !(64..=992).contains(&nr) || !nr.is_multiple_of(32) {
             return Err(InvalidTopology::InvalidGicNrIrqs(nr));
         }
         let mpidrs = (0..proc_count).map(|vp_index| {

--- a/vm/vmcore/vm_topology/src/processor/aarch64.rs
+++ b/vm/vmcore/vm_topology/src/processor/aarch64.rs
@@ -38,6 +38,26 @@ pub struct Aarch64TopologyBuilderState {
     platform: Aarch64PlatformConfig,
 }
 
+/// GIC version and version-specific addressing for the virtual machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "inspect", derive(inspect::Inspect))]
+#[cfg_attr(feature = "inspect", inspect(external_tag))]
+pub enum GicVersion {
+    /// GICv2 — uses a shared CPU interface region instead of per-VP redistributors.
+    /// Required for platforms like Raspberry Pi 5 (GIC-400).
+    V2 {
+        /// Physical base address of the GIC CPU interface.
+        #[cfg_attr(feature = "inspect", inspect(hex))]
+        cpu_interface_base: u64,
+    },
+    /// GICv3 — uses per-VP redistributors. Default for most server/desktop platforms.
+    V3 {
+        /// Physical base address of the GIC redistributor region.
+        #[cfg_attr(feature = "inspect", inspect(hex))]
+        redistributors_base: u64,
+    },
+}
+
 /// ARM64 platform interrupt and GIC configuration.
 ///
 /// Groups GIC base addresses, MSI frame info, and platform interrupt
@@ -49,15 +69,19 @@ pub struct Aarch64PlatformConfig {
     /// GIC distributor base address.
     #[cfg_attr(feature = "inspect", inspect(hex))]
     pub gic_distributor_base: u64,
-    /// GIC redistributors base address.
-    #[cfg_attr(feature = "inspect", inspect(hex))]
-    pub gic_redistributors_base: u64,
+    /// GIC version and version-specific addresses.
+    pub gic_version: GicVersion,
     /// GIC v2m MSI frame, if MSIs via v2m are supported.
     pub gic_v2m: Option<GicV2mInfo>,
     /// Performance Monitor Unit GSIV (GIC INTID). `None` if not available.
     pub pmu_gsiv: Option<u32>,
     /// Virtual timer PPI (GIC INTID, e.g. 20 for PPI 4).
     pub virt_timer_ppi: u32,
+    /// Total number of GIC interrupts (SGIs + PPIs + SPIs).
+    ///
+    /// KVM requires: `64 <= gic_nr_irqs <= 1023` and a multiple of 32.
+    /// The maximum valid value is 992 (31 × 32).
+    pub gic_nr_irqs: u32,
 }
 
 /// GIC v2m MSI frame parameters.
@@ -83,9 +107,9 @@ pub struct Aarch64VpInfo {
     /// The MPIDR_EL1 value of the processor.
     #[cfg_attr(feature = "inspect", inspect(hex, with = "|&x| u64::from(x)"))]
     pub mpidr: MpidrEl1,
-    /// GIC Redistributor Address
+    /// GIC Redistributor Address (GICv3 only; `None` for GICv2).
     #[cfg_attr(feature = "inspect", inspect(hex))]
-    pub gicr: u64,
+    pub gicr: Option<u64>,
     /// Performance Interrupt GSIV (PMU)
     #[cfg_attr(feature = "inspect", inspect(hex))]
     pub pmu_gsiv: Option<u32>,
@@ -128,6 +152,10 @@ impl TopologyBuilder<Aarch64Topology> {
                 return Err(InvalidTopology::InvalidPpiIntid(gsiv));
             }
         }
+        let nr = self.arch.platform.gic_nr_irqs;
+        if nr < 64 || nr > 992 || nr % 32 != 0 {
+            return Err(InvalidTopology::InvalidGicNrIrqs(nr));
+        }
         let mpidrs = (0..proc_count).map(|vp_index| {
             // TODO: construct mpidr appropriately for the specified
             // topology.
@@ -141,15 +169,25 @@ impl TopologyBuilder<Aarch64Topology> {
                 .with_aff2(aff.next().unwrap())
                 .with_aff3(aff.next().unwrap())
         });
-        self.build_with_vp_info(mpidrs.enumerate().map(|(id, mpidr)| Aarch64VpInfo {
-            base: VpInfo {
-                vp_index: VpIndex::new(id as u32),
-                vnode: 0,
-            },
-            mpidr,
-            gicr: self.arch.platform.gic_redistributors_base
-                + id as u64 * aarch64defs::GIC_REDISTRIBUTOR_SIZE,
-            pmu_gsiv: self.arch.platform.pmu_gsiv,
+        let gic_version = self.arch.platform.gic_version;
+        self.build_with_vp_info(mpidrs.enumerate().map(move |(id, mpidr)| {
+            // GICv3 assigns a per-VP redistributor region; GICv2 has no
+            // redistributors so the field is zero.
+            let gicr = match gic_version {
+                GicVersion::V3 {
+                    redistributors_base,
+                } => Some(redistributors_base + id as u64 * aarch64defs::GIC_REDISTRIBUTOR_SIZE),
+                GicVersion::V2 { .. } => None,
+            };
+            Aarch64VpInfo {
+                base: VpInfo {
+                    vp_index: VpIndex::new(id as u32),
+                    vnode: 0,
+                },
+                mpidr,
+                gicr,
+                pmu_gsiv: self.arch.platform.pmu_gsiv,
+            }
         }))
     }
 
@@ -182,14 +220,14 @@ impl TopologyBuilder<Aarch64Topology> {
 }
 
 impl ProcessorTopology<Aarch64Topology> {
+    /// Returns the GIC version and version-specific addresses.
+    pub fn gic_version(&self) -> GicVersion {
+        self.arch.platform.gic_version
+    }
+
     /// Returns the GIC distributor base
     pub fn gic_distributor_base(&self) -> u64 {
         self.arch.platform.gic_distributor_base
-    }
-
-    /// Returns the GIC redistributors base
-    pub fn gic_redistributors_base(&self) -> u64 {
-        self.arch.platform.gic_redistributors_base
     }
 
     /// Returns the PMU GSIV
@@ -205,5 +243,10 @@ impl ProcessorTopology<Aarch64Topology> {
     /// Returns the virtual timer PPI (GIC INTID).
     pub fn virt_timer_ppi(&self) -> u32 {
         self.arch.platform.virt_timer_ppi
+    }
+
+    /// Returns the total number of GIC interrupts to configure.
+    pub fn gic_nr_irqs(&self) -> u32 {
+        self.arch.platform.gic_nr_irqs
     }
 }

--- a/vm/vmcore/vm_topology/src/processor/aarch64.rs
+++ b/vm/vmcore/vm_topology/src/processor/aarch64.rs
@@ -142,6 +142,11 @@ impl TopologyBuilder<Aarch64Topology> {
                 max: u8::MAX.into(),
             });
         }
+        if let GicVersion::V2 { .. } = self.arch.platform.gic_version {
+            if proc_count > 8 {
+                return Err(InvalidTopology::TooManyCpusForGicV2(proc_count));
+            }
+        }
         if !(16..32).contains(&self.arch.platform.virt_timer_ppi) {
             return Err(InvalidTopology::InvalidPpiIntid(
                 self.arch.platform.virt_timer_ppi,

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -154,21 +154,37 @@ impl AcpiTopology for Aarch64Topology {
     }
 
     fn extend_madt(topology: &ProcessorTopology<Self>, madt: &mut Vec<u8>) {
-        // GIC version 3.
+        use vm_topology::processor::aarch64::GicVersion;
+
+        let gic_acpi_version: u8 = match topology.gic_version() {
+            GicVersion::V2 { .. } => 2,
+            GicVersion::V3 { .. } => 3,
+        };
+
         madt.extend_from_slice(
-            acpi_spec::madt::MadtGicd::new(0, topology.gic_distributor_base(), 3).as_bytes(),
+            acpi_spec::madt::MadtGicd::new(0, topology.gic_distributor_base(), gic_acpi_version)
+                .as_bytes(),
         );
         for vp in topology.vps_arch() {
             let uid = vp.base.vp_index.index() + 1;
 
             // ACPI specifies that just the MPIDR affinity fields should be included.
             let mpidr = u64::from(vp.mpidr) & u64::from(aarch64defs::MpidrEl1::AFFINITY_MASK);
-            let gicr = topology.gic_redistributors_base()
-                + vp.base.vp_index.index() as u64 * aarch64defs::GIC_REDISTRIBUTOR_SIZE;
-            let pmu_gsiv = topology.pmu_gsiv().unwrap_or(0);
-            madt.extend_from_slice(
-                acpi_spec::madt::MadtGicc::new(uid, mpidr, gicr, pmu_gsiv).as_bytes(),
-            );
+
+            let mut gicc = acpi_spec::madt::MadtGicc::new(uid, mpidr);
+
+            if let Some(gicr) = vp.gicr {
+                gicc.gicr_base_address = gicr.into();
+            }
+
+            if let GicVersion::V2 { cpu_interface_base } = topology.gic_version() {
+                gicc.base_address = cpu_interface_base.into();
+            }
+
+            if let Some(pmu_gsiv) = topology.pmu_gsiv() {
+                gicc.performance_monitoring_gsiv = pmu_gsiv.into();
+            }
+            madt.extend_from_slice(gicc.as_bytes());
         }
 
         // GIC v2m MSI frame for PCIe MSI support.

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -42,6 +42,24 @@ use vmcore::vpci_msi::MsiAddressData;
 use vmcore::vpci_msi::RegisterInterruptError;
 use vmcore::vpci_msi::VpciInterruptParameters;
 
+/// Platform capabilities detected from the hypervisor before partition
+/// creation. On x86 there are currently no pre-partition queries.
+#[cfg(guest_arch = "x86_64")]
+#[derive(Debug, Clone, Default)]
+pub struct PlatformInfo {}
+
+/// Platform capabilities detected from the hypervisor before partition
+/// creation.
+#[cfg(guest_arch = "aarch64")]
+#[derive(Debug, Clone)]
+pub struct PlatformInfo {
+    /// The platform PMU GSIV (GIC INTID), if available.
+    pub platform_gsiv: Option<u32>,
+    /// Whether the hypervisor supports GICv3. When `false`, only
+    /// GICv2 is available (e.g., Raspberry Pi 5 with GIC-400).
+    pub supports_gic_v3: bool,
+}
+
 pub trait Hypervisor: 'static {
     /// The prototype partition type.
     type ProtoPartition<'a>: ProtoPartition<Partition = Self::Partition>;
@@ -50,13 +68,12 @@ pub trait Hypervisor: 'static {
     /// The error type when creating the partition.
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// Returns the platform PMU GSIV for this hypervisor, if any.
+    /// Returns platform capabilities detected from the hypervisor.
     ///
-    /// On aarch64, this is used to configure the GIC topology with the
-    /// correct PMU interrupt ID before creating the partition.
-    fn platform_gsiv(&self) -> Option<u32> {
-        None
-    }
+    /// This is called before partition creation to query platform-specific
+    /// information needed for topology construction and firmware table
+    /// generation.
+    fn platform_info(&self) -> PlatformInfo;
 
     /// Returns a new prototype partition from the given configuration.
     fn new_partition<'a>(

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -92,6 +92,13 @@ impl virt::Hypervisor for HvfHypervisor {
     type Partition = HvfPartition;
     type Error = Error;
 
+    fn platform_info(&self) -> virt::PlatformInfo {
+        virt::PlatformInfo {
+            platform_gsiv: None,
+            supports_gic_v3: true,
+        }
+    }
+
     fn new_partition<'a>(
         &'a mut self,
         config: virt::ProtoPartitionConfig<'a>,
@@ -113,6 +120,17 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
         self,
         config: virt::PartitionConfig<'_>,
     ) -> Result<(Self::Partition, Vec<Self::ProcessorBinder>), Self::Error> {
+        use vm_topology::processor::aarch64::GicVersion;
+
+        let gic_redistributors_base = match self.config.processor_topology.gic_version() {
+            GicVersion::V3 {
+                redistributors_base,
+            } => redistributors_base,
+            GicVersion::V2 { .. } => {
+                anyhow::bail!("HVF does not support GICv2; only GICv3 is supported");
+            }
+        };
+
         // SAFETY: no safety requirements.
         unsafe { abi::hv_vm_create(null_mut()) }.chk()?;
 
@@ -127,8 +145,8 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
         let mut gicd = gic::Distributor::new(
             self.config.processor_topology.gic_distributor_base(),
             MemoryRange::new(
-                self.config.processor_topology.gic_redistributors_base()
-                    ..self.config.processor_topology.gic_redistributors_base()
+                gic_redistributors_base
+                    ..gic_redistributors_base
                         + aarch64defs::GIC_REDISTRIBUTOR_SIZE
                             * self.config.processor_topology.vp_count() as u64,
             ),
@@ -186,7 +204,11 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
                         .config
                         .vmtime
                         .access(format!("vp{}", vp.base.vp_index.index())),
-                    gicr_range: vp.gicr..vp.gicr + aarch64defs::GIC_REDISTRIBUTOR_SIZE,
+                    gicr_range: {
+                        // Guaranteed to be Some since we validated GICv3 above.
+                        let gicr = vp.gicr.unwrap();
+                        gicr..gicr + aarch64defs::GIC_REDISTRIBUTOR_SIZE
+                    },
                 }),
             });
         }

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -127,7 +127,9 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
                 redistributors_base,
             } => redistributors_base,
             GicVersion::V2 { .. } => {
-                anyhow::bail!("HVF does not support GICv2; only GICv3 is supported");
+                return Err(
+                    anyhow::anyhow!("HVF does not support GICv2; only GICv3 is supported").into(),
+                );
             }
         };
 

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -21,12 +21,16 @@ use hvdef::Vtl;
 use inspect::Inspect;
 use inspect::InspectMut;
 use kvm::KVM_CAP_ARM_VM_IPA_SIZE;
+use kvm::KVM_CREATE_DEVICE_TEST;
 use kvm::KVM_DEV_ARM_VGIC_CTRL_INIT;
 use kvm::KVM_DEV_ARM_VGIC_GRP_ADDR;
 use kvm::KVM_DEV_ARM_VGIC_GRP_CTRL;
 use kvm::KVM_DEV_ARM_VGIC_GRP_NR_IRQS;
+use kvm::KVM_VGIC_V2_ADDR_TYPE_CPU;
+use kvm::KVM_VGIC_V2_ADDR_TYPE_DIST;
 use kvm::KVM_VGIC_V3_ADDR_TYPE_DIST;
 use kvm::KVM_VGIC_V3_ADDR_TYPE_REDIST;
+use kvm::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2;
 use kvm::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3;
 use kvm::kvm_regs;
 use kvm::user_pt_regs;
@@ -206,8 +210,54 @@ impl KvmVpInner {
     }
 }
 
+use vm_topology::processor::aarch64::GicVersion;
+
 #[derive(Debug)]
-pub struct Kvm;
+pub struct Kvm {
+    kvm: kvm::Kvm,
+    supports_gic_v3: bool,
+}
+
+impl Kvm {
+    /// Opens `/dev/kvm` and probes whether the host supports GICv3 or GICv2.
+    pub fn new() -> Result<Self, KvmError> {
+        Self::from_kvm(kvm::Kvm::new()?.into())
+    }
+
+    /// Creates a `Kvm` from a pre-opened `/dev/kvm` file descriptor.
+    pub fn from_kvm(file: std::fs::File) -> Result<Self, KvmError> {
+        // Probe GIC version by creating a throwaway VM and attempting to
+        // create a GICv3 device. If that fails, try GICv2.
+        let kvm = kvm::Kvm::from(file);
+        let probe_vm = kvm.new_vm()?;
+        let supports_gic_v3 = if probe_vm
+            .create_device(
+                kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
+                KVM_CREATE_DEVICE_TEST,
+            )
+            .is_ok()
+        {
+            true
+        } else if probe_vm
+            .create_device(
+                kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2,
+                KVM_CREATE_DEVICE_TEST,
+            )
+            .is_ok()
+        {
+            false
+        } else {
+            return Err(KvmError::NoGic);
+        };
+
+        tracing::info!(supports_gic_v3, "detected KVM GIC version");
+
+        Ok(Self {
+            kvm,
+            supports_gic_v3,
+        })
+    }
+}
 
 #[derive(InspectMut)]
 pub struct KvmProcessor<'a> {
@@ -496,20 +546,20 @@ pub struct KvmProtoPartition<'a> {
 }
 
 impl KvmProtoPartition<'_> {
-    fn add_gicv3(&mut self) -> Result<(), KvmError> {
+    fn add_gicv3(&mut self, redistributors_base: u64) -> Result<(), KvmError> {
         // KVM requires the distributor and redistributor bases be _64KiB aligned_,
         // these ranges come from the OpenVMM MMIO gaps.
         const GIC_ALIGNMENT: u64 = 0x10000;
         let gic_dist_base: u64 = self.config.processor_topology.gic_distributor_base();
-        let gic_redist_base: u64 = self.config.processor_topology.gic_redistributors_base();
         if !gic_dist_base.is_multiple_of(GIC_ALIGNMENT)
-            || !gic_redist_base.is_multiple_of(GIC_ALIGNMENT)
+            || !redistributors_base.is_multiple_of(GIC_ALIGNMENT)
         {
             return Err(KvmError::Misaligned);
         }
 
-        const GIC_NR_IRQS: u32 = 64;
-        const GIC_NR_SPIS: u32 = 32;
+        // KVM validates: 64 <= nr_irqs <= 1023 and must be a multiple of 32.
+        // 992 is the largest valid value (31 * 32).
+        let gic_nr_irqs: u32 = self.config.processor_topology.gic_nr_irqs();
 
         let gicv3 = self
             .vm
@@ -524,7 +574,7 @@ impl KvmProtoPartition<'_> {
                 .set_device_attr::<u64>(
                     KVM_DEV_ARM_VGIC_GRP_ADDR,
                     KVM_VGIC_V3_ADDR_TYPE_REDIST,
-                    &gic_redist_base,
+                    &redistributors_base,
                     0,
                 )
                 .map_err(kvm::Error::SetDeviceAttr)?;
@@ -545,7 +595,7 @@ impl KvmProtoPartition<'_> {
         // SAFETY: passing the right type for the attribute.
         unsafe {
             gicv3
-                .set_device_attr::<u32>(KVM_DEV_ARM_VGIC_GRP_NR_IRQS, 0, &GIC_NR_IRQS, 0)
+                .set_device_attr::<u32>(KVM_DEV_ARM_VGIC_GRP_NR_IRQS, 0, &gic_nr_irqs, 0)
                 .map_err(kvm::Error::SetDeviceAttr)?;
         }
 
@@ -565,6 +615,66 @@ impl KvmProtoPartition<'_> {
 
         // TODO: save gicv3 to a File to ensure it is cleaned up.
         std::mem::forget(gicv3);
+        Ok(())
+    }
+
+    fn add_gicv2(&mut self, cpu_interface_base: u64) -> Result<(), KvmError> {
+        let gic_dist_base: u64 = self.config.processor_topology.gic_distributor_base();
+
+        let gic_nr_irqs: u32 = self.config.processor_topology.gic_nr_irqs();
+
+        let gicv2 = self
+            .vm
+            .create_device(kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2, 0)
+            .map_err(kvm::Error::CreateDevice)?;
+
+        // SAFETY: passing the right type for the attribute.
+        unsafe {
+            gicv2
+                .set_device_attr::<u64>(
+                    KVM_DEV_ARM_VGIC_GRP_ADDR,
+                    KVM_VGIC_V2_ADDR_TYPE_DIST,
+                    &gic_dist_base,
+                    0,
+                )
+                .map_err(kvm::Error::SetDeviceAttr)?;
+        }
+
+        // SAFETY: passing the right type for the attribute.
+        unsafe {
+            gicv2
+                .set_device_attr::<u64>(
+                    KVM_DEV_ARM_VGIC_GRP_ADDR,
+                    KVM_VGIC_V2_ADDR_TYPE_CPU,
+                    &cpu_interface_base,
+                    0,
+                )
+                .map_err(kvm::Error::SetDeviceAttr)?;
+        }
+
+        // SAFETY: passing the right type for the attribute.
+        unsafe {
+            gicv2
+                .set_device_attr::<u32>(KVM_DEV_ARM_VGIC_GRP_NR_IRQS, 0, &gic_nr_irqs, 0)
+                .map_err(kvm::Error::SetDeviceAttr)?;
+        }
+
+        // Initialize the GICv2 device.
+        //
+        // SAFETY: passing the right type for the attribute.
+        unsafe {
+            gicv2
+                .set_device_attr::<()>(
+                    KVM_DEV_ARM_VGIC_GRP_CTRL,
+                    KVM_DEV_ARM_VGIC_CTRL_INIT,
+                    &(),
+                    0,
+                )
+                .map_err(kvm::Error::SetDeviceAttr)?;
+        }
+
+        // TODO: save gicv2 to a File to ensure it is cleaned up.
+        std::mem::forget(gicv2);
         Ok(())
     }
 
@@ -615,8 +725,13 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
             self.vm.add_vp(vp_idx as u32)?;
         }
 
-        // TODO: Save the GICv3 FD to a File to ensure it is cleaned up.
-        self.add_gicv3()?;
+        // Set up the GIC device matching the topology's GIC version.
+        match self.config.processor_topology.gic_version() {
+            GicVersion::V3 {
+                redistributors_base,
+            } => self.add_gicv3(redistributors_base)?,
+            GicVersion::V2 { cpu_interface_base } => self.add_gicv2(cpu_interface_base)?,
+        }
 
         // Configure the virtual timer PPI from topology. KVM also requires
         // a physical timer PPI, but we don't expose it to the guest.
@@ -747,8 +862,7 @@ const GIC_IRQ_MAX: u32 = 0x3fb;
 
 impl virt::irqcon::ControlGic for KvmPartitionInner {
     fn set_spi_irq(&self, irq_id: u32, high: bool) {
-        // tracing::warn!("set_spi_irq: irq_id={}", irq_id);
-        debug_assert!(
+        assert!(
             (GIC_IRQ_BASE..=GIC_IRQ_MAX).contains(&irq_id),
             "invalid irq_id"
         );
@@ -756,15 +870,20 @@ impl virt::irqcon::ControlGic for KvmPartitionInner {
         let irqchip_irq =
             (KVM_ARM_IRQ_TYPE_SPI << KVM_ARM_IRQ_TYPE_SHIFT) | ((irq_id) & KVM_ARM_IRQ_NUM_MASK);
 
-        self.kvm
-            .irq_line(irqchip_irq, high)
-            .expect("interrupt delivery failure");
+        if let Err(err) = self.kvm.irq_line(irqchip_irq, high) {
+            tracelimit::warn_ratelimited!(
+                irq_id,
+                high,
+                err = &err as &dyn std::error::Error,
+                "failed to set SPI IRQ",
+            );
+        }
     }
 }
 
 impl virt::Aarch64Partition for KvmPartition {
     fn control_gic(&self, vtl: Vtl) -> Arc<dyn virt::irqcon::ControlGic> {
-        debug_assert!(vtl == Vtl::Vtl0);
+        assert!(vtl == Vtl::Vtl0);
         self.inner.clone()
     }
 }
@@ -808,6 +927,13 @@ impl virt::Hypervisor for Kvm {
     type Partition = KvmPartition;
     type Error = KvmError;
 
+    fn platform_info(&self) -> virt::PlatformInfo {
+        virt::PlatformInfo {
+            platform_gsiv: None,
+            supports_gic_v3: self.supports_gic_v3,
+        }
+    }
+
     fn new_partition<'a>(
         &'a mut self,
         config: ProtoPartitionConfig<'a>,
@@ -816,20 +942,23 @@ impl virt::Hypervisor for Kvm {
             return Err(KvmError::IsolationNotSupported);
         }
 
-        let kvm = kvm::Kvm::new()?;
-
         if let Some(hv_config) = &config.hv_config {
             if hv_config.vtl2.is_some() {
                 return Err(KvmError::Vtl2NotSupported);
             }
         }
 
-        let vm = kvm.new_vm()?;
+        let ipa_size = self
+            .kvm
+            .check_extension(KVM_CAP_ARM_VM_IPA_SIZE)
+            .unwrap_or(40) as u8;
+
+        let vm = self.kvm.new_vm()?;
 
         Ok(KvmProtoPartition {
             vm,
             config,
-            ipa_size: kvm.check_extension(KVM_CAP_ARM_VM_IPA_SIZE).unwrap_or(40) as u8,
+            ipa_size,
         })
     }
 }

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -546,7 +546,7 @@ pub struct KvmProtoPartition<'a> {
 }
 
 impl KvmProtoPartition<'_> {
-    fn add_gicv3(&mut self, redistributors_base: u64) -> Result<(), KvmError> {
+    fn add_gicv3(&mut self, redistributors_base: u64) -> Result<kvm::Device, KvmError> {
         // KVM requires the distributor and redistributor bases be _64KiB aligned_,
         // these ranges come from the OpenVMM MMIO gaps.
         const GIC_ALIGNMENT: u64 = 0x10000;
@@ -613,12 +613,10 @@ impl KvmProtoPartition<'_> {
                 .map_err(kvm::Error::SetDeviceAttr)?;
         }
 
-        // TODO: save gicv3 to a File to ensure it is cleaned up.
-        std::mem::forget(gicv3);
-        Ok(())
+        Ok(gicv3)
     }
 
-    fn add_gicv2(&mut self, cpu_interface_base: u64) -> Result<(), KvmError> {
+    fn add_gicv2(&mut self, cpu_interface_base: u64) -> Result<kvm::Device, KvmError> {
         let gic_dist_base: u64 = self.config.processor_topology.gic_distributor_base();
 
         let gic_nr_irqs: u32 = self.config.processor_topology.gic_nr_irqs();
@@ -673,9 +671,7 @@ impl KvmProtoPartition<'_> {
                 .map_err(kvm::Error::SetDeviceAttr)?;
         }
 
-        // TODO: save gicv2 to a File to ensure it is cleaned up.
-        std::mem::forget(gicv2);
-        Ok(())
+        Ok(gicv2)
     }
 
     fn set_timer_ppis(&mut self, virt: u32, phys: u32) -> Result<(), KvmError> {
@@ -726,12 +722,12 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
         }
 
         // Set up the GIC device matching the topology's GIC version.
-        match self.config.processor_topology.gic_version() {
+        let gic_device = match self.config.processor_topology.gic_version() {
             GicVersion::V3 {
                 redistributors_base,
             } => self.add_gicv3(redistributors_base)?,
             GicVersion::V2 { cpu_interface_base } => self.add_gicv2(cpu_interface_base)?,
-        }
+        };
 
         // Configure the virtual timer PPI from topology. KVM also requires
         // a physical timer PPI, but we don't expose it to the guest.
@@ -772,6 +768,7 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
                 })
                 .collect(),
             caps,
+            _gic_device: gic_device,
             gic_v2m: self.config.processor_topology.gic_v2m(),
             synic_ports: Default::default(),
         });

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -21,7 +21,6 @@ use hvdef::Vtl;
 use inspect::Inspect;
 use inspect::InspectMut;
 use kvm::KVM_CAP_ARM_VM_IPA_SIZE;
-use kvm::KVM_CREATE_DEVICE_TEST;
 use kvm::KVM_DEV_ARM_VGIC_CTRL_INIT;
 use kvm::KVM_DEV_ARM_VGIC_GRP_ADDR;
 use kvm::KVM_DEV_ARM_VGIC_GRP_CTRL;
@@ -231,18 +230,12 @@ impl Kvm {
         let kvm = kvm::Kvm::from(file);
         let probe_vm = kvm.new_vm()?;
         let supports_gic_v3 = if probe_vm
-            .create_device(
-                kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
-                KVM_CREATE_DEVICE_TEST,
-            )
+            .test_create_device(kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3)
             .is_ok()
         {
             true
         } else if probe_vm
-            .create_device(
-                kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2,
-                KVM_CREATE_DEVICE_TEST,
-            )
+            .test_create_device(kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2)
             .is_ok()
         {
             false
@@ -770,6 +763,7 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
             caps,
             _gic_device: gic_device,
             gic_v2m: self.config.processor_topology.gic_v2m(),
+            gic_nr_irqs: self.config.processor_topology.gic_nr_irqs(),
             synic_ports: Default::default(),
         });
 
@@ -855,14 +849,18 @@ const KVM_ARM_IRQ_TYPE_SHIFT: u32 = 24;
 const KVM_ARM_IRQ_NUM_MASK: u32 = 0xffff;
 
 const GIC_IRQ_BASE: u32 = 0x20;
-const GIC_IRQ_MAX: u32 = 0x3fb;
 
 impl virt::irqcon::ControlGic for KvmPartitionInner {
     fn set_spi_irq(&self, irq_id: u32, high: bool) {
-        assert!(
-            (GIC_IRQ_BASE..=GIC_IRQ_MAX).contains(&irq_id),
-            "invalid irq_id"
-        );
+        if !(GIC_IRQ_BASE..self.gic_nr_irqs).contains(&irq_id) {
+            tracelimit::warn_ratelimited!(
+                irq_id,
+                high,
+                gic_nr_irqs = self.gic_nr_irqs,
+                "SPI IRQ out of configured range",
+            );
+            return;
+        }
 
         let irqchip_irq =
             (KVM_ARM_IRQ_TYPE_SPI << KVM_ARM_IRQ_TYPE_SHIFT) | ((irq_id) & KVM_ARM_IRQ_NUM_MASK);
@@ -945,10 +943,14 @@ impl virt::Hypervisor for Kvm {
             }
         }
 
-        let ipa_size = self
+        let ipa_size = match self
             .kvm
             .check_extension(KVM_CAP_ARM_VM_IPA_SIZE)
-            .unwrap_or(40) as u8;
+            .map_err(kvm::Error::CheckExtension)?
+        {
+            v if v > 0 => v as u8,
+            _ => 40,
+        };
 
         let vm = self.kvm.new_vm()?;
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -139,8 +139,8 @@ impl virt::Hypervisor for Kvm {
             return Err(KvmError::IsolationNotSupported);
         }
 
-        let kvm = kvm::Kvm::new()?;
-        let mut cpuid_entries = kvm
+        let mut cpuid_entries = self
+            .kvm
             .supported_cpuid()?
             .into_iter()
             .filter_map(|entry| {
@@ -259,7 +259,7 @@ impl virt::Hypervisor for Kvm {
 
         let cpuid_entries = CpuidLeafSet::new(cpuid_entries);
 
-        let vm = kvm.new_vm()?;
+        let vm = self.kvm.new_vm()?;
         vm.enable_split_irqchip(virt::irqcon::IRQ_LINES as u32)?;
         vm.enable_x2apic_api()?;
         vm.enable_unknown_msr_exits()?;

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -93,7 +93,28 @@ use zerocopy::IntoBytes;
 const MYSTERY_MSRS: &[u32] = &[0x88, 0x89, 0x8a, 0x116, 0x118, 0x119, 0x11a, 0x11b, 0x11e];
 
 #[derive(Debug)]
-pub struct Kvm;
+pub struct Kvm {
+    kvm: kvm::Kvm,
+}
+
+impl Kvm {
+    /// Creates a new KVM hypervisor instance.
+    pub fn new() -> Result<Self, KvmError> {
+        Ok(Self {
+            kvm: kvm::Kvm::new()?,
+        })
+    }
+
+    /// Creates a KVM hypervisor instance from a pre-opened `/dev/kvm` fd.
+    ///
+    /// On x86_64, the fd is not retained; it will be re-opened in
+    /// `new_partition`. This exists for API symmetry with the aarch64
+    /// implementation.
+    pub fn from_kvm(file: std::fs::File) -> Result<Self, KvmError> {
+        let kvm = kvm::Kvm::from(file);
+        Ok(Self { kvm })
+    }
+}
 
 /// CPUID leaf and flag for GB page support.
 const GB_PAGE_LEAF: u32 = 0x80000001;
@@ -109,6 +130,10 @@ impl virt::Hypervisor for Kvm {
     type ProtoPartition<'a> = KvmProtoPartition<'a>;
     type Partition = KvmPartition;
     type Error = KvmError;
+
+    fn platform_info(&self) -> virt::PlatformInfo {
+        virt::PlatformInfo {}
+    }
 
     fn new_partition<'a>(
         &mut self,

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -106,10 +106,6 @@ impl Kvm {
     }
 
     /// Creates a KVM hypervisor instance from a pre-opened `/dev/kvm` fd.
-    ///
-    /// On x86_64, the fd is not retained; it will be re-opened in
-    /// `new_partition`. This exists for API symmetry with the aarch64
-    /// implementation.
     pub fn from_kvm(file: std::fs::File) -> Result<Self, KvmError> {
         let kvm = kvm::Kvm::from(file);
         Ok(Self { kvm })

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -109,6 +109,10 @@ struct KvmPartitionInner {
     #[cfg(guest_arch = "x86_64")]
     cpuid: virt::CpuidLeafSet,
 
+    /// The GIC device fd, kept alive for the VM lifetime.
+    #[cfg(guest_arch = "aarch64")]
+    #[inspect(skip)]
+    _gic_device: kvm::Device,
     #[cfg(guest_arch = "aarch64")]
     #[inspect(skip)]
     gic_v2m: Option<vm_topology::processor::aarch64::GicV2mInfo>,

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -116,6 +116,9 @@ struct KvmPartitionInner {
     #[cfg(guest_arch = "aarch64")]
     #[inspect(skip)]
     gic_v2m: Option<vm_topology::processor::aarch64::GicV2mInfo>,
+    /// Total configured GIC interrupt count (SGIs + PPIs + SPIs).
+    #[cfg(guest_arch = "aarch64")]
+    gic_nr_irqs: u32,
     synic_ports: virt::synic::SynicPortMap,
 }
 

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -56,6 +56,8 @@ pub enum KvmError {
     InvalidState(&'static str),
     #[error("misaligned gic base address")]
     Misaligned,
+    #[error("host does not support GICv2 or GICv3")]
+    NoGic,
     #[error("host does not support required cpu capabilities")]
     Capabilities(virt::PartitionCapabilitiesError),
     #[cfg(guest_arch = "x86_64")]

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -106,6 +106,10 @@ impl virt::Hypervisor for LinuxMshv {
     type Partition = MshvPartition;
     type Error = Error;
 
+    fn platform_info(&self) -> virt::PlatformInfo {
+        virt::PlatformInfo {}
+    }
+
     fn new_partition<'a>(
         &mut self,
         config: ProtoPartitionConfig<'a>,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -671,7 +671,10 @@ impl virt::BindProcessor for WhpProcessorBinder {
                     .for_op("set mpidr")?;
                 vp.vp
                     .whp(vtl)
-                    .set_register(whp::Register64::GicrBaseGpa, vp_info.gicr)
+                    .set_register(
+                        whp::Register64::GicrBaseGpa,
+                        vp_info.gicr.expect("WHP always uses GICv3"),
+                    )
                     .for_op("set GICR base")?;
             }
         }
@@ -730,6 +733,8 @@ pub enum Error {
     InvalidApicBase(#[source] virt_support_apic::InvalidApicBase),
     #[error("host does not support required cpu capabilities")]
     Capabilities(virt::PartitionCapabilitiesError),
+    #[error("WHP does not support GICv2; only GICv3 is supported")]
+    GicV2NotSupported,
     #[error("failed to compute topology cpuid")]
     TopologyCpuid(#[source] virt::x86::topology::UnknownVendor),
 }
@@ -752,6 +757,20 @@ impl virt::Hypervisor for Whp {
     type Partition = WhpPartition;
     type Error = Error;
 
+    fn platform_info(&self) -> virt::PlatformInfo {
+        #[cfg(guest_arch = "x86_64")]
+        {
+            virt::PlatformInfo {}
+        }
+        #[cfg(guest_arch = "aarch64")]
+        {
+            virt::PlatformInfo {
+                platform_gsiv: Some(WHP_PMU_GSIV),
+                supports_gic_v3: true,
+            }
+        }
+    }
+
     fn new_partition<'a>(
         &mut self,
         config: ProtoPartitionConfig<'a>,
@@ -768,11 +787,6 @@ impl virt::Hypervisor for Whp {
         };
 
         Ok(WhpProtoPartition { vtl0, vtl2, config })
-    }
-
-    #[cfg(guest_arch = "aarch64")]
-    fn platform_gsiv(&self) -> Option<u32> {
-        Some(WHP_PMU_GSIV)
     }
 }
 
@@ -812,6 +826,17 @@ impl ProtoPartition for WhpProtoPartition<'_> {
         self,
         config: PartitionConfig<'_>,
     ) -> Result<(Self::Partition, Vec<Self::ProcessorBinder>), Self::Error> {
+        #[cfg(guest_arch = "aarch64")]
+        {
+            use vm_topology::processor::aarch64::GicVersion;
+            if matches!(
+                self.config.processor_topology.gic_version(),
+                GicVersion::V2 { .. }
+            ) {
+                return Err(Error::GicV2NotSupported);
+            }
+        }
+
         let inner = Arc::new(WhpPartitionInner::new(
             config,
             &self.config,


### PR DESCRIPTION
The Raspberry Pi 5 uses a GIC-400 (GICv2), but virt_kvm hardcoded GICv3 everywhere — from KVM device creation to ACPI/DT generation. This made it impossible to run OpenVMM guests on any aarch64 platform without GICv3 hardware.

This change introduces a GicVersion enum (V2/V3) that threads through the entire aarch64 stack: processor topology, config definitions, ACPI MADT builder, device tree builder, and the KVM partition setup. At hypervisor init time, virt_kvm now probes the host by creating a throwaway VM and testing GICv3/GICv2 device creation via KVM_CREATE_DEVICE_TEST. The result is surfaced through a new platform_info() method on the Hypervisor trait (replacing the narrower platform_gsiv()), so that the topology builder can select the correct GIC version and address layout without explicit user configuration.

On GICv2 platforms, the MADT reports GIC version 2 and populates the CPU interface base address instead of per-VP redistributor addresses, the device tree uses the "arm,cortex-a15-gic" compatible string, and KVM gets a VGIC_V2 device with distributor + CPU interface regions.

The Kvm struct is also changed from a unit struct to hold the open /dev/kvm fd and the probed GIC version, so the fd opened during auto-detection is reused for partition creation rather than re-opened. The hardcoded GIC_NR_IRQS of 64 is replaced with a configurable value from topology (default 992) to provide enough SPIs for virtio and other device interrupts. SPI delivery failures now use rate-limited tracing instead of panicking.