### PR TITLE
ci: add github branch to memory validation metadata

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -125,6 +125,7 @@ jobs:
             --file /dev/null \
             --metadata \
               "ghpr=$SOURCE_PR" \
+              "ghbranch=$SOURCE_BRANCH" \
             --auth-mode login
         env:
           run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Adding GitHub branch to memory validation metadata to differentiate test results between branches.