### PR TITLE
flowey: include repo names in gh-release-download cache keys

### DIFF
--- a/flowey/flowey_lib_common/src/download_gh_release.rs
+++ b/flowey/flowey_lib_common/src/download_gh_release.rs
@@ -159,8 +159,14 @@ impl Node {
             |_| Ok(std::env::current_dir()?.absolute()?)
         });
 
-        let request_set_hash = {
+        // Build a human-readable cache key from repo names and tags so
+        // that cache entries are identifiable in the CI cache UI.
+        // The hash ensures uniqueness; the descriptive prefix aids debugging.
+        let cache_key = {
+            use std::fmt::Write as _;
+
             let hasher = &mut rustc_hash::FxHasher::default();
+            let mut key = String::from("gh-release-download-");
             for ((repo_owner, repo_name, tag), files) in &download_reqs {
                 std::hash::Hash::hash(repo_owner, hasher);
                 std::hash::Hash::hash(repo_name, hasher);
@@ -168,12 +174,17 @@ impl Node {
                 for file in files.keys() {
                     std::hash::Hash::hash(&file, hasher);
                 }
+                write!(key, "{repo_name}-{tag}_").unwrap();
             }
             let hash = std::hash::Hasher::finish(hasher);
-            format!("{:08x?}", hash)
-        };
 
-        let cache_key = ReadVar::from_static(format!("gh-release-download-{request_set_hash}"));
+            // Actions cache keys are limited to 512 characters total, but
+            // subsequent machinery adds some more stuff to the key. Truncate
+            // generously.
+            key.truncate(256);
+            write!(key, "{:016x}", hash).unwrap();
+            ReadVar::from_static(key)
+        };
         let hitvar = ctx.reqv(|v| {
             crate::cache::Request {
                 label: "gh-release-download".into(),


### PR DESCRIPTION
The CI cache key for downloaded GitHub release artifacts was an opaque hash like `gh-release-download-c0fe86102c35d692`, which made it impossible to tell from the cache UI what each entry contained or why it was created. This made debugging cache bloat and eviction issues needlessly difficult.

Replace the opaque key with a human-readable one that includes the repo name and tag for each downloaded artifact, followed by the hash for uniqueness. A typical key now looks like
`gh-release-download-protobuf-27.1_openvmm-deps-0.1.0-20260401.1_<hash>`, making it immediately clear what versions are cached and which version bump orphaned a stale entry. The key is truncated to stay within the 512-character GitHub Actions limit.