### PR TITLE
Fix build and re-enable docs tests for all PRs

### DIFF
--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -14,11 +14,6 @@ on:
   push:
     branches:
     - main
-    paths:
-    - Guide/**
-    - petri/logview/**
-    - .github/workflows/openvmm-docs-*.yaml
-    - flowey/**
 jobs:
   job0:
     name: build mdbook guide

--- a/.github/workflows/openvmm-docs-pr.yaml
+++ b/.github/workflows/openvmm-docs-pr.yaml
@@ -19,11 +19,6 @@ on:
     - synchronize
     - reopened
     - ready_for_review
-    paths:
-    - Guide/**
-    - petri/logview/**
-    - .github/workflows/openvmm-docs-*.yaml
-    - flowey/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/flowey/flowey_hvlite/src/pipelines/build_docs.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_docs.rs
@@ -44,18 +44,11 @@ impl IntoPipeline for BuildDocsCli {
         // the Guide directory or the docs workflow/pipeline definitions are modified.
         {
             let branches = vec!["main".into()];
-            let paths = vec![
-                "Guide/**".into(),
-                "petri/logview/**".into(),
-                ".github/workflows/openvmm-docs-*.yaml".into(),
-                "flowey/**".into(),
-            ];
             match config {
                 PipelineConfig::Ci => {
                     pipeline
                         .gh_set_ci_triggers(GhCiTriggers {
                             branches,
-                            paths,
                             ..Default::default()
                         })
                         .gh_set_name("OpenVMM Docs CI");
@@ -64,7 +57,6 @@ impl IntoPipeline for BuildDocsCli {
                     pipeline
                         .gh_set_pr_triggers(GhPrTriggers {
                             branches,
-                            paths,
                             ..GhPrTriggers::new_draftable()
                         })
                         .gh_set_name("OpenVMM Docs PR");

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -1507,7 +1507,7 @@ pub mod hypercall {
         pub intercept_parameters: HvInterceptParameters,
     }
 
-    /// Input for [`HvCallRegisterInterceptResult`] with CPUID intercept type.
+    /// Input for [`HypercallCode::HvCallRegisterInterceptResult`] with CPUID intercept type.
     #[repr(C)]
     #[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Debug)]
     pub struct RegisterInterceptResultCpuid {


### PR DESCRIPTION
The docs jobs don't just ensure the guide is building, they validate `cargo doc`. Run them for every PR, and fix the build regression that snuck in.