### PR TITLE
Repo: Fix lints for Rust 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -701,6 +701,7 @@ unnecessary_box_returns = "warn"
 # flattened statements.
 collapsible_else_if = "allow"
 collapsible_if = "allow"
+collapsible_match = "allow"
 # There are types where it makes sense to define the length, but it can never
 # be empty. This lint is reasonable for container-like data-structures, but
 # makes less sense for hardware-backed data structures.

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -231,7 +231,7 @@ impl FlowNode for Node {
                             }
                             v.push("-p".into());
                             v.push(crate_name.clone());
-                            v.extend(features.to_cargo_arg_strings().into_iter());
+                            v.extend(features.to_cargo_arg_strings());
                             if let Some(target) = &target {
                                 v.push("--target".into());
                                 v.push(target.to_string());

--- a/openhcl/hcl/src/ioctl/register.rs
+++ b/openhcl/hcl/src/ioctl/register.rs
@@ -145,7 +145,7 @@ impl<'a, T: Backing<'a>> ProcessorRunner<'a, T> {
                     .get_vp_registers_hypercall(vtl, hv_names, &mut values)
                     .map_err(GetRegError::Hypercall)?;
 
-                for (dest, value) in hv_values.iter_mut().zip(values.into_iter()) {
+                for (dest, value) in hv_values.iter_mut().zip(values) {
                     **dest = value;
                 }
                 hv_names.clear();

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -82,12 +82,10 @@ fn pkcs11_rsa_aes_key_unwrap(
 
     let (wrapped_aes_key, wrapped_rsa_key) = wrapped_key_blob
         .split_at_checked(modulus_size)
-        .ok_or_else(|| {
-            Pkcs11RsaAesKeyUnwrapError::UndersizedWrappedAesKey(
-                modulus_size,
-                wrapped_key_blob.len(),
-            )
-        })?;
+        .ok_or(Pkcs11RsaAesKeyUnwrapError::UndersizedWrappedAesKey(
+            modulus_size,
+            wrapped_key_blob.len(),
+        ))?;
 
     if wrapped_rsa_key.is_empty() {
         return Err(Pkcs11RsaAesKeyUnwrapError::EmptyWrappedRsaKey);

--- a/openhcl/underhill_crash/src/lib.rs
+++ b/openhcl/underhill_crash/src/lib.rs
@@ -206,11 +206,9 @@ async fn send_dump(
         // Compute stats
         let wrote_bytes_total = streamer.wrote_bytes_total();
         let nanos = now.elapsed().as_nanos();
-        let speed = if nanos != 0 {
-            (wrote_bytes_total as u128) * 1_000_000_000 / nanos
-        } else {
-            0
-        };
+        let speed = (wrote_bytes_total as u128 * 1_000_000_000)
+            .checked_div(nanos)
+            .unwrap_or(0);
         tracing::info!(size = wrote_bytes_total, speed, "Reported crash");
 
         Ok::<(), anyhow::Error>(())

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -695,10 +695,8 @@ mod tests {
             index: CpuidPageIndex::new(pages.as_slice()),
         };
 
-        let mut expected_value = 1;
-        for entry in iter {
+        for (entry, expected_value) in iter.zip(1..) {
             assert_eq!(expected_value, entry.result.eax);
-            expected_value += 1;
         }
     }
 }

--- a/petri/burette/src/tests/platform.rs
+++ b/petri/burette/src/tests/platform.rs
@@ -284,7 +284,7 @@ mod linux {
         );
 
         // Sort by private descending.
-        mappings.sort_by(|a, b| b.private_kib.cmp(&a.private_kib));
+        mappings.sort_by_key(|a| std::cmp::Reverse(a.private_kib));
 
         // Sum private bytes from mappings named [anon:guest-ram-*].
         let mut guest_ram_private_kib: u64 = mappings

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -196,7 +196,7 @@ impl PetriVmConfigOpenVmm {
                 ProcessConfig::new("vmm")
                     .process_name(&resources.openvmm_path)
                     .stderr(Some(stderr_write))
-                    .env(vmm_env.into_iter()),
+                    .env(vmm_env),
                 openvmm_defs::entrypoint::MeshHostParams { runner },
             )
             .await?;

--- a/vm/devices/get/underhill_config/src/schema/v1.rs
+++ b/vm/devices/get/underhill_config/src/schema/v1.rs
@@ -388,7 +388,7 @@ impl ParseSchema<crate::IdeController> for StorageController {
                 .flat_map(|lun| lun.parse(errors).collect_error(errors))
                 .collect::<Vec<crate::IdeDisk>>();
 
-            disks.sort_by(|a, b| (a.location).cmp(&b.location));
+            disks.sort_by_key(|a| a.location);
 
             for (a, b) in disks.iter().zip(disks.iter().skip(1)) {
                 if a.channel == b.channel && a.location == b.location {

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -616,8 +616,8 @@ impl ScsiCommandQueue {
                     .controller
                     .disks
                     .read()
-                    .iter()
-                    .flat_map(|(path, _)| {
+                    .keys()
+                    .flat_map(|path| {
                         // Use the original path ID and not the forced one to
                         // match Hyper-V storvsp behavior.
                         if request.path_id == path.path && request.target_id == path.target {


### PR DESCRIPTION
Pretty small ones this release. There is a new lint to go along with the stabilization of match guards, but I didn't like how it looked and we already allow very similar lints, so I just added it to the list.