### PR TITLE
setup-alpine.sh: switch Alpine setup to virtio-console (hvc0)

### DIFF
--- a/Guide/src/user_guide/openvmm/alpine.md
+++ b/Guide/src/user_guide/openvmm/alpine.md
@@ -36,9 +36,9 @@ the VM to other hosts.
    The script uses Python to find and decompress the gzip-embedded ELF.
 5. **Creates a cloud-init data disk** (`cidata.img`), a small FAT image
    labeled `cidata` containing `user-data` and `meta-data` files. Alpine's
-   `tiny-cloud` service reads these on first boot. The `user-data` uses a
-   `runcmd` to set the root password (tiny-cloud does not support the
-   `passwd` field directly).
+   `tiny-cloud` service reads these on first boot. The `user-data` uses
+   `runcmd` to set the root password and add a getty on `hvc0` (Alpine does
+   not spawn one by default).
 
 ### Required host tools
 
@@ -51,16 +51,23 @@ the VM to other hosts.
 - **`--pcie-root-complex` and `--pcie-root-port`**: Required for PCI device
   visibility. The default direct boot DSDT does not include a PCI bus, so
   without these flags, virtio devices will not be detected by the kernel.
-- **`--virtio-blk ...,pcie_port=rp0`**: Attaches the raw disk image as a
+- **`--virtio-blk ...,pcie_port=disk`**: Attaches the raw disk image as a
   virtio-blk device on a PCIe root port.
-- **`--virtio-blk ...,ro,pcie_port=rp1`**: Attaches the cloud-init data
+- **`--virtio-blk ...,ro,pcie_port=cidata`**: Attaches the cloud-init data
   image read-only on a second PCIe root port.
-- **`--virtio-net pcie_port=rp2:consomme`**: Adds a virtio-net NIC using
+- **`--virtio-net pcie_port=net:consomme`**: Adds a virtio-net NIC using
   the consomme user-mode NAT backend, on a third PCIe root port.
+- **`--com1 none`**: Disables the default COM1 serial port (which would
+  otherwise claim the console).
+- **`--virtio-console console --virtio-console-pcie-port console`**: Adds a
+  virtio-console device (`/dev/hvc0` in the guest) on a fourth PCIe root
+  port. This replaces COM1 as the interactive console.
 - **`root=/dev/vda2`**: The root filesystem is on partition 2 of the virtio
   disk.
 - **`modules=virtio_pci,virtio_blk,ext4`**: Tells the Alpine initramfs to
   load these modules early, before attempting to mount the root filesystem.
+- **`console=hvc0`**: Directs the kernel to use the virtio-console
+  (`/dev/hvc0`) for console output instead of the legacy serial port.
 
 ```admonish tip
 Use `ctrl-q` then `q` to quit OpenVMM (not `ctrl-c`).

--- a/scripts/setup-alpine.sh
+++ b/scripts/setup-alpine.sh
@@ -109,6 +109,8 @@ cat > user-data <<'USERDATA'
 #cloud-config
 runcmd:
   - echo 'root:alpine' | chpasswd
+  - grep -q hvc0 /etc/inittab || echo 'hvc0::respawn:/sbin/getty 115200 hvc0' >> /etc/inittab
+  - kill -HUP 1
 USERDATA
 
 cat > meta-data <<'METADATA'
@@ -141,12 +143,15 @@ To boot with OpenVMM (from the openvmm repo root):
     -k ${ABSDIR}/vmlinux-virt \\
     -r ${ABSDIR}/initramfs-virt \\
     --pcie-root-complex rc0,segment=0,start_bus=0,end_bus=255,low_mmio=4M,high_mmio=1G \\
-    --pcie-root-port rc0:rp0 \\
-    --pcie-root-port rc0:rp1 \\
-    --pcie-root-port rc0:rp2 \\
-    --virtio-blk file:${ABSDIR}/disk.raw,pcie_port=rp0 \\
-    --virtio-blk file:${ABSDIR}/cidata.img,ro,pcie_port=rp1 \\
-    --virtio-net pcie_port=rp2:consomme \\
+    --pcie-root-port rc0:disk \\
+    --pcie-root-port rc0:cidata \\
+    --pcie-root-port rc0:net \\
+    --pcie-root-port rc0:console \\
+    --virtio-blk file:${ABSDIR}/disk.raw,pcie_port=disk \\
+    --virtio-blk file:${ABSDIR}/cidata.img,ro,pcie_port=cidata \\
+    --virtio-net pcie_port=net:consomme \\
+    --com1 none \\
+    --virtio-console console --virtio-console-pcie-port console \\
     -c "root=/dev/vda2 rootfstype=ext4 modules=virtio_pci,virtio_blk,ext4" \\
     -m 512M \\
     -p 2 \\


### PR DESCRIPTION
The default COM1 serial console works but virtio-console is much faster.

This changes the Alpine setup script and guide to disable COM1 and instead attach a virtio-console device, directing the kernel console to /dev/hvc0. The cloud-init user-data now also adds a getty on hvc0 so there is a login prompt on the virtio console after boot. The PCIe root port names are switched from generic "rp0/rp1/rp2" to descriptive names ("disk", "cidata", "net", "console") to make the boot command easier to read.