### PR TITLE
fuzz_uefi: Convert to crypto crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,11 +2347,11 @@ name = "fuzz_firmware_uefi"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
+ "crypto",
  "firmware_uefi",
  "guestmem",
  "guid",
  "libfuzzer-sys",
- "openssl",
  "ucs2 0.0.0",
  "uefi_nvram_specvars",
  "xtask_fuzz",

--- a/support/crypto/src/pkcs7/mod.rs
+++ b/support/crypto/src/pkcs7/mod.rs
@@ -37,6 +37,21 @@ impl Pkcs7SignedData {
         sys::Pkcs7SignedDataInner::from_der(data).map(Self)
     }
 
+    /// Encode this PKCS#7 object as DER bytes.
+    pub fn to_der(&self) -> Result<Vec<u8>, Pkcs7Error> {
+        self.0.to_der()
+    }
+
+    /// Creates a PKCS#7 signed-data object by signing `data` with the given
+    /// certificate and key pair.
+    pub fn sign(
+        cert: &super::x509::X509Certificate,
+        key_pair: &super::rsa::RsaKeyPair,
+        data: &[u8],
+    ) -> Result<Self, Pkcs7Error> {
+        sys::Pkcs7SignedDataInner::sign(cert, key_pair, data).map(Self)
+    }
+
     /// Verifies signed data against a trusted certificate store.
     ///
     /// Consumes the store, since the backend may need to finalize it.

--- a/support/crypto/src/pkcs7/ossl.rs
+++ b/support/crypto/src/pkcs7/ossl.rs
@@ -34,6 +34,32 @@ impl Pkcs7SignedDataInner {
             .map_err(|e| err(e, "decoding pkcs#7 from DER"))
     }
 
+    pub fn to_der(&self) -> Result<Vec<u8>, Pkcs7Error> {
+        self.0
+            .to_der()
+            .map_err(|e| err(e, "encoding pkcs#7 as DER"))
+    }
+
+    pub fn sign(
+        cert: &crate::x509::X509Certificate,
+        key_pair: &crate::rsa::RsaKeyPair,
+        data: &[u8],
+    ) -> Result<Self, Pkcs7Error> {
+        let pkey = openssl::pkey::PKey::from_rsa(key_pair.0.rsa.clone())
+            .map_err(|e| err(e, "converting RSA key for pkcs7 signing"))?;
+        let certs =
+            openssl::stack::Stack::new().map_err(|e| err(e, "creating empty certificate stack"))?;
+        let pkcs7 = openssl::pkcs7::Pkcs7::sign(
+            &cert.0.cert,
+            &pkey,
+            &certs,
+            data,
+            openssl::pkcs7::Pkcs7Flags::empty(),
+        )
+        .map_err(|e| err(e, "pkcs7 signing"))?;
+        Ok(Self(pkcs7))
+    }
+
     pub fn verify(
         &self,
         mut store: Pkcs7CertStoreInner,

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 /// An error for RSA operations.
 #[derive(Debug, Error)]
 #[error("RSA error")]
-pub struct RsaError(#[source] pub(crate) super::BackendError);
+pub struct RsaError(#[source] super::BackendError);
 
 /// Hash algorithm for RSA-OAEP encryption/decryption.
 #[derive(Debug, Clone, Copy)]

--- a/support/crypto/src/x509/mod.rs
+++ b/support/crypto/src/x509/mod.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 pub struct X509Error(#[source] super::BackendError);
 
 /// An X.509 certificate.
-pub struct X509Certificate(sys::X509CertificateInner);
+pub struct X509Certificate(pub(crate) sys::X509CertificateInner);
 
 impl X509Certificate {
     /// Parse an X.509 certificate from DER-encoded bytes.

--- a/support/crypto/src/x509/ossl.rs
+++ b/support/crypto/src/x509/ossl.rs
@@ -8,7 +8,7 @@ fn err(err: openssl::error::ErrorStack, op: &'static str) -> X509Error {
 }
 
 pub struct X509CertificateInner {
-    cert: openssl::x509::X509,
+    pub(crate) cert: openssl::x509::X509,
 }
 
 impl X509CertificateInner {

--- a/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
@@ -9,11 +9,11 @@ rust-version.workspace = true
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-firmware_uefi = { workspace = true, features = ["auth-var-verify-crypto", "fuzzing", "ossl_vendored"] }
+crypto = { workspace = true, features = ["ossl_vendored"] }
+firmware_uefi = { workspace = true, features = ["auth-var-verify-crypto", "fuzzing"] }
 guid.workspace = true
 guestmem.workspace = true
 libfuzzer-sys.workspace = true
-openssl.workspace = true
 ucs2.workspace = true
 uefi_nvram_specvars.workspace = true
 xtask_fuzz.workspace = true

--- a/vm/devices/firmware/firmware_uefi/fuzz/fuzz_nvram.rs
+++ b/vm/devices/firmware/firmware_uefi/fuzz/fuzz_nvram.rs
@@ -6,23 +6,14 @@
 #![cfg(all(target_os = "linux", target_env = "gnu"))]
 
 use arbitrary::Arbitrary;
+use crypto::pkcs7::Pkcs7SignedData;
+use crypto::rsa::RsaKeyPair;
+use crypto::x509::X509Builder;
+use crypto::x509::X509Certificate;
 use firmware_uefi::platform::nvram::EFI_TIME;
 use firmware_uefi::service::nvram::spec_services::ParsedAuthVar;
 use firmware_uefi::service::nvram::spec_services::auth_var_crypto;
 use guid::Guid;
-use openssl::asn1::Asn1Time;
-use openssl::hash::MessageDigest;
-use openssl::pkcs7::Pkcs7;
-use openssl::pkcs7::Pkcs7Flags;
-use openssl::pkey::PKey;
-use openssl::pkey::PKeyRef;
-use openssl::pkey::Private;
-use openssl::rsa::Rsa;
-use openssl::stack::Stack;
-use openssl::x509::X509;
-use openssl::x509::X509Builder;
-use openssl::x509::X509NameBuilder;
-use openssl::x509::X509Ref;
 use std::borrow::Cow;
 use ucs2::Ucs2LeVec;
 use uefi_nvram_specvars::signature_list::SignatureData;
@@ -85,8 +76,8 @@ fn do_fuzz(input: FuzzInput) {
         }
         FuzzInput::MatchingPkcs7AndSignatureLists { var, input } => {
             let pkey = test_pkey();
-            let signcert = test_x509(pkey.as_ref());
-            let pkcs7 = test_pkcs7_data_inner(&signcert, &pkey, &input);
+            let signcert = test_x509(&pkey);
+            let pkcs7 = Pkcs7SignedData::sign(&signcert, &pkey, &input).unwrap();
             let signature_lists = test_signature_list_from_x509(&signcert);
             (var, signature_lists, pkcs7.to_der().unwrap())
         }
@@ -178,7 +169,7 @@ fn test_valid_signature_lists() -> Vec<u8> {
     buf
 }
 
-fn test_signature_list_from_x509(signcert: &X509Ref) -> Vec<u8> {
+fn test_signature_list_from_x509(signcert: &X509Certificate) -> Vec<u8> {
     let list = SignatureList::X509(SignatureData::new_x509(
         OWNER_1,
         Cow::Owned(signcert.to_der().unwrap()),
@@ -188,52 +179,31 @@ fn test_signature_list_from_x509(signcert: &X509Ref) -> Vec<u8> {
     buf
 }
 
-fn test_pkey() -> PKey<Private> {
-    let rsa = Rsa::generate(1024).unwrap();
-    PKey::from_rsa(rsa).unwrap()
+fn test_pkey() -> RsaKeyPair {
+    RsaKeyPair::generate(1024).unwrap()
 }
 
-fn test_x509(pkey: &PKeyRef<Private>) -> X509 {
-    // Build the X.509 name
-    let mut name_builder = X509NameBuilder::new().unwrap();
-    name_builder.append_entry_by_text("C", "US").unwrap();
-    name_builder
-        .append_entry_by_text("ST", "Washington")
-        .unwrap();
-    name_builder.append_entry_by_text("L", "Redmond").unwrap();
-    name_builder
-        .append_entry_by_text("O", "Example Organization")
-        .unwrap();
-    name_builder
-        .append_entry_by_text("CN", "example.com")
-        .unwrap();
-    let name = name_builder.build();
-
-    // Build the X.509 certificate
+fn test_x509(pkey: &RsaKeyPair) -> X509Certificate {
     let mut builder = X509Builder::new().unwrap();
-    builder.set_subject_name(&name).unwrap();
-    builder.set_issuer_name(&name).unwrap();
-    builder.set_pubkey(pkey).unwrap();
     builder
-        .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+        .set_subject_and_issuer_name(
+            "US",
+            "Washington",
+            "Redmond",
+            "Example Organization",
+            "example.com",
+        )
         .unwrap();
-    builder
-        .set_not_after(&Asn1Time::days_from_now(365).unwrap())
-        .unwrap();
-    builder.sign(pkey, MessageDigest::sha256()).unwrap();
-    builder.build()
+    builder.set_pubkey_from_rsa_key_pair(pkey).unwrap();
+    builder.set_validity_days(365).unwrap();
+    builder.sign_and_build(pkey).unwrap()
 }
 
 fn test_pkcs7_data(input: &[u8]) -> Vec<u8> {
     let pkey = test_pkey();
-    let signcert = test_x509(pkey.as_ref());
-    test_pkcs7_data_inner(&signcert, &pkey, input)
+    let signcert = test_x509(&pkey);
+    Pkcs7SignedData::sign(&signcert, &pkey, input)
+        .unwrap()
         .to_der()
         .unwrap()
-}
-
-fn test_pkcs7_data_inner(signcert: &X509Ref, pkey: &PKeyRef<Private>, input: &[u8]) -> Pkcs7 {
-    let certs = Stack::new().unwrap();
-    let flags = Pkcs7Flags::empty();
-    Pkcs7::sign(signcert, pkey, &certs, input, flags).unwrap()
 }


### PR DESCRIPTION
Convert the uefi fuzzer to use the new crypto crate, instead of calling openssl directly.