### PR TITLE
nvme_driver: disable nvme keepalive (#3267)

### DIFF
--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -123,7 +123,7 @@ impl BootCommandLineOptions {
             confidential_debug: false,
             enable_vtl2_gpa_pool: Vtl2GpaPoolConfig::Heuristics(Vtl2GpaPoolLookupTable::Release), // use the release config by default
             sidecar: SidecarOptions::default(),
-            disable_nvme_keep_alive: false,
+            disable_nvme_keep_alive: true,
         }
     }
 }
@@ -131,6 +131,9 @@ impl BootCommandLineOptions {
 impl BootCommandLineOptions {
     /// Parse arguments from a command line.
     pub fn parse(&mut self, cmdline: &str) {
+        // Workaround for a host side issue: disable NVMe keepalive by default.
+        self.disable_nvme_keep_alive = true;
+
         let mut override_vtl2_gpa_pool: Option<Vtl2GpaPoolConfig> = None;
         for arg in cmdline.split_whitespace() {
             if arg.starts_with(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME) {
@@ -173,8 +176,8 @@ impl BootCommandLineOptions {
                 }
             } else if arg.starts_with(DISABLE_NVME_KEEP_ALIVE) {
                 let arg = arg.split_once('=').map(|(_, arg)| arg);
-                if arg.is_some_and(|a| a != "0") {
-                    self.disable_nvme_keep_alive = true;
+                if arg.is_some_and(|a| a == "0") {
+                    self.disable_nvme_keep_alive = false;
                 }
             }
         }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -148,7 +148,9 @@ async fn servicing_keepalive_no_device<T: PetriVmmBackend>(
 ) -> anyhow::Result<()> {
     let flags = config.default_servicing_flags();
     openhcl_servicing_core(
-        config.with_openhcl_command_line("OPENHCL_ENABLE_VTL2_GPA_POOL=512"),
+        config.with_openhcl_command_line(
+            "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
+        ),
         igvm_file,
         flags,
         DEFAULT_SERVICING_COUNT,
@@ -166,7 +168,9 @@ async fn servicing_keepalive_with_device<T: PetriVmmBackend>(
     let flags = config.default_servicing_flags();
     openhcl_servicing_core(
         config
-            .with_openhcl_command_line("OPENHCL_ENABLE_VTL2_GPA_POOL=512")
+            .with_openhcl_command_line(
+                "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
+            )
             .with_boot_device_type(petri::BootDeviceType::ScsiViaNvme)
             .with_vmbus_redirect(true), // Need this to attach the NVMe device
         igvm_file,
@@ -842,7 +846,9 @@ async fn create_keepalive_test_config(
 
     config
         .with_vmbus_redirect(true)
-        .with_openhcl_command_line("OPENHCL_ENABLE_VTL2_GPA_POOL=512")
+        .with_openhcl_command_line(
+            "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
+        )
         .modify_backend(move |b| {
             b.with_custom_config(|c| {
                 // Add a fault controller to test the nvme controller functionality

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -194,7 +194,7 @@ async fn nvme_relay_explicit_private_pool(
     nvme_relay_test_core(
         config,
         NvmeRelayTestParams {
-            openhcl_cmdline: "OPENHCL_ENABLE_VTL2_GPA_POOL=512",
+            openhcl_cmdline: "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
             expected_props: Some(ExpectedNvmeDeviceProperties {
                 save_restore_supported: true,
                 qsize: 256, // private pool should allow contiguous allocations.
@@ -219,7 +219,7 @@ async fn nvme_relay_heuristic_debug_16vp_768mb_heavy(
     nvme_relay_test_core(
         config,
         NvmeRelayTestParams {
-            openhcl_cmdline: "",
+            openhcl_cmdline: "OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
             processor_topology: Some(ProcessorTopology {
                 vp_count: 16,
                 ..Default::default()
@@ -250,7 +250,7 @@ async fn nvme_relay_heuristic_release_16vp_256mb_heavy(
     nvme_relay_test_core(
         config,
         NvmeRelayTestParams {
-            openhcl_cmdline: "",
+            openhcl_cmdline: "OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
             processor_topology: Some(ProcessorTopology {
                 vp_count: 16,
                 ..Default::default()
@@ -284,7 +284,7 @@ async fn nvme_relay_heuristic_release_32vp_500mb_very_heavy(
     nvme_relay_test_core(
         config,
         NvmeRelayTestParams {
-            openhcl_cmdline: "",
+            openhcl_cmdline: "OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
             processor_topology: Some(ProcessorTopology {
                 vp_count: 32,
                 ..Default::default()
@@ -317,7 +317,7 @@ async fn nvme_relay_32vp_768mb_very_heavy(
             ..Default::default()
         }),
         NvmeRelayTestParams {
-            openhcl_cmdline: "OPENHCL_ENABLE_VTL2_GPA_POOL=10240",
+            openhcl_cmdline: "OPENHCL_ENABLE_VTL2_GPA_POOL=10240 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
             processor_topology: Some(ProcessorTopology {
                 vp_count: 32,
                 ..Default::default()


### PR DESCRIPTION
While we have a workaround for host-side device behavior, this may
exacerbate another issue we are seeing in production.
So: disable to guarantee safety until this can be sorted out. ( :( )

(cherry picked from commit e84570e190f22cc8ed0508c7449b346c81da5fd3)
