### PR TITLE
ci: fix ImageOverride in ADO pool demands

### DIFF
--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -21,7 +21,7 @@ jobs:
   displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -269,7 +269,7 @@ jobs:
   displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -510,7 +510,7 @@ jobs:
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -738,7 +738,7 @@ jobs:
   displayName: build openhcl [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -1141,7 +1141,7 @@ jobs:
   displayName: build openhcl [aarch64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -1443,7 +1443,7 @@ jobs:
   displayName: build artifacts [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -1782,7 +1782,7 @@ jobs:
   displayName: build artifacts [aarch64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -2069,7 +2069,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -2345,7 +2345,7 @@ jobs:
   displayName: run vmm-tests [x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job10
@@ -2564,7 +2564,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job10
@@ -2819,7 +2819,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job10
@@ -3074,7 +3074,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [x64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -3274,7 +3274,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -3545,7 +3545,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -3741,7 +3741,7 @@ jobs:
   displayName: xtask fmt (linux)
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
@@ -3902,7 +3902,7 @@ jobs:
   displayName: xtask fmt (windows)
   pool:
     demands:
-    - 1ES.ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job2
@@ -4055,7 +4055,7 @@ jobs:
   displayName: quick check [fmt, clippy x64-linux]
   pool:
     demands:
-    - 1ES.ImageOverride -equals ubuntu2404-amd64-256gb
+    - ImageOverride -equals ubuntu2404-amd64-256gb
     name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))

--- a/flowey/flowey_hvlite/src/pipelines_shared/ado_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/ado_pools.rs
@@ -11,7 +11,7 @@ pub const INTEL_POOL: &str = "openvmm-ado-intel-centralus";
 fn intel_pool_with_image(image: &str) -> AdoPool {
     AdoPool {
         name: INTEL_POOL.into(),
-        demands: vec![format!("1ES.ImageOverride -equals {image}")],
+        demands: vec![format!("ImageOverride -equals {image}")],
     }
 }
 


### PR DESCRIPTION
Backport of microsoft/openvmm#3251 to release/1.7.2511.

The ADO pipeline demands used '1ES.ImageOverride' which is the GitHub Actions syntax. ADO pipelines require 'ImageOverride' without the '1ES.' prefix for image overrides to be respected.