### PR TITLE
petri: Add VPCI support requirement

### DIFF
--- a/petri/src/requirements.rs
+++ b/petri/src/requirements.rs
@@ -175,9 +175,27 @@ pub enum TestRequirement {
     Or(Box<TestRequirement>, Box<TestRequirement>),
     /// Logical NOT of a requirement.
     Not(Box<TestRequirement>),
+    /// Requirement satisfied by any host context.
+    Any,
 }
 
 impl TestRequirement {
+    /// Combine this requirement with another requirement using logical AND.
+    pub fn and(self, other: TestRequirement) -> TestRequirement {
+        TestRequirement::And(Box::new(self), Box::new(other))
+    }
+
+    /// Combine this requirement with another requirement using logical OR.
+    pub fn or(self, other: TestRequirement) -> TestRequirement {
+        TestRequirement::Or(Box::new(self), Box::new(other))
+    }
+
+    /// Negate this requirement.
+    #[expect(clippy::should_implement_trait)]
+    pub fn not(self) -> TestRequirement {
+        TestRequirement::Not(Box::new(self))
+    }
+
     /// Evaluate if this requirement is satisfied with the given host context
     pub fn is_satisfied(&self, context: &HostContext) -> bool {
         match self {
@@ -202,6 +220,7 @@ impl TestRequirement {
                 req1.is_satisfied(context) || req2.is_satisfied(context)
             }
             TestRequirement::Not(req) => !req.is_satisfied(context),
+            TestRequirement::Any => true,
         }
     }
 }

--- a/petri/src/requirements.rs
+++ b/petri/src/requirements.rs
@@ -63,6 +63,8 @@ pub struct HostContext {
     pub vendor: Vendor,
     /// Execution environment
     pub execution_environment: ExecutionEnvironment,
+    /// Whether the host hypervisor supports software VPCI device emulation
+    pub vpci_supported: bool,
 }
 
 impl HostContext {
@@ -140,6 +142,9 @@ impl HostContext {
             }
         };
 
+        // VPCI support: only Windows (virt_whp and Hyper-V) supports it for now.
+        let vpci_supported = cfg!(windows);
+
         Self {
             vm_host_info,
             vendor,
@@ -148,6 +153,7 @@ impl HostContext {
             } else {
                 ExecutionEnvironment::Baremetal
             },
+            vpci_supported,
         }
     }
 }
@@ -160,6 +166,9 @@ pub enum TestRequirement {
     Vendor(Vendor),
     /// Isolation requirement.
     Isolation(IsolationType),
+    /// Requires a hypervisor backend that supports VPCI (virtual PCI)
+    /// device emulation. On Linux this means /dev/mshv (not KVM).
+    VpciSupport,
     /// Logical AND of two requirements.
     And(Box<TestRequirement>, Box<TestRequirement>),
     /// Logical OR of two requirements.
@@ -185,6 +194,7 @@ impl TestRequirement {
                     false
                 }
             }
+            TestRequirement::VpciSupport => context.vpci_supported,
             TestRequirement::And(req1, req2) => {
                 req1.is_satisfied(context) && req2.is_satisfied(context)
             }

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -36,6 +36,7 @@ struct ResolvedConfig {
     arch: MachineArch,
     extra_deps: Vec<Path>,
     unstable: bool,
+    requires_vpci: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -90,6 +91,7 @@ struct ArgsWithOverrides {
     vmm: Option<Vmm>,
     unstable: bool,
     with_vtl0_pipette: bool,
+    requires_vpci: bool,
 }
 
 struct ResolvedArgs {
@@ -248,6 +250,7 @@ impl Parse for ArgsWithOverrides {
         let mut unstable = None;
         let mut with_vtl0_pipette = None;
         let mut vmm = None;
+        let mut requires_vpci = None;
 
         let word = input.parse::<Ident>()?;
         let conflict_err = || Err::<Self, Error>(Error::new(word.span(), "conflicting override"));
@@ -264,6 +267,12 @@ impl Parse for ArgsWithOverrides {
                         return conflict_err();
                     }
                     with_vtl0_pipette = Some(false);
+                }
+                "vpci" => {
+                    if requires_vpci.is_some() {
+                        return conflict_err();
+                    }
+                    requires_vpci = Some(true);
                 }
                 "hyperv" => {
                     if vmm.is_some() {
@@ -283,6 +292,7 @@ impl Parse for ArgsWithOverrides {
 
         let unstable = unstable.unwrap_or(false);
         let with_vtl0_pipette = with_vtl0_pipette.unwrap_or(true);
+        let requires_vpci = requires_vpci.unwrap_or(false);
 
         let parens;
         syn::parenthesized!(parens in input);
@@ -293,6 +303,7 @@ impl Parse for ArgsWithOverrides {
             vmm,
             with_vtl0_pipette,
             unstable,
+            requires_vpci,
         })
     }
 }
@@ -304,6 +315,7 @@ impl ArgsWithOverrides {
             vmm,
             unstable,
             with_vtl0_pipette,
+            requires_vpci,
         } = self;
 
         let mut resolved_configs = Vec::new();
@@ -324,6 +336,7 @@ impl ArgsWithOverrides {
                 arch: config.arch,
                 extra_deps: config.extra_deps,
                 unstable: config.unstable || unstable,
+                requires_vpci,
             });
         }
 
@@ -728,6 +741,7 @@ pub fn vmm_test(
         vmm: None,
         unstable: false,
         with_vtl0_pipette: true,
+        requires_vpci: false,
     };
     let item = parse_macro_input!(item as ItemFn);
     make_vmm_test(args, item)
@@ -767,6 +781,7 @@ pub fn openvmm_test(
         vmm: Some(Vmm::OpenVmm),
         unstable: false,
         with_vtl0_pipette: true,
+        requires_vpci: false,
     };
     let item = parse_macro_input!(item as ItemFn);
     make_vmm_test(args, item)
@@ -786,6 +801,7 @@ pub fn openvmm_test_no_agent(
         vmm: Some(Vmm::OpenVmm),
         unstable: false,
         with_vtl0_pipette: false,
+        requires_vpci: false,
     };
     let item = parse_macro_input!(item as ItemFn);
     make_vmm_test(args, item)
@@ -817,7 +833,8 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
         let name = format!("{}_{original_name}", config.name_prefix());
 
         // Build requirements based on the configuration and resolved VMM
-        let requirements = build_requirements(&config.firmware, &name, config.vmm);
+        let requirements =
+            build_requirements(&config.firmware, &name, config.vmm, config.requires_vpci);
         let requirements = if let Some(req) = requirements {
             quote! { Some(#req) }
         } else {
@@ -881,7 +898,12 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
 }
 
 // Helper to build requirements TokenStream for firmware and resolved VMM
-fn build_requirements(firmware: &Firmware, name: &str, resolved_vmm: Vmm) -> Option<TokenStream> {
+fn build_requirements(
+    firmware: &Firmware,
+    name: &str,
+    resolved_vmm: Vmm,
+    requires_vpci: bool,
+) -> Option<TokenStream> {
     let mut requirement_expr: Option<TokenStream> = None;
     let mut is_vbs = false;
     // Add isolation requirement if specified
@@ -926,6 +948,19 @@ fn build_requirements(firmware: &Firmware, name: &str, resolved_vmm: Vmm) -> Opt
                 )
             )),
             None => Some(hyperv_vbs_requirement_expr),
+        };
+    }
+
+    if requires_vpci {
+        let vpci_expr = quote!(::petri::requirements::TestRequirement::VpciSupport);
+        requirement_expr = match requirement_expr {
+            Some(existing) => Some(quote!(
+                ::petri::requirements::TestRequirement::And(
+                    Box::new(#existing),
+                    Box::new(#vpci_expr)
+                )
+            )),
+            None => Some(vpci_expr),
         };
     }
 

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -833,13 +833,7 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
         let name = format!("{}_{original_name}", config.name_prefix());
 
         // Build requirements based on the configuration and resolved VMM
-        let requirements =
-            build_requirements(&config.firmware, &name, config.vmm, config.requires_vpci);
-        let requirements = if let Some(req) = requirements {
-            quote! { Some(#req) }
-        } else {
-            quote! { None }
-        };
+        let requirements = build_requirements(&config.firmware, config.vmm, config.requires_vpci);
 
         // Now move the values for the FirmwareAndArch and extra_deps
         let extra_deps = config.extra_deps;
@@ -883,7 +877,7 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
                         #original_name(#original_args).await
                     })
                 },
-                #requirements,
+                Some(#requirements),
                 #unstable,
             ).into(),
         };
@@ -898,13 +892,8 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
 }
 
 // Helper to build requirements TokenStream for firmware and resolved VMM
-fn build_requirements(
-    firmware: &Firmware,
-    name: &str,
-    resolved_vmm: Vmm,
-    requires_vpci: bool,
-) -> Option<TokenStream> {
-    let mut requirement_expr: Option<TokenStream> = None;
+fn build_requirements(firmware: &Firmware, resolved_vmm: Vmm, requires_vpci: bool) -> TokenStream {
+    let mut requirement_expr: TokenStream = quote!(::petri::requirements::TestRequirement::Any);
     let mut is_vbs = false;
     // Add isolation requirement if specified
     if let Firmware::OpenhclUefi(
@@ -929,44 +918,25 @@ fn build_requirements(
             )),
         };
 
-        requirement_expr = Some(isolation_requirement);
+        requirement_expr = quote!(#requirement_expr.and(#isolation_requirement));
     }
 
     let is_hyperv = resolved_vmm == Vmm::HyperV;
 
     if is_hyperv && is_vbs {
-        let hyperv_vbs_requirement_expr = quote!(
+        requirement_expr = quote!(#requirement_expr.and(
             ::petri::requirements::TestRequirement::ExecutionEnvironment(
                 ::petri::requirements::ExecutionEnvironment::Baremetal
             )
-        );
-        requirement_expr = match requirement_expr {
-            Some(existing) => Some(quote!(
-                ::petri::requirements::TestRequirement::And(
-                    Box::new(#existing),
-                    Box::new(#hyperv_vbs_requirement_expr)
-                )
-            )),
-            None => Some(hyperv_vbs_requirement_expr),
-        };
+        ));
     }
 
     if requires_vpci {
-        let vpci_expr = quote!(::petri::requirements::TestRequirement::VpciSupport);
-        requirement_expr = match requirement_expr {
-            Some(existing) => Some(quote!(
-                ::petri::requirements::TestRequirement::And(
-                    Box::new(#existing),
-                    Box::new(#vpci_expr)
-                )
-            )),
-            None => Some(vpci_expr),
-        };
+        requirement_expr =
+            quote!(#requirement_expr.and(::petri::requirements::TestRequirement::VpciSupport));
     }
 
-    if requirement_expr.is_some() {
-        Some(quote!(::petri::requirements::TestCaseRequirements::new(#requirement_expr)))
-    } else {
-        None
-    }
+    quote!(
+        ::petri::requirements::TestCaseRequirements::new(#requirement_expr)
+    )
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -207,15 +207,14 @@ async fn boot_single_proc<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyh
     Ok(())
 }
 
-#[cfg(windows)] // requires VPCI support, which is only on Windows right now
-#[vmm_test(
+#[vmm_test_with(vpci(
     // TODO: virt_whp is missing VPCI LPI interrupt support, used by Windows (but not Linux)
     // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // TODO: Linux image is missing VPCI driver in its initrd
     // openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     // openvmm_uefi_x64(vhd(ubuntu_2504_server_x64))
-)]
+))]
 async fn boot_nvme<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let (vm, agent) = config
         .with_boot_device_type(petri::BootDeviceType::Nvme)
@@ -227,15 +226,14 @@ async fn boot_nvme<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Res
 }
 
 /// Tests NVMe boot with OpenHCL VPCI relaying enabled.
-#[cfg(windows)] // requires VPCI support, which is only on Windows right now
-#[vmm_test(
+#[vmm_test_with(vpci(
     // TODO: aarch64 support (WHP missing ARM64 VTL2 support)
     // openvmm_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     // openvmm_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // TODO: Linux image is missing VPCI driver in its initrd
     // openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
-)]
+))]
 async fn boot_nvme_vpci_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let (vm, agent) = config
         .with_boot_device_type(petri::BootDeviceType::Nvme)


### PR DESCRIPTION
virt_mshv will soon support VPCI devices. This change prepares petri, making it easy to enable VPCI VMM tests on virt_mshv without enabling them on virt_kvm.

I don't know if this is actually the right approach--looking for feedback.