### PR TITLE
virt_mshv: register CPUID overrides via HvCallRegisterInterceptResult

### DIFF
--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -26,6 +26,7 @@ pub const HV_PAGE_SHIFT: u64 = 12;
 
 pub const HV_PARTITION_ID_SELF: u64 = u64::MAX;
 pub const HV_VP_INDEX_SELF: u32 = 0xfffffffe;
+pub const HV_ANY_VP: u32 = 0xffffffff;
 
 pub const HV_CPUID_FUNCTION_VERSION_AND_FEATURES: u32 = 0x00000001;
 pub const HV_CPUID_FUNCTION_HV_VENDOR_AND_MAX_FUNCTION: u32 = 0x40000000;
@@ -306,6 +307,7 @@ open_enum! {
         HvCallGetSystemProperty = 0x007b,
         HvCallRetargetDeviceInterrupt = 0x007e,
         HvCallNotifyPartitionEvent = 0x0087,
+        HvCallRegisterInterceptResult = 0x0091,
         HvCallAssertVirtualInterrupt = 0x0094,
         HvCallStartVirtualProcessor = 0x0099,
         HvCallGetVpIndexFromApicId = 0x009A,
@@ -1264,6 +1266,51 @@ pub mod hypercall {
         pub access_type_mask: u32,
         pub intercept_type: HvInterceptType,
         pub intercept_parameters: HvInterceptParameters,
+    }
+
+    /// Input for [`HvCallRegisterInterceptResult`] with CPUID intercept type.
+    #[repr(C)]
+    #[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Debug)]
+    pub struct RegisterInterceptResultCpuid {
+        pub partition_id: u64,
+        pub vp_index: u32,
+        pub intercept_type: HvInterceptType,
+        pub parameters: HvRegisterX64CpuidResultParameters,
+        /// Explicit tail padding (struct alignment is 8 due to partition_id).
+        pub _reserved: u32,
+    }
+
+    /// CPUID intercept result parameters.
+    #[repr(C)]
+    #[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Debug)]
+    pub struct HvRegisterX64CpuidResultParameters {
+        pub input: HvRegisterX64CpuidResultParametersInput,
+        pub result: HvRegisterX64CpuidResultParametersOutput,
+    }
+
+    /// Input portion of CPUID intercept result parameters.
+    #[repr(C)]
+    #[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Debug)]
+    pub struct HvRegisterX64CpuidResultParametersInput {
+        pub eax: u32,
+        pub ecx: u32,
+        pub subleaf_specific: u8,
+        pub always_override: u8,
+        pub padding: u16,
+    }
+
+    /// Output portion of CPUID intercept result parameters.
+    #[repr(C)]
+    #[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Debug)]
+    pub struct HvRegisterX64CpuidResultParametersOutput {
+        pub eax: u32,
+        pub eax_mask: u32,
+        pub ebx: u32,
+        pub ebx_mask: u32,
+        pub ecx: u32,
+        pub ecx_mask: u32,
+        pub edx: u32,
+        pub edx_mask: u32,
     }
 
     #[repr(C)]

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -232,7 +232,6 @@ impl ProtoPartition for MshvProtoPartition<'_> {
         config: PartitionConfig<'_>,
     ) -> Result<(Self::Partition, Vec<Self::ProcessorBinder>), Self::Error> {
         // Build topology CPUID leaves.
-        // TODO: actually apply these to the partition's CPUID results.
         let mut cpuid_leaves: Vec<virt::CpuidLeaf> = config.cpuid.to_vec();
         virt::x86::topology::topology_cpuid(
             self.config.processor_topology,
@@ -246,14 +245,58 @@ impl ProtoPartition for MshvProtoPartition<'_> {
         )
         .map_err(Error::TopologyCpuid)?;
 
+        let cpuid = virt::CpuidLeafSet::new(cpuid_leaves);
+
+        // Apply CPUID overrides partition-wide.
+        // The hypervisor handles per-VP APIC ID fixups in topology leaves
+        // automatically.
+        for leaf in cpuid.leaves().iter() {
+            let input = hvdef::hypercall::RegisterInterceptResultCpuid {
+                partition_id: 0, // overwritten by kernel
+                vp_index: hvdef::HV_ANY_VP,
+                intercept_type: hvdef::hypercall::HvInterceptType::HvInterceptTypeX64Cpuid,
+                parameters: hvdef::hypercall::HvRegisterX64CpuidResultParameters {
+                    input: hvdef::hypercall::HvRegisterX64CpuidResultParametersInput {
+                        eax: leaf.function,
+                        ecx: leaf.index.unwrap_or(0),
+                        subleaf_specific: u8::from(leaf.index.is_some()),
+                        always_override: 1,
+                        padding: 0,
+                    },
+                    result: hvdef::hypercall::HvRegisterX64CpuidResultParametersOutput {
+                        eax: leaf.result[0],
+                        eax_mask: leaf.mask[0],
+                        ebx: leaf.result[1],
+                        ebx_mask: leaf.mask[1],
+                        ecx: leaf.result[2],
+                        ecx_mask: leaf.mask[2],
+                        edx: leaf.result[3],
+                        edx_mask: leaf.mask[3],
+                    },
+                },
+                _reserved: 0,
+            };
+            let mut args = mshv_bindings::mshv_root_hvcall {
+                code: hvdef::HypercallCode::HvCallRegisterInterceptResult.0,
+                in_sz: size_of_val(&input) as u16,
+                in_ptr: std::ptr::addr_of!(input) as u64,
+                ..Default::default()
+            };
+            self.vmfd.hvcall(&mut args).map_err(Error::RegisterCpuid)?;
+        }
+
         // Get caps via cpuid
         let caps = virt::PartitionCapabilities::from_cpuid(
             self.config.processor_topology,
             &mut |function, index| {
-                self.vps[0]
-                    .vcpufd
-                    .get_cpuid_values(function, index, 0, 0)
-                    .expect("cpuid should not fail")
+                cpuid.result(
+                    function,
+                    index,
+                    &self.vps[0]
+                        .vcpufd
+                        .get_cpuid_values(function, index, 0, 0)
+                        .expect("cpuid should not fail"),
+                )
             },
         )
         .map_err(Error::Capabilities)?;
@@ -268,6 +311,7 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             gsi_states: Mutex::new(Box::new([irqfd::GsiState::Unallocated; irqfd::NUM_GSIS])),
             caps,
             synic_ports: Default::default(),
+            cpuid,
         });
 
         let partition = MshvPartition {
@@ -289,23 +333,29 @@ impl ProtoPartition for MshvProtoPartition<'_> {
     }
 }
 
-// TODO: remove these workarounds when mshv-ioctl implements the Debug trait
-#[derive(Debug)]
+#[derive(Debug, Inspect)]
 pub struct MshvPartition {
+    #[inspect(flatten)]
     inner: Arc<MshvPartitionInner>,
+    #[inspect(skip)]
     synic_ports: Arc<virt::synic::SynicPorts<MshvPartitionInner>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Inspect)]
 struct MshvPartitionInner {
+    #[inspect(skip)]
     vmfd: VmFd,
+    #[inspect(skip)]
     memory: Mutex<MshvMemoryRangeState>,
     gm: GuestMemory,
+    #[inspect(skip)]
     vps: Vec<MshvVpInner>,
     irq_routes: virt::irqcon::IrqRoutes,
+    #[inspect(skip)]
     gsi_states: Mutex<Box<[irqfd::GsiState; irqfd::NUM_GSIS]>>,
     caps: virt::PartitionCapabilities,
     synic_ports: virt::synic::SynicPortMap,
+    cpuid: virt::CpuidLeafSet,
 }
 
 #[derive(Debug)]
@@ -1127,6 +1177,8 @@ pub enum Error {
     Register(#[source] MshvError),
     #[error("install instercept failed")]
     InstallIntercept(#[source] MshvError),
+    #[error("failed to register cpuid override")]
+    RegisterCpuid(#[source] MshvError),
     #[error("host does not support required cpu capabilities")]
     Capabilities(virt::PartitionCapabilitiesError),
     #[error("failed to compute topology cpuid")]
@@ -1397,13 +1449,6 @@ impl hv1_hypercall::SignalEvent for MshvHypercallHandler<'_> {
         self.partition
             .synic_ports
             .handle_signal_event(Vtl::Vtl0, connection_id, flag)
-    }
-}
-
-impl Inspect for MshvPartition {
-    fn inspect(&self, req: inspect::Request<'_>) {
-        // TODO: implementation
-        req.respond();
     }
 }
 

--- a/vmm_core/virt_mshv/src/vp_state.rs
+++ b/vmm_core/virt_mshv/src/vp_state.rs
@@ -111,19 +111,19 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
     }
 
     fn xsave(&mut self) -> Result<vp::Xsave, Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn set_xsave(&mut self, _value: &vp::Xsave) -> Result<(), Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn apic(&mut self) -> Result<vp::Apic, Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn set_apic(&mut self, _value: &vp::Apic) -> Result<(), Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn xcr(&mut self) -> Result<vp::Xcr0, Self::Error> {
@@ -215,40 +215,40 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
     }
 
     fn synic_timers(&mut self) -> Result<vp::SynicTimers, Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn set_synic_timers(&mut self, _value: &vp::SynicTimers) -> Result<(), Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn synic_message_queues(&mut self) -> Result<vp::SynicMessageQueues, Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn set_synic_message_queues(
         &mut self,
         _value: &vp::SynicMessageQueues,
     ) -> Result<(), Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn synic_message_page(&mut self) -> Result<vp::SynicMessagePage, Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn set_synic_message_page(&mut self, _value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn synic_event_flags_page(&mut self) -> Result<vp::SynicEventFlagsPage, Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 
     fn set_synic_event_flags_page(
         &mut self,
         _value: &vp::SynicEventFlagsPage,
     ) -> Result<(), Self::Error> {
-        todo!()
+        Err(Error::NotSupported)
     }
 }


### PR DESCRIPTION
The mshv backend computed topology and other CPUID leaves but never actually applied them to the partition, so guests saw incomplete CPUID results. This fixes the problem by calling HvCallRegisterInterceptResult for each leaf at partition build time, which tells the hypervisor to override CPUID results partition-wide (with HV_ANY_VP). The capabilities query now also applies the CPUID leaf set so that the VMM itself sees consistent values.

This change also derives Inspect on MshvPartition and MshvPartitionInner, replacing the previous empty manual implementation, and replaces todo!() panics in unimplemented VP state accessors with Err(Error::NotSupported) so that the partition does not crash when save/restore probes these paths.