### PR TITLE
vmm-tests-run: use lazy disks by default, add copilot files to use it

### DIFF
--- a/.github/instructions/vmm-tests.instructions.md
+++ b/.github/instructions/vmm-tests.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "vmm_tests/**,petri/**"
+---
+
+# Running VMM Tests
+
+VMM tests are **not** regular unit tests. Do NOT run them with
+`cargo nextest run -p vmm_tests` or `cargo test -p vmm_tests` — they require
+external artifacts (disk images, firmware, OpenHCL binaries) that won't be
+present, causing confusing failures.
+
+Use `cargo xflowey vmm-tests-run` instead. It automatically discovers
+artifacts, builds dependencies, and runs tests in a single command:
+
+```bash
+cargo xflowey vmm-tests-run --filter "test(my_test_name)" --dir /tmp/vmm-tests-run
+```
+
+To learn the full workflow (filter syntax, cross-compilation, logging, common
+pitfalls), load the `vmm-tests` skill.

--- a/.github/skills/openvmm-ci-investigation/SKILL.md
+++ b/.github/skills/openvmm-ci-investigation/SKILL.md
@@ -39,6 +39,17 @@ Read the script's output to identify:
 
 Then use the information to diagnose the issue and suggest fixes.
 
+## Step 3: Reproduce Locally (VMM Test Failures)
+
+If the failure is a VMM test, check whether the failing platform matches
+your host architecture — you can only reproduce tests locally on the same
+arch. If it doesn't match, diagnose from CI logs and test code alone.
+
+To reproduce locally, load the `vmm-tests` skill for instructions on
+running with `cargo xflowey vmm-tests-run`. Do **not** use
+`cargo nextest run -p vmm_tests` directly — it won't have the required
+artifacts.
+
 ## Reference: Manual Commands
 
 > **Only use these if the script fails or you need to dig deeper into a

--- a/.github/skills/openvmm-ci-investigation/SKILL.md
+++ b/.github/skills/openvmm-ci-investigation/SKILL.md
@@ -39,11 +39,23 @@ Read the script's output to identify:
 
 Then use the information to diagnose the issue and suggest fixes.
 
-## Step 3: Reproduce Locally (VMM Test Failures)
+## Step 3: Diagnose from Logs and Code
 
-If the failure is a VMM test, check whether the failing platform matches
-your host architecture — you can only reproduce tests locally on the same
-arch. If it doesn't match, diagnose from CI logs and test code alone.
+**Always try to diagnose the failure from CI logs, test code, and error
+messages first.** Most failures can be understood without local reproduction.
+Read the relevant test source, trace the error through the code, and form
+a hypothesis before considering local repro.
+
+## Step 4: Reproduce Locally (Only If Needed)
+
+If you cannot diagnose the failure from logs alone, **ask the user** whether
+they want to attempt local reproduction before proceeding. Do not
+automatically start building or running tests on the user's machine.
+
+If the user agrees, check whether the failing platform matches the host
+architecture — you can only reproduce tests locally on the same arch. If
+it doesn't match, explain this to the user and continue diagnosing from
+CI logs and test code.
 
 To reproduce locally, load the `vmm-tests` skill for instructions on
 running with `cargo xflowey vmm-tests-run`. Do **not** use

--- a/.github/skills/vmm-tests/SKILL.md
+++ b/.github/skills/vmm-tests/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: vmm-tests
-description: "Run VMM tests locally with cargo xflowey vmm-tests-run. Load when writing, running, or debugging VMM tests, or when you need to understand the petri test framework, artifact handling, or cross-compilation for VMM tests."
+description: "Run VMM tests locally with cargo xflowey vmm-tests-run. Load when running or debugging VMM tests, or when you need to understand the petri test framework, artifact handling, or cross-compilation for VMM tests."
 ---
 
 # Running VMM Tests
 
 VMM tests boot full virtual machines and validate behavior. They live in
-`vmm_tests/vmm_tests/tests/` and use the `petri` test framework.
+`vmm_tests/vmm_tests/tests/tests/` and use the `petri` test framework.
 
 **Always use `cargo xflowey vmm-tests-run`** — never raw `cargo nextest run -p
 vmm_tests`. The xflowey command handles artifact discovery, dependency
@@ -26,6 +26,8 @@ cargo xflowey vmm-tests-run --filter "all()" --dir /tmp/vmm-tests-run
 ```
 
 The `--dir` flag is **required** and specifies where build artifacts go.
+**Always ask the user** which directory to use for `--dir` — do not guess
+or pick a default. Storage requirements vary and the user knows their setup.
 
 ## Filter Syntax
 
@@ -90,42 +92,6 @@ OPENVMM_LOG=trace cargo xflowey vmm-tests-run --filter "test(foo)" --dir /tmp/vm
 | `--custom-kernel <PATH>` | Use a custom kernel image |
 
 Run `cargo xflowey vmm-tests-run --help` for the full option list.
-
-## Writing VMM Tests
-
-Tests use the `petri` framework with the `#[vmm_test]` macro for
-parameterized test generation. Start by reading:
-
-- Existing tests: `vmm_tests/vmm_tests/tests/tests/multiarch.rs`
-- `petri` rustdoc: `cargo doc -p petri --open`
-
-### Test weight annotations
-
-Put these words in your test name to control resource allocation:
-
-- `heavy` — test needs more resources (e.g., 16 VPs)
-- `very_heavy` — even more resources (e.g., 32 VPs)
-
-### Unstable tests
-
-If a test isn't reliable enough to gate PRs, mark individual variants
-or the whole test as `unstable`:
-
-```rust,ignore
-#[vmm_test(
-    unstable_hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
-    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-)]
-async fn my_test<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
-    // ...
-}
-```
-
-Unstable tests run in CI but don't gate PRs. To promote to stable, remove
-`unstable` from the macro — no CI config changes needed.
-
-To treat unstable failures as errors locally:
-`PETRI_REPORT_UNSTABLE_FAIL=1`
 
 ## Common Pitfalls
 

--- a/.github/skills/vmm-tests/SKILL.md
+++ b/.github/skills/vmm-tests/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: vmm-tests
+description: "Run VMM tests locally with cargo xflowey vmm-tests-run. Load when writing, running, or debugging VMM tests, or when you need to understand the petri test framework, artifact handling, or cross-compilation for VMM tests."
+---
+
+# Running VMM Tests
+
+VMM tests boot full virtual machines and validate behavior. They live in
+`vmm_tests/vmm_tests/tests/` and use the `petri` test framework.
+
+**Always use `cargo xflowey vmm-tests-run`** — never raw `cargo nextest run -p
+vmm_tests`. The xflowey command handles artifact discovery, dependency
+building, and test execution automatically.
+
+## Quick Start
+
+```bash
+# Run a specific test
+cargo xflowey vmm-tests-run --filter "test(my_test_name)" --dir /tmp/vmm-tests-run
+
+# Run all tests matching a prefix
+cargo xflowey vmm-tests-run --filter "test(/^boot_/)" --dir /tmp/vmm-tests-run
+
+# Run all tests (rarely needed locally)
+cargo xflowey vmm-tests-run --filter "all()" --dir /tmp/vmm-tests-run
+```
+
+The `--dir` flag is **required** and specifies where build artifacts go.
+
+## Filter Syntax
+
+Filters use [nextest filter expressions](https://nexte.st/docs/filtersets/):
+
+| Expression | Matches |
+|-----------|---------|
+| `test(foo)` | Tests with `foo` in the name |
+| `test(/^boot_/)` | Tests starting with `boot_` (regex) |
+| `test(foo) & !test(hyperv)` | `foo` tests excluding Hyper-V variants |
+| `all()` | Everything |
+
+## Platform Targeting
+
+By default, tests build for the current host. Use `--target` for
+cross-compilation:
+
+```bash
+# Cross-compile and run Windows tests from WSL2
+cargo xflowey vmm-tests-run --target windows-x64 --dir /mnt/d/vmm_tests
+```
+
+| Target | Description |
+|--------|-------------|
+| `windows-x64` | Windows x86_64 (Hyper-V / WHP) |
+| `windows-aarch64` | Windows ARM64 (Hyper-V / WHP) |
+| `linux-x64` | Linux x86_64 |
+
+**Windows from WSL2**: The output directory **must** be on the Windows
+filesystem (e.g., `/mnt/d/...`). Cross-compilation setup is required first —
+see `Guide/src/dev_guide/getting_started/cross_compile.md`.
+
+## Artifact Handling (Lazy Fetch)
+
+By default, disk images (VHDs/ISOs) are streamed on demand via HTTP with local
+SQLite caching. This avoids multi-GB upfront downloads.
+
+- `--no-lazy-fetch` — download all images upfront instead of streaming
+- Lazy fetch is automatically disabled for Hyper-V tests (they need local files)
+- `--skip-vhd-prompt` — skip interactive VHD download prompts (useful for
+  automation)
+
+## Viewing Logs
+
+```bash
+# Show test output (petri logs, guest serial, etc.)
+cargo xflowey vmm-tests-run --filter "test(foo)" --dir /tmp/vmm-tests-run -- --no-capture
+
+# Full OpenVMM trace output
+OPENVMM_LOG=trace cargo xflowey vmm-tests-run --filter "test(foo)" --dir /tmp/vmm-tests-run -- --no-capture
+```
+
+## Other Useful Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--release` | Release build (default: debug) |
+| `--build-only` | Build without running |
+| `--verbose` | Verbose cargo output |
+| `--install-missing-deps` | Auto-install missing system dependencies |
+| `--custom-uefi-firmware <PATH>` | Use a custom UEFI firmware (MSVM.fd) |
+| `--custom-kernel <PATH>` | Use a custom kernel image |
+
+Run `cargo xflowey vmm-tests-run --help` for the full option list.
+
+## Writing VMM Tests
+
+Tests use the `petri` framework with the `#[vmm_test]` macro for
+parameterized test generation. Start by reading:
+
+- Existing tests: `vmm_tests/vmm_tests/tests/tests/multiarch.rs`
+- `petri` rustdoc: `cargo doc -p petri --open`
+
+### Test weight annotations
+
+Put these words in your test name to control resource allocation:
+
+- `heavy` — test needs more resources (e.g., 16 VPs)
+- `very_heavy` — even more resources (e.g., 32 VPs)
+
+### Unstable tests
+
+If a test isn't reliable enough to gate PRs, mark individual variants
+or the whole test as `unstable`:
+
+```rust,ignore
+#[vmm_test(
+    unstable_hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+)]
+async fn my_test<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
+    // ...
+}
+```
+
+Unstable tests run in CI but don't gate PRs. To promote to stable, remove
+`unstable` from the macro — no CI config changes needed.
+
+To treat unstable failures as errors locally:
+`PETRI_REPORT_UNSTABLE_FAIL=1`
+
+## Common Pitfalls
+
+- **Don't use `cargo nextest run -p vmm_tests` directly** — artifacts won't
+  be present and tests will fail with missing-artifact errors.
+- **Windows output dir from WSL** — must be on `/mnt/c/` or `/mnt/d/`, not
+  in the WSL filesystem.
+- **Hyper-V tests** — require Hyper-V Administrators group membership and
+  disable lazy fetch automatically.
+- **CI failures** — use the `openvmm-ci-investigation` skill to diagnose
+  failing VMM tests in CI, not this workflow.

--- a/Guide/src/dev_guide/tests/vmm.md
+++ b/Guide/src/dev_guide/tests/vmm.md
@@ -123,6 +123,19 @@ Hyper-V Administrators group.
 
 To see all available options: `cargo xflowey vmm-tests-run --help`.
 
+### Lazy Fetch (Default)
+
+By default, VHD/ISO disk images are streamed on demand via HTTP and cached
+locally in a SQLite database. This avoids multi-GB upfront downloads and
+significantly speeds up the dev inner loop once the cache is warm.
+
+Lazy fetch is automatically disabled for Hyper-V tests, which require local
+files. To force all images to be downloaded upfront, pass `--no-lazy-fetch`:
+
+```bash
+cargo xflowey vmm-tests-run --filter "test(my_test)" --dir /tmp/vmm-tests-run --no-lazy-fetch
+```
+
 ## Running VMM Tests (Manual)
 
 ```admonish tip

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -70,6 +70,14 @@ pub struct VmmTestsRunCli {
     #[clap(long)]
     skip_vhd_prompt: bool,
 
+    /// Download all disk images upfront instead of streaming on demand.
+    ///
+    /// By default, VHD/ISO disk images are streamed on demand via HTTP
+    /// and cached locally, avoiding large upfront downloads. Use this
+    /// flag to force all images to be downloaded before tests run.
+    #[clap(long)]
+    no_lazy_fetch: bool,
+
     /// Optional: custom kernel modules
     #[clap(long)]
     custom_kernel_modules: Option<PathBuf>,
@@ -99,6 +107,7 @@ impl IntoPipeline for VmmTestsRunCli {
             build_only,
             copy_extras,
             skip_vhd_prompt,
+            no_lazy_fetch,
             custom_kernel_modules,
             custom_kernel,
             custom_uefi_firmware,
@@ -117,11 +126,12 @@ impl IntoPipeline for VmmTestsRunCli {
         // 3. Run artifact discovery inline at pipeline construction time
         log::info!("Step 1: Discovering required artifacts...");
         let repo_root = crate::repo_root();
-        let artifacts_json = discover_artifacts(&repo_root, &target_str, &filter, release)
-            .context("during artifact discovery")?;
+        let (artifacts_json, test_names) =
+            discover_artifacts(&repo_root, &target_str, &filter, release)
+                .context("during artifact discovery")?;
 
         // 4. Resolve to build selections
-        let resolved = ResolvedArtifactSelections::from_artifact_list_json(
+        let mut resolved = ResolvedArtifactSelections::from_artifact_list_json(
             &artifacts_json,
             target_architecture,
             target_os,
@@ -135,6 +145,33 @@ impl IntoPipeline for VmmTestsRunCli {
             );
         }
 
+        // 5. Determine lazy fetch mode.
+        //
+        // By default, VHD/ISO downloads are skipped and disk images are
+        // streamed on demand via HTTP (with local SQLite caching). This
+        // avoids multi-GB upfront downloads for dev-inner-loop scenarios.
+        //
+        // Lazy fetch is disabled when:
+        //   - The user passes --no-lazy-fetch
+        //   - Any Hyper-V test is selected (Hyper-V requires local files)
+        let lazy_fetch = if no_lazy_fetch {
+            log::info!("Lazy fetch disabled by --no-lazy-fetch");
+            false
+        } else {
+            let has_hyperv_tests = test_names.iter().any(|name| name.contains("hyperv_"));
+            if has_hyperv_tests {
+                log::info!("Hyper-V tests detected in selection, downloading disk images upfront");
+                false
+            } else {
+                true
+            }
+        };
+
+        if lazy_fetch {
+            log::info!("Lazy fetch enabled: disk images will be streamed on demand via HTTP");
+            resolved.downloads.clear();
+        }
+
         log::info!("Resolved build selections: {:?}", resolved.build);
         log::info!(
             "Resolved downloads: {:?}",
@@ -143,7 +180,7 @@ impl IntoPipeline for VmmTestsRunCli {
 
         let selections = selections_from_resolved(filter, resolved, target_os);
 
-        // 5. Construct and return the pipeline
+        // 6. Construct and return the pipeline
         log::info!("Step 2: Building and running tests...");
         build_vmm_tests_pipeline(
             backend_hint,
@@ -169,13 +206,14 @@ impl IntoPipeline for VmmTestsRunCli {
 /// Run artifact discovery by invoking `cargo nextest list` and the test
 /// binary's `--list-required-artifacts` flag.
 ///
-/// Returns the raw JSON string describing required/optional artifacts.
+/// Returns the raw JSON string describing required/optional artifacts, plus
+/// the list of matching test names (used for backend detection).
 fn discover_artifacts(
     repo_root: &Path,
     target: &str,
     filter: &str,
     release: bool,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<(String, Vec<String>)> {
     // Check that cargo-nextest is available
     let nextest_check = Command::new("cargo")
         .args(["nextest", "--version"])
@@ -228,7 +266,7 @@ fn discover_artifacts(
             "required": [],
             "optional": []
         });
-        return Ok(serde_json::to_string_pretty(&empty_output)?);
+        return Ok((serde_json::to_string_pretty(&empty_output)?, Vec::new()));
     }
 
     log::info!("Found {} matching tests", test_names.len());
@@ -269,7 +307,8 @@ fn discover_artifacts(
     let artifact_stdout = String::from_utf8(artifact_output.stdout)
         .map_err(|e| anyhow::anyhow!("test output is not valid UTF-8: {}", e))?;
 
-    parse_artifacts_output(&artifact_stdout, target)
+    let json = parse_artifacts_output(&artifact_stdout, target)?;
+    Ok((json, test_names))
 }
 
 /// Parse `cargo nextest list --message-format json` output to extract test

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -126,7 +126,7 @@ impl IntoPipeline for VmmTestsRunCli {
         // 3. Run artifact discovery inline at pipeline construction time
         log::info!("Step 1: Discovering required artifacts...");
         let repo_root = crate::repo_root();
-        let (artifacts_json, test_names) =
+        let (artifacts_json, test_names, test_binary) =
             discover_artifacts(&repo_root, &target_str, &filter, release)
                 .context("during artifact discovery")?;
 
@@ -154,22 +154,40 @@ impl IntoPipeline for VmmTestsRunCli {
         // Lazy fetch is disabled when:
         //   - The user passes --no-lazy-fetch
         //   - Any Hyper-V test is selected (Hyper-V requires local files)
-        let lazy_fetch = if no_lazy_fetch {
+        //
+        // When both Hyper-V and non-Hyper-V tests are selected, only the
+        // artifacts required by Hyper-V tests are downloaded upfront; the
+        // rest are lazy-fetched.
+        if no_lazy_fetch {
             log::info!("Lazy fetch disabled by --no-lazy-fetch");
-            false
         } else {
-            let has_hyperv_tests = test_names.iter().any(|name| name.contains("hyperv_"));
-            if has_hyperv_tests {
-                log::info!("Hyper-V tests detected in selection, downloading disk images upfront");
-                false
-            } else {
-                true
-            }
-        };
+            let hyperv_names: Vec<_> = test_names
+                .iter()
+                .filter(|name| name.contains("hyperv_"))
+                .cloned()
+                .collect();
 
-        if lazy_fetch {
-            log::info!("Lazy fetch enabled: disk images will be streamed on demand via HTTP");
-            resolved.downloads.clear();
+            if hyperv_names.is_empty() {
+                log::info!("Lazy fetch enabled: disk images will be streamed on demand via HTTP");
+                resolved.downloads.clear();
+            } else if hyperv_names.len() == test_names.len() {
+                log::info!("All selected tests are Hyper-V tests, downloading disk images upfront");
+            } else {
+                log::info!(
+                    "Mixed selection: downloading only disk images required by {} Hyper-V tests",
+                    hyperv_names.len()
+                );
+                let hyperv_json =
+                    query_test_binary_artifacts(&test_binary, &hyperv_names, &target_str)
+                        .context("during Hyper-V artifact discovery")?;
+                let hyperv_resolved = ResolvedArtifactSelections::from_artifact_list_json(
+                    &hyperv_json,
+                    target_architecture,
+                    target_os,
+                )
+                .context("failed to parse Hyper-V artifacts")?;
+                resolved.downloads = hyperv_resolved.downloads;
+            }
         }
 
         log::info!("Resolved build selections: {:?}", resolved.build);
@@ -206,14 +224,15 @@ impl IntoPipeline for VmmTestsRunCli {
 /// Run artifact discovery by invoking `cargo nextest list` and the test
 /// binary's `--list-required-artifacts` flag.
 ///
-/// Returns the raw JSON string describing required/optional artifacts, plus
-/// the list of matching test names (used for backend detection).
+/// Returns the raw JSON string describing required/optional artifacts, the
+/// list of matching test names (used for backend detection), and the path
+/// to the test binary (for follow-up queries).
 fn discover_artifacts(
     repo_root: &Path,
     target: &str,
     filter: &str,
     release: bool,
-) -> anyhow::Result<(String, Vec<String>)> {
+) -> anyhow::Result<(String, Vec<String>, PathBuf)> {
     // Check that cargo-nextest is available
     let nextest_check = Command::new("cargo")
         .args(["nextest", "--version"])
@@ -266,7 +285,11 @@ fn discover_artifacts(
             "required": [],
             "optional": []
         });
-        return Ok((serde_json::to_string_pretty(&empty_output)?, Vec::new()));
+        return Ok((
+            serde_json::to_string_pretty(&empty_output)?,
+            Vec::new(),
+            test_binary,
+        ));
     }
 
     log::info!("Found {} matching tests", test_names.len());
@@ -275,13 +298,26 @@ fn discover_artifacts(
     }
 
     // Step 2: Query petri for artifacts of each matching test
+    let json = query_test_binary_artifacts(&test_binary, &test_names, target)?;
+    Ok((json, test_names, test_binary))
+}
+
+/// Query the test binary for required artifacts given a list of test names.
+///
+/// This invokes the binary with `--list-required-artifacts --tests-from-stdin`
+/// and returns the parsed JSON output.
+fn query_test_binary_artifacts(
+    test_binary: &Path,
+    test_names: &[String],
+    target: &str,
+) -> anyhow::Result<String> {
     log::info!("Using test binary: {}", test_binary.display());
     log::info!("Querying artifacts for {} tests", test_names.len());
     let stdin_data = test_names
         .iter()
         .map(|n| format!("{n}\n"))
         .collect::<String>();
-    let mut child = Command::new(&test_binary)
+    let mut child = Command::new(test_binary)
         .args(["--list-required-artifacts", "--tests-from-stdin"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -307,8 +343,7 @@ fn discover_artifacts(
     let artifact_stdout = String::from_utf8(artifact_output.stdout)
         .map_err(|e| anyhow::anyhow!("test output is not valid UTF-8: {}", e))?;
 
-    let json = parse_artifacts_output(&artifact_stdout, target)?;
-    Ok((json, test_names))
+    parse_artifacts_output(&artifact_stdout, target)
 }
 
 /// Parse `cargo nextest list --message-format json` output to extract test

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -253,6 +253,7 @@ fn discover_artifacts(
     // Step 1: Use nextest to resolve the filter expression to test names and
     // get the binary path
     let mut cmd = Command::new("cargo");
+    cmd.stderr(Stdio::inherit());
     cmd.current_dir(repo_root).args([
         "nextest",
         "list",
@@ -271,8 +272,7 @@ fn discover_artifacts(
     let nextest_output = cmd.output().context("failed to run cargo nextest list")?;
     anyhow::ensure!(
         nextest_output.status.success(),
-        "cargo nextest list failed: {}",
-        String::from_utf8_lossy(&nextest_output.stderr)
+        "cargo nextest list failed",
     );
     let nextest_stdout = String::from_utf8(nextest_output.stdout)
         .map_err(|e| anyhow::anyhow!("nextest output is not valid UTF-8: {}", e))?;

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -170,11 +170,9 @@ impl IntoPipeline for VmmTestsRunCli {
             if hyperv_names.is_empty() {
                 log::info!("Lazy fetch enabled: disk images will be streamed on demand via HTTP");
                 resolved.downloads.clear();
-            } else if hyperv_names.len() == test_names.len() {
-                log::info!("All selected tests are Hyper-V tests, downloading disk images upfront");
             } else {
                 log::info!(
-                    "Mixed selection: downloading only disk images required by {} Hyper-V tests",
+                    "Downloading disk images required by {} Hyper-V tests",
                     hyperv_names.len()
                 );
                 let hyperv_json =
@@ -270,10 +268,7 @@ fn discover_artifacts(
         cmd.arg("--release");
     }
     let nextest_output = cmd.output().context("failed to run cargo nextest list")?;
-    anyhow::ensure!(
-        nextest_output.status.success(),
-        "cargo nextest list failed",
-    );
+    anyhow::ensure!(nextest_output.status.success(), "cargo nextest list failed",);
     let nextest_stdout = String::from_utf8(nextest_output.stdout)
         .map_err(|e| anyhow::anyhow!("nextest output is not valid UTF-8: {}", e))?;
     let (test_binary, test_names) = parse_nextest_output(&nextest_stdout)?;
@@ -305,7 +300,8 @@ fn discover_artifacts(
 /// Query the test binary for required artifacts given a list of test names.
 ///
 /// This invokes the binary with `--list-required-artifacts --tests-from-stdin`
-/// and returns the parsed JSON output.
+/// and returns the resulting JSON as a string after processing it to inject
+/// the `target` field.
 fn query_test_binary_artifacts(
     test_binary: &Path,
     test_names: &[String],


### PR DESCRIPTION
Have vmm-tests-run use lazy disks by default, which significantly speeds up test execution for large images. Once the cache is warm, tests execute pretty fast (for example, a windows test takes ~120 seconds on first boot, and ~20 seconds on subsequent boots). 

Additionally, add copilot instructions and skills to use vmm-tests-run when investigating vmm-tests or ci failures. 