### PR TITLE
cvm: incorrect extended state enumeration cpuid parsing

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -648,9 +648,9 @@ impl CpuidResults {
 
         let CpuidResult {
             eax: xsave_low,
-            ebx: xsave_high,
+            ebx: _,
             ecx: _,
-            edx: _,
+            edx: xsave_high,
         } = *self
             .leaf_result_ref(CpuidFunction::ExtendedStateEnumeration, Some(0), true)
             .expect("validated this subleaf exists");


### PR DESCRIPTION
Supported xsave bits in the extended state enumeration leaf should be edx:eax, not ebx:eax

Tested:
SNP boots