### PR TITLE
Add nextest "agent" profile for quiet test runs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -47,6 +47,20 @@ filter = 'package(~vmm_tests)'
 # threads running via the -j cli arg.
 threads-required = 2
 
+# Profile for AI agent runs. Minimizes output noise: only prints slow, failing,
+# and flaky tests. Agents should use: cargo nextest run -p <pkg> --profile agent
+[profile.agent]
+# Only show slow and failing tests during the run (hide PASS lines).
+status-level = "slow"
+# Show failures and flaky tests in the final summary.
+final-status-level = "flaky"
+# Mark tests slow after 5s, kill after 30s (6 periods).
+slow-timeout = { period = "5s", terminate-after = 6 }
+# Print failure output immediately so humans watching can see it.
+failure-output = "immediate"
+# Don't fail fast--let the agent see all failures at once.
+fail-fast = false
+
 # Profile for CI runs.
 [profile.ci]
 # Set the default timeout to 1 second, with tests terminated after 10 seconds

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,10 +80,15 @@ Both OpenVMM and OpenHCL process data from untrusted sources. Code must
 
 ## Testing
 
-Run tests with cargo-nextest in the specific packages you are modifying:
+Run tests with cargo-nextest using the `agent` profile, which suppresses
+output for passing tests and only shows slow/failing tests:
 ```bash
-cargo nextest run -p <package-name>
+cargo nextest run --profile agent -p <package-name>
 ```
+
+**Do NOT pipe test output to `grep`, `tail`, or other filters.** The `agent`
+profile already minimizes output. Piping hides failures and makes hangs
+invisible.
 
 For VMM test validation during development, use `cargo xflowey vmm-tests-run`:
 ```bash
@@ -138,7 +143,7 @@ locally, avoiding slow push-and-wait cycles.
 2. **Check compilation:** `cargo check -p <package>` — fast type-check.
 3. **Clippy:** `cargo clippy --all-targets -p <package>` — lint.
 4. **Doc:** `cargo doc --no-deps -p <package>` — catch doc errors.
-5. **Unit tests:** `cargo nextest run -p <package>` — run the crate's
+5. **Unit tests:** `cargo nextest run --profile agent -p <package>` — run the crate's
    tests. If nextest is not installed, use `cargo test -p <package>`.
 6. **Formatting:** `cargo xtask fmt --fix` — run last, since earlier
    fixes may introduce formatting changes.


### PR DESCRIPTION
AI coding agents tend to pipe test output through grep or tail to reduce noise, which hides failures and makes hangs invisible. This adds a dedicated nextest profile that solves the problem at the source: it suppresses PASS lines (status-level = "slow"), shows failure output immediately, and terminates hung tests after 30 seconds. Agents get minimal output on the happy path and useful diagnostics on failure, removing the temptation to filter output.

The copilot-instructions are updated to direct agents to use "--profile agent" and to explicitly prohibit piping test output.