### PR TITLE
Repo: Cleanup features related to vendoring crypto

### DIFF
--- a/.github/skills/fuzzing/SKILL.md
+++ b/.github/skills/fuzzing/SKILL.md
@@ -328,7 +328,7 @@ improvements should focus on primary scope first.
 | fuzz_ide | `ide/src/` | `scsidisk/src/scsidvd/`, `scsidisk/src/atapi_scsi.rs`, `disk_backend/`, `disklayer_ram/` | `pci_core/`, `vmcore/`, `guestmem/` (infrastructure) |
 | fuzz_storvsp | `storvsp/src/` | `scsidisk/src/lib.rs`, `vmbus_ring/`, `vmbus_async/`, `disk_backend/` | `vmbus_channel/`, `vmbus_core/` (infrastructure) |
 | fuzz_nvme_driver | `nvme_driver/src/` | `nvme/src/`, `nvme_spec/`, `user_driver/` | `page_pool_alloc/`, `vmcore/` |
-| fuzz_firmware_uefi_nvram | `firmware_uefi/src/service/nvram/` | `uefi_nvram_specvars/` | `openssl` (infrastructure) |
+| fuzz_firmware_uefi_nvram | `firmware_uefi/src/service/nvram/` | `uefi_nvram_specvars/` | `crypto`, `openssl` (infrastructure) |
 | fuzz_firmware_uefi_diagnostics | `firmware_uefi/src/service/diagnostics/` | — | `guestmem/` |
 | fuzz_chipset_cmos_rtc | `chipset/src/cmos_rtc/` | `chipset_device_fuzz/` | `pal_async/`, `vmcore/` |
 | fuzz_scsi_buffers | `scsi_buffers/src/` | — | `guestmem/` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5327,6 +5327,7 @@ dependencies = [
  "clap",
  "clap_dyn_complete",
  "console_relay",
+ "crypto",
  "debug_worker_defs",
  "diag_client",
  "dirs",
@@ -5358,7 +5359,6 @@ dependencies = [
  "net_tap",
  "netvsp_resources",
  "nvme_resources",
- "openssl",
  "openvmm_defs",
  "openvmm_helpers",
  "openvmm_pcat_locator",
@@ -8313,6 +8313,7 @@ dependencies = [
  "chipset_device_worker_defs",
  "chipset_legacy",
  "closeable_mutex",
+ "crypto",
  "cvm_tracing",
  "debug_ptr",
  "debug_worker_defs",
@@ -9839,6 +9840,7 @@ dependencies = [
 name = "vmgs_lib"
 version = "0.0.0"
 dependencies = [
+ "crypto",
  "disk_backend",
  "disk_vhd1",
  "futures",
@@ -9862,6 +9864,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "crypto",
  "disk_backend",
  "disk_vhd1",
  "fs-err",

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -6,11 +6,6 @@ name = "underhill_attestation"
 edition.workspace = true
 rust-version.workspace = true
 
-[features]
-# Enable locally compiling and statically linking a copy of OpenSSL.
-# The build process requires a C compiler, perl, and make.
-openssl-vendored = ["crypto/ossl_vendored"]
-
 [target.'cfg(target_os = "linux")'.dependencies]
 crypto.workspace = true
 guest_emulation_transport.workspace = true

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -15,10 +15,6 @@ mem-profile-tracing = ["dep:mem_profile_tracing", "diag_server/mem-profile-traci
 # Enable gdbstub support
 gdb = ["debug_worker_defs", "vmm_core/gdb", "virt_mshv_vtl/gdb"]
 
-# Enable locally compiling and statically linking a copy of OpenSSL.
-# The build process requires a C compiler, perl, and make.
-openssl-vendored = ["underhill_attestation/openssl-vendored"]
-
 # Enable TIO support for SEV-SNP
 dev_snp_ohcl_tio_support = ["tee_call/dev_snp_ohcl_tio_support"]
 
@@ -143,6 +139,7 @@ x86defs.workspace = true
 safe_intrinsics.workspace = true
 debug_ptr.workspace = true
 guid.workspace = true
+crypto = { workspace = true, features = ["vendored"] }
 inspect.workspace = true
 kmsg.workspace = true
 local_clock.workspace = true
@@ -198,3 +195,7 @@ build_rs_guest_arch.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.xtask.unused-deps]
+# keep the crypto dep so we can specify the vendored feature
+ignored = ["crypto"]

--- a/openvmm/openvmm/Cargo.toml
+++ b/openvmm/openvmm/Cargo.toml
@@ -22,7 +22,7 @@ default = [
 # see the `openvmm_entry` crate for more info on these features
 encryption = ["openvmm_entry/encryption"]
 gdb = ["openvmm_resources/gdb"]
-openssl-vendored = ["openvmm_entry/openssl-vendored"]
+vendored_crypto = ["openvmm_entry/vendored_crypto"]
 tpm = ["openvmm_resources/tpm"]
 virt_hvf = ["openvmm_resources/virt_hvf"]
 virt_kvm = ["openvmm_resources/virt_kvm"]

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -9,9 +9,7 @@ rust-version.workspace = true
 [features]
 default = ["ttrpc", "grpc"]
 
-# Enable locally compiling and statically linking a copy of OpenSSL.
-# The build process requires a C compiler, perl, and make.
-openssl-vendored = ["openssl/vendored"]
+vendored_crypto = ["crypto/vendored"]
 
 encryption = ["vmotherboard/encryption"]
 
@@ -71,6 +69,7 @@ pcie_remote_resources.workspace = true
 
 clap_dyn_complete.workspace = true
 console_relay.workspace = true
+crypto = { workspace = true, optional = true }
 guid.workspace = true
 inspect.workspace = true
 inspect_proto.workspace = true
@@ -93,7 +92,6 @@ fs-err.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
 getrandom.workspace = true
-openssl = { optional = true, workspace = true }
 parking_lot.workspace = true
 prost.workspace = true
 rustyline = { workspace = true, features = ["derive"] }
@@ -128,5 +126,5 @@ build_rs_guest_arch.workspace = true
 workspace = true
 
 [package.metadata.xtask.unused-deps]
-# keep the ossl dep so we can specify the vendored feature
-ignored = ["openssl"]
+# keep the crypto dep so we can specify the vendored feature
+ignored = ["crypto"]

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -7,15 +7,18 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-ossl_vendored = ["openssl/vendored"]
+# If the chosen backend supports it, vendor it.
+# If the chosen backend is natively available, this feature is a no-op.
+# If the chosen backend is not natively available and can't be vendored, this will trigger a compile error.
+vendored = ["openssl/vendored"]
 
 [dependencies]
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-openssl.workspace = true
 openssl_kdf.workspace = true
+openssl.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 wchar.workspace = true

--- a/vm/devices/firmware/firmware_uefi/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/Cargo.toml
@@ -20,8 +20,6 @@ auth-var-verify-crypto = ["crypto", "der"]
 # exposes private modules so that they can be fuzzed
 fuzzing = []
 
-ossl_vendored = ["crypto?/ossl_vendored"]
-
 [dependencies]
 firmware_uefi_custom_vars.workspace = true
 uefi_nvram_storage = { workspace = true, features = ["inspect", "save_restore"] }

--- a/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-crypto = { workspace = true, features = ["ossl_vendored"] }
+crypto = { workspace = true, features = ["vendored"] }
 firmware_uefi = { workspace = true, features = ["auth-var-verify-crypto", "fuzzing"] }
 guid.workspace = true
 guestmem.workspace = true

--- a/vm/vmgs/vmgs/Cargo.toml
+++ b/vm/vmgs/vmgs/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 inspect = ["vmgs_format/inspect", "dep:inspect", "dep:inspect_counters"]
 save_restore = ["dep:mesh_protobuf"]
 mesh = ["dep:mesh_protobuf"]
-encryption = ["dep:crypto", "crypto/ossl_vendored"]
+encryption = ["dep:crypto"]
 test_helpers = []
 
 # run encryption unit tests in CI

--- a/vm/vmgs/vmgs_lib/Cargo.toml
+++ b/vm/vmgs/vmgs_lib/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+crypto = { workspace = true, features = ["vendored"] }
 disk_backend.workspace = true
 disk_vhd1.workspace = true
 futures.workspace = true
@@ -18,3 +19,7 @@ vmgs = { workspace = true, features = ["encryption"] }
 
 [lints]
 workspace = true
+
+[package.metadata.xtask.unused-deps]
+# keep the crypto dep so we can specify the vendored feature
+ignored = ["crypto"]

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [features]
 default = []
 
-encryption = ["vmgs/encryption"]
+encryption = ["vmgs/encryption", "crypto/vendored"]
 
 test_helpers = ["vmgs/test_helpers", "getrandom", "dep:resource_dll_parser"]
 
@@ -32,6 +32,7 @@ vmgs_format.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 clap = { workspace = true, features = ["derive"] }
+crypto = { workspace = true, optional = true }
 hex.workspace = true
 fs-err.workspace = true
 getrandom = { workspace = true, optional = true}
@@ -48,3 +49,7 @@ tempfile.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.xtask.unused-deps]
+# keep the crypto dep so we can specify the vendored feature
+ignored = ["crypto"]


### PR DESCRIPTION
Whether or not to vendor the crypto libraries we use is a decision that should be made at the topmost binary level, and never one that should be made by any individual library crate. However threading through a `vendored` feature on every library that happens to use `crypto` is tedious and easy to forget. Instead, this PR updates binaries to directly depend on `crypto` and set the `vendored` feature themselves, and remove all threaded library crate features.

Note: The openvmm_entry feature is maintained so it can be shared by internal builds.