### PR TITLE
virt_mshv: handle APIC EOI exits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8938,7 +8938,6 @@ dependencies = [
  "parking_lot",
  "pci_core",
  "signal-hook",
- "static_assertions",
  "thiserror 2.0.16",
  "tracelimit",
  "tracing",

--- a/vmm_core/virt_mshv/Cargo.toml
+++ b/vmm_core/virt_mshv/Cargo.toml
@@ -32,7 +32,6 @@ arrayvec.workspace = true
 libc.workspace = true
 parking_lot.workspace = true
 signal-hook.workspace = true
-static_assertions.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -23,7 +23,6 @@ use hvdef::HvError;
 use hvdef::HvMessage;
 use hvdef::HvMessageType;
 use hvdef::HvX64RegisterName;
-use hvdef::HvX64VpExecutionState;
 use hvdef::Vtl;
 use hvdef::hypercall::HV_INTERCEPT_ACCESS_MASK_EXECUTE;
 use hvdef::hypercall::HvRegisterAssoc;
@@ -33,10 +32,6 @@ use mshv_bindings::MSHV_SET_MEM_BIT_EXECUTABLE;
 use mshv_bindings::MSHV_SET_MEM_BIT_WRITABLE;
 use mshv_bindings::hv_message;
 use mshv_bindings::hv_register_assoc;
-use mshv_bindings::hv_register_value;
-use mshv_bindings::hv_u128;
-use mshv_bindings::hv_x64_io_port_intercept_message;
-use mshv_bindings::hv_x64_memory_intercept_message;
 use mshv_bindings::hv_x64_segment_register;
 use mshv_bindings::mshv_install_intercept;
 use mshv_bindings::mshv_user_mem_region;
@@ -46,7 +41,6 @@ use mshv_ioctls::MshvError;
 use mshv_ioctls::VcpuFd;
 use mshv_ioctls::VmFd;
 use mshv_ioctls::set_bits;
-use mshv_ioctls::set_registers_64;
 use pal::unix::pthread::*;
 use pal_event::Event;
 use parking_lot::Mutex;
@@ -85,6 +79,39 @@ use vmcore::synic::GuestEventPort;
 use x86defs::RFlags;
 use x86defs::SegmentRegister;
 use zerocopy::IntoBytes;
+
+/// Extension trait for [`VcpuFd`] to accept hvdef register types directly.
+trait VcpuFdExt {
+    fn get_hvdef_regs(&self, regs: &mut [HvRegisterAssoc]) -> Result<(), MshvError>;
+    fn set_hvdef_regs(&self, regs: &[HvRegisterAssoc]) -> Result<(), MshvError>;
+    fn set_hvdef_regs_64(&self, regs: &[(HvX64RegisterName, u64)]) -> Result<(), MshvError>;
+}
+
+impl VcpuFdExt for VcpuFd {
+    fn get_hvdef_regs(&self, regs: &mut [HvRegisterAssoc]) -> Result<(), MshvError> {
+        // SAFETY: HvRegisterAssoc and hv_register_assoc have the same layout
+        // (verified by static assertions in vp_state.rs).
+        self.get_reg(unsafe {
+            std::mem::transmute::<&mut [HvRegisterAssoc], &mut [hv_register_assoc]>(regs)
+        })
+    }
+
+    fn set_hvdef_regs(&self, regs: &[HvRegisterAssoc]) -> Result<(), MshvError> {
+        // SAFETY: HvRegisterAssoc and hv_register_assoc have the same layout
+        // (verified by static assertions in vp_state.rs).
+        self.set_reg(unsafe {
+            std::mem::transmute::<&[HvRegisterAssoc], &[hv_register_assoc]>(regs)
+        })
+    }
+
+    fn set_hvdef_regs_64(&self, regs: &[(HvX64RegisterName, u64)]) -> Result<(), MshvError> {
+        let assocs: ArrayVec<HvRegisterAssoc, 18> = regs
+            .iter()
+            .map(|&(name, value)| HvRegisterAssoc::from((name, value)))
+            .collect();
+        self.set_hvdef_regs(&assocs)
+    }
+}
 
 #[derive(Debug)]
 pub struct LinuxMshv;
@@ -529,14 +556,15 @@ impl Hv1 for MshvPartition {
 
 impl GetReferenceTime for MshvPartitionInner {
     fn now(&self) -> ReferenceTimeResult {
-        let mut regs = [hv_register_assoc {
-            name: hvdef::HvAllArchRegisterName::TimeRefCount.0,
-            value: hv_register_value { reg64: 0 },
-            ..Default::default()
-        }];
-        self.vp(VpIndex::BSP).vcpufd.get_reg(&mut regs).unwrap();
-        // SAFETY: the value has been written by the kernel.
-        let ref_time = unsafe { regs[0].value.reg64 };
+        let mut regs = [HvRegisterAssoc::from((
+            hvdef::HvAllArchRegisterName::TimeRefCount,
+            0u64,
+        ))];
+        self.vp(VpIndex::BSP)
+            .vcpufd
+            .get_hvdef_regs(&mut regs)
+            .unwrap();
+        let ref_time = regs[0].value.as_u64();
         ReferenceTimeResult {
             ref_time,
             system_time: None,
@@ -601,7 +629,7 @@ pub struct MshvProcessor<'a> {
 impl MshvProcessor<'_> {
     async fn emulate(
         &self,
-        message: &hv_message,
+        message: &HvMessage,
         devices: &impl CpuIo,
         interruption_pending: bool,
     ) -> Result<(), VpHaltReason> {
@@ -625,45 +653,38 @@ impl MshvProcessor<'_> {
 
     async fn handle_io_port_intercept(
         &self,
-        message: &hv_message,
+        message: &HvMessage,
         devices: &impl CpuIo,
     ) -> Result<(), VpHaltReason> {
-        let info = message.to_ioport_info().unwrap();
+        let info = message.as_message::<hvdef::HvX64IoPortInterceptMessage>();
         let access_info = info.access_info;
-        // SAFETY: This union only contains one field.
-        let port_access_info = unsafe { access_info.__bindgen_anon_1 };
 
-        if port_access_info.string_op() != 0 || port_access_info.rep_prefix() != 0 {
-            let execution_state = info.header.execution_state;
-            // SAFETY: This union only contains one field.
-            let io_execution_state = unsafe { execution_state.__bindgen_anon_1 };
-            let interruption_pending = io_execution_state.interruption_pending() != 0;
+        if access_info.string_op() || access_info.rep_prefix() {
+            let interruption_pending = info.header.execution_state.interruption_pending();
 
             self.emulate(message, devices, interruption_pending).await?
         } else {
             let mut ret_rax = info.rax;
             virt_support_x86emu::emulate::emulate_io(
                 self.vpindex,
-                info.header.intercept_access_type == 1,
+                info.header.intercept_access_type == hvdef::HvInterceptAccessType::WRITE,
                 info.port_number,
                 &mut ret_rax,
-                port_access_info.access_size(),
+                access_info.access_size(),
                 devices,
             )
             .await;
 
-            let insn_len = info.header.instruction_length() as u64;
+            let insn_len = info.header.instruction_len() as u64;
 
             /* Advance RIP and update RAX */
-            let arr_reg_name_value = [
-                (
-                    mshv_bindings::hv_register_name_HV_X64_REGISTER_RIP,
-                    info.header.rip + insn_len,
-                ),
-                (mshv_bindings::hv_register_name_HV_X64_REGISTER_RAX, ret_rax),
-            ];
-
-            set_registers_64!(self.inner.vcpufd, arr_reg_name_value).unwrap();
+            self.inner
+                .vcpufd
+                .set_hvdef_regs_64(&[
+                    (HvX64RegisterName::Rip, info.header.rip + insn_len),
+                    (HvX64RegisterName::Rax, ret_rax),
+                ])
+                .unwrap();
         }
 
         Ok(())
@@ -671,28 +692,24 @@ impl MshvProcessor<'_> {
 
     async fn handle_mmio_intercept(
         &self,
-        message: &hv_message,
+        message: &HvMessage,
         devices: &impl CpuIo,
     ) -> Result<(), VpHaltReason> {
-        let execution_state = message.to_memory_info().unwrap().header.execution_state;
-        // SAFETY: This union only contains one field.
-        let mmio_execution_state = unsafe { execution_state.__bindgen_anon_1 };
-        let interruption_pending = mmio_execution_state.interruption_pending() != 0;
+        let info = message.as_message::<hvdef::HvX64MemoryInterceptMessage>();
+        let interruption_pending = info.header.execution_state.interruption_pending();
 
         self.emulate(message, devices, interruption_pending).await
     }
 
-    fn handle_synic_deliverable_exit(&self, message: &hv_message, _devices: &impl CpuIo) {
-        let info = message.to_sint_deliverable_info().unwrap();
+    fn handle_synic_deliverable_exit(&self, message: &HvMessage, _devices: &impl CpuIo) {
+        let info = message.as_message::<hvdef::HvX64SynicSintDeliverableMessage>();
         self.flush_messages(info.deliverable_sints);
     }
 
-    fn handle_hypercall_intercept(&self, message: &hv_message, _devices: &impl CpuIo) {
-        let info = message.to_hypercall_intercept_info().unwrap();
-        let execution_state = info.header.execution_state;
-        // SAFETY: Accessing the raw field of this union is always safe.
-        let vp_state = unsafe { HvX64VpExecutionState::from(execution_state.as_uint16) };
-        let is_64bit = vp_state.cr0_pe() && vp_state.efer_lma();
+    fn handle_hypercall_intercept(&self, message: &HvMessage, _devices: &impl CpuIo) {
+        let info = message.as_message::<hvdef::HvX64HypercallInterceptMessage>();
+        let is_64bit =
+            info.header.execution_state.cr0_pe() && info.header.execution_state.efer_lma();
         let mut hpc_context = MshvHypercallContext {
             rax: info.rax,
             rbx: info.rbx,
@@ -701,7 +718,9 @@ impl MshvProcessor<'_> {
             r8: info.r8,
             rsi: info.rsi,
             rdi: info.rdi,
-            xmm: info.xmmregisters,
+            xmm: info
+                .xmm_registers
+                .map(|x| u128::from_ne_bytes(x.as_ne_bytes())),
         };
         let mut handler = MshvHypercallHandler {
             partition: self.partition,
@@ -717,84 +736,37 @@ impl MshvProcessor<'_> {
             X64RegisterIo::new(&mut handler, is_64bit),
         );
 
-        let mut dirty_regs = ArrayVec::<hv_register_assoc, 14>::new();
+        let mut dirty_regs = ArrayVec::<HvRegisterAssoc, 14>::new();
 
         if handler.gp_dirty {
             dirty_regs.extend([
-                hv_register_assoc {
-                    name: mshv_bindings::hv_register_name_HV_X64_REGISTER_RAX,
-                    value: hv_register_value {
-                        reg64: handler.context.rax,
-                    },
-                    ..Default::default()
-                },
-                hv_register_assoc {
-                    name: mshv_bindings::hv_register_name_HV_X64_REGISTER_RBX,
-                    value: hv_register_value {
-                        reg64: handler.context.rbx,
-                    },
-                    ..Default::default()
-                },
-                hv_register_assoc {
-                    name: mshv_bindings::hv_register_name_HV_X64_REGISTER_RCX,
-                    value: hv_register_value {
-                        reg64: handler.context.rcx,
-                    },
-                    ..Default::default()
-                },
-                hv_register_assoc {
-                    name: mshv_bindings::hv_register_name_HV_X64_REGISTER_RDX,
-                    value: hv_register_value {
-                        reg64: handler.context.rdx,
-                    },
-                    ..Default::default()
-                },
-                hv_register_assoc {
-                    name: mshv_bindings::hv_register_name_HV_X64_REGISTER_R8,
-                    value: hv_register_value {
-                        reg64: handler.context.r8,
-                    },
-                    ..Default::default()
-                },
-                hv_register_assoc {
-                    name: mshv_bindings::hv_register_name_HV_X64_REGISTER_RSI,
-                    value: hv_register_value {
-                        reg64: handler.context.rsi,
-                    },
-                    ..Default::default()
-                },
-                hv_register_assoc {
-                    name: mshv_bindings::hv_register_name_HV_X64_REGISTER_RDI,
-                    value: hv_register_value {
-                        reg64: handler.context.rdi,
-                    },
-                    ..Default::default()
-                },
+                HvRegisterAssoc::from((HvX64RegisterName::Rax, handler.context.rax)),
+                HvRegisterAssoc::from((HvX64RegisterName::Rbx, handler.context.rbx)),
+                HvRegisterAssoc::from((HvX64RegisterName::Rcx, handler.context.rcx)),
+                HvRegisterAssoc::from((HvX64RegisterName::Rdx, handler.context.rdx)),
+                HvRegisterAssoc::from((HvX64RegisterName::R8, handler.context.r8)),
+                HvRegisterAssoc::from((HvX64RegisterName::Rsi, handler.context.rsi)),
+                HvRegisterAssoc::from((HvX64RegisterName::Rdi, handler.context.rdi)),
             ]);
         }
 
         if handler.xmm_dirty {
-            dirty_regs.extend((0..5).map(|i| hv_register_assoc {
-                name: mshv_bindings::hv_register_name_HV_X64_REGISTER_XMM0 + i,
-                value: hv_register_value {
-                    reg128: handler.context.xmm[i as usize],
-                },
-                ..Default::default()
+            dirty_regs.extend((0..5u32).map(|i| {
+                HvRegisterAssoc::from((
+                    HvX64RegisterName(HvX64RegisterName::Xmm0.0 + i),
+                    handler.context.xmm[i as usize],
+                ))
             }));
         }
 
         if handler.rip_dirty {
-            dirty_regs.push(hv_register_assoc {
-                name: mshv_bindings::hv_register_name_HV_X64_REGISTER_RIP,
-                value: hv_register_value { reg64: handler.rip },
-                ..Default::default()
-            });
+            dirty_regs.push(HvRegisterAssoc::from((HvX64RegisterName::Rip, handler.rip)));
         }
 
         if !dirty_regs.is_empty() {
             self.inner
                 .vcpufd
-                .set_reg(&dirty_regs)
+                .set_hvdef_regs(&dirty_regs)
                 .expect("RIP setting is not a fallable operation");
         }
     }
@@ -870,7 +842,7 @@ struct MshvEmulationState<'a> {
     partition: &'a MshvPartitionInner,
     processor: &'a MshvVpInner,
     vp_index: VpIndex,
-    message: &'a hv_message,
+    message: &'a HvMessage,
     interruption_pending: bool,
     cache: MshvEmuCache,
 }
@@ -923,180 +895,97 @@ impl EmulatorSupport for MshvEmulationState<'_> {
     fn xmm(&mut self, reg: usize) -> u128 {
         assert!(reg < 16);
         let name = HvX64RegisterName(HvX64RegisterName::Xmm0.0 + reg as u32);
-        // SAFETY: `HvRegisterAssoc` and `hv_register_assoc` have the same layout.
-        let reg = unsafe {
-            std::mem::transmute::<HvRegisterAssoc, hv_register_assoc>(HvRegisterAssoc::from((
-                name, 0u128,
-            )))
-        };
-        let _ = self.processor.vcpufd.get_reg(&mut [reg]);
-        // SAFETY: Accessing the u128 field of this union is always safe.
-        hvu128_to_u128(unsafe { &reg.value.reg128 })
+        let mut assoc = [HvRegisterAssoc::from((name, 0u128))];
+        let _ = self.processor.vcpufd.get_hvdef_regs(&mut assoc);
+        assoc[0].value.as_u128()
     }
 
     fn set_xmm(&mut self, reg: usize, value: u128) {
         assert!(reg < 16);
         let name = HvX64RegisterName(HvX64RegisterName::Xmm0.0 + reg as u32);
-        // SAFETY: `HvRegisterAssoc` and `hv_register_assoc` have the same layout.
-        let reg = unsafe {
-            std::mem::transmute::<HvRegisterAssoc, hv_register_assoc>(HvRegisterAssoc::from((
-                name, value,
-            )))
-        };
-        self.processor.vcpufd.set_reg(&[reg]).unwrap();
+        let assoc = [HvRegisterAssoc::from((name, value))];
+        self.processor.vcpufd.set_hvdef_regs(&assoc).unwrap();
     }
 
     fn flush(&mut self) {
-        let arr_reg_name_value = [
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RIP,
-                self.cache.rip,
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RFLAGS,
-                self.cache.rflags.into(),
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RAX,
-                self.cache.gps[0],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RCX,
-                self.cache.gps[1],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RDX,
-                self.cache.gps[2],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RBX,
-                self.cache.gps[3],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RSP,
-                self.cache.gps[4],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RBP,
-                self.cache.gps[5],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RSI,
-                self.cache.gps[6],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_RDI,
-                self.cache.gps[7],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_R8,
-                self.cache.gps[8],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_R9,
-                self.cache.gps[9],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_R10,
-                self.cache.gps[10],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_R11,
-                self.cache.gps[11],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_R12,
-                self.cache.gps[12],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_R13,
-                self.cache.gps[13],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_R14,
-                self.cache.gps[14],
-            ),
-            (
-                mshv_bindings::hv_register_name_HV_X64_REGISTER_R15,
-                self.cache.gps[15],
-            ),
-        ];
-
-        set_registers_64!(self.processor.vcpufd, arr_reg_name_value).unwrap();
+        self.processor
+            .vcpufd
+            .set_hvdef_regs_64(&[
+                (HvX64RegisterName::Rip, self.cache.rip),
+                (HvX64RegisterName::Rflags, self.cache.rflags.into()),
+                (HvX64RegisterName::Rax, self.cache.gps[0]),
+                (HvX64RegisterName::Rcx, self.cache.gps[1]),
+                (HvX64RegisterName::Rdx, self.cache.gps[2]),
+                (HvX64RegisterName::Rbx, self.cache.gps[3]),
+                (HvX64RegisterName::Rsp, self.cache.gps[4]),
+                (HvX64RegisterName::Rbp, self.cache.gps[5]),
+                (HvX64RegisterName::Rsi, self.cache.gps[6]),
+                (HvX64RegisterName::Rdi, self.cache.gps[7]),
+                (HvX64RegisterName::R8, self.cache.gps[8]),
+                (HvX64RegisterName::R9, self.cache.gps[9]),
+                (HvX64RegisterName::R10, self.cache.gps[10]),
+                (HvX64RegisterName::R11, self.cache.gps[11]),
+                (HvX64RegisterName::R12, self.cache.gps[12]),
+                (HvX64RegisterName::R13, self.cache.gps[13]),
+                (HvX64RegisterName::R14, self.cache.gps[14]),
+                (HvX64RegisterName::R15, self.cache.gps[15]),
+            ])
+            .unwrap();
     }
 
     fn instruction_bytes(&self) -> &[u8] {
-        match HvMessageType(self.message.header.message_type) {
+        match self.message.header.typ {
             HvMessageType::HvMessageTypeGpaIntercept
             | HvMessageType::HvMessageTypeUnmappedGpa
             | HvMessageType::HvMessageTypeUnacceptedGpa => {
-                // SAFETY: We have checked the message type.
-                unsafe {
-                    let info = (&raw const self.message.u.payload)
-                        .cast::<hv_x64_memory_intercept_message>();
-                    let instruction_bytes = &raw const (*info).instruction_bytes;
-                    let instruction_byte_count =
-                        std::ptr::read_unaligned(&raw const (*info).instruction_byte_count);
-                    std::slice::from_raw_parts(
-                        instruction_bytes.cast(),
-                        instruction_byte_count as usize,
-                    )
-                }
+                let info = self
+                    .message
+                    .as_message::<hvdef::HvX64MemoryInterceptMessage>();
+                &info.instruction_bytes[..info.instruction_byte_count as usize]
             }
             HvMessageType::HvMessageTypeX64IoPortIntercept => {
-                // SAFETY: We have checked the message type.
-                unsafe {
-                    let info = (&raw const self.message.u.payload)
-                        .cast::<hv_x64_io_port_intercept_message>();
-                    let instruction_bytes = &raw const (*info).instruction_bytes;
-                    let instruction_byte_count =
-                        std::ptr::read_unaligned(&raw const (*info).instruction_byte_count);
-                    std::slice::from_raw_parts(
-                        instruction_bytes.cast(),
-                        instruction_byte_count as usize,
-                    )
-                }
+                let info = self
+                    .message
+                    .as_message::<hvdef::HvX64IoPortInterceptMessage>();
+                &info.instruction_bytes[..info.instruction_byte_count as usize]
             }
             _ => unreachable!(),
         }
     }
 
     fn physical_address(&self) -> Option<u64> {
-        if self.message.header.message_type == HvMessageType::HvMessageTypeGpaIntercept.0
-            || self.message.header.message_type == HvMessageType::HvMessageTypeUnmappedGpa.0
-            || self.message.header.message_type == HvMessageType::HvMessageTypeUnacceptedGpa.0
-        {
-            let info = self.message.to_memory_info().unwrap();
-            Some(info.guest_physical_address)
-        } else {
-            None
+        match self.message.header.typ {
+            HvMessageType::HvMessageTypeGpaIntercept
+            | HvMessageType::HvMessageTypeUnmappedGpa
+            | HvMessageType::HvMessageTypeUnacceptedGpa => {
+                let info = self
+                    .message
+                    .as_message::<hvdef::HvX64MemoryInterceptMessage>();
+                Some(info.guest_physical_address)
+            }
+            _ => None,
         }
     }
 
     fn initial_gva_translation(
         &mut self,
     ) -> Option<virt_support_x86emu::emulate::InitialTranslation> {
-        if (self.message.header.message_type != HvMessageType::HvMessageTypeGpaIntercept.0)
-            && (self.message.header.message_type != HvMessageType::HvMessageTypeUnmappedGpa.0)
-            && (self.message.header.message_type != HvMessageType::HvMessageTypeUnacceptedGpa.0)
-        {
+        match self.message.header.typ {
+            HvMessageType::HvMessageTypeGpaIntercept
+            | HvMessageType::HvMessageTypeUnmappedGpa
+            | HvMessageType::HvMessageTypeUnacceptedGpa => {}
+            _ => return None,
+        }
+
+        let message = self
+            .message
+            .as_message::<hvdef::HvX64MemoryInterceptMessage>();
+
+        if !message.memory_access_info.gva_gpa_valid() {
             return None;
         }
 
-        let message = self.message.to_memory_info().unwrap();
-
-        // SAFETY: access to union as uint8 is safe because in this case, the actual
-        // type doesn't matter so much as the bits
-        let memory_access_info =
-            unsafe { hvdef::HvX64MemoryAccessInfo::from(message.memory_access_info.as_uint8) };
-
-        if !memory_access_info.gva_gpa_valid() {
-            return None;
-        }
-
-        if let Ok(translate_mode) = TranslateMode::try_from(hvdef::HvInterceptAccessType(
-            message.header.intercept_access_type,
-        )) {
+        if let Ok(translate_mode) = TranslateMode::try_from(message.header.intercept_access_type) {
             Some(virt_support_x86emu::emulate::InitialTranslation {
                 gva: message.guest_virtual_address,
                 gpa: message.guest_physical_address,
@@ -1129,20 +1018,19 @@ impl EmulatorSupport for MshvEmulationState<'_> {
     }
 
     fn inject_pending_event(&mut self, event_info: hvdef::HvX64PendingEvent) {
-        // SAFETY: `HvRegisterAssoc` and `hv_register_assoc` have the same layout.
-        let reg = unsafe {
-            &[
-                std::mem::transmute::<HvRegisterAssoc, hv_register_assoc>(HvRegisterAssoc::from((
+        self.processor
+            .vcpufd
+            .set_hvdef_regs(&[
+                HvRegisterAssoc::from((
                     HvX64RegisterName::PendingEvent0,
                     u128::from(event_info.reg_0),
-                ))),
-                std::mem::transmute::<HvRegisterAssoc, hv_register_assoc>(HvRegisterAssoc::from((
+                )),
+                HvRegisterAssoc::from((
                     HvX64RegisterName::PendingEvent1,
                     u128::from(event_info.reg_1),
-                ))),
-            ]
-        };
-        self.processor.vcpufd.set_reg(reg).unwrap();
+                )),
+            ])
+            .unwrap();
     }
 
     fn is_gpa_mapped(&self, gpa: u64, write: bool) -> bool {
@@ -1194,15 +1082,7 @@ impl TranslateGvaSupport for MshvEmulationState<'_> {
         .map(|n| HvRegisterAssoc::from((n, 0u64)));
 
         // SAFETY: `HvRegisterAssoc` and `hv_register_assoc` have the same size.
-        unsafe {
-            self.processor
-                .vcpufd
-                .get_reg(std::mem::transmute::<
-                    &mut [HvRegisterAssoc],
-                    &mut [hv_register_assoc],
-                >(&mut reg[..]))
-                .unwrap();
-        }
+        self.processor.vcpufd.get_hvdef_regs(&mut reg[..]).unwrap();
 
         let [cr0, cr4, efer, cr3, rflags, ss] = reg.map(|v| v.value);
 
@@ -1376,7 +1256,7 @@ impl virt::PartitionMemoryMap for MshvPartitionInner {
 struct MshvDoorbellEntry;
 
 impl MshvDoorbellEntry {
-    pub fn new(
+    fn new(
         _guest_address: u64,
         _value: Option<u64>,
         _length: Option<u32>,
@@ -1405,15 +1285,15 @@ impl DoorbellRegistration for MshvPartition {
     }
 }
 
-pub struct MshvHypercallContext {
-    pub rax: u64,
-    pub rbx: u64,
-    pub rcx: u64,
-    pub rdx: u64,
-    pub r8: u64,
-    pub rsi: u64,
-    pub rdi: u64,
-    pub xmm: [hv_u128; 6],
+struct MshvHypercallContext {
+    rax: u64,
+    rbx: u64,
+    rcx: u64,
+    rdx: u64,
+    r8: u64,
+    rsi: u64,
+    rdi: u64,
+    xmm: [u128; 6],
 }
 
 impl hv1_hypercall::X64RegisterState for MshvHypercallHandler<'_> {
@@ -1452,37 +1332,12 @@ impl hv1_hypercall::X64RegisterState for MshvHypercallHandler<'_> {
     }
 
     fn xmm(&mut self, n: usize) -> u128 {
-        let r = &self.context.xmm[n];
-        hvu128_to_u128(r)
+        self.context.xmm[n]
     }
 
     fn set_xmm(&mut self, n: usize, value: u128) {
-        self.context.xmm[n] = u128_to_hvu128(value);
+        self.context.xmm[n] = value;
         self.xmm_dirty = true;
-    }
-}
-
-fn hvu128_to_u128(r: &hv_u128) -> u128 {
-    (r.high_part as u128) << 64 | r.low_part as u128
-}
-
-fn u128_to_hvu128(value: u128) -> hv_u128 {
-    hv_u128 {
-        high_part: (value >> 64) as u64,
-        low_part: (value & (u64::MAX as u128)) as u64,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn u128_roundtrip() {
-        let original = 0x0123_4567_89ab_cdef_fedc_ba98_7654_3210;
-        let hv = u128_to_hvu128(original);
-        let roundtrip = hvu128_to_u128(&hv);
-        assert_eq!(roundtrip, original);
     }
 }
 
@@ -1556,29 +1411,40 @@ impl virt::Processor for MshvProcessor<'_> {
             stop.check()?;
 
             match vcpufd.run() {
-                Ok(exit) => match HvMessageType(exit.header.message_type) {
-                    HvMessageType::HvMessageTypeUnrecoverableException => {
-                        return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
+                Ok(exit) => {
+                    // SAFETY: hv_message and HvMessage have the same size
+                    // (256 bytes) and compatible layout (header + 240-byte
+                    // payload).
+                    let exit: HvMessage =
+                        unsafe { std::mem::transmute::<hv_message, HvMessage>(exit) };
+                    match exit.header.typ {
+                        HvMessageType::HvMessageTypeUnrecoverableException => {
+                            return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
+                        }
+                        HvMessageType::HvMessageTypeX64IoPortIntercept => {
+                            self.handle_io_port_intercept(&exit, dev).await?;
+                        }
+                        HvMessageType::HvMessageTypeUnmappedGpa
+                        | HvMessageType::HvMessageTypeGpaIntercept => {
+                            self.handle_mmio_intercept(&exit, dev).await?;
+                        }
+                        HvMessageType::HvMessageTypeSynicSintDeliverable => {
+                            tracing::trace!("SYNIC_SINT_DELIVERABLE");
+                            self.handle_synic_deliverable_exit(&exit, dev);
+                        }
+                        HvMessageType::HvMessageTypeHypercallIntercept => {
+                            tracing::trace!("HYPERCALL_INTERCEPT");
+                            self.handle_hypercall_intercept(&exit, dev);
+                        }
+                        HvMessageType::HvMessageTypeX64ApicEoi => {
+                            let msg = exit.as_message::<hvdef::HvX64ApicEoiMessage>();
+                            dev.handle_eoi(msg.interrupt_vector);
+                        }
+                        exit => {
+                            panic!("Unhandled vcpu exit code {exit:?}");
+                        }
                     }
-                    HvMessageType::HvMessageTypeX64IoPortIntercept => {
-                        self.handle_io_port_intercept(&exit, dev).await?;
-                    }
-                    HvMessageType::HvMessageTypeUnmappedGpa
-                    | HvMessageType::HvMessageTypeGpaIntercept => {
-                        self.handle_mmio_intercept(&exit, dev).await?;
-                    }
-                    HvMessageType::HvMessageTypeSynicSintDeliverable => {
-                        tracing::trace!("SYNIC_SINT_DELIVERABLE");
-                        self.handle_synic_deliverable_exit(&exit, dev);
-                    }
-                    HvMessageType::HvMessageTypeHypercallIntercept => {
-                        tracing::trace!("HYPERCALL_INTERCEPT");
-                        self.handle_hypercall_intercept(&exit, dev);
-                    }
-                    exit => {
-                        panic!("Unhandled vcpu exit code {exit:?}");
-                    }
-                },
+                }
 
                 Err(e) => match e.errno() {
                     libc::EAGAIN | libc::EINTR => {}

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -89,21 +89,29 @@ trait VcpuFdExt {
 
 impl VcpuFdExt for VcpuFd {
     fn get_hvdef_regs(&self, regs: &mut [HvRegisterAssoc]) -> Result<(), MshvError> {
-        // SAFETY: HvRegisterAssoc and hv_register_assoc have the same layout
-        // (verified by static assertions in vp_state.rs).
+        const {
+            assert!(size_of::<HvRegisterAssoc>() == size_of::<hv_register_assoc>());
+            assert!(align_of::<HvRegisterAssoc>() >= align_of::<hv_register_assoc>());
+        }
+        // SAFETY: HvRegisterAssoc and hv_register_assoc have the same layout.
         self.get_reg(unsafe {
             std::mem::transmute::<&mut [HvRegisterAssoc], &mut [hv_register_assoc]>(regs)
         })
     }
 
     fn set_hvdef_regs(&self, regs: &[HvRegisterAssoc]) -> Result<(), MshvError> {
-        // SAFETY: HvRegisterAssoc and hv_register_assoc have the same layout
-        // (verified by static assertions in vp_state.rs).
+        const {
+            assert!(size_of::<HvRegisterAssoc>() == size_of::<hv_register_assoc>());
+            assert!(align_of::<HvRegisterAssoc>() >= align_of::<hv_register_assoc>());
+        }
+        // SAFETY: HvRegisterAssoc and hv_register_assoc have the same layout.
         self.set_reg(unsafe {
             std::mem::transmute::<&[HvRegisterAssoc], &[hv_register_assoc]>(regs)
         })
     }
 
+    // TODO: this is only used for registers that are on the register page.
+    // Remove once the register page is implemented.
     fn set_hvdef_regs_64(&self, regs: &[(HvX64RegisterName, u64)]) -> Result<(), MshvError> {
         let assocs: ArrayVec<HvRegisterAssoc, 18> = regs
             .iter()

--- a/vmm_core/virt_mshv/src/vp_state.rs
+++ b/vmm_core/virt_mshv/src/vp_state.rs
@@ -2,12 +2,10 @@
 // Licensed under the MIT License.
 
 use super::Error;
+use super::VcpuFdExt;
 use crate::MshvProcessor;
 use hvdef::HvX64RegisterName;
 use hvdef::hypercall::HvRegisterAssoc;
-use mshv_bindings::hv_register_assoc;
-use static_assertions::assert_eq_size;
-use std::mem::offset_of;
 use virt::state::HvRegisterState;
 use virt::x86::vp;
 use virt::x86::vp::AccessVpState;
@@ -28,7 +26,7 @@ impl MshvProcessor<'_> {
 
         self.inner
             .vcpufd
-            .set_reg(hvdef_to_mshv(&assoc[..]))
+            .set_hvdef_regs(&assoc[..])
             .map_err(Error::Register)?;
 
         Ok(())
@@ -47,40 +45,12 @@ impl MshvProcessor<'_> {
 
         self.inner
             .vcpufd
-            .get_reg(hvdef_to_mshv_mut(&mut assoc[..]))
+            .get_hvdef_regs(&mut assoc[..])
             .map_err(Error::Register)?;
 
         regs.set_values(assoc.iter().map(|assoc| assoc.value));
         Ok(regs)
     }
-}
-
-fn hvdef_to_mshv(regs: &[HvRegisterAssoc]) -> &[hv_register_assoc] {
-    assert_eq_size!(HvRegisterAssoc, hv_register_assoc);
-    assert_eq!(
-        offset_of!(HvRegisterAssoc, name),
-        offset_of!(hv_register_assoc, name)
-    );
-    assert_eq!(
-        offset_of!(HvRegisterAssoc, value),
-        offset_of!(hv_register_assoc, value)
-    );
-    // SAFETY: HvRegisterAssoc and hv_register_assoc have compatible definitions.
-    unsafe { std::mem::transmute(regs) }
-}
-
-fn hvdef_to_mshv_mut(regs: &mut [HvRegisterAssoc]) -> &mut [hv_register_assoc] {
-    assert_eq_size!(HvRegisterAssoc, hv_register_assoc);
-    assert_eq!(
-        offset_of!(HvRegisterAssoc, name),
-        offset_of!(hv_register_assoc, name)
-    );
-    assert_eq!(
-        offset_of!(HvRegisterAssoc, value),
-        offset_of!(hv_register_assoc, value)
-    );
-    // SAFETY: HvRegisterAssoc and hv_register_assoc have compatible definitions.
-    unsafe { std::mem::transmute(regs) }
 }
 
 impl AccessVpState for &'_ mut MshvProcessor<'_> {


### PR DESCRIPTION
The `HvMessageTypeX64ApicEoi` exit was unhandled, causing a panic when the guest triggered an EOI. This adds a handler that parses the interrupt vector from the exit message and routes it to `CpuIo::handle_eoi`.

While here, clean up the crate to use hvdef types instead of mshv-bindings types for exit message parsing and register access. The mshv-bindings `hv_message` is transmuted once to `hvdef::HvMessage` at the top of the run loop, and all intercept messages are parsed via the typed `HvMessage::as_message<T>()` API, replacing unsafe union access and raw pointer casts.
