### PR TITLE
netvsp: fix arithmetic underflow on oid sent by guest

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -3750,7 +3750,12 @@ impl Adapter {
                 let value = value.read_n::<u16>(info.value_length as usize / 2)?;
                 let value =
                     String::from_utf16(&value).map_err(|_| OidError::InvalidInput("value"))?;
-                let as_num = value.as_bytes().first().map_or(0, |c| c - b'0');
+                let as_num = value
+                    .as_bytes()
+                    .first()
+                    .map(|c| c.wrapping_sub(b'0'))
+                    .filter(|&c| c <= 9)
+                    .ok_or(OidError::InvalidInput("value as num"))?;
                 let tx = as_num & 1 != 0;
                 let rx = as_num & 2 != 0;
 


### PR DESCRIPTION
In `oid_set_rndis_config_parameter()`, the first byte of the guest-provided UTF-16 value string is subtracted by b'0' to parse it as a digit. If the byte is less than b'0' (e.g. a space character 0x20), this causes a u8 underflow: panic in debug builds, wrapping in release builds.

* Replace `c - b'0'` with `c.wrapping_sub(b'0')` guarded by a `.filter(|&c| c <= 9)` check, returning OidError::InvalidInput for non-digit values. 
* Guest will receive a `MESSAGE_TYPE_SET_CMPLT` message with `STATUS_INVALID_DATA`.