### PR TITLE
vhost-user: add per-device queue and config support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5389,7 +5389,6 @@ dependencies = [
  "unix_socket",
  "video_core",
  "virt_whp",
- "virtio",
  "virtio_resources",
  "vm_manifest_builder",
  "vm_resource",

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -39,18 +39,23 @@ as well as the generated CLI help (via `cargo run -- --help`).
   The guest kernel must have `CONFIG_HW_RANDOM_VIRTIO` enabled.
 * `--virtio-rng-bus <BUS>`: Select the bus for the virtio-rng device (`auto`, `mmio`, `pci`, `vpci`).
   Defaults to `auto`.
-* `--vhost-user <SOCKET_PATH>,type=<TYPE>[,tag=<NAME>][,pcie_port=<PORT>]`: Attach a
+* `--vhost-user <SOCKET_PATH>,type=<TYPE>[,tag=<NAME>][,num_queues=<N>][,queue_size=<N>][,pcie_port=<PORT>]`: Attach a
   vhost-user device backed by an external process over a Unix socket (Linux
   only). The backend process must already be listening on `SOCKET_PATH`.
   Supported `type` values: `blk`, `fs`. For `type=fs`, `tag=<NAME>` is required
   and specifies the mount tag exposed to the guest (max 36 bytes).
+  `num_queues` and `queue_size` control the queue layout (defaults: blk
+  num_queues=1/queue_size=128, fs num_queues=1/queue_size=1024).
   Alternatively, use `device_id=<N>` instead of `type=` to specify the numeric
-  virtio device ID directly. Examples:
+  virtio device ID directly, with `queue_sizes=[N,N,N]` for per-queue sizes.
+  Examples:
   ```sh
   --vhost-user /tmp/vhost-blk.sock,type=blk
+  --vhost-user /tmp/vhost-blk.sock,type=blk,num_queues=4,queue_size=512
   --vhost-user /tmp/vhost-blk.sock,type=blk,pcie_port=rp0
   --vhost-user /tmp/virtiofsd.sock,type=fs,tag=myfs
-  --vhost-user /tmp/vhost.sock,device_id=26
+  --vhost-user /tmp/virtiofsd.sock,type=fs,tag=myfs,num_queues=2,queue_size=1024
+  --vhost-user /tmp/vhost.sock,device_id=26,queue_sizes=[256,256]
   ```
 
 Serial devices can be configured to appear as different devices inside the guest:

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -57,7 +57,6 @@ tpm_resources.workspace = true
 uidevices_resources.workspace = true
 video_core.workspace = true
 virtio_resources.workspace = true
-virtio.workspace = true
 vmbfs_resources.workspace = true
 vmbus_core.workspace = true
 vmbus_serial_resources.workspace = true

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -249,6 +249,9 @@ options:
     ///   type=blk|fs                        — device type (shorthand)
     ///   device_id=N                        — numeric virtio device ID
     ///   tag=NAME                           — mount tag (required for type=fs)
+    ///   num_queues=N                       — queue count (type=blk/fs only)
+    ///   queue_size=N                       — per-queue size (type=blk/fs only)
+    ///   queue_sizes=[N:N:N]                — per-queue sizes (device_id= only)
     ///   pcie_port=NAME                     — present on PCIe under the specified port
     /// ```
     ///
@@ -256,9 +259,11 @@ options:
     ///
     /// ```text
     ///   --vhost-user /tmp/vhost.sock,type=blk
-    ///   --vhost-user /tmp/vhost.sock,device_id=2
+    ///   --vhost-user /tmp/vhost.sock,type=blk,num_queues=4,queue_size=512
+    ///   --vhost-user /tmp/vhost.sock,device_id=2,queue_sizes=[128:128]
     ///   --vhost-user /tmp/vhost.sock,type=blk,pcie_port=port0
     ///   --vhost-user /tmp/virtiofsd.sock,type=fs,tag=myfs
+    ///   --vhost-user /tmp/virtiofsd.sock,type=fs,tag=myfs,num_queues=2,queue_size=1024
     /// ```
     #[cfg(target_os = "linux")]
     #[clap(long = "vhost-user")]
@@ -1977,12 +1982,23 @@ impl From<&std::ffi::OsStr> for OptionalPathBuf {
 #[cfg(target_os = "linux")]
 #[derive(Clone)]
 pub enum VhostUserDeviceTypeCli {
-    /// Block device — config from backend via GET_CONFIG.
-    Blk,
+    /// Block device — config from backend via GET_CONFIG, with num_queues
+    /// patched by the frontend.
+    Blk {
+        num_queues: Option<u16>,
+        queue_size: Option<u16>,
+    },
     /// Filesystem device — frontend-owned config with mount tag.
-    Fs { tag: String },
+    Fs {
+        tag: String,
+        num_queues: Option<u16>,
+        queue_size: Option<u16>,
+    },
     /// Generic device identified by numeric virtio device ID.
-    Other { device_id: u16 },
+    Other {
+        device_id: u16,
+        queue_sizes: Vec<u16>,
+    },
 }
 
 #[cfg(target_os = "linux")]
@@ -2005,6 +2021,9 @@ impl FromStr for VhostUserCli {
         let mut tag: Option<String> = None;
         let mut pcie_port: Option<String> = None;
         let mut type_name = None;
+        let mut num_queues: Option<u16> = None;
+        let mut queue_size: Option<u16> = None;
+        let mut queue_sizes: Option<Vec<u16>> = None;
         for opt in opts {
             let (key, val) = opt.split_once('=').context("expected key=value option")?;
             match key {
@@ -2020,6 +2039,25 @@ impl FromStr for VhostUserCli {
                 "pcie_port" => {
                     pcie_port = Some(val.to_string());
                 }
+                "num_queues" => {
+                    num_queues = Some(val.parse().context("invalid num_queues")?);
+                }
+                "queue_size" => {
+                    queue_size = Some(val.parse().context("invalid queue_size")?);
+                }
+                "queue_sizes" => {
+                    // Parse bracket-delimited comma-separated list: [N,N,N]
+                    let trimmed = val
+                        .strip_prefix('[')
+                        .and_then(|v| v.strip_suffix(']'))
+                        .context("queue_sizes must be bracketed: [N,N,N]")?;
+                    let sizes: Vec<u16> = trimmed
+                        .split(':')
+                        .map(|s| s.parse().context("invalid queue size in queue_sizes"))
+                        .collect::<anyhow::Result<_>>()?;
+                    anyhow::ensure!(!sizes.is_empty(), "queue_sizes must be non-empty");
+                    queue_sizes = Some(sizes);
+                }
                 other => anyhow::bail!("unknown vhost-user option: '{other}'"),
             }
         }
@@ -2032,17 +2070,38 @@ impl FromStr for VhostUserCli {
         let device_type = match type_name {
             Some("fs") => {
                 let tag = tag.take().context("type=fs requires tag=<name>")?;
-                VhostUserDeviceTypeCli::Fs { tag }
+                VhostUserDeviceTypeCli::Fs {
+                    tag,
+                    num_queues: num_queues.take(),
+                    queue_size: queue_size.take(),
+                }
             }
-            Some("blk") => VhostUserDeviceTypeCli::Blk,
-            Some(ty) => anyhow::bail!("unknown vhost-user device type: '{ty}'"),
-            None => VhostUserDeviceTypeCli::Other {
-                device_id: device_id.unwrap(),
+            Some("blk") => VhostUserDeviceTypeCli::Blk {
+                num_queues: num_queues.take(),
+                queue_size: queue_size.take(),
             },
+            Some(ty) => anyhow::bail!("unknown vhost-user device type: '{ty}'"),
+            None => {
+                let queue_sizes = queue_sizes
+                    .take()
+                    .context("device_id= requires queue_sizes=[N:N:...]")?;
+                VhostUserDeviceTypeCli::Other {
+                    device_id: device_id.unwrap(),
+                    queue_sizes,
+                }
+            }
         };
 
         if tag.is_some() {
             anyhow::bail!("tag= is only valid for type=fs");
+        }
+        if queue_sizes.is_some() {
+            anyhow::bail!("queue_sizes= is only valid for device_id=");
+        }
+        if num_queues.is_some() || queue_size.is_some() {
+            anyhow::bail!(
+                "num_queues= and queue_size= are not valid for device_id=; use queue_sizes="
+            );
         }
 
         Ok(VhostUserCli {

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -2010,15 +2010,20 @@ pub struct VhostUserCli {
 }
 
 /// Split a string on commas, but not inside `[…]` brackets.
+///
+/// Returns an error on mismatched brackets (unmatched `]` or unclosed `[`).
 #[cfg(target_os = "linux")]
-fn split_respecting_brackets(s: &str) -> Vec<&str> {
+fn split_respecting_brackets(s: &str) -> anyhow::Result<Vec<&str>> {
     let mut result = Vec::new();
     let mut start = 0;
-    let mut depth = 0u32;
+    let mut depth: i32 = 0;
     for (i, c) in s.char_indices() {
         match c {
             '[' => depth += 1,
-            ']' => depth = depth.saturating_sub(1),
+            ']' => {
+                depth -= 1;
+                anyhow::ensure!(depth >= 0, "unmatched ']' in option string");
+            }
             ',' if depth == 0 => {
                 result.push(&s[start..i]);
                 start = i + 1;
@@ -2026,8 +2031,9 @@ fn split_respecting_brackets(s: &str) -> Vec<&str> {
             _ => {}
         }
     }
+    anyhow::ensure!(depth == 0, "unclosed '[' in option string");
     result.push(&s[start..]);
-    result
+    Ok(result)
 }
 
 #[cfg(target_os = "linux")]
@@ -2036,7 +2042,7 @@ impl FromStr for VhostUserCli {
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
         // Split on commas, but not inside brackets (for queue_sizes=[N,N]).
-        let parts = split_respecting_brackets(s);
+        let parts = split_respecting_brackets(s)?;
         let mut parts_iter = parts.into_iter();
         let socket_path = parts_iter
             .next()

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -2038,7 +2038,10 @@ impl FromStr for VhostUserCli {
         // Split on commas, but not inside brackets (for queue_sizes=[N,N]).
         let parts = split_respecting_brackets(s);
         let mut parts_iter = parts.into_iter();
-        let socket_path = parts_iter.next().context("missing socket path")?.to_string();
+        let socket_path = parts_iter
+            .next()
+            .context("missing socket path")?
+            .to_string();
 
         let mut device_id: Option<u16> = None;
         let mut tag: Option<String> = None;

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -251,7 +251,7 @@ options:
     ///   tag=NAME                           — mount tag (required for type=fs)
     ///   num_queues=N                       — queue count (type=blk/fs only)
     ///   queue_size=N                       — per-queue size (type=blk/fs only)
-    ///   queue_sizes=[N:N:N]                — per-queue sizes (device_id= only)
+    ///   queue_sizes=[N,N,N]                — per-queue sizes (device_id= only)
     ///   pcie_port=NAME                     — present on PCIe under the specified port
     /// ```
     ///
@@ -260,7 +260,7 @@ options:
     /// ```text
     ///   --vhost-user /tmp/vhost.sock,type=blk
     ///   --vhost-user /tmp/vhost.sock,type=blk,num_queues=4,queue_size=512
-    ///   --vhost-user /tmp/vhost.sock,device_id=2,queue_sizes=[128:128]
+    ///   --vhost-user /tmp/vhost.sock,device_id=2,queue_sizes=[128,128]
     ///   --vhost-user /tmp/vhost.sock,type=blk,pcie_port=port0
     ///   --vhost-user /tmp/virtiofsd.sock,type=fs,tag=myfs
     ///   --vhost-user /tmp/virtiofsd.sock,type=fs,tag=myfs,num_queues=2,queue_size=1024
@@ -2009,13 +2009,36 @@ pub struct VhostUserCli {
     pub pcie_port: Option<String>,
 }
 
+/// Split a string on commas, but not inside `[…]` brackets.
+#[cfg(target_os = "linux")]
+fn split_respecting_brackets(s: &str) -> Vec<&str> {
+    let mut result = Vec::new();
+    let mut start = 0;
+    let mut depth = 0u32;
+    for (i, c) in s.char_indices() {
+        match c {
+            '[' => depth += 1,
+            ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                result.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    result.push(&s[start..]);
+    result
+}
+
 #[cfg(target_os = "linux")]
 impl FromStr for VhostUserCli {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
-        let mut opts = s.split(',');
-        let socket_path = opts.next().context("missing socket path")?.to_string();
+        // Split on commas, but not inside brackets (for queue_sizes=[N,N]).
+        let parts = split_respecting_brackets(s);
+        let mut parts_iter = parts.into_iter();
+        let socket_path = parts_iter.next().context("missing socket path")?.to_string();
 
         let mut device_id: Option<u16> = None;
         let mut tag: Option<String> = None;
@@ -2024,7 +2047,7 @@ impl FromStr for VhostUserCli {
         let mut num_queues: Option<u16> = None;
         let mut queue_size: Option<u16> = None;
         let mut queue_sizes: Option<Vec<u16>> = None;
-        for opt in opts {
+        for opt in parts_iter {
             let (key, val) = opt.split_once('=').context("expected key=value option")?;
             match key {
                 "type" => {
@@ -2052,7 +2075,7 @@ impl FromStr for VhostUserCli {
                         .and_then(|v| v.strip_suffix(']'))
                         .context("queue_sizes must be bracketed: [N,N,N]")?;
                     let sizes: Vec<u16> = trimmed
-                        .split(':')
+                        .split(',')
                         .map(|s| s.parse().context("invalid queue size in queue_sizes"))
                         .collect::<anyhow::Result<_>>()?;
                     anyhow::ensure!(!sizes.is_empty(), "queue_sizes must be non-empty");
@@ -2084,7 +2107,7 @@ impl FromStr for VhostUserCli {
             None => {
                 let queue_sizes = queue_sizes
                     .take()
-                    .context("device_id= requires queue_sizes=[N:N:...]")?;
+                    .context("device_id= requires queue_sizes=[N,N,...]")?;
                 VhostUserDeviceTypeCli::Other {
                     device_id: device_id.unwrap(),
                     queue_sizes,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1465,25 +1465,35 @@ async fn vm_config_from_command_line(
 
         use crate::cli_args::VhostUserDeviceTypeCli;
         let resource: Resource<VirtioDeviceHandle> = match vhost_cli.device_type {
-            VhostUserDeviceTypeCli::Fs { ref tag } => {
-                virtio_resources::vhost_user::VhostUserFsHandle {
-                    socket: stream.into(),
-                    tag: tag.clone(),
-                }
-                .into_resource()
-            }
-            VhostUserDeviceTypeCli::Blk => virtio_resources::vhost_user::VhostUserDeviceHandle {
+            VhostUserDeviceTypeCli::Fs {
+                ref tag,
+                num_queues,
+                queue_size,
+            } => virtio_resources::vhost_user::VhostUserFsHandle {
                 socket: stream.into(),
-                device_id: virtio::spec::VirtioDeviceType::BLK.0,
+                tag: tag.clone(),
+                num_queues,
+                queue_size,
             }
             .into_resource(),
-            VhostUserDeviceTypeCli::Other { device_id } => {
-                virtio_resources::vhost_user::VhostUserDeviceHandle {
-                    socket: stream.into(),
-                    device_id,
-                }
-                .into_resource()
+            VhostUserDeviceTypeCli::Blk {
+                num_queues,
+                queue_size,
+            } => virtio_resources::vhost_user::VhostUserBlkHandle {
+                socket: stream.into(),
+                num_queues,
+                queue_size,
             }
+            .into_resource(),
+            VhostUserDeviceTypeCli::Other {
+                device_id,
+                ref queue_sizes,
+            } => virtio_resources::vhost_user::VhostUserGenericHandle {
+                socket: stream.into(),
+                device_id,
+                queue_sizes: queue_sizes.clone(),
+            }
+            .into_resource(),
         };
         if let Some(pcie_port) = &vhost_cli.pcie_port {
             pcie_devices.push(PcieDeviceConfig {

--- a/vm/devices/virtio/vhost_user_frontend/src/lib.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/lib.rs
@@ -172,7 +172,13 @@ impl VhostUserFrontend {
             !config.queue_sizes.is_empty(),
             "queue_sizes must be non-empty"
         );
-        let max_queues = config.queue_sizes.len() as u16;
+        let max_queues = u16::try_from(config.queue_sizes.len()).map_err(|_| {
+            anyhow::anyhow!(
+                "queue_sizes has {} entries, exceeding maximum supported queue count {}",
+                config.queue_sizes.len(),
+                u16::MAX
+            )
+        })?;
         if let Some(backend_max) = backend_max_queues {
             anyhow::ensure!(
                 max_queues <= backend_max,
@@ -1688,21 +1694,29 @@ mod tests {
     }
 
     /// BLK with num_queues=2, queue_size=512: 2 queues, queue_size returns
-    /// 512 for all, config patch at offset 36 overrides num_queues.
+    /// 512 for all, config patch overrides num_queues.
     #[async_test]
     async fn blk_multi_queue_config(driver: DefaultDriver) {
+        use virtio::spec::blk;
+
         let num_queues: u16 = 2; // MockBackendDevice supports max 2
         let queue_size: u16 = 512;
+        let num_queues_offset = core::mem::offset_of!(blk::VirtioBlkConfig, num_queues) as u16;
 
         let config = VhostUserConfig {
             device_id: VirtioDeviceType::BLK,
             config_space: None,
             queue_sizes: vec![queue_size; num_queues as usize],
-            config_patches: vec![(36u16, num_queues.to_le_bytes().to_vec())],
+            config_patches: vec![(num_queues_offset, num_queues.to_le_bytes().to_vec())],
         };
 
-        let (frontend, _guest_memory, backend_task) =
-            setup_frontend_backend_with_config(&driver, MockBackendDevice::new(), config).await;
+        // Backend needs config space so CONFIG protocol feature is
+        // negotiated and GET_CONFIG works.
+        let mut mock = MockBackendDevice::new();
+        mock.traits.device_register_length = 64;
+
+        let (mut frontend, _guest_memory, backend_task) =
+            setup_frontend_backend_with_config(&driver, mock, config).await;
 
         // Verify queue count.
         assert_eq!(frontend.traits().max_queues, num_queues);
@@ -1711,6 +1725,11 @@ mod tests {
         for i in 0..num_queues {
             assert_eq!(frontend.queue_size(i), queue_size);
         }
+
+        // Verify the config patch is applied: reading num_queues from
+        // config space should return the patched value.
+        let val = frontend.read_registers_u32(num_queues_offset).await;
+        assert_eq!(val, num_queues as u32);
 
         drop(frontend);
         backend_task.await;

--- a/vm/devices/virtio/vhost_user_frontend/src/lib.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/lib.rs
@@ -161,7 +161,8 @@ impl VhostUserFrontend {
             Some(
                 send_get_u64(&socket, VhostUserRequestCode::GET_QUEUE_NUM)
                     .await
-                    .context("GET_QUEUE_NUM failed despite MQ being negotiated")? as u16,
+                    .context("GET_QUEUE_NUM failed despite MQ being negotiated")?
+                    as u16,
             )
         } else {
             None

--- a/vm/devices/virtio/vhost_user_frontend/src/lib.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod resolver;
 
+use anyhow::Context as _;
 use guestmem::GuestMemory;
 use guestmem::ShareableRegion;
 use inspect::InspectMut;
@@ -50,21 +51,25 @@ const GPA_TO_VA_OFFSET: u64 = 1 << 52;
 /// Configuration for creating a `VhostUserFrontend`.
 ///
 /// Each device-type resolver builds an appropriate `VhostUserConfig`:
-/// - FS: frontend-owned config space, +1 hiprio queue, sized per handle
-/// - BLK: backend config with num_queues patch, sized per handle
-/// - Generic: no config space, explicit per-queue sizes
+/// - FS: `use_backend_config: false`, full config as a patch at offset 0
+/// - BLK: `use_backend_config: true`, num_queues patched
+/// - Generic: `use_backend_config: true`, no patches
 pub struct VhostUserConfig {
     /// Virtio device ID (e.g., BLK, FS).
     pub device_id: VirtioDeviceType,
-    /// Frontend-owned config space. When `Some`, config reads are served
-    /// locally and `VHOST_USER_PROTOCOL_F_CONFIG` is not negotiated.
-    pub config_space: Option<Vec<u8>>,
+    /// When true, negotiate `VHOST_USER_PROTOCOL_F_CONFIG` with the
+    /// backend and use GET_CONFIG/SET_CONFIG for config reads/writes.
+    /// When false, config reads start from zeros (patches still apply)
+    /// and writes are dropped.
+    pub use_backend_config: bool,
     /// Per-queue sizes. Length determines the queue count; must be
     /// non-empty.
     pub queue_sizes: Vec<u16>,
-    /// Sparse patches applied to GET_CONFIG responses before returning
-    /// to the guest. Each entry is `(byte_offset, replacement_bytes)`.
-    /// Writes pass through to SET_CONFIG unchanged.
+    /// Sparse patches applied to config reads before returning to the
+    /// guest. Each entry is `(byte_offset, replacement_bytes)`. The
+    /// base is either GET_CONFIG (when `use_backend_config` is true)
+    /// or zeros. Writes pass through to SET_CONFIG unchanged when
+    /// `use_backend_config` is true.
     pub config_patches: Vec<(u16, Vec<u8>)>,
 }
 
@@ -85,13 +90,9 @@ pub struct VhostUserFrontend {
     device_traits: DeviceTraits,
     protocol_features: VhostUserProtocolFeatures,
     socket: VhostUserSocket,
-    /// Frontend-owned config space, if provided. When `Some`, config
-    /// reads are served locally and `VHOST_USER_PROTOCOL_F_CONFIG` is
-    /// not negotiated with the backend.
-    config_space: Option<Vec<u8>>,
     /// Per-queue sizes. `queue_size()` indexes into this.
     queue_sizes: Vec<u16>,
-    /// Sparse patches applied to GET_CONFIG responses. Each entry is
+    /// Sparse patches applied to config reads. Each entry is
     /// `(byte_offset, replacement_bytes)`.
     config_patches: Vec<(u16, Vec<u8>)>,
     /// Device feature bits from GET_FEATURES (used to mask guest features).
@@ -136,7 +137,7 @@ impl VhostUserFrontend {
             let wanted = VhostUserProtocolFeatures::new()
                 .with_mq(true)
                 .with_reply_ack(true)
-                .with_config(config.config_space.is_none())
+                .with_config(config.use_backend_config)
                 .with_reset_device(true);
             let negotiated =
                 VhostUserProtocolFeatures::from_bits(proto_features_raw & wanted.into_bits());
@@ -160,7 +161,7 @@ impl VhostUserFrontend {
             Some(
                 send_get_u64(&socket, VhostUserRequestCode::GET_QUEUE_NUM)
                     .await
-                    .unwrap_or(1) as u16,
+                    .context("GET_QUEUE_NUM failed despite MQ being negotiated")? as u16,
             )
         } else {
             None
@@ -192,16 +193,19 @@ impl VhostUserFrontend {
 
         // Determine the config register length.
         //
-        // When the frontend owns config, use the provided length.
-        // Otherwise, if the backend supports GET_CONFIG/SET_CONFIG, use
-        // the vhost-user max config size (256); reads beyond the
-        // backend's actual config space will return zeros.
-        let device_register_length = if let Some(ref cs) = config.config_space {
-            cs.len() as u32
-        } else if negotiated_proto.config() {
+        // When the backend supports GET_CONFIG, use the vhost-user max
+        // config size (256); reads beyond the backend's actual config
+        // space will return zeros. Otherwise, derive the length from
+        // the patches (the guest only sees patched fields).
+        let device_register_length = if negotiated_proto.config() {
             256
         } else {
-            0
+            config
+                .config_patches
+                .iter()
+                .map(|(off, data)| *off as u32 + data.len() as u32)
+                .max()
+                .unwrap_or(0)
         };
 
         let device_traits = DeviceTraits {
@@ -225,7 +229,6 @@ impl VhostUserFrontend {
             device_traits,
             protocol_features: negotiated_proto,
             socket,
-            config_space: config.config_space,
             queue_sizes,
             config_patches: config.config_patches,
             device_features_raw,
@@ -248,28 +251,25 @@ impl VirtioDevice for VhostUserFrontend {
     }
 
     async fn read_registers_u32(&mut self, offset: u16) -> u32 {
-        if let Some(ref config) = self.config_space {
-            return read_config_u32(config, offset as usize);
-        }
-
-        if !self.protocol_features.config() {
-            return 0;
-        }
-        let mut buf = match send_get_config(&self.socket, offset as u32, 4).await {
-            Ok(data) if data.len() >= 4 => {
-                let mut b = [0u8; 4];
-                b.copy_from_slice(&data[..4]);
-                b
+        let mut buf = if self.protocol_features.config() {
+            match send_get_config(&self.socket, offset as u32, 4).await {
+                Ok(data) if data.len() >= 4 => {
+                    let mut b = [0u8; 4];
+                    b.copy_from_slice(&data[..4]);
+                    b
+                }
+                Ok(_) => [0u8; 4],
+                Err(e) => {
+                    tracelimit::warn_ratelimited!(
+                        error = &*e as &dyn std::error::Error,
+                        offset,
+                        "GET_CONFIG failed"
+                    );
+                    [0u8; 4]
+                }
             }
-            Ok(_) => [0u8; 4],
-            Err(e) => {
-                tracelimit::warn_ratelimited!(
-                    error = &*e as &dyn std::error::Error,
-                    offset,
-                    "GET_CONFIG failed"
-                );
-                return 0;
-            }
+        } else {
+            [0u8; 4]
         };
 
         // Apply config patches to the read buffer.
@@ -294,10 +294,6 @@ impl VirtioDevice for VhostUserFrontend {
     }
 
     async fn write_registers_u32(&mut self, offset: u16, val: u32) {
-        if self.config_space.is_some() {
-            return;
-        }
-
         if !self.protocol_features.config() {
             return;
         }
@@ -978,17 +974,6 @@ async fn send_set_config(
     Ok(())
 }
 
-/// Read a little-endian `u32` from config bytes, zero-padding any trailing
-/// bytes when the read overlaps the end of the slice.
-fn read_config_u32(config: &[u8], offset: usize) -> u32 {
-    let mut buf = [0u8; 4];
-    if offset < config.len() {
-        let end = std::cmp::min(offset + buf.len(), config.len());
-        buf[..end - offset].copy_from_slice(&config[offset..end]);
-    }
-    u32::from_le_bytes(buf)
-}
-
 /// Read the used_index from the used ring in guest memory.
 ///
 /// The used ring starts at `params.used_addr`. The `idx` field is at
@@ -1194,7 +1179,7 @@ mod tests {
             frontend_socket,
             VhostUserConfig {
                 device_id: VirtioDeviceType::BLK,
-                config_space: None,
+                use_backend_config: true,
                 queue_sizes: vec![DEFAULT_QUEUE_SIZE; 2],
                 config_patches: vec![],
             },
@@ -1390,7 +1375,7 @@ mod tests {
             device,
             VhostUserConfig {
                 device_id: VirtioDeviceType::BLK,
-                config_space: None,
+                use_backend_config: true,
                 queue_sizes: vec![DEFAULT_QUEUE_SIZE; 2],
                 config_patches: vec![],
             },
@@ -1574,8 +1559,9 @@ mod tests {
         backend_task.await;
     }
 
-    /// When `config_space` is provided, the frontend owns config reads
-    /// locally and does not negotiate VHOST_USER_PROTOCOL_F_CONFIG.
+    /// When `use_backend_config` is false with a full config patch, the
+    /// frontend serves config reads from the patch and does not negotiate
+    /// VHOST_USER_PROTOCOL_F_CONFIG.
     #[async_test]
     async fn frontend_owned_config_space(driver: DefaultDriver) {
         use virtio::spec::fs as virtio_fs;
@@ -1609,9 +1595,9 @@ mod tests {
             frontend_socket,
             VhostUserConfig {
                 device_id: VirtioDeviceType::FS,
-                config_space: Some(config_bytes.clone()),
+                use_backend_config: false,
                 queue_sizes: vec![1024; 2], // hiprio + 1 request queue
-                config_patches: vec![],
+                config_patches: vec![(0, config_bytes.clone())],
             },
         )
         .await
@@ -1665,9 +1651,9 @@ mod tests {
 
         let config = VhostUserConfig {
             device_id: VirtioDeviceType::FS,
-            config_space: Some(fs_config.as_bytes().to_vec()),
+            use_backend_config: false,
             queue_sizes: vec![queue_size; total_queues],
-            config_patches: vec![],
+            config_patches: vec![(0, fs_config.as_bytes().to_vec())],
         };
 
         // Need a mock device with enough queues (3).
@@ -1705,7 +1691,7 @@ mod tests {
 
         let config = VhostUserConfig {
             device_id: VirtioDeviceType::BLK,
-            config_space: None,
+            use_backend_config: true,
             queue_sizes: vec![queue_size; num_queues as usize],
             config_patches: vec![(num_queues_offset, num_queues.to_le_bytes().to_vec())],
         };
@@ -1742,7 +1728,7 @@ mod tests {
 
         let config = VhostUserConfig {
             device_id: VirtioDeviceType::BLK, // device type doesn't matter for this test
-            config_space: None,
+            use_backend_config: true,
             queue_sizes: queue_sizes.clone(),
             config_patches: vec![],
         };
@@ -1767,7 +1753,7 @@ mod tests {
         // MockBackendDevice supports max_queues=2.
         let config = VhostUserConfig {
             device_id: VirtioDeviceType::BLK,
-            config_space: None,
+            use_backend_config: true,
             queue_sizes: vec![256; 4], // 4 > 2
             config_patches: vec![],
         };

--- a/vm/devices/virtio/vhost_user_frontend/src/lib.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/lib.rs
@@ -15,14 +15,11 @@
 
 pub mod resolver;
 
-use anyhow::Context as _;
 use guestmem::GuestMemory;
 use guestmem::ShareableRegion;
 use inspect::InspectMut;
-use pal_async::socket::PolledSocket;
 use std::os::fd::AsFd;
 use std::os::fd::OwnedFd;
-use unix_socket::UnixStream;
 use vhost_user_protocol::*;
 use virtio::DeviceTraits;
 use virtio::DeviceTraitsSharedMemory;
@@ -50,6 +47,27 @@ use zerocopy::IntoBytes;
 /// there is no possible collision with any valid GPA.
 const GPA_TO_VA_OFFSET: u64 = 1 << 52;
 
+/// Configuration for creating a `VhostUserFrontend`.
+///
+/// Each device-type resolver builds an appropriate `VhostUserConfig`:
+/// - FS: frontend-owned config space, +1 hiprio queue, sized per handle
+/// - BLK: backend config with num_queues patch, sized per handle
+/// - Generic: no config space, explicit per-queue sizes
+pub struct VhostUserConfig {
+    /// Virtio device ID (e.g., BLK, FS).
+    pub device_id: VirtioDeviceType,
+    /// Frontend-owned config space. When `Some`, config reads are served
+    /// locally and `VHOST_USER_PROTOCOL_F_CONFIG` is not negotiated.
+    pub config_space: Option<Vec<u8>>,
+    /// Per-queue sizes. Length determines the queue count; must be
+    /// non-empty.
+    pub queue_sizes: Vec<u16>,
+    /// Sparse patches applied to GET_CONFIG responses before returning
+    /// to the guest. Each entry is `(byte_offset, replacement_bytes)`.
+    /// Writes pass through to SET_CONFIG unchanged.
+    pub config_patches: Vec<(u16, Vec<u8>)>,
+}
+
 /// Per-queue tracking state.
 struct FrontendQueueState {
     active: bool,
@@ -71,6 +89,11 @@ pub struct VhostUserFrontend {
     /// reads are served locally and `VHOST_USER_PROTOCOL_F_CONFIG` is
     /// not negotiated with the backend.
     config_space: Option<Vec<u8>>,
+    /// Per-queue sizes. `queue_size()` indexes into this.
+    queue_sizes: Vec<u16>,
+    /// Sparse patches applied to GET_CONFIG responses. Each entry is
+    /// `(byte_offset, replacement_bytes)`.
+    config_patches: Vec<(u16, Vec<u8>)>,
     /// Device feature bits from GET_FEATURES (used to mask guest features).
     device_features_raw: VirtioDeviceFeatures,
     guest_features_sent: bool,
@@ -94,40 +117,11 @@ impl VhostUserFrontend {
         self.protocol_features.reply_ack()
     }
 
-    /// Connect to a vhost-user backend, negotiate features, and send
-    /// the memory table.
-    ///
-    /// `device_id` is the virtio device ID (e.g., 2 for block) —
-    /// vhost-user has no GET_DEVICE_ID message so this must come from
-    /// the resource configuration.
-    pub async fn new(
-        driver: VmTaskDriver,
-        socket_path: &std::path::Path,
-        device_id: VirtioDeviceType,
-    ) -> anyhow::Result<Self> {
-        let stream = UnixStream::connect(socket_path)
-            .with_context(|| format!("failed to connect to {}", socket_path.display()))?;
-        let polled = PolledSocket::new(&driver, stream)?;
-        let socket = VhostUserSocket::new(polled);
-
-        Self::from_socket(driver, socket, device_id, None).await
-    }
-
-    /// Create from an already-connected socket (useful for testing with
-    /// socketpairs).
-    ///
-    /// When `config_space` is `Some`, the frontend owns the device config
-    /// space and serves all config reads locally; `VHOST_USER_PROTOCOL_F_CONFIG`
-    /// is not negotiated with the backend and writes are dropped.
-    ///
-    /// When `config_space` is `None`, config reads/writes are forwarded
-    /// to the backend via `GET_CONFIG`/`SET_CONFIG` (if the backend
-    /// supports it).
+    /// Create from an already-connected socket.
     pub async fn from_socket(
         driver: VmTaskDriver,
         socket: VhostUserSocket,
-        device_id: VirtioDeviceType,
-        config_space: Option<Vec<u8>>,
+        config: VhostUserConfig,
     ) -> anyhow::Result<Self> {
         // 1. GET_FEATURES
         let device_features_raw = VirtioDeviceFeatures::from_bits(
@@ -142,7 +136,7 @@ impl VhostUserFrontend {
             let wanted = VhostUserProtocolFeatures::new()
                 .with_mq(true)
                 .with_reply_ack(true)
-                .with_config(config_space.is_none())
+                .with_config(config.config_space.is_none())
                 .with_reset_device(true);
             let negotiated =
                 VhostUserProtocolFeatures::from_bits(proto_features_raw & wanted.into_bits());
@@ -162,14 +156,30 @@ impl VhostUserFrontend {
         send_simple(&socket, VhostUserRequestCode::SET_OWNER, false).await?;
 
         // 4. GET_QUEUE_NUM (requires MQ protocol feature)
-        let max_queues = if negotiated_proto.mq() {
-            send_get_u64(&socket, VhostUserRequestCode::GET_QUEUE_NUM)
-                .await
-                .unwrap_or(1) as u16
+        let backend_max_queues = if negotiated_proto.mq() {
+            Some(
+                send_get_u64(&socket, VhostUserRequestCode::GET_QUEUE_NUM)
+                    .await
+                    .unwrap_or(1) as u16,
+            )
         } else {
-            1
+            None
         };
-        tracing::trace!(max_queues, "GET_QUEUE_NUM");
+        tracing::trace!(?backend_max_queues, "GET_QUEUE_NUM");
+
+        // Validate the requested queue count against the backend.
+        anyhow::ensure!(
+            !config.queue_sizes.is_empty(),
+            "queue_sizes must be non-empty"
+        );
+        let max_queues = config.queue_sizes.len() as u16;
+        if let Some(backend_max) = backend_max_queues {
+            anyhow::ensure!(
+                max_queues <= backend_max,
+                "requested {max_queues} queues but backend supports at most {backend_max}"
+            );
+        }
+        let queue_sizes = config.queue_sizes;
 
         // Build DeviceTraits from the wire features.
         let device_features = device_features_raw.with_vhost_user_protocol_features(false);
@@ -180,7 +190,7 @@ impl VhostUserFrontend {
         // Otherwise, if the backend supports GET_CONFIG/SET_CONFIG, use
         // the vhost-user max config size (256); reads beyond the
         // backend's actual config space will return zeros.
-        let device_register_length = if let Some(ref cs) = config_space {
+        let device_register_length = if let Some(ref cs) = config.config_space {
             cs.len() as u32
         } else if negotiated_proto.config() {
             256
@@ -189,7 +199,7 @@ impl VhostUserFrontend {
         };
 
         let device_traits = DeviceTraits {
-            device_id,
+            device_id: config.device_id,
             device_features,
             max_queues,
             device_register_length,
@@ -209,7 +219,9 @@ impl VhostUserFrontend {
             device_traits,
             protocol_features: negotiated_proto,
             socket,
-            config_space,
+            config_space: config.config_space,
+            queue_sizes,
+            config_patches: config.config_patches,
             device_features_raw,
             guest_features_sent: false,
             mem_table_sent: false,
@@ -225,6 +237,10 @@ impl VirtioDevice for VhostUserFrontend {
         self.device_traits.clone()
     }
 
+    fn queue_size(&self, queue_index: u16) -> u16 {
+        self.queue_sizes[queue_index as usize]
+    }
+
     async fn read_registers_u32(&mut self, offset: u16) -> u32 {
         if let Some(ref config) = self.config_space {
             return read_config_u32(config, offset as usize);
@@ -233,18 +249,42 @@ impl VirtioDevice for VhostUserFrontend {
         if !self.protocol_features.config() {
             return 0;
         }
-        match send_get_config(&self.socket, offset as u32, 4).await {
-            Ok(data) if data.len() >= 4 => u32::from_le_bytes(data[..4].try_into().unwrap()),
-            Ok(_) => 0,
+        let mut buf = match send_get_config(&self.socket, offset as u32, 4).await {
+            Ok(data) if data.len() >= 4 => {
+                let mut b = [0u8; 4];
+                b.copy_from_slice(&data[..4]);
+                b
+            }
+            Ok(_) => [0u8; 4],
             Err(e) => {
                 tracelimit::warn_ratelimited!(
                     error = &*e as &dyn std::error::Error,
                     offset,
                     "GET_CONFIG failed"
                 );
-                0
+                return 0;
+            }
+        };
+
+        // Apply config patches to the read buffer.
+        for (patch_offset, patch_data) in &self.config_patches {
+            let p_start = *patch_offset as usize;
+            let p_end = p_start + patch_data.len();
+            let r_start = offset as usize;
+            let r_end = r_start + 4;
+            // Check for overlap.
+            if p_start < r_end && p_end > r_start {
+                let overlap_start = p_start.max(r_start);
+                let overlap_end = p_end.min(r_end);
+                let buf_offset = overlap_start - r_start;
+                let patch_src_offset = overlap_start - p_start;
+                let len = overlap_end - overlap_start;
+                buf[buf_offset..buf_offset + len]
+                    .copy_from_slice(&patch_data[patch_src_offset..patch_src_offset + len]);
             }
         }
+
+        u32::from_le_bytes(buf)
     }
 
     async fn write_registers_u32(&mut self, offset: u16, val: u32) {
@@ -975,7 +1015,9 @@ mod tests {
     use std::sync::atomic::AtomicU32;
     use std::sync::atomic::Ordering;
     use test_with_tracing::test;
+    use unix_socket::UnixStream;
     use vhost_user_backend::VhostUserDeviceServer;
+    use virtio::DEFAULT_QUEUE_SIZE;
     use virtio::DeviceTraits;
     use virtio::DeviceTraitsSharedMemory;
     use virtio::QueueResources;
@@ -1141,10 +1183,18 @@ mod tests {
         let guest_memory = ShareableGuestMemory::new(65536).into_guest_memory();
 
         let vm_driver = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())).simple();
-        let frontend =
-            VhostUserFrontend::from_socket(vm_driver, frontend_socket, VirtioDeviceType::BLK, None)
-                .await
-                .expect("frontend handshake failed");
+        let frontend = VhostUserFrontend::from_socket(
+            vm_driver,
+            frontend_socket,
+            VhostUserConfig {
+                device_id: VirtioDeviceType::BLK,
+                config_space: None,
+                queue_sizes: vec![DEFAULT_QUEUE_SIZE; 2],
+                config_patches: vec![],
+            },
+        )
+        .await
+        .expect("frontend handshake failed");
 
         (frontend, guest_memory, backend_task)
     }
@@ -1329,7 +1379,25 @@ mod tests {
         driver: &DefaultDriver,
         device: impl VirtioDevice + 'static,
     ) -> (VhostUserFrontend, GuestMemory, pal_async::task::Task<()>) {
-        let device_id = device.traits().device_id;
+        setup_frontend_backend_with_config(
+            driver,
+            device,
+            VhostUserConfig {
+                device_id: VirtioDeviceType::BLK,
+                config_space: None,
+                queue_sizes: vec![DEFAULT_QUEUE_SIZE; 2],
+                config_patches: vec![],
+            },
+        )
+        .await
+    }
+
+    /// Create a frontend+backend pair with a custom device and config.
+    async fn setup_frontend_backend_with_config(
+        driver: &DefaultDriver,
+        device: impl VirtioDevice + 'static,
+        config: VhostUserConfig,
+    ) -> (VhostUserFrontend, GuestMemory, pal_async::task::Task<()>) {
         let (frontend_stream, backend_stream) = socket_pair();
 
         let backend_polled = PolledSocket::new(driver, backend_stream).unwrap();
@@ -1347,7 +1415,7 @@ mod tests {
         let guest_memory = ShareableGuestMemory::new(65536).into_guest_memory();
 
         let vm_driver = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())).simple();
-        let frontend = VhostUserFrontend::from_socket(vm_driver, frontend_socket, device_id, None)
+        let frontend = VhostUserFrontend::from_socket(vm_driver, frontend_socket, config)
             .await
             .expect("frontend handshake failed");
 
@@ -1533,8 +1601,12 @@ mod tests {
         let mut frontend = VhostUserFrontend::from_socket(
             vm_driver,
             frontend_socket,
-            VirtioDeviceType::FS,
-            Some(config_bytes.clone()),
+            VhostUserConfig {
+                device_id: VirtioDeviceType::FS,
+                config_space: Some(config_bytes.clone()),
+                queue_sizes: vec![1024; 2], // hiprio + 1 request queue
+                config_patches: vec![],
+            },
         )
         .await
         .expect("frontend handshake failed");
@@ -1564,6 +1636,150 @@ mod tests {
         frontend.write_registers_u32(0, 0xdeadbeef).await;
 
         drop(frontend);
+        backend_task.await;
+    }
+
+    /// FS with num_request_queues=2: 3 total queues (1 hiprio + 2 request),
+    /// queue_size returns 1024 for all, config reads back num_request_queues=2.
+    #[async_test]
+    async fn fs_multi_queue_config(driver: DefaultDriver) {
+        use virtio::spec::fs as virtio_fs;
+        use zerocopy::IntoBytes;
+
+        let num_request_queues: u16 = 2;
+        let queue_size: u16 = 1024;
+        let total_queues = 1 + num_request_queues as usize; // hiprio + request
+
+        let mut fs_config = virtio_fs::Config {
+            tag: [0; virtio_fs::TAG_LEN],
+            num_request_queues: (num_request_queues as u32).into(),
+        };
+        let tag = b"testfs";
+        fs_config.tag[..tag.len()].copy_from_slice(tag);
+
+        let config = VhostUserConfig {
+            device_id: VirtioDeviceType::FS,
+            config_space: Some(fs_config.as_bytes().to_vec()),
+            queue_sizes: vec![queue_size; total_queues],
+            config_patches: vec![],
+        };
+
+        // Need a mock device with enough queues (3).
+        let mut mock = MockBackendDevice::new();
+        mock.traits.max_queues = 4;
+
+        let (mut frontend, _guest_memory, backend_task) =
+            setup_frontend_backend_with_config(&driver, mock, config).await;
+
+        // Verify total queue count.
+        assert_eq!(frontend.traits().max_queues, total_queues as u16);
+
+        // Verify queue_size returns 1024 for all queues.
+        for i in 0..total_queues {
+            assert_eq!(frontend.queue_size(i as u16), queue_size);
+        }
+
+        // Verify config space reads back num_request_queues=2.
+        let val = frontend.read_registers_u32(virtio_fs::TAG_LEN as u16).await;
+        assert_eq!(val, num_request_queues as u32);
+
+        drop(frontend);
+        backend_task.await;
+    }
+
+    /// BLK with num_queues=2, queue_size=512: 2 queues, queue_size returns
+    /// 512 for all, config patch at offset 36 overrides num_queues.
+    #[async_test]
+    async fn blk_multi_queue_config(driver: DefaultDriver) {
+        let num_queues: u16 = 2; // MockBackendDevice supports max 2
+        let queue_size: u16 = 512;
+
+        let config = VhostUserConfig {
+            device_id: VirtioDeviceType::BLK,
+            config_space: None,
+            queue_sizes: vec![queue_size; num_queues as usize],
+            config_patches: vec![(36u16, num_queues.to_le_bytes().to_vec())],
+        };
+
+        let (frontend, _guest_memory, backend_task) =
+            setup_frontend_backend_with_config(&driver, MockBackendDevice::new(), config).await;
+
+        // Verify queue count.
+        assert_eq!(frontend.traits().max_queues, num_queues);
+
+        // Verify queue_size returns 512 for all queues.
+        for i in 0..num_queues {
+            assert_eq!(frontend.queue_size(i), queue_size);
+        }
+
+        drop(frontend);
+        backend_task.await;
+    }
+
+    /// Generic with queue_sizes=[256, 512]: 2 queues with per-queue sizes.
+    #[async_test]
+    async fn generic_per_queue_sizes(driver: DefaultDriver) {
+        let queue_sizes = vec![256u16, 512u16];
+
+        let config = VhostUserConfig {
+            device_id: VirtioDeviceType::BLK, // device type doesn't matter for this test
+            config_space: None,
+            queue_sizes: queue_sizes.clone(),
+            config_patches: vec![],
+        };
+
+        let (frontend, _guest_memory, backend_task) =
+            setup_frontend_backend_with_config(&driver, MockBackendDevice::new(), config).await;
+
+        // Verify queue count.
+        assert_eq!(frontend.traits().max_queues, 2);
+
+        // Verify per-queue sizes.
+        assert_eq!(frontend.queue_size(0), 256);
+        assert_eq!(frontend.queue_size(1), 512);
+
+        drop(frontend);
+        backend_task.await;
+    }
+
+    /// Requesting more queues than the backend supports should fail.
+    #[async_test]
+    async fn queue_count_exceeds_backend(driver: DefaultDriver) {
+        // MockBackendDevice supports max_queues=2.
+        let config = VhostUserConfig {
+            device_id: VirtioDeviceType::BLK,
+            config_space: None,
+            queue_sizes: vec![256; 4], // 4 > 2
+            config_patches: vec![],
+        };
+
+        let (frontend_stream, backend_stream) = socket_pair();
+
+        let backend_polled = PolledSocket::new(&driver, backend_stream).unwrap();
+        let backend_socket = VhostUserSocket::new(backend_polled);
+
+        let server = VhostUserDeviceServer::new(Box::new(MockBackendDevice::new()));
+        let backend_task = driver.spawn("backend", async move {
+            // The backend will see the connection drop when the frontend
+            // rejects the queue count. Ignore the serve error.
+            let _ = server.serve_connection(backend_socket).await;
+        });
+
+        let frontend_polled = PolledSocket::new(&driver, frontend_stream).unwrap();
+        let frontend_socket = VhostUserSocket::new(frontend_polled);
+
+        let vm_driver = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())).simple();
+        let result = VhostUserFrontend::from_socket(vm_driver, frontend_socket, config).await;
+
+        let err = result
+            .err()
+            .expect("should fail when queue count exceeds backend");
+        let err_msg = format!("{err}");
+        assert!(
+            err_msg.contains("4 queues"),
+            "error should mention requested count: {err_msg}"
+        );
+
         backend_task.await;
     }
 }

--- a/vm/devices/virtio/vhost_user_frontend/src/resolver.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/resolver.rs
@@ -144,7 +144,8 @@ impl AsyncResolveResource<VirtioDeviceHandle, VhostUserBlkHandle> for VhostUserF
         // Patch the num_queues field in the backend's config space.
         // Config reads are proxied from the backend with this patch
         // applied; writes pass through unchanged.
-        let num_queues_offset = core::mem::offset_of!(virtio::spec::blk::VirtioBlkConfig, num_queues) as u16;
+        let num_queues_offset =
+            core::mem::offset_of!(virtio::spec::blk::VirtioBlkConfig, num_queues) as u16;
         let config_patches = vec![(num_queues_offset, num_queues.to_le_bytes().to_vec())];
 
         let config = crate::VhostUserConfig {

--- a/vm/devices/virtio/vhost_user_frontend/src/resolver.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/resolver.rs
@@ -69,7 +69,7 @@ impl AsyncResolveResource<VirtioDeviceHandle, VhostUserGenericHandle>
         );
         let config = crate::VhostUserConfig {
             device_id: VirtioDeviceType(resource.device_id),
-            config_space: None,
+            use_backend_config: true,
             queue_sizes: resource.queue_sizes,
             config_patches: vec![],
         };
@@ -113,9 +113,9 @@ impl AsyncResolveResource<VirtioDeviceHandle, VhostUserFsHandle> for VhostUserFr
 
         let vhost_config = crate::VhostUserConfig {
             device_id: VirtioDeviceType::FS,
-            config_space: Some(config.as_bytes().to_vec()),
+            use_backend_config: false,
             queue_sizes,
-            config_patches: vec![],
+            config_patches: vec![(0, config.as_bytes().to_vec())],
         };
 
         let frontend = connect_frontend(input, resource.socket, vhost_config)
@@ -149,7 +149,7 @@ impl AsyncResolveResource<VirtioDeviceHandle, VhostUserBlkHandle> for VhostUserF
 
         let config = crate::VhostUserConfig {
             device_id: VirtioDeviceType::BLK,
-            config_space: None,
+            use_backend_config: true,
             queue_sizes,
             config_patches,
         };

--- a/vm/devices/virtio/vhost_user_frontend/src/resolver.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/resolver.rs
@@ -141,10 +141,11 @@ impl AsyncResolveResource<VirtioDeviceHandle, VhostUserBlkHandle> for VhostUserF
         let queue_size = resource.queue_size.unwrap_or(128);
         let queue_sizes = vec![queue_size; num_queues as usize];
 
-        // Patch the num_queues field in the virtio_blk config at offset
-        // 36 (per virtio spec §5.2.4). Config reads are proxied from the
-        // backend with this patch applied; writes pass through unchanged.
-        let config_patches = vec![(36u16, num_queues.to_le_bytes().to_vec())];
+        // Patch the num_queues field in the backend's config space.
+        // Config reads are proxied from the backend with this patch
+        // applied; writes pass through unchanged.
+        let num_queues_offset = core::mem::offset_of!(virtio::spec::blk::VirtioBlkConfig, num_queues) as u16;
+        let config_patches = vec![(num_queues_offset, num_queues.to_le_bytes().to_vec())];
 
         let config = crate::VhostUserConfig {
             device_id: VirtioDeviceType::BLK,

--- a/vm/devices/virtio/vhost_user_frontend/src/resolver.rs
+++ b/vm/devices/virtio/vhost_user_frontend/src/resolver.rs
@@ -14,8 +14,9 @@ use virtio::resolve::ResolvedVirtioDevice;
 use virtio::resolve::VirtioResolveInput;
 use virtio::spec::VirtioDeviceType;
 use virtio::spec::fs as virtio_fs;
-use virtio_resources::vhost_user::VhostUserDeviceHandle;
+use virtio_resources::vhost_user::VhostUserBlkHandle;
 use virtio_resources::vhost_user::VhostUserFsHandle;
+use virtio_resources::vhost_user::VhostUserGenericHandle;
 use vm_resource::AsyncResolveResource;
 use vm_resource::ResourceResolver;
 use vm_resource::declare_static_async_resolver;
@@ -27,16 +28,16 @@ pub struct VhostUserFrontendResolver;
 
 declare_static_async_resolver! {
     VhostUserFrontendResolver,
-    (VirtioDeviceHandle, VhostUserDeviceHandle),
+    (VirtioDeviceHandle, VhostUserGenericHandle),
     (VirtioDeviceHandle, VhostUserFsHandle),
+    (VirtioDeviceHandle, VhostUserBlkHandle),
 }
 
 /// Connect a vhost-user socket fd and create the frontend.
 async fn connect_frontend(
     input: VirtioResolveInput<'_>,
     socket_fd: OwnedFd,
-    device_id: VirtioDeviceType,
-    config_space: Option<Vec<u8>>,
+    config: crate::VhostUserConfig,
 ) -> anyhow::Result<VhostUserFrontend> {
     let driver = input.driver_source.simple();
     let stream = UnixStream::from(socket_fd);
@@ -44,29 +45,35 @@ async fn connect_frontend(
         PolledSocket::new(&driver, stream).context("failed to register vhost-user socket")?;
     let socket = VhostUserSocket::new(polled);
 
-    VhostUserFrontend::from_socket(driver, socket, device_id, config_space)
+    VhostUserFrontend::from_socket(driver, socket, config)
         .await
         .context("vhost-user handshake failed")
 }
 
 #[async_trait]
-impl AsyncResolveResource<VirtioDeviceHandle, VhostUserDeviceHandle> for VhostUserFrontendResolver {
+impl AsyncResolveResource<VirtioDeviceHandle, VhostUserGenericHandle>
+    for VhostUserFrontendResolver
+{
     type Output = ResolvedVirtioDevice;
     type Error = anyhow::Error;
 
     async fn resolve(
         &self,
         _resolver: &ResourceResolver,
-        resource: VhostUserDeviceHandle,
+        resource: VhostUserGenericHandle,
         input: VirtioResolveInput<'_>,
     ) -> Result<Self::Output, Self::Error> {
-        let frontend = connect_frontend(
-            input,
-            resource.socket,
-            VirtioDeviceType(resource.device_id),
-            None,
-        )
-        .await?;
+        anyhow::ensure!(
+            !resource.queue_sizes.is_empty(),
+            "vhost-user generic device requires non-empty queue_sizes"
+        );
+        let config = crate::VhostUserConfig {
+            device_id: VirtioDeviceType(resource.device_id),
+            config_space: None,
+            queue_sizes: resource.queue_sizes,
+            config_patches: vec![],
+        };
+        let frontend = connect_frontend(input, resource.socket, config).await?;
         Ok(frontend.into())
     }
 }
@@ -89,22 +96,66 @@ impl AsyncResolveResource<VirtioDeviceHandle, VhostUserFsHandle> for VhostUserFr
             virtio_fs::TAG_LEN,
         );
 
+        let num_request_queues = resource.num_queues.unwrap_or(1);
+        let queue_size = resource.queue_size.unwrap_or(1024);
+
+        // Total queues = 1 hiprio queue + N request queues.
+        let total_queues = 1 + num_request_queues as usize;
+        let queue_sizes = vec![queue_size; total_queues];
+
         // Build the config space locally — the tag is a host-side
         // decision, not sourced from the backend.
         let mut config = virtio_fs::Config {
             tag: [0; virtio_fs::TAG_LEN],
-            num_request_queues: 1.into(),
+            num_request_queues: (num_request_queues as u32).into(),
         };
         config.tag[..resource.tag.len()].copy_from_slice(resource.tag.as_bytes());
 
-        let frontend = connect_frontend(
-            input,
-            resource.socket,
-            VirtioDeviceType::FS,
-            Some(config.as_bytes().to_vec()),
-        )
-        .await
-        .context("failed to set up vhost-user-fs device")?;
+        let vhost_config = crate::VhostUserConfig {
+            device_id: VirtioDeviceType::FS,
+            config_space: Some(config.as_bytes().to_vec()),
+            queue_sizes,
+            config_patches: vec![],
+        };
+
+        let frontend = connect_frontend(input, resource.socket, vhost_config)
+            .await
+            .context("failed to set up vhost-user-fs device")?;
+
+        Ok(frontend.into())
+    }
+}
+
+#[async_trait]
+impl AsyncResolveResource<VirtioDeviceHandle, VhostUserBlkHandle> for VhostUserFrontendResolver {
+    type Output = ResolvedVirtioDevice;
+    type Error = anyhow::Error;
+
+    async fn resolve(
+        &self,
+        _resolver: &ResourceResolver,
+        resource: VhostUserBlkHandle,
+        input: VirtioResolveInput<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        let num_queues = resource.num_queues.unwrap_or(1);
+        let queue_size = resource.queue_size.unwrap_or(128);
+        let queue_sizes = vec![queue_size; num_queues as usize];
+
+        // Patch the num_queues field in the virtio_blk config at offset
+        // 36 (per virtio spec §5.2.4). Config reads are proxied from the
+        // backend with this patch applied; writes pass through unchanged.
+        let config_patches = vec![(36u16, num_queues.to_le_bytes().to_vec())];
+
+        let config = crate::VhostUserConfig {
+            device_id: VirtioDeviceType::BLK,
+            config_space: None,
+            queue_sizes,
+            config_patches,
+        };
+
+        let frontend = connect_frontend(input, resource.socket, config)
+            .await
+            .context("failed to set up vhost-user-blk device")?;
 
         Ok(frontend.into())
     }

--- a/vm/devices/virtio/virtio/src/device.rs
+++ b/vm/devices/virtio/virtio/src/device.rs
@@ -33,6 +33,10 @@ pub trait VirtioDevice: InspectMut + Send {
     /// Must be a power of two, >0, and ≤ [`crate::MAX_QUEUE_SIZE`]. The
     /// transport validates these invariants at construction time.
     ///
+    /// `queue_index` must be less than `traits().max_queues`. The caller
+    /// is responsible for bounds checking; implementations may panic on
+    /// out-of-range indices.
+    ///
     /// Override to provide per-device or per-queue sizes. The default
     /// returns [`DEFAULT_QUEUE_SIZE`] (256).
     fn queue_size(&self, _queue_index: u16) -> u16 {

--- a/vm/devices/virtio/virtio_blk/src/integration_tests.rs
+++ b/vm/devices/virtio/virtio_blk/src/integration_tests.rs
@@ -8,8 +8,8 @@
 //! descriptor ring just as a guest driver would.
 
 use crate::VirtioBlkDevice;
-use crate::spec::VirtioBlkDiscardWriteZeroes;
-use crate::spec::*;
+use virtio::spec::blk::VirtioBlkDiscardWriteZeroes;
+use virtio::spec::blk::*;
 use disk_backend::Disk;
 use disk_backend::DiskError;
 use disk_backend::DiskIo;

--- a/vm/devices/virtio/virtio_blk/src/integration_tests.rs
+++ b/vm/devices/virtio/virtio_blk/src/integration_tests.rs
@@ -8,8 +8,6 @@
 //! descriptor ring just as a guest driver would.
 
 use crate::VirtioBlkDevice;
-use virtio::spec::blk::VirtioBlkDiscardWriteZeroes;
-use virtio::spec::blk::*;
 use disk_backend::Disk;
 use disk_backend::DiskError;
 use disk_backend::DiskIo;
@@ -27,6 +25,8 @@ use virtio::QueueResources;
 use virtio::VirtioDevice;
 use virtio::queue::QueueParams;
 use virtio::spec::VirtioDeviceFeatures;
+use virtio::spec::blk::VirtioBlkDiscardWriteZeroes;
+use virtio::spec::blk::*;
 use virtio::spec::queue::DescriptorFlags;
 use virtio::test_helpers::init_avail_ring;
 use virtio::test_helpers::init_used_ring;

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -10,7 +10,6 @@ pub mod resolver;
 #[cfg(test)]
 mod integration_tests;
 
-use virtio::spec::blk::*;
 use anyhow::Context as _;
 use disk_backend::Disk;
 use futures::StreamExt;
@@ -42,11 +41,11 @@ use virtio::regions::DataRegion;
 use virtio::regions::data_regions;
 use virtio::regions::try_build_gpn_list;
 use virtio::spec::VirtioDeviceFeatures;
+use virtio::spec::blk::*;
 use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
-
 
 /// Maximum number of segments per request advertised via `seg_max` (spec §5.2.4).
 ///

--- a/vm/devices/virtio/virtio_blk/src/lib.rs
+++ b/vm/devices/virtio/virtio_blk/src/lib.rs
@@ -6,12 +6,11 @@
 #![forbid(unsafe_code)]
 
 pub mod resolver;
-mod spec;
 
 #[cfg(test)]
 mod integration_tests;
 
-use crate::spec::*;
+use virtio::spec::blk::*;
 use anyhow::Context as _;
 use disk_backend::Disk;
 use futures::StreamExt;
@@ -47,6 +46,16 @@ use vmcore::vm_task::VmTaskDriver;
 use vmcore::vm_task::VmTaskDriverSource;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
+
+
+/// Maximum number of segments per request advertised via `seg_max` (spec §5.2.4).
+///
+/// This is the maximum number of data descriptors (excluding header and
+/// status) in a single request. The virtio spec requires that a
+/// descriptor chain is no longer than the queue size, and each block
+/// request uses one descriptor for the header and one for the status
+/// byte, so the data segment limit is `DEFAULT_QUEUE_SIZE - 2`.
+const DEFAULT_SEG_MAX: u32 = virtio::DEFAULT_QUEUE_SIZE as u32 - 2;
 
 const MAX_IO_DEPTH: usize = 64;
 

--- a/vm/devices/virtio/virtio_resources/src/lib.rs
+++ b/vm/devices/virtio/virtio_resources/src/lib.rs
@@ -203,10 +203,6 @@ pub mod vhost_user {
     }
 
     /// Handle for a vhost-user virtio-blk device.
-    ///
-    /// Config reads are proxied from the backend via `GET_CONFIG`,
-    /// with `num_queues` patched at offset 36 to reflect the
-    /// configured queue count.
     #[derive(MeshPayload)]
     pub struct VhostUserBlkHandle {
         /// Connected Unix socket fd to the vhost-user backend.

--- a/vm/devices/virtio/virtio_resources/src/lib.rs
+++ b/vm/devices/virtio/virtio_resources/src/lib.rs
@@ -157,26 +157,27 @@ pub mod vhost_user {
     use vm_resource::ResourceId;
     use vm_resource::kind::VirtioDeviceHandle;
 
-    /// Handle for a vhost-user device backed by an external process.
+    /// Handle for a generic vhost-user device backed by an external process.
     ///
     /// The socket must already be connected. The CLI layer connects
     /// to the backend and passes the connected fd here.
     ///
-    /// Config reads/writes are forwarded to the backend via
-    /// `GET_CONFIG`/`SET_CONFIG` if the backend supports it. For
-    /// device types that need frontend-owned config (e.g., virtiofs
-    /// with a tag), use a device-specific handle like
-    /// [`VhostUserFsHandle`] instead.
+    /// For device types with specific handles (FS, BLK), use those
+    /// instead. This handle is for devices identified only by their
+    /// numeric virtio device ID.
     #[derive(MeshPayload)]
-    pub struct VhostUserDeviceHandle {
+    pub struct VhostUserGenericHandle {
         /// Connected Unix socket fd to the vhost-user backend.
         pub socket: OwnedFd,
         /// Virtio device ID (e.g., 2 for block, 1 for net).
         pub device_id: u16,
+        /// Per-queue sizes. Length determines the queue count.
+        /// Required — must be non-empty.
+        pub queue_sizes: Vec<u16>,
     }
 
-    impl ResourceId<VirtioDeviceHandle> for VhostUserDeviceHandle {
-        const ID: &'static str = "vhost-user";
+    impl ResourceId<VirtioDeviceHandle> for VhostUserGenericHandle {
+        const ID: &'static str = "vhost-user-generic";
     }
 
     /// Handle for a vhost-user virtio-fs device.
@@ -191,10 +192,33 @@ pub mod vhost_user {
         pub socket: OwnedFd,
         /// The mount tag exposed to the guest (max 36 bytes).
         pub tag: String,
+        /// Number of request queues (default 1 in resolver).
+        pub num_queues: Option<u16>,
+        /// Queue size for all queues (default 1024 in resolver).
+        pub queue_size: Option<u16>,
     }
 
     impl ResourceId<VirtioDeviceHandle> for VhostUserFsHandle {
         const ID: &'static str = "vhost-user-fs";
+    }
+
+    /// Handle for a vhost-user virtio-blk device.
+    ///
+    /// Config reads are proxied from the backend via `GET_CONFIG`,
+    /// with `num_queues` patched at offset 36 to reflect the
+    /// configured queue count.
+    #[derive(MeshPayload)]
+    pub struct VhostUserBlkHandle {
+        /// Connected Unix socket fd to the vhost-user backend.
+        pub socket: OwnedFd,
+        /// Number of queues (default 1 in resolver).
+        pub num_queues: Option<u16>,
+        /// Queue size for all queues (default 128 in resolver).
+        pub queue_size: Option<u16>,
+    }
+
+    impl ResourceId<VirtioDeviceHandle> for VhostUserBlkHandle {
+        const ID: &'static str = "vhost-user-blk";
     }
 }
 

--- a/vm/devices/virtio/virtio_spec/src/blk.rs
+++ b/vm/devices/virtio/virtio_spec/src/blk.rs
@@ -6,11 +6,6 @@
 //! Based on OASIS VIRTIO v1.2, Section 5.2.
 //! <https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html>
 
-#![expect(
-    dead_code,
-    reason = "This module defines constants and types for the virtio-blk spec, but not all of them are used in our implementation."
-)]
-
 use inspect::Inspect;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
@@ -50,15 +45,6 @@ pub const VIRTIO_BLK_S_UNSUPP: u8 = 2;
 
 /// Maximum length of the device ID string (spec §5.2.6).
 pub const VIRTIO_BLK_ID_BYTES: usize = 20;
-
-/// Maximum number of segments per request advertised via `seg_max` (spec §5.2.4).
-///
-/// This is the maximum number of data descriptors (excluding header and
-/// status) in a single request. The virtio spec requires that a
-/// descriptor chain is no longer than the queue size, and each block
-/// request uses one descriptor for the header and one for the status
-/// byte, so the data segment limit is `DEFAULT_QUEUE_SIZE - 2`.
-pub const DEFAULT_SEG_MAX: u32 = virtio::DEFAULT_QUEUE_SIZE as u32 - 2;
 
 /// Flag bit in `VirtioBlkDiscardWriteZeroes::flags` (spec §5.2.6).
 /// When set in a write zeroes command, allows the device to deallocate

--- a/vm/devices/virtio/virtio_spec/src/lib.rs
+++ b/vm/devices/virtio/virtio_spec/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![expect(missing_docs)]
 
+pub mod blk;
 pub mod fs;
 
 use bitfield_struct::bitfield;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -490,7 +490,7 @@ async fn vhost_user_blk_device(
     use openvmm_defs::config::VirtioBus;
     use pal_async::pipe::PolledPipe;
     use pal_async::task::Spawn;
-    use virtio_resources::vhost_user::VhostUserDeviceHandle;
+    use virtio_resources::vhost_user::VhostUserBlkHandle;
     use vm_resource::IntoResource;
 
     let openvmm_vhost_path =
@@ -568,9 +568,10 @@ async fn vhost_user_blk_device(
     let stream =
         unix_socket::UnixStream::connect(&socket_path).context("connect to vhost-user socket")?;
 
-    let vhost_resource = VhostUserDeviceHandle {
+    let vhost_resource = VhostUserBlkHandle {
         socket: stream.into(),
-        device_id: 2, // VIRTIO_ID_BLOCK
+        num_queues: None,
+        queue_size: None,
     }
     .into_resource();
 


### PR DESCRIPTION
The vhost-user frontend was too generic — it used the backend's GET_QUEUE_NUM as the sole source of queue count and DEFAULT_QUEUE_SIZE (256) for every queue, with no way to configure per-device queue sizes or counts. This made it impossible to match Cloud Hypervisor's behavior for FS (1024-entry queues, hiprio queue offset) or BLK (128-entry queues, frontend-controlled num_queues).

This change introduces VhostUserConfig, a struct that each device-type resolver builds to describe the desired queue layout and config space strategy. The frontend's from_socket now takes this config instead of bare device_id and config_space parameters. Queue sizes are required and validated against the backend's GET_QUEUE_NUM when the MQ protocol feature is negotiated; when MQ is absent, validation is skipped, matching Cloud Hypervisor's approach.

The existing VhostUserDeviceHandle is renamed to VhostUserGenericHandle with a required queue_sizes vec, and a new VhostUserBlkHandle is added alongside the existing VhostUserFsHandle. The BLK resolver uses a config_patches mechanism to override fields in GET_CONFIG responses without caching or owning the full config space. The FS resolver accounts for the hiprio queue by adding one to the requested queue count and sets num_request_queues in the frontend-owned config space accordingly.

The CLI learns num_queues, queue_size, and queue_sizes options for the --vhost-user flag, with defaults matching Cloud Hypervisor (FS: num_queues=1, queue_size=1024; BLK: num_queues=1, queue_size=128).