### PR TITLE
vmm-tests: correctly request vhost dependency, update mapping

### DIFF
--- a/flowey/flowey_lib_hvlite/src/artifact_to_build_mapping.rs
+++ b/flowey/flowey_lib_hvlite/src/artifact_to_build_mapping.rs
@@ -130,6 +130,13 @@ impl ResolvedArtifactSelections {
                 true
             }
 
+            // OpenVMM vhost binary (Linux only)
+            "petri_artifacts_vmm_test::artifacts::OPENVMM_VHOST_LINUX_X64"
+            | "petri_artifacts_vmm_test::artifacts::OPENVMM_VHOST_LINUX_AARCH64" => {
+                self.build.openvmm_vhost = true;
+                true
+            }
+
             // OpenHCL IGVM files
             "petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64"
             | "petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_DEV_KERNEL_X64"

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -10,12 +10,15 @@ use petri::PetriHaltReason;
 use petri::PetriVmBuilder;
 use petri::PetriVmmBackend;
 use petri::ProcessorTopology;
+use petri::ResolvedArtifact;
 use petri::SIZE_1_GB;
 use petri::ShutdownKind;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::cmd;
 use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_common::tags::OsFlavor;
+#[cfg(target_os = "linux")]
+use petri_artifacts_vmm_test::artifacts::OPENVMM_VHOST_NATIVE;
 use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
 use vmm_test_macros::vmm_test_with;
@@ -481,10 +484,13 @@ async fn guest_test_uefi<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
 /// virtio transport → frontend protocol → socket → backend protocol →
 /// virtio-blk device → disk file.
 #[cfg(target_os = "linux")]
-#[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
-async fn vhost_user_blk_device(
+#[openvmm_test(
+    linux_direct_x64[OPENVMM_VHOST_NATIVE],
+    linux_direct_aarch64[OPENVMM_VHOST_NATIVE],
+)]
+async fn vhost_user_blk_device<T>(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
-    _extra_deps: (),
+    extra_deps: (ResolvedArtifact<T>,),
     driver: pal_async::DefaultDriver,
 ) -> anyhow::Result<()> {
     use openvmm_defs::config::VirtioBus;
@@ -493,8 +499,8 @@ async fn vhost_user_blk_device(
     use virtio_resources::vhost_user::VhostUserDeviceHandle;
     use vm_resource::IntoResource;
 
-    let openvmm_vhost_path =
-        petri_artifact_resolver_openvmm_known_paths::get_output_executable_path("openvmm_vhost")?;
+    let (openvmm_vhost_artifact,) = extra_deps;
+    let openvmm_vhost_path = openvmm_vhost_artifact.get();
 
     let log_file = config.log_source().log_file("openvmm_vhost")?;
 
@@ -513,7 +519,7 @@ async fn vhost_user_blk_device(
     // Spawn the openvmm_vhost backend process. Pipe stderr so we can
     // forward it to the petri log system.
     let (stderr_read, stderr_write) = pal::pipe_pair()?;
-    let backend_child = std::process::Command::new(&openvmm_vhost_path)
+    let backend_child = std::process::Command::new(openvmm_vhost_path)
         .arg("--socket")
         .arg(&socket_path)
         .arg("blk")

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -10,7 +10,6 @@ use petri::PetriHaltReason;
 use petri::PetriVmBuilder;
 use petri::PetriVmmBackend;
 use petri::ProcessorTopology;
-use petri::ResolvedArtifact;
 use petri::SIZE_1_GB;
 use petri::ShutdownKind;
 use petri::openvmm::OpenVmmPetriBackend;
@@ -490,7 +489,7 @@ async fn guest_test_uefi<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
 )]
 async fn vhost_user_blk_device<T>(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
-    extra_deps: (ResolvedArtifact<T>,),
+    extra_deps: (petri::ResolvedArtifact<T>,),
     driver: pal_async::DefaultDriver,
 ) -> anyhow::Result<()> {
     use openvmm_defs::config::VirtioBus;


### PR DESCRIPTION
This seemed to have been merged after another refactor, but this correctly expresses the dependency used by the vhost test. 