### PR TITLE
lxutil: fix UB and correctness bugs

### DIFF
--- a/vm/devices/support/fs/lxutil/src/lib.rs
+++ b/vm/devices/support/fs/lxutil/src/lib.rs
@@ -786,7 +786,7 @@ impl LxVolumeOptions {
                 }
                 "mode" => {
                     if let Some(value) = value {
-                        if let Ok(mode) = value.parse::<u32>() {
+                        if let Ok(mode) = u32::from_str_radix(value, 8) {
                             if (mode & !0o777) == 0 {
                                 options.mode(mode);
                             } else {
@@ -823,7 +823,7 @@ impl LxVolumeOptions {
                 }
                 "umask" => {
                     if let Some(value) = value {
-                        if let Ok(umask) = value.parse::<u32>() {
+                        if let Ok(umask) = u32::from_str_radix(value, 8) {
                             if (umask & !0o777) == 0 {
                                 options.umask(umask);
                             } else {
@@ -838,7 +838,7 @@ impl LxVolumeOptions {
                 }
                 "dmask" => {
                     if let Some(value) = value {
-                        if let Ok(dmask) = value.parse::<u32>() {
+                        if let Ok(dmask) = u32::from_str_radix(value, 8) {
                             if (dmask & !0o777) == 0 {
                                 options.dmask(dmask);
                             } else {
@@ -853,7 +853,7 @@ impl LxVolumeOptions {
                 }
                 "fmask" => {
                     if let Some(value) = value {
-                        if let Ok(fmask) = value.parse::<u32>() {
+                        if let Ok(fmask) = u32::from_str_radix(value, 8) {
                             if (fmask & !0o777) == 0 {
                                 options.fmask(fmask);
                             } else {

--- a/vm/devices/support/fs/lxutil/src/windows/fs.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/fs.rs
@@ -316,7 +316,7 @@ pub fn delete_file(fs_context: &FsContext, file_handle: &OwnedHandle) -> lx::Res
         Err(e) => match analyze_delete_error(e, file_handle) {
             DeleteErrorAction::ReturnError(err) => Err(err),
             DeleteErrorAction::TryReadOnlyWorkaround => {
-                delete_read_only_file(fs_context, file_handle)
+                delete_read_only_file(fs_context, file_handle, e)
             }
         },
     }
@@ -344,14 +344,23 @@ pub fn delete_file_core(fs_context: &FsContext, file_handle: &OwnedHandle) -> lx
     }
 }
 
-pub fn delete_read_only_file(fs_context: &FsContext, file_handle: &OwnedHandle) -> lx::Result<()> {
+pub fn delete_read_only_file(
+    fs_context: &FsContext,
+    file_handle: &OwnedHandle,
+    original_error: lx::Error,
+) -> lx::Result<()> {
     let info: FileSystem::FILE_BASIC_INFORMATION = util::query_information_file(file_handle)?;
 
     if info.FileAttributes & W32Fs::FILE_ATTRIBUTE_READONLY.0 == 0 {
-        Err(lx::Error::from_lx(lx::EIO))
+        Err(original_error)
     } else {
         util::set_readonly_attribute(file_handle, info.FileAttributes, false)?;
-        delete_file_core(fs_context, file_handle)
+        let result = delete_file_core(fs_context, file_handle);
+        if result.is_err() {
+            // Best-effort restore the read-only attribute.
+            let _ = util::set_readonly_attribute(file_handle, info.FileAttributes, true);
+        }
+        result
     }
 }
 
@@ -877,8 +886,12 @@ pub fn read_link_length(file_handle: &OwnedHandle, state: &VolumeState) -> lx::R
             match version {
                 LX_UTIL_SYMLINK_DATA_VERSION_2 => {
                     // SAFETY: Accessing union field of type returned from Win32 API
-                    let data_length = unsafe { reparse_buffer.head.header.ReparseDataLength };
-                    Ok(data_length as u32 - LX_UTIL_SYMLINK_TARGET_OFFSET)
+                    let data_length =
+                        unsafe { reparse_buffer.head.header.ReparseDataLength } as u32;
+                    if data_length < LX_UTIL_SYMLINK_TARGET_OFFSET {
+                        return Err(lx::Error::EIO);
+                    }
+                    Ok(data_length - LX_UTIL_SYMLINK_TARGET_OFFSET)
                 }
                 _ => Err(lx::Error::EIO),
             }
@@ -922,6 +935,9 @@ pub fn read_reparse_link(
                 LX_UTIL_SYMLINK_DATA_VERSION_2 => {
                     // SAFETY: Accessing union field of type returned from Win32 API
                     let data_length = unsafe { reparse_buffer.head.header.ReparseDataLength };
+                    if (data_length as u32) < LX_UTIL_SYMLINK_TARGET_OFFSET {
+                        return Err(lx::Error::EIO);
+                    }
                     let path_length = data_length - LX_UTIL_SYMLINK_TARGET_OFFSET as u16;
                     if iosb.Information < LX_UTIL_SYMLINK_REPARSE_BASE_SIZE as usize
                         || iosb.Information
@@ -994,24 +1010,14 @@ fn determine_fallback_mode(
 
     // Check if FILE_STAT_(LX_)INFORMATION is supported even if query by name is not.
     if fallback_mode < LX_DRVFS_DISABLE_QUERY_BY_NAME_AND_STAT_INFO {
-        if util::query_information_file_by_name::<FileSystem::FILE_STAT_LX_INFORMATION>(
-            Some(file_handle),
-            &empty_string,
-        )
-        .is_ok()
+        if util::query_information_file::<FileSystem::FILE_STAT_LX_INFORMATION>(file_handle).is_ok()
         {
             flags.set_supports_stat_info(true);
             flags.set_supports_stat_lx_info(true);
             return;
         };
 
-        if util::query_information_file_by_name::<FileSystem::FILE_STAT_INFORMATION>(
-            Some(file_handle),
-            &empty_string,
-        )
-        .is_ok()
-        {
-            flags.set_supports_query_by_name(true);
+        if util::query_information_file::<FileSystem::FILE_STAT_INFORMATION>(file_handle).is_ok() {
             flags.set_supports_stat_info(true);
         };
     }
@@ -1096,11 +1102,15 @@ pub fn create_link_reparse_buffer(target: &lx::LxStr) -> lx::Result<Vec<u8>> {
     }
 
     let mut buf = vec![0u8; reparse_size];
-    // SAFETY: Casting buffer which is guaranteed to be large enough.
-    let reparse = unsafe { buf.as_mut_ptr().cast::<SymlinkReparse>().as_mut().unwrap() };
-    reparse.header.ReparseTag = FileSystem::IO_REPARSE_TAG_LX_SYMLINK as u32;
-    reparse.header.ReparseDataLength = LX_UTIL_SYMLINK_TARGET_OFFSET as u16 + target_length as u16;
-    reparse.data.symlink.version = LX_UTIL_SYMLINK_DATA_VERSION_2;
+    let tag_off = offset_of!(FileSystem::REPARSE_DATA_BUFFER, ReparseTag);
+    buf[tag_off..tag_off + 4]
+        .copy_from_slice(&(FileSystem::IO_REPARSE_TAG_LX_SYMLINK as u32).to_ne_bytes());
+    let len_off = offset_of!(FileSystem::REPARSE_DATA_BUFFER, ReparseDataLength);
+    buf[len_off..len_off + 2].copy_from_slice(
+        &(LX_UTIL_SYMLINK_TARGET_OFFSET as u16 + target_length as u16).to_ne_bytes(),
+    );
+    let ver_off = REPARSE_DATA_BUFFER_HEADER_SIZE + offset_of!(SymlinkData, version);
+    buf[ver_off..ver_off + 4].copy_from_slice(&LX_UTIL_SYMLINK_DATA_VERSION_2.to_ne_bytes());
     let offset = REPARSE_DATA_BUFFER_HEADER_SIZE + LX_UTIL_SYMLINK_TARGET_OFFSET as usize;
     buf[offset..offset + target_length].copy_from_slice(link_target.as_slice());
     Ok(buf)
@@ -1184,13 +1194,8 @@ fn add_ea(
         return Err(lx::Error::EINVAL);
     }
 
-    // SAFETY: Writing to a properly sized buffer.
-    let ea = unsafe {
-        &mut *buffer[*offset..]
-            .as_mut_ptr()
-            .cast::<FileSystem::FILE_FULL_EA_INFORMATION>()
-    };
-    ea.EaNameLength = LX_UTIL_FILE_METADATA_EA_NAME_LENGTH as u8;
+    buffer[*offset + offset_of!(FileSystem::FILE_FULL_EA_INFORMATION, EaNameLength)] =
+        LX_UTIL_FILE_METADATA_EA_NAME_LENGTH as u8;
 
     // Copy the name and null terminator into the buffer
     let name_offset = *offset + offset_of!(FileSystem::FILE_FULL_EA_INFORMATION, EaName);
@@ -1202,20 +1207,27 @@ fn add_ea(
         *offset + offset_of!(FileSystem::FILE_FULL_EA_INFORMATION, EaName) + name.len() + 1;
     buffer[value_offset..value_offset + size_of::<u32>()].copy_from_slice(&value1.to_ne_bytes());
 
+    let val_len_off = *offset + offset_of!(FileSystem::FILE_FULL_EA_INFORMATION, EaValueLength);
+    let next_off = *offset + offset_of!(FileSystem::FILE_FULL_EA_INFORMATION, NextEntryOffset);
+
     if let Some(value2) = value2 {
         // Copy value2 after value1
         let value2_offset = value_offset + size_of::<u32>();
         buffer[value2_offset..value2_offset + size_of::<u32>()]
             .copy_from_slice(&value2.to_ne_bytes());
 
-        ea.EaValueLength = (size_of::<u32>() * 2) as u16;
-        ea.NextEntryOffset = LX_UTIL_FS_METADATA_EA_BUFFER_DEVICE_ID_SIZE as u32;
+        buffer[val_len_off..val_len_off + 2]
+            .copy_from_slice(&((size_of::<u32>() * 2) as u16).to_ne_bytes());
+        buffer[next_off..next_off + 4]
+            .copy_from_slice(&(LX_UTIL_FS_METADATA_EA_BUFFER_DEVICE_ID_SIZE as u32).to_ne_bytes());
     } else {
-        ea.EaValueLength = size_of::<u32>() as u16;
-        ea.NextEntryOffset = LX_UTIL_FS_METADATA_EA_BUFFER_BASE_SIZE as u32;
+        buffer[val_len_off..val_len_off + 2]
+            .copy_from_slice(&(size_of::<u32>() as u16).to_ne_bytes());
+        buffer[next_off..next_off + 4]
+            .copy_from_slice(&(LX_UTIL_FS_METADATA_EA_BUFFER_BASE_SIZE as u32).to_ne_bytes());
     }
 
-    Ok(*offset + ea.NextEntryOffset as usize)
+    Ok(*offset + u32::from_ne_bytes(buffer[next_off..next_off + 4].try_into().unwrap()) as usize)
 }
 
 /// Creates the EA buffer for LX metadata.
@@ -1266,13 +1278,9 @@ pub fn create_metadata_ea_buffer(
 
     // The last EA added should have a NextEntryOffset of 0.
     if offset > 0 {
-        // SAFETY: Writing to a properly sized buffer.
-        let ea = unsafe {
-            &mut *buffer[last_offset..]
-                .as_mut_ptr()
-                .cast::<FileSystem::FILE_FULL_EA_INFORMATION>()
-        };
-        ea.NextEntryOffset = 0;
+        let next_off =
+            last_offset + offset_of!(FileSystem::FILE_FULL_EA_INFORMATION, NextEntryOffset);
+        buffer[next_off..next_off + 4].copy_from_slice(&0u32.to_ne_bytes());
     }
 
     Ok(offset)

--- a/vm/devices/support/fs/lxutil/src/windows/fs.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/fs.rs
@@ -888,10 +888,9 @@ pub fn read_link_length(file_handle: &OwnedHandle, state: &VolumeState) -> lx::R
                     // SAFETY: Accessing union field of type returned from Win32 API
                     let data_length =
                         unsafe { reparse_buffer.head.header.ReparseDataLength } as u32;
-                    if data_length < LX_UTIL_SYMLINK_TARGET_OFFSET {
-                        return Err(lx::Error::EIO);
-                    }
-                    Ok(data_length - LX_UTIL_SYMLINK_TARGET_OFFSET)
+                    data_length
+                        .checked_sub(LX_UTIL_SYMLINK_TARGET_OFFSET)
+                        .ok_or(lx::Error::EIO)
                 }
                 _ => Err(lx::Error::EIO),
             }
@@ -935,10 +934,9 @@ pub fn read_reparse_link(
                 LX_UTIL_SYMLINK_DATA_VERSION_2 => {
                     // SAFETY: Accessing union field of type returned from Win32 API
                     let data_length = unsafe { reparse_buffer.head.header.ReparseDataLength };
-                    if (data_length as u32) < LX_UTIL_SYMLINK_TARGET_OFFSET {
-                        return Err(lx::Error::EIO);
-                    }
-                    let path_length = data_length - LX_UTIL_SYMLINK_TARGET_OFFSET as u16;
+                    let path_length = data_length
+                        .checked_sub(LX_UTIL_SYMLINK_TARGET_OFFSET as u16)
+                        .ok_or(lx::Error::EIO)?;
                     if iosb.Information < LX_UTIL_SYMLINK_REPARSE_BASE_SIZE as usize
                         || iosb.Information
                             != REPARSE_DATA_BUFFER_HEADER_SIZE + data_length as usize

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -979,7 +979,7 @@ impl LxVolume {
                         W32Fs::DELETE | W32Fs::FILE_READ_ATTRIBUTES | W32Fs::FILE_WRITE_ATTRIBUTES,
                     )?;
 
-                    fs::delete_read_only_file(&self.state.fs_context, &handle)
+                    fs::delete_read_only_file(&self.state.fs_context, &handle, e)
                 }
             },
         }
@@ -1185,6 +1185,9 @@ impl LxFile {
         offset: lx::off_t,
         thread_uid: lx::uid_t,
     ) -> lx::Result<usize> {
+        if offset < 0 {
+            return Err(lx::Error::EINVAL);
+        }
         unsafe {
             // When metadata is enabled, the Linux behavior of clearing set-user-ID and set-group-ID
             // on write must be emulated. This should actually be based on CAP_FSETID, but that
@@ -1230,6 +1233,10 @@ impl LxFile {
     where
         F: FnMut(lx::DirEntry) -> lx::Result<bool>,
     {
+        if offset < 0 {
+            return Err(lx::Error::EINVAL);
+        }
+
         if self.enumerator.is_none() {
             self.enumerator = Some(readdir::DirectoryEnumerator::new(false)?);
         }

--- a/vm/devices/support/fs/lxutil/src/windows/readdir.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/readdir.rs
@@ -709,18 +709,22 @@ impl DirectoryEnumerator {
                 break;
             }
 
-            // Try to grow the buffer. The size is guaranteed not to overflow as
-            // buffer_size is u32 and usize::MAX > u32::MAX.
+            // Try to grow the buffer.
             self.free_buffer();
+            let new_size = self
+                .buffer_size
+                .checked_add(BUFFER_EXTRA_SIZE as u32)
+                .ok_or(lx::Error::ENOMEM)?;
             let buf = unsafe {
                 FileSystem::RtlAllocateHeap(
                     Memory::GetProcessHeap().map_err(|_| lx::Error::ENOMEM)?.0,
                     None,
-                    self.buffer_size as usize + BUFFER_EXTRA_SIZE,
+                    new_size as usize,
                 )
             };
             assert!(!buf.is_null(), "out of memory");
             self.buffer = buf;
+            self.buffer_size = new_size;
         }
         Ok(iosb.Information as _)
     }

--- a/vm/devices/support/fs/lxutil/src/windows/readdir.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/readdir.rs
@@ -9,7 +9,6 @@ use arrayvec::ArrayVec;
 use bitfield_struct::bitfield;
 use pal::windows::UnicodeString;
 use pal::windows::UnicodeStringRef;
-use std::ffi;
 use std::os::windows::io::AsRawHandle;
 use std::os::windows::io::FromRawHandle;
 use std::os::windows::io::OwnedHandle;
@@ -20,7 +19,6 @@ use windows::Wdk::System::Threading;
 use windows::Win32::Foundation;
 use windows::Win32::Storage::FileSystem as W32Fs;
 use windows::Win32::System::Kernel;
-use windows::Win32::System::Memory;
 use windows::Win32::System::Threading as W32Threading;
 
 const DIR_ENUM_BUFFER_SIZE: usize = 4096;
@@ -341,9 +339,8 @@ impl DirEntryCursor {
 
 /// A DirectoryEnumerator that owns its buffer.
 pub struct DirectoryEnumerator {
-    buffer: *mut ffi::c_void,
-    buffer_next_entry: *mut ffi::c_void,
-    buffer_size: u32,
+    buffer: Vec<u8>,
+    buffer_next_entry: Option<usize>,
     next_read_index: u32,
     file_information_class: DirectoryEnumeratorFileInformationClass,
     flags: DirectoryEnumeratorFlags,
@@ -357,26 +354,12 @@ pub struct FileDirectoryInformation {
     reparse_tag: u32,
 }
 
-unsafe impl Send for DirectoryEnumerator {}
-
-unsafe impl Sync for DirectoryEnumerator {}
-
 impl DirectoryEnumerator {
-    /// Create a new DirectoryEnumerator that owns its buffer. The buffer will be
-    /// freed on drop.
+    /// Create a new DirectoryEnumerator that owns its buffer.
     pub fn new(asynchronous_mode: bool) -> lx::Result<Self> {
-        let buf = unsafe {
-            FileSystem::RtlAllocateHeap(
-                Memory::GetProcessHeap().map_err(|_| lx::Error::ENOMEM)?.0,
-                None,
-                DIR_ENUM_BUFFER_SIZE,
-            )
-        };
-        assert!(!buf.is_null(), "out of memory");
         Ok(Self {
-            buffer: buf,
-            buffer_next_entry: ptr::null_mut(),
-            buffer_size: DIR_ENUM_BUFFER_SIZE as _,
+            buffer: vec![0u8; DIR_ENUM_BUFFER_SIZE],
+            buffer_next_entry: None,
             flags: DirectoryEnumeratorFlags::new().with_asynchronous_mode(asynchronous_mode),
             next_read_index: 0,
             file_information_class:
@@ -461,7 +444,7 @@ impl DirectoryEnumerator {
             self.cursor.reset();
             // Also reset the Windows enumerator state.
             self.next_read_index = 0;
-            self.buffer_next_entry = ptr::null_mut();
+            self.buffer_next_entry = None;
             self.flags.set_end_reached(false);
         }
 
@@ -511,7 +494,7 @@ impl DirectoryEnumerator {
         restart_scan: bool,
     ) -> lx::Result<Option<FileDirectoryInformation>> {
         if restart_scan {
-            self.buffer_next_entry = ptr::null_mut();
+            self.buffer_next_entry = None;
             self.flags.set_end_reached(false);
         }
 
@@ -524,18 +507,18 @@ impl DirectoryEnumerator {
             return Ok(None);
         }
 
-        if self.buffer_next_entry.is_null() {
+        if self.buffer_next_entry.is_none() {
             let bytes_read = self.fill_buffer(handle, restart_scan)?;
 
             if bytes_read == 0 {
-                debug_assert!(self.buffer_next_entry.is_null());
+                debug_assert!(self.buffer_next_entry.is_none());
 
                 self.flags.set_end_reached(true);
                 return Ok(None);
             }
         }
 
-        debug_assert!(!self.buffer_next_entry.is_null());
+        debug_assert!(self.buffer_next_entry.is_some());
         let entry: &dyn DirectoryInformation = match self.file_information_class {
             DirectoryEnumeratorFileInformationClass::FileId64ExtdDirectoryInformation => {
                 self.get_next_entry::<FILE_ID_64_EXTD_DIR_INFORMATION>()?
@@ -575,7 +558,7 @@ impl DirectoryEnumerator {
 
     /// Fills the buffer of the enumerator. Returns the number of bytes read into the buffer.
     fn fill_buffer(&mut self, handle: &OwnedHandle, restart_scan: bool) -> lx::Result<u32> {
-        debug_assert!(self.buffer_next_entry.is_null());
+        debug_assert!(self.buffer_next_entry.is_none());
 
         let mut raw_event = Default::default();
         let _event;
@@ -607,8 +590,8 @@ impl DirectoryEnumerator {
                     None,
                     None,
                     &mut iosb,
-                    self.buffer,
-                    self.buffer_size,
+                    self.buffer.as_mut_ptr().cast(),
+                    self.buffer.len().try_into().map_err(|_| lx::Error::EOVERFLOW)?,
                     self.current_file_information_class(),
                     false,
                     None,
@@ -705,26 +688,17 @@ impl DirectoryEnumerator {
             // the buffer can't hold at least one entry. On subsequent calls, it
             // returns success but the number of bytes read is zero.
             if !buffer_too_small && iosb.Information != 0 {
-                self.buffer_next_entry = self.buffer;
+                self.buffer_next_entry = Some(0);
                 break;
             }
 
             // Try to grow the buffer.
-            self.free_buffer();
             let new_size = self
-                .buffer_size
-                .checked_add(BUFFER_EXTRA_SIZE as u32)
+                .buffer
+                .len()
+                .checked_add(BUFFER_EXTRA_SIZE)
                 .ok_or(lx::Error::ENOMEM)?;
-            let buf = unsafe {
-                FileSystem::RtlAllocateHeap(
-                    Memory::GetProcessHeap().map_err(|_| lx::Error::ENOMEM)?.0,
-                    None,
-                    new_size as usize,
-                )
-            };
-            assert!(!buf.is_null(), "out of memory");
-            self.buffer = buf;
-            self.buffer_size = new_size;
+            self.buffer = vec![0u8; new_size];
         }
         Ok(iosb.Information as _)
     }
@@ -733,12 +707,12 @@ impl DirectoryEnumerator {
     where
         T: DirectoryInformation,
     {
-        if self.buffer.is_null() || offset + size_of::<T>() > self.buffer_size as _ {
+        if offset + size_of::<T>() > self.buffer.len() {
             return Err(lx::Error::EFAULT);
         }
 
         // The buffer is guaranteed to be large enough for this operation.
-        let ptr = self.buffer.wrapping_byte_add(offset as _);
+        let ptr = self.buffer.as_mut_ptr().wrapping_byte_add(offset);
 
         if ptr.align_offset(align_of::<T>()) != 0 {
             return Err(lx::Error::EFAULT);
@@ -752,19 +726,23 @@ impl DirectoryEnumerator {
     where
         T: DirectoryInformation,
     {
-        if self.buffer_next_entry.is_null()
-            || self.buffer_next_entry.align_offset(align_of::<T>()) != 0
-        {
+        let offset = self.buffer_next_entry.ok_or(lx::Error::EFAULT)?;
+        if offset + size_of::<T>() > self.buffer.len() {
+            return Err(lx::Error::EFAULT);
+        }
+
+        let ptr = self.buffer.as_mut_ptr().wrapping_byte_add(offset);
+        if ptr.align_offset(align_of::<T>()) != 0 {
             return Err(lx::Error::EFAULT);
         }
 
         // SAFETY: The pointer is aligned and will read within the buffer bounds.
-        unsafe { Ok(&mut *(self.buffer_next_entry.cast())) }
+        unsafe { Ok(&mut *(ptr.cast())) }
     }
 
     /// Advances the enumerator to the next entry.
     fn next(&mut self) -> lx::Result<()> {
-        debug_assert!(!self.buffer.is_null() && !self.buffer_next_entry.is_null());
+        debug_assert!(!self.buffer.is_empty() && self.buffer_next_entry.is_some());
 
         // If the end was previously reached, do nothing.
         if self.flags.end_reached() {
@@ -775,9 +753,9 @@ impl DirectoryEnumerator {
         if entry.NextEntryOffset != 0 {
             self.buffer_next_entry = self
                 .buffer_next_entry
-                .wrapping_byte_add(entry.NextEntryOffset as _);
+                .map(|off| off + entry.NextEntryOffset as usize);
         } else {
-            self.buffer_next_entry = ptr::null_mut();
+            self.buffer_next_entry = None;
         }
 
         Ok(())
@@ -808,20 +786,6 @@ impl DirectoryEnumerator {
                 FileSystem::FileDirectoryInformation
             }
         }
-    }
-
-    /// Free the buffer with RtlFreeHeap.
-    fn free_buffer(&self) {
-        // SAFETY: Calling Win32 API as documented.
-        unsafe {
-            FileSystem::RtlFreeHeap(Memory::GetProcessHeap().unwrap().0, None, Some(self.buffer))
-        };
-    }
-}
-
-impl Drop for DirectoryEnumerator {
-    fn drop(&mut self) {
-        self.free_buffer();
     }
 }
 

--- a/vm/devices/support/fs/lxutil/src/windows/symlink.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/symlink.rs
@@ -138,9 +138,24 @@ pub unsafe fn read_nt_symlink_length(
     reparse: &FileSystem::REPARSE_DATA_BUFFER,
     state: &super::VolumeState,
 ) -> lx::Result<u32> {
-    // The length is just the target's UTF-8 length.
     // SAFETY: The validity of the reparse buffer is guaranteed by the caller.
-    Ok(unsafe { read_nt_symlink(reparse, state) }?.len() as _)
+    match unsafe { read_nt_symlink(reparse, state) } {
+        Ok(target) => Ok(target.len() as u32),
+        Err(lx::Error::EPERM) => {
+            // For absolute symlinks blocked by sandbox policy, compute a length
+            // from the raw substitute name so lstat reports a nonzero size.
+            // SAFETY: The validity of the reparse buffer is guaranteed by the caller.
+            let (substitute_name, _) = unsafe { get_substitute_name(reparse)? };
+            let name = if substitute_name.last().is_some_and(|&c| c == 0) {
+                &substitute_name[..substitute_name.len() - 1]
+            } else {
+                substitute_name
+            };
+            let utf8 = String::from_utf16(name).map_err(|_| lx::Error::EIO)?;
+            Ok(utf8.len() as u32)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 pub fn read(link_file: &OwnedHandle) -> lx::Result<lx::LxString> {

--- a/vm/devices/support/fs/lxutil/src/windows/util.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/util.rs
@@ -108,7 +108,8 @@ pub fn open_relative_file(
     let mut handle = Default::default();
     let mut iosb = Default::default();
     let (ea_ptr, ea_len) = if let Some(ea) = ea_buffer {
-        (Some(ea.as_ptr().cast()), ea.len() as u32)
+        let len: u32 = ea.len().try_into().map_err(|_| lx::Error::EINVAL)?;
+        (Some(ea.as_ptr().cast()), len)
     } else {
         (None, 0)
     };
@@ -155,18 +156,18 @@ fn get_token_for_access_check() -> lx::Result<OwnedHandle> {
     let mut client_token_raw = Foundation::HANDLE::default();
     let mut duplicate_token_raw = Foundation::HANDLE::default();
     // SAFETY: Calling Win32 API as documented.
-    let result = unsafe {
-        check_status(FileSystem::NtOpenThreadToken(
+    let status = unsafe {
+        FileSystem::NtOpenThreadToken(
             Threading::GetCurrentThread(),
             Security::TOKEN_QUERY.0 | Security::TOKEN_DUPLICATE.0,
             true,
             &mut client_token_raw,
-        ))
+        )
     };
 
-    if let Err(e) = result {
-        // Use the process token if there's no token.
-        if e.value() == Foundation::STATUS_NO_TOKEN.0 {
+    if status.is_err() {
+        if status == Foundation::STATUS_NO_TOKEN {
+            // Use the process token if there's no thread token.
             // SAFETY: Calling Win32 API as documented.
             unsafe {
                 let _ = check_status(FileSystem::NtOpenProcessToken(
@@ -176,7 +177,7 @@ fn get_token_for_access_check() -> lx::Result<OwnedHandle> {
                 ))?;
             }
         } else {
-            return Err(e);
+            return Err(nt_status_to_lx(status));
         }
     }
 
@@ -252,29 +253,35 @@ pub fn check_security(
     let mut length_needed: u32 = 0;
 
     // Call NtQuerySecurityObject until we pass a big enough buffer.
-    while let Err(e) =
-        // unsafe: calling Win32 API as documented.
-        unsafe {
-            // If the buffer was too small, try again and remember the size
-            // for future calls. This is the same strategy used by
-            // ObGetObjectSecurity.
-            check_status(FileSystem::NtQuerySecurityObject(
+    // If the buffer was too small, try again and remember the size
+    // for future calls. This is the same strategy used by
+    // ObGetObjectSecurity.
+    let mut current_size = initial_size;
+    loop {
+        // SAFETY: Calling Win32 API as documented.
+        let status = unsafe {
+            FileSystem::NtQuerySecurityObject(
                 Foundation::HANDLE(file.as_raw_handle()),
                 (Security::OWNER_SECURITY_INFORMATION
                     | Security::GROUP_SECURITY_INFORMATION
                     | Security::DACL_SECURITY_INFORMATION)
                     .0,
                 Some(Security::PSECURITY_DESCRIPTOR(sd.as_mut_ptr().cast())),
-                initial_size as u32,
+                current_size as u32,
                 &mut length_needed,
-            ))
+            )
+        };
+
+        if status.is_ok() {
+            break;
         }
-    {
-        if e.value() == Foundation::STATUS_BUFFER_TOO_SMALL.0 {
-            LX_UTIL_FS_SECURITY_DESCRIPTOR_SIZE.store(length_needed as usize, Ordering::Relaxed);
-            sd.reserve_tail(length_needed as usize);
+
+        if status == Foundation::STATUS_BUFFER_TOO_SMALL {
+            current_size = length_needed as usize;
+            LX_UTIL_FS_SECURITY_DESCRIPTOR_SIZE.store(current_size, Ordering::Relaxed);
+            sd.reserve_tail(current_size);
         } else {
-            return Err(e);
+            return Err(nt_status_to_lx(status));
         }
     }
 
@@ -1048,13 +1055,15 @@ pub fn permissions_for_set_attr(attr: &SetAttributes, metadata: bool) -> W32Fs::
 pub fn set_extended_attr(handle: &OwnedHandle, ea_buffer: &[u8]) -> lx::Result<()> {
     let mut iosb = Default::default();
 
+    let ea_len: u32 = ea_buffer.len().try_into().map_err(|_| lx::Error::EINVAL)?;
+
     // SAFETY: Calling NtSetEaFile as documented.
     unsafe {
         let _ = check_status(FileSystem::NtSetEaFile(
             Foundation::HANDLE(handle.as_raw_handle()),
             &mut iosb,
             ea_buffer.as_ptr() as *mut ffi::c_void,
-            ea_buffer.len() as u32,
+            ea_len,
         ))?;
 
         Ok(())

--- a/vm/devices/support/fs/lxutil/src/windows/util.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/util.rs
@@ -279,7 +279,9 @@ pub fn check_security(
         if status == Foundation::STATUS_BUFFER_TOO_SMALL {
             current_size = length_needed as usize;
             LX_UTIL_FS_SECURITY_DESCRIPTOR_SIZE.store(current_size, Ordering::Relaxed);
-            sd.reserve_tail(current_size);
+            let tail_size =
+                current_size.saturating_sub(size_of::<Security::SECURITY_DESCRIPTOR>());
+            sd.reserve_tail(tail_size);
         } else {
             return Err(nt_status_to_lx(status));
         }

--- a/vm/devices/support/fs/lxutil/src/windows/xattr.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/xattr.rs
@@ -15,7 +15,7 @@ const LX_UTIL_CASE_SENSITIVE: &str = "system.wsl_case_sensitive";
 
 const LX_UTIL_XATTR_NAME_PREFIX: &str = "LX.";
 const LX_UTIL_XATTR_NAME_PREFIX_LENGTH: usize = LX_UTIL_XATTR_NAME_PREFIX.len();
-const LX_UTIL_XATTR_NAME_MAX: usize = u16::MAX as usize - LX_UTIL_XATTR_NAME_PREFIX_LENGTH;
+const LX_UTIL_XATTR_NAME_MAX: usize = u8::MAX as usize - LX_UTIL_XATTR_NAME_PREFIX_LENGTH;
 
 const LX_UTILP_XATTR_QUERY_RESTART_SCAN: i32 = 0x1;
 const LX_UTILP_XATTR_QUERY_RETURN_SINGLE_ENTRY: i32 = 0x2;
@@ -118,7 +118,7 @@ pub fn get_system(handle: &OwnedHandle, name: &str, value: Option<&mut [u8]>) ->
 fn set_name(name: &str, buffer: &mut [u8]) -> lx::Result<usize> {
     let name_bytes = name.as_bytes();
 
-    if name_bytes.len() >= LX_UTIL_XATTR_NAME_MAX {
+    if name_bytes.len() > LX_UTIL_XATTR_NAME_MAX {
         return Err(lx::Error::ERANGE);
     }
 
@@ -245,8 +245,7 @@ pub fn get(handle: &OwnedHandle, name: &str, value: Option<&mut [u8]>) -> lx::Re
         .map_err(|_| lx::Error::EIO)?
         .0;
 
-    // The attribute doesn't exist.
-    if (ea_info.ea_value_length.get() as usize) < LX_UTILP_EA_VALUE_HEADER_SIZE {
+    if !has_valid_ea_value_header(&ea, &ea_info) {
         return Err(lx::Error::ENODATA);
     }
 
@@ -287,12 +286,7 @@ fn check_exists(handle: &OwnedHandle, name: &str) -> lx::Result<bool> {
         .map_err(|_| lx::Error::EIO)?
         .0;
 
-    // The attribute doesn't exist.
-    if (ea_info.ea_value_length.get() as usize) < LX_UTILP_EA_VALUE_HEADER_SIZE {
-        return Ok(false);
-    }
-
-    Ok(true)
+    Ok(has_valid_ea_value_header(&ea, &ea_info))
 }
 
 /// Set an extended attribute on a file
@@ -379,6 +373,20 @@ pub fn set_system(handle: &OwnedHandle, name: &str, value: &[u8], flags: i32) ->
     }
 }
 
+/// Check if an EA buffer contains a valid Linux xattr value header magic.
+fn has_valid_ea_value_header(ea_buf: &[u8], ea_info: &FileFullEaInformation) -> bool {
+    if (ea_info.ea_value_length.get() as usize) < LX_UTILP_EA_VALUE_HEADER_SIZE {
+        return false;
+    }
+    let header_start = size_of::<FileFullEaInformation>() + ea_info.ea_name_length as usize + 1;
+    let header_end = header_start + LX_UTILP_EA_VALUE_HEADER_SIZE;
+    if header_end > ea_buf.len() {
+        return false;
+    }
+    let header = u32::from_ne_bytes(ea_buf[header_start..header_end].try_into().unwrap());
+    header == LX_UTILP_EA_VALUE_HEADER
+}
+
 /// Check if the EaName of a specified FILE_FULL_EA_INFORMATION buffer matches the Linux EA prefix and namespaces.
 fn is_linux_ea(ea_buf: &[u8]) -> bool {
     if ea_buf.len() < size_of::<FileFullEaInformation>() + LX_UTIL_XATTR_NAME_PREFIX_LENGTH {
@@ -393,9 +401,19 @@ fn is_linux_ea(ea_buf: &[u8]) -> bool {
     }
 
     let name = &ea_buf[name_start + LX_UTIL_XATTR_NAME_PREFIX_LENGTH..];
-    name.starts_with(LX_UTILP_XATTR_NAMESPACE_SECURITY.as_bytes())
-        || name.starts_with(LX_UTILP_XATTR_NAMESPACE_TRUSTED.as_bytes())
-        || name.starts_with(LX_UTILP_XATTR_NAMESPACE_USER.as_bytes())
+    if !name.starts_with(LX_UTILP_XATTR_NAMESPACE_SECURITY.as_bytes())
+        && !name.starts_with(LX_UTILP_XATTR_NAMESPACE_TRUSTED.as_bytes())
+        && !name.starts_with(LX_UTILP_XATTR_NAMESPACE_USER.as_bytes())
+    {
+        return false;
+    }
+
+    let ea_info = match FileFullEaInformation::read_from_prefix(ea_buf) {
+        Ok((info, _)) => info,
+        Err(_) => return false,
+    };
+
+    has_valid_ea_value_header(ea_buf, &ea_info)
 }
 
 /// List extended attributes on a file.


### PR DESCRIPTION
Fix undefined behavior and correctness bugs found during code review of `lxutil`:

## Undefined Behavior

## Correctness Fixes
- Fix `mode`/`umask`/`dmask`/`fmask` mount option parsing to use octal instead of decimal.
- Fix NTSTATUS vs `lx::Error` domain mismatch in `util.rs` where `STATUS_NO_TOKEN` and `STATUS_BUFFER_TOO_SMALL` comparisons were dead code.
- Fix security descriptor retry loop to pass the updated buffer size.
- Add negative offset validation to `pwrite()` (matching `pread()`).
- Fix `read_dir()` to return `EINVAL` on negative offset instead of panicking.
- Fix `delete_read_only_file()` to preserve original error and restore read-only attribute on failure.
- Fix reparse data length validation to check before subtraction (underflow).
- Fix capability probe to use handle-based `query_information_file` instead of `query_information_file_by_name`.
- Fix readdir buffer growth to update `buffer_size` after reallocation.
- Fix EA buffer length truncation from silent `as u32` to checked `try_into()`.
- Add EA value header magic validation to prevent misinterpreting non-Linux EAs as Linux xattrs.
- Fix `read_nt_symlink_length()` to compute length from raw substitute name on `EPERM`, instead of reporting 0 for policy-blocked absolute symlinks.