### PR TITLE
virt_mshv: implement save/restore and reset support

### DIFF
--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -418,6 +418,7 @@ impl ProtoPartition for MshvProtoPartition<'_> {
         // Attach all the resources created above to a Partition object.
         let inner = Arc::new(MshvPartitionInner {
             vmfd: self.vmfd,
+            bsp_vcpufd: self.bsp,
             memory: Default::default(),
             gm: config.guest_memory.clone(),
             vps: self.vps,
@@ -434,7 +435,6 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             inner,
         };
 
-        let mut bsp = Some(self.bsp);
         let vps = self
             .config
             .processor_topology
@@ -442,7 +442,7 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             .map(|vp| MshvProcessorBinder {
                 partition: partition.inner.clone(),
                 vpindex: vp.vp_index,
-                vcpufd: bsp.take(),
+                vcpufd: None,
             })
             .collect();
 
@@ -462,6 +462,10 @@ pub struct MshvPartition {
 struct MshvPartitionInner {
     #[inspect(skip)]
     vmfd: VmFd,
+    /// The BSP's VcpuFd, retained for partition-level register access
+    /// (VM state get/set). Only used while VPs are stopped.
+    #[inspect(skip)]
+    bsp_vcpufd: VcpuFd,
     #[inspect(skip)]
     memory: Mutex<MshvMemoryRangeState>,
     gm: GuestMemory,
@@ -496,7 +500,7 @@ impl Drop for MshvVpInnerCleaner<'_> {
 
 impl virt::Partition for MshvPartition {
     fn supports_reset(&self) -> Option<&dyn virt::ResetPartition<Error = Error>> {
-        None
+        Some(self)
     }
 
     fn doorbell_registration(
@@ -546,6 +550,28 @@ impl virt::X86Partition for MshvPartition {
     fn pulse_lint(&self, vp_index: VpIndex, vtl: Vtl, lint: u8) {
         // TODO
         tracelimit::warn_ratelimited!(?vp_index, ?vtl, lint, "ignored lint pulse");
+    }
+}
+
+impl virt::ResetPartition for MshvPartition {
+    type Error = Error;
+
+    fn reset(&self) -> Result<(), Error> {
+        use virt::x86::vm::AccessVmState;
+
+        // Reset IRQ routing table to the initial state (all routes cleared).
+        for irq in 0..virt::irqcon::IRQ_LINES as u8 {
+            self.inner.irq_routes.set_irq_route(irq, None);
+        }
+
+        // Reset VM-level HV registers (GuestOsId, Hypercall, ReferenceTsc)
+        // via the BSP's VcpuFd. VPs must be stopped when this is called.
+        let bsp_vp_info = &self.inner.vps[0].vp_info;
+        self.access_state(Vtl::Vtl0)
+            .reset_all(bsp_vp_info)
+            .map_err(|e| Error::ResetState(Box::new(e)))?;
+
+        Ok(())
     }
 }
 
@@ -670,16 +696,21 @@ impl virt::BindProcessor for MshvProcessorBinder {
     fn bind(&mut self) -> Result<Self::Processor<'_>, Self::Error> {
         let inner = &self.partition.vps[self.vpindex.index() as usize];
 
-        if self.vcpufd.is_none() {
-            let vcpufd = self
-                .partition
-                .vmfd
-                .create_vcpu(u8::try_from(self.vpindex.index()).expect("validated above"))
-                .map_err(Error::CreateVcpu)?;
-            self.vcpufd = Some(vcpufd);
+        // The BSP's VcpuFd lives in the partition (for VM-level state
+        // access). Other VPs create their fd lazily here.
+        let vcpufd = if self.vpindex.is_bsp() {
+            &self.partition.bsp_vcpufd
+        } else {
+            if self.vcpufd.is_none() {
+                let vcpufd = self
+                    .partition
+                    .vmfd
+                    .create_vcpu(u8::try_from(self.vpindex.index()).expect("validated above"))
+                    .map_err(Error::CreateVcpu)?;
+                self.vcpufd = Some(vcpufd);
+            }
+            self.vcpufd.as_ref().unwrap()
         };
-
-        let vcpufd = self.vcpufd.as_ref().unwrap();
 
         let reg_page_ptr = vcpufd
             .get_vp_reg_page()
@@ -1123,6 +1154,10 @@ pub enum Error {
     SetPartitionProperty(#[source] anyhow::Error),
     #[error("register access error")]
     Register(#[source] MshvError),
+    #[error("failed to get/set VP state")]
+    VpState(#[source] MshvError),
+    #[error("failed to reset state")]
+    ResetState(#[source] Box<virt::state::StateError<Self>>),
     #[error("install instercept failed")]
     InstallIntercept(#[source] MshvError),
     #[error("failed to register cpuid override")]
@@ -1540,6 +1575,25 @@ impl virt::Processor for MshvProcessor<'_> {
     fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
         assert_eq!(vtl, Vtl::Vtl0);
         self
+    }
+
+    fn reset(&mut self) -> Result<(), impl std::error::Error + Send + Sync + 'static> {
+        use virt::x86::vp::AccessVpState;
+
+        // Reset all VP state elements to their initial values.
+        let vp_info = self.inner.vp_info;
+        self.access_state(Vtl::Vtl0)
+            .reset_all(&vp_info)
+            .map_err(|e| Error::ResetState(Box::new(e)))?;
+
+        // Clear VMM-side message queues.
+        self.inner.message_queues.clear();
+
+        // Reset deliverability notifications.
+        *self.inner.deliverability_notifications.lock() =
+            HvDeliverabilityNotificationsRegister::new();
+
+        Ok::<(), Error>(())
     }
 }
 

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -1150,6 +1150,8 @@ pub enum Error {
     AvailableCheck(#[source] io::Error),
     #[error("failed to open /dev/mshv")]
     OpenMshv(#[source] MshvError),
+    #[error("failed to get partition property")]
+    GetPartitionProperty(#[source] anyhow::Error),
     #[error("failed to set partition property")]
     SetPartitionProperty(#[source] anyhow::Error),
     #[error("register access error")]

--- a/vmm_core/virt_mshv/src/vm_state.rs
+++ b/vmm_core/virt_mshv/src/vm_state.rs
@@ -83,7 +83,7 @@ impl AccessVmState for &'_ MshvPartition {
             .inner
             .vmfd
             .get_partition_property(hv_partition_property_code_HV_PARTITION_PROPERTY_REFERENCE_TIME)
-            .map_err(|e| Error::SetPartitionProperty(e.into()))?;
+            .map_err(|e| Error::GetPartitionProperty(e.into()))?;
         Ok(vm::ReferenceTime { value: ref_time })
     }
 

--- a/vmm_core/virt_mshv/src/vm_state.rs
+++ b/vmm_core/virt_mshv/src/vm_state.rs
@@ -1,10 +1,63 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! VM-level state access for mshv.
+//!
+//! VM-level HV registers (GuestOsId, Hypercall, ReferenceTsc) are accessed
+//! via the VP register interface using the BSP's VcpuFd, which is retained
+//! in `MshvPartitionInner`. These accessors must only be called while VPs
+//! are stopped (e.g., during reset or save/restore).
+
 use super::Error;
+use super::VcpuFdExt;
 use crate::MshvPartition;
+use hvdef::HvX64RegisterName;
+use hvdef::hypercall::HvRegisterAssoc;
+use mshv_bindings::hv_partition_property_code_HV_PARTITION_PROPERTY_REFERENCE_TIME;
+use virt::state::HvRegisterState;
 use virt::x86::vm;
 use virt::x86::vm::AccessVmState;
+use zerocopy::FromZeros;
+
+impl MshvPartition {
+    fn get_vm_register_state<T, const N: usize>(&self) -> Result<T, Error>
+    where
+        T: HvRegisterState<HvX64RegisterName, N>,
+    {
+        let mut regs = T::default();
+        let mut assoc = regs.names().map(|name| HvRegisterAssoc {
+            name: name.into(),
+            pad: [0; 3],
+            value: FromZeros::new_zeroed(),
+        });
+
+        self.inner
+            .bsp_vcpufd
+            .get_hvdef_regs(&mut assoc[..])
+            .map_err(Error::Register)?;
+
+        regs.set_values(assoc.iter().map(|assoc| assoc.value));
+        Ok(regs)
+    }
+
+    fn set_vm_register_state<T, const N: usize>(&self, regs: &T) -> Result<(), Error>
+    where
+        T: HvRegisterState<HvX64RegisterName, N>,
+    {
+        let mut assoc = regs.names().map(|name| HvRegisterAssoc {
+            name: name.into(),
+            pad: [0; 3],
+            value: FromZeros::new_zeroed(),
+        });
+
+        regs.get_values(assoc.iter_mut().map(|assoc| &mut assoc.value));
+
+        self.inner
+            .bsp_vcpufd
+            .set_hvdef_regs(&assoc[..])
+            .map_err(Error::Register)
+    }
+}
 
 impl AccessVmState for &'_ MshvPartition {
     type Error = Error;
@@ -14,30 +67,41 @@ impl AccessVmState for &'_ MshvPartition {
     }
 
     fn commit(&mut self) -> Result<(), Self::Error> {
-        todo!()
+        Ok(())
     }
 
     fn hypercall(&mut self) -> Result<vm::HypercallMsrs, Self::Error> {
-        todo!()
+        self.get_vm_register_state()
     }
 
-    fn set_hypercall(&mut self, _value: &vm::HypercallMsrs) -> Result<(), Self::Error> {
-        todo!()
+    fn set_hypercall(&mut self, value: &vm::HypercallMsrs) -> Result<(), Self::Error> {
+        self.set_vm_register_state(value)
     }
 
     fn reftime(&mut self) -> Result<vm::ReferenceTime, Self::Error> {
-        todo!()
+        let ref_time = self
+            .inner
+            .vmfd
+            .get_partition_property(hv_partition_property_code_HV_PARTITION_PROPERTY_REFERENCE_TIME)
+            .map_err(|e| Error::SetPartitionProperty(e.into()))?;
+        Ok(vm::ReferenceTime { value: ref_time })
     }
 
-    fn set_reftime(&mut self, _value: &vm::ReferenceTime) -> Result<(), Self::Error> {
-        todo!()
+    fn set_reftime(&mut self, value: &vm::ReferenceTime) -> Result<(), Self::Error> {
+        self.inner
+            .vmfd
+            .set_partition_property(
+                hv_partition_property_code_HV_PARTITION_PROPERTY_REFERENCE_TIME,
+                value.value,
+            )
+            .map_err(|e| Error::SetPartitionProperty(e.into()))
     }
 
     fn reference_tsc_page(&mut self) -> Result<vm::ReferenceTscPage, Self::Error> {
-        todo!()
+        self.get_vm_register_state()
     }
 
-    fn set_reference_tsc_page(&mut self, _value: &vm::ReferenceTscPage) -> Result<(), Self::Error> {
-        todo!()
+    fn set_reference_tsc_page(&mut self, value: &vm::ReferenceTscPage) -> Result<(), Self::Error> {
+        self.set_vm_register_state(value)
     }
 }

--- a/vmm_core/virt_mshv/src/vp_state.rs
+++ b/vmm_core/virt_mshv/src/vp_state.rs
@@ -7,10 +7,15 @@ use crate::MshvProcessor;
 use hvdef::HvX64RegisterName;
 use hvdef::hypercall::HvRegisterAssoc;
 use mshv_bindings::LapicState;
+use mshv_bindings::MSHV_VP_STATE_SIEFP;
+use mshv_bindings::MSHV_VP_STATE_SIMP;
+use mshv_bindings::MSHV_VP_STATE_SYNTHETIC_TIMERS;
+use mshv_bindings::mshv_get_set_vp_state;
 use virt::state::HvRegisterState;
 use virt::x86::vp;
 use virt::x86::vp::AccessVpState;
 use zerocopy::FromZeros;
+use zerocopy::IntoBytes;
 
 impl MshvProcessor<'_> {
     pub(crate) fn set_register_state<T, const N: usize>(&self, regs: &T) -> Result<(), Error>
@@ -74,19 +79,47 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
     }
 
     fn activity(&mut self) -> Result<vp::Activity, Self::Error> {
-        self.get_register_state()
+        let mut activity: vp::Activity = self.get_register_state()?;
+        // The NMI pending bit is not part of the register state; it lives
+        // in the APIC page.
+        let lapic = self.runner.vcpufd.get_lapic().map_err(Error::VpState)?;
+        let page: [u8; 1024] = lapic.regs.map(|b| b as u8);
+        activity.nmi_pending = vp::hv_apic_nmi_pending(&page);
+        Ok(activity)
     }
 
     fn set_activity(&mut self, value: &vp::Activity) -> Result<(), Self::Error> {
-        self.set_register_state(value)
+        self.set_register_state(value)?;
+        // The NMI pending bit is not part of the register state; it must
+        // be set via the APIC page.
+        let mut lapic = self.runner.vcpufd.get_lapic().map_err(Error::VpState)?;
+        let mut page: [u8; 1024] = lapic.regs.map(|b| b as u8);
+        vp::set_hv_apic_nmi_pending(&mut page, value.nmi_pending);
+        lapic.regs = page.map(|b| b as std::os::raw::c_char);
+        self.runner
+            .vcpufd
+            .set_lapic(&lapic)
+            .map_err(Error::VpState)?;
+        Ok(())
     }
 
     fn xsave(&mut self) -> Result<vp::Xsave, Self::Error> {
-        Err(Error::NotSupported)
+        let xsave = self.runner.vcpufd.get_xsave().map_err(Error::VpState)?;
+        Ok(vp::Xsave::from_compact(&xsave.buffer, &self.partition.caps))
     }
 
-    fn set_xsave(&mut self, _value: &vp::Xsave) -> Result<(), Self::Error> {
-        Err(Error::NotSupported)
+    fn set_xsave(&mut self, value: &vp::Xsave) -> Result<(), Self::Error> {
+        let data = value.compact();
+        let vp_state = mshv_get_set_vp_state {
+            type_: mshv_bindings::MSHV_VP_STATE_XSAVE as u8,
+            buf_sz: data.len() as u32,
+            buf_ptr: data.as_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .set_vp_state_ioctl(&vp_state)
+            .map_err(Error::VpState)
     }
 
     fn apic(&mut self) -> Result<vp::Apic, Self::Error> {
@@ -103,7 +136,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         let apic_base = assoc[0].value.as_u64();
 
         // Get the LAPIC state page.
-        let lapic = self.runner.vcpufd.get_lapic().map_err(Error::Register)?;
+        let lapic = self.runner.vcpufd.get_lapic().map_err(Error::VpState)?;
         let mut page: [u8; 1024] = lapic.regs.map(|b| b as u8);
 
         // Clear the non-architectural NMI pending bit.
@@ -124,7 +157,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
             .map_err(Error::Register)?;
 
         // Preserve the current NMI pending state across the restore.
-        let current_lapic = self.runner.vcpufd.get_lapic().map_err(Error::Register)?;
+        let current_lapic = self.runner.vcpufd.get_lapic().map_err(Error::VpState)?;
         let current_page: [u8; 1024] = current_lapic.regs.map(|b| b as u8);
         let nmi_pending = vp::hv_apic_nmi_pending(&current_page);
 
@@ -137,7 +170,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         self.runner
             .vcpufd
             .set_lapic(&lapic)
-            .map_err(Error::Register)?;
+            .map_err(Error::VpState)?;
 
         Ok(())
     }
@@ -231,40 +264,102 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
     }
 
     fn synic_timers(&mut self) -> Result<vp::SynicTimers, Self::Error> {
-        Err(Error::NotSupported)
+        let mut state = hvdef::HvSyntheticTimersState::new_zeroed();
+        let mut vp_state = mshv_get_set_vp_state {
+            type_: MSHV_VP_STATE_SYNTHETIC_TIMERS as u8,
+            buf_sz: size_of_val(&state) as u32,
+            buf_ptr: state.as_mut_bytes().as_mut_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .get_vp_state_ioctl(&mut vp_state)
+            .map_err(Error::VpState)?;
+        Ok(vp::SynicTimers::from_hv(state))
     }
 
-    fn set_synic_timers(&mut self, _value: &vp::SynicTimers) -> Result<(), Self::Error> {
-        Err(Error::NotSupported)
+    fn set_synic_timers(&mut self, value: &vp::SynicTimers) -> Result<(), Self::Error> {
+        let state = value.as_hv();
+        let vp_state = mshv_get_set_vp_state {
+            type_: MSHV_VP_STATE_SYNTHETIC_TIMERS as u8,
+            buf_sz: size_of_val(&state) as u32,
+            buf_ptr: state.as_bytes().as_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .set_vp_state_ioctl(&vp_state)
+            .map_err(Error::VpState)
     }
 
     fn synic_message_queues(&mut self) -> Result<vp::SynicMessageQueues, Self::Error> {
-        Err(Error::NotSupported)
+        Ok(self.inner.message_queues.save())
     }
 
     fn set_synic_message_queues(
         &mut self,
-        _value: &vp::SynicMessageQueues,
+        value: &vp::SynicMessageQueues,
     ) -> Result<(), Self::Error> {
-        Err(Error::NotSupported)
+        self.inner.message_queues.restore(value);
+        Ok(())
     }
 
     fn synic_message_page(&mut self) -> Result<vp::SynicMessagePage, Self::Error> {
-        Err(Error::NotSupported)
+        let mut state = vp::SynicMessagePage { data: [0; 4096] };
+        let mut vp_state = mshv_get_set_vp_state {
+            type_: MSHV_VP_STATE_SIMP as u8,
+            buf_sz: size_of_val(&state.data) as u32,
+            buf_ptr: state.data.as_mut_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .get_vp_state_ioctl(&mut vp_state)
+            .map_err(Error::VpState)?;
+        Ok(state)
     }
 
-    fn set_synic_message_page(&mut self, _value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
-        Err(Error::NotSupported)
+    fn set_synic_message_page(&mut self, value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
+        let vp_state = mshv_get_set_vp_state {
+            type_: MSHV_VP_STATE_SIMP as u8,
+            buf_sz: size_of_val(&value.data) as u32,
+            buf_ptr: value.data.as_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .set_vp_state_ioctl(&vp_state)
+            .map_err(Error::VpState)
     }
 
     fn synic_event_flags_page(&mut self) -> Result<vp::SynicEventFlagsPage, Self::Error> {
-        Err(Error::NotSupported)
+        let mut state = vp::SynicEventFlagsPage { data: [0; 4096] };
+        let mut vp_state = mshv_get_set_vp_state {
+            type_: MSHV_VP_STATE_SIEFP as u8,
+            buf_sz: size_of_val(&state.data) as u32,
+            buf_ptr: state.data.as_mut_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .get_vp_state_ioctl(&mut vp_state)
+            .map_err(Error::VpState)?;
+        Ok(state)
     }
 
     fn set_synic_event_flags_page(
         &mut self,
-        _value: &vp::SynicEventFlagsPage,
+        value: &vp::SynicEventFlagsPage,
     ) -> Result<(), Self::Error> {
-        Err(Error::NotSupported)
+        let vp_state = mshv_get_set_vp_state {
+            type_: MSHV_VP_STATE_SIEFP as u8,
+            buf_sz: size_of_val(&value.data) as u32,
+            buf_ptr: value.data.as_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .set_vp_state_ioctl(&vp_state)
+            .map_err(Error::VpState)
     }
 }


### PR DESCRIPTION
The mshv backend had many state access methods stubbed out as todo!() or returning NotSupported, making save/restore and VM reset impossible.

Implement the missing pieces:

VM-level state (GuestOsId, Hypercall, ReferenceTsc) is accessed via the BSP's VcpuFd, which is now retained in MshvPartitionInner rather than handed off to the BSP's processor binder. This lets partition-level code read and write these registers while VPs are stopped.

VP-level state gains full xsave support, activity state with NMI pending bit handling through the APIC page, synthetic timer state, synic message queues, and synic message/event-flags pages—all using the mshv VP state ioctls.

Reset is wired up at both levels: the partition clears IRQ routes and resets VM HV registers, and each VP resets its register state, message queues, and deliverability notifications.