### PR TITLE
virt_mshv: fix save/restore/reset

### DIFF
--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -4203,3 +4203,31 @@ pub struct HvRegisterCrInterceptControl {
     #[bits(35)]
     _rsvd_z: u64,
 }
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct HvX64InterruptControllerState {
+    pub apic_id: u32,
+    pub apic_version: u32,
+    pub apic_ldr: u32,
+    pub apic_dfr: u32,
+    pub apic_spurious: u32,
+    pub apic_isr: [u32; 8],
+    pub apic_tmr: [u32; 8],
+    pub apic_irr: [u32; 8],
+    pub apic_esr: u32,
+    pub apic_icr_high: u32,
+    pub apic_icr_low: u32,
+    pub apic_lvt_timer: u32,
+    pub apic_lvt_thermal: u32,
+    pub apic_lvt_perfmon: u32,
+    pub apic_lvt_lint0: u32,
+    pub apic_lvt_lint1: u32,
+    pub apic_lvt_error: u32,
+    pub apic_lvt_cmci: u32,
+    pub apic_error_status: u32,
+    pub apic_initial_count: u32,
+    pub apic_counter_value: u32,
+    pub apic_divide_configuration: u32,
+    pub apic_remote_read: u32,
+}

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -1495,29 +1495,32 @@ impl<'a> Processor<'a> {
         }
     }
 
-    pub fn get_apic(&self) -> Result<Vec<u8>> {
-        let mut r = Vec::with_capacity(4096);
+    pub fn get_apic(&self) -> Result<[u8; 1024]> {
+        // Only the first 1024 bytes are used but the API requires a full page,
+        // for some unknown reason.
+        let mut r = [[0u8; 1024]; 4];
         unsafe {
             let mut n = 0;
             check_hresult(api::WHvGetVirtualProcessorInterruptControllerState2(
                 self.partition.handle,
                 self.index,
-                r.as_mut_ptr(),
-                r.capacity() as u32,
+                r.as_mut_ptr().cast(),
+                size_of_val(&r) as u32,
                 &mut n,
             ))?;
-            r.set_len(n as usize);
+            assert_eq!(n, size_of_val(&r) as u32);
         }
-        Ok(r)
+        Ok(r[0])
     }
 
-    pub fn set_apic(&self, data: &[u8]) -> Result<()> {
+    pub fn set_apic(&self, data: &[u8; 1024]) -> Result<()> {
+        let r = [*data, [0u8; 1024], [0u8; 1024], [0u8; 1024]];
         unsafe {
             check_hresult(api::WHvSetVirtualProcessorInterruptControllerState2(
                 self.partition.handle,
                 self.index,
-                data.as_ptr(),
-                data.len() as u32,
+                r.as_ptr().cast(),
+                size_of_val(&r) as u32,
             ))
         }
     }

--- a/vmm_core/virt/src/x86/vp.rs
+++ b/vmm_core/virt/src/x86/vp.rs
@@ -966,7 +966,7 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for Xsave {
 pub struct Apic {
     #[mesh(1)]
     pub apic_base: u64,
-    #[inspect(with = "ApicRegisters::from")]
+    #[inspect(with = "ApicRegisters::from_array_ref")]
     #[mesh(2)]
     pub registers: [u32; 64],
     #[inspect(iter_by_index)]
@@ -989,8 +989,22 @@ impl Debug for Apic {
     }
 }
 
+impl Apic {
+    pub fn new(apic_base: ApicBase, registers: ApicRegisters, auto_eoi: [u32; 8]) -> Self {
+        Self {
+            apic_base: apic_base.into(),
+            registers: *registers.as_array(),
+            auto_eoi,
+        }
+    }
+
+    pub fn registers(&self) -> &ApicRegisters {
+        ApicRegisters::from_array_ref(&self.registers)
+    }
+}
+
 #[repr(C)]
-#[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
 #[inspect(hex)]
 pub struct ApicRegisters {
     #[inspect(skip)]
@@ -1036,15 +1050,96 @@ pub struct ApicRegisters {
 
 const _: () = assert!(size_of::<ApicRegisters>() == 0x100);
 
-impl From<&'_ [u32; 64]> for ApicRegisters {
-    fn from(value: &'_ [u32; 64]) -> Self {
-        Self::read_from_bytes(value.as_bytes()).unwrap()
+impl From<ApicRegisters> for hvdef::HvX64InterruptControllerState {
+    fn from(value: ApicRegisters) -> Self {
+        Self {
+            apic_id: value.id,
+            apic_version: value.version,
+            apic_ldr: value.ldr,
+            apic_dfr: value.dfr,
+            apic_spurious: value.svr,
+            apic_isr: value.isr,
+            apic_tmr: value.tmr,
+            apic_irr: value.irr,
+            apic_esr: value.esr,
+            apic_icr_high: value.icr[1],
+            apic_icr_low: value.icr[0],
+            apic_lvt_timer: value.lvt_timer,
+            apic_lvt_thermal: value.lvt_thermal,
+            apic_lvt_perfmon: value.lvt_pmc,
+            apic_lvt_lint0: value.lvt_lint0,
+            apic_lvt_lint1: value.lvt_lint1,
+            apic_lvt_error: value.lvt_error,
+            apic_lvt_cmci: value.lvt_cmci,
+            apic_error_status: value.esr,
+            apic_initial_count: value.timer_icr,
+            apic_counter_value: value.timer_ccr,
+            apic_divide_configuration: value.timer_dcr,
+            apic_remote_read: value.rrd,
+        }
     }
 }
 
-impl From<ApicRegisters> for [u32; 64] {
-    fn from(value: ApicRegisters) -> Self {
-        Self::read_from_bytes(value.as_bytes()).unwrap()
+impl From<hvdef::HvX64InterruptControllerState> for ApicRegisters {
+    fn from(value: hvdef::HvX64InterruptControllerState) -> Self {
+        let hvdef::HvX64InterruptControllerState {
+            apic_id,
+            apic_version,
+            apic_ldr,
+            apic_dfr,
+            apic_spurious,
+            apic_isr,
+            apic_tmr,
+            apic_irr,
+            apic_esr,
+            apic_icr_high,
+            apic_icr_low,
+            apic_lvt_timer,
+            apic_lvt_thermal,
+            apic_lvt_perfmon,
+            apic_lvt_lint0,
+            apic_lvt_lint1,
+            apic_lvt_error,
+            apic_lvt_cmci,
+            // The unlatched error status is not preserved across save/restore.
+            apic_error_status: _,
+            apic_initial_count,
+            apic_counter_value,
+            apic_divide_configuration,
+            apic_remote_read,
+        } = value;
+        Self {
+            reserved_0: [0; 2],
+            id: apic_id,
+            version: apic_version,
+            reserved_4: [0; 4],
+            tpr: 0,
+            apr: 0,
+            ppr: 0,
+            eoi: 0,
+            rrd: apic_remote_read,
+            ldr: apic_ldr,
+            dfr: apic_dfr,
+            svr: apic_spurious,
+            isr: apic_isr,
+            tmr: apic_tmr,
+            irr: apic_irr,
+            esr: apic_esr,
+            reserved_29: [0; 6],
+            lvt_cmci: apic_lvt_cmci,
+            icr: [apic_icr_low, apic_icr_high],
+            lvt_timer: apic_lvt_timer,
+            lvt_thermal: apic_lvt_thermal,
+            lvt_pmc: apic_lvt_perfmon,
+            lvt_lint0: apic_lvt_lint0,
+            lvt_lint1: apic_lvt_lint1,
+            lvt_error: apic_lvt_error,
+            timer_icr: apic_initial_count,
+            timer_ccr: apic_counter_value,
+            reserved_3a: [0; 4],
+            timer_dcr: apic_divide_configuration,
+            reserved_3f: 0,
+        }
     }
 }
 
@@ -1055,14 +1150,22 @@ struct ApicRegister {
     zero: [u32; 3],
 }
 
-// The IRR bit number corresponding to NMI pending in the Hyper-V exo APIC saved
-// state.
-const HV_IRR_NMI_PENDING_SHIFT: u32 = 2;
+impl ApicRegisters {
+    pub fn as_array(&self) -> &[u32; 64] {
+        zerocopy::transmute_ref!(self)
+    }
 
-impl Apic {
+    pub fn from_array(array: [u32; 64]) -> Self {
+        zerocopy::transmute!(array)
+    }
+
+    pub fn from_array_ref(array: &[u32; 64]) -> &Self {
+        zerocopy::transmute_ref!(array)
+    }
+
     pub fn as_page(&self) -> [u8; 1024] {
         let mut bytes = [0; 1024];
-        self.registers
+        self.as_array()
             .map(|value| ApicRegister {
                 value,
                 zero: [0; 3],
@@ -1073,16 +1176,9 @@ impl Apic {
     }
 
     /// Convert from an APIC page.
-    ///
-    /// N.B. The MS hypervisor's APIC page format includes a non-architectural
-    /// NMI pending bit that should be stripped first.
-    pub fn from_page(apic_base: u64, page: &[u8; 1024]) -> Self {
+    pub fn from_page(page: &[u8; 1024]) -> Self {
         let registers = <[ApicRegister; 64]>::read_from_bytes(page.as_slice()).unwrap();
-        Self {
-            apic_base,
-            registers: registers.map(|reg| reg.value),
-            auto_eoi: [0; 8],
-        }
+        Self::from_array(registers.map(|reg| reg.value))
     }
 }
 
@@ -1123,11 +1219,7 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for Apic {
             .with_x2apic(x2apic)
             .with_enable(true);
 
-        Apic {
-            apic_base: apic_base.into(),
-            registers: regs.into(),
-            auto_eoi: [0; 8],
-        }
+        Apic::new(apic_base, regs, [0; 8])
     }
 
     fn can_compare(caps: &X86PartitionCapabilities) -> bool {
@@ -1137,15 +1229,21 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for Apic {
     }
 }
 
-/// Sets the non-architectural Hyper-V NMI pending bit in the APIC page.
-pub fn set_hv_apic_nmi_pending(page: &mut [u8], pending: bool) {
-    page[0x200] &= !(1 << HV_IRR_NMI_PENDING_SHIFT);
-    page[0x200] |= (pending as u8) << HV_IRR_NMI_PENDING_SHIFT;
-}
+// The IRR bit number corresponding to NMI pending in the Hyper-V exo APIC saved
+// state.
+const NMI_VECTOR: u32 = 2;
 
-/// Gets the non-architectural Hyper-V NMI pending bit from the APIC page.
-pub fn hv_apic_nmi_pending(page: &[u8]) -> bool {
-    page[0x200] & (1 << HV_IRR_NMI_PENDING_SHIFT) != 0
+impl ApicRegisters {
+    /// Sets the non-architectural Hyper-V NMI pending bit in the APIC page.
+    pub fn set_hv_apic_nmi_pending(&mut self, pending: bool) {
+        self.irr[0] &= !(1 << NMI_VECTOR);
+        self.irr[0] |= (pending as u32) << NMI_VECTOR;
+    }
+
+    /// Gets the non-architectural Hyper-V NMI pending bit from the APIC page.
+    pub fn hv_apic_nmi_pending(&self) -> bool {
+        self.irr[0] & (1 << NMI_VECTOR) != 0
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Protobuf, Inspect)]

--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -374,14 +374,20 @@ impl AccessVpState for KvmVpStateAccess<'_> {
     }
 
     fn apic(&mut self) -> Result<vp::Apic, Self::Error> {
-        let mut apic_base = [0];
-        self.kvm()
-            .get_msrs(&[x86defs::X86X_MSR_APIC_BASE], &mut apic_base)?;
+        let mut apic_base = 0;
+        self.kvm().get_msrs(
+            &[x86defs::X86X_MSR_APIC_BASE],
+            std::slice::from_mut(&mut apic_base),
+        )?;
 
         let mut state = FromZeros::new_zeroed();
         self.kvm().get_lapic(&mut state)?;
 
-        Ok(vp::Apic::from_page(apic_base[0], &state))
+        Ok(vp::Apic::new(
+            apic_base.into(),
+            vp::ApicRegisters::from_page(&state),
+            [0; 8],
+        ))
     }
 
     fn set_apic(&mut self, value: &vp::Apic) -> Result<(), Self::Error> {
@@ -390,7 +396,7 @@ impl AccessVpState for KvmVpStateAccess<'_> {
         self.kvm()
             .set_msrs(&[(x86defs::X86X_MSR_APIC_BASE, value.apic_base)])?;
 
-        self.kvm().set_lapic(&value.as_page())?;
+        self.kvm().set_lapic(&value.registers().as_page())?;
         Ok(())
     }
 

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -398,15 +398,19 @@ impl ProtoPartition for MshvProtoPartition<'_> {
         }
 
         // Get caps via cpuid
-        let caps = virt::PartitionCapabilities::from_cpuid(
-            self.config.processor_topology,
-            &mut |function, index| {
-                self.bsp
-                    .get_cpuid_values(function, index, 0, 0)
-                    .expect("cpuid should not fail")
-            },
-        )
-        .map_err(Error::Capabilities)?;
+        let caps = {
+            let mut caps = virt::PartitionCapabilities::from_cpuid(
+                self.config.processor_topology,
+                &mut |function, index| {
+                    self.bsp
+                        .get_cpuid_values(function, index, 0, 0)
+                        .expect("cpuid should not fail")
+                },
+            )
+            .map_err(Error::Capabilities)?;
+            caps.xsaves_state_bv_broken = true;
+            caps
+        };
 
         let apic_id_map = self
             .config
@@ -1156,11 +1160,21 @@ pub enum Error {
     SetPartitionProperty(#[source] anyhow::Error),
     #[error("register access error")]
     Register(#[source] MshvError),
-    #[error("failed to get/set VP state")]
-    VpState(#[source] MshvError),
+    #[error("failed to get VP state {ty}")]
+    GetVpState {
+        #[source]
+        error: MshvError,
+        ty: u8,
+    },
+    #[error("failed to set VP state {ty}")]
+    SetVpState {
+        #[source]
+        error: MshvError,
+        ty: u8,
+    },
     #[error("failed to reset state")]
     ResetState(#[source] Box<virt::state::StateError<Self>>),
-    #[error("install instercept failed")]
+    #[error("install intercept failed")]
     InstallIntercept(#[source] MshvError),
     #[error("failed to register cpuid override")]
     RegisterCpuid(#[source] MshvError),

--- a/vmm_core/virt_mshv/src/vp_state.rs
+++ b/vmm_core/virt_mshv/src/vp_state.rs
@@ -6,12 +6,14 @@ use super::VcpuFdExt;
 use crate::MshvProcessor;
 use hvdef::HvX64RegisterName;
 use hvdef::hypercall::HvRegisterAssoc;
-use mshv_bindings::LapicState;
 use mshv_bindings::MSHV_VP_STATE_SIEFP;
 use mshv_bindings::MSHV_VP_STATE_SIMP;
 use mshv_bindings::MSHV_VP_STATE_SYNTHETIC_TIMERS;
 use mshv_bindings::mshv_get_set_vp_state;
+use std::ptr::NonNull;
+use std::sync::OnceLock;
 use virt::state::HvRegisterState;
+use virt::vp::ApicRegisters;
 use virt::x86::vp;
 use virt::x86::vp::AccessVpState;
 use zerocopy::FromZeros;
@@ -57,6 +59,120 @@ impl MshvProcessor<'_> {
         regs.set_values(assoc.iter().map(|assoc| assoc.value));
         Ok(regs)
     }
+
+    fn set_state(&self, ty: u32, data: &[u8]) -> Result<(), Error> {
+        // The kernel requires a page-aligned buffer for VP state operations.
+        let mut buf = PageAlignedBuffer::new(data.len());
+        buf.as_mut_bytes().copy_from_slice(data);
+
+        let vp_state = mshv_get_set_vp_state {
+            type_: ty as u8,
+            buf_sz: buf.aligned_len() as u32,
+            buf_ptr: buf.as_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .set_vp_state_ioctl(&vp_state)
+            .map_err(|e| Error::SetVpState {
+                error: e,
+                ty: ty as u8,
+            })
+    }
+
+    fn get_fixed_state<T: zerocopy::FromBytes>(&self, ty: u32) -> Result<T, Error> {
+        let state = self.get_state(ty, size_of::<T>())?;
+        Ok(T::read_from_prefix(state.as_bytes()).unwrap().0)
+    }
+
+    fn get_state(&self, ty: u32, size: usize) -> Result<PageAlignedBuffer, Error> {
+        // The kernel requires a page-aligned buffer for VP state operations.
+        let mut buf = PageAlignedBuffer::new(size);
+        let mut vp_state = mshv_get_set_vp_state {
+            type_: ty as u8,
+            buf_sz: buf.aligned_len() as u32,
+            buf_ptr: buf.as_mut_ptr() as u64,
+            ..Default::default()
+        };
+        self.runner
+            .vcpufd
+            .get_vp_state_ioctl(&mut vp_state)
+            .map_err(|e| Error::GetVpState {
+                error: e,
+                ty: ty as u8,
+            })?;
+        Ok(buf)
+    }
+
+    fn get_lapic(&self) -> Result<ApicRegisters, Error> {
+        let hv_state: hvdef::HvX64InterruptControllerState =
+            self.get_fixed_state(mshv_bindings::MSHV_VP_STATE_LAPIC)?;
+
+        Ok(ApicRegisters::from(hv_state))
+    }
+
+    fn set_lapic(&self, lapic: &ApicRegisters) -> Result<(), Error> {
+        let hv_state: hvdef::HvX64InterruptControllerState = (*lapic).into();
+        self.set_state(mshv_bindings::MSHV_VP_STATE_LAPIC, hv_state.as_bytes())
+    }
+}
+
+struct PageAlignedBuffer {
+    ptr: NonNull<u8>,
+    len: usize,
+    layout: std::alloc::Layout,
+}
+
+impl PageAlignedBuffer {
+    fn page_size() -> usize {
+        static PAGE_SIZE: OnceLock<usize> = OnceLock::new();
+        // SAFETY: sysconf(_SC_PAGESIZE) is always safe to call.
+        *PAGE_SIZE.get_or_init(|| unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize)
+    }
+
+    fn new(len: usize) -> Self {
+        let page_size = Self::page_size();
+        let layout =
+            std::alloc::Layout::from_size_align(len.next_multiple_of(page_size), page_size)
+                .unwrap();
+        // SAFETY: layout has non-zero size and page alignment.
+        let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+        let Some(ptr) = NonNull::new(ptr) else {
+            std::alloc::handle_alloc_error(layout);
+        };
+        Self { ptr, len, layout }
+    }
+
+    fn aligned_len(&self) -> usize {
+        self.layout.size()
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.ptr.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        // SAFETY: ptr is valid for layout.size() >= self.len bytes and is
+        // uniquely owned.
+        unsafe { std::slice::from_raw_parts(self.as_ptr(), self.len) }
+    }
+
+    fn as_mut_bytes(&mut self) -> &mut [u8] {
+        // SAFETY: ptr is valid for layout.size() >= self.len bytes, and &mut
+        // self guarantees exclusive access.
+        unsafe { std::slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
+    }
+}
+
+impl Drop for PageAlignedBuffer {
+    fn drop(&mut self) {
+        // SAFETY: ptr was allocated with this layout via alloc_zeroed.
+        unsafe { std::alloc::dealloc(self.ptr.as_ptr(), self.layout) };
+    }
 }
 
 impl AccessVpState for &'_ mut MshvProcessor<'_> {
@@ -82,9 +198,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         let mut activity: vp::Activity = self.get_register_state()?;
         // The NMI pending bit is not part of the register state; it lives
         // in the APIC page.
-        let lapic = self.runner.vcpufd.get_lapic().map_err(Error::VpState)?;
-        let page: [u8; 1024] = lapic.regs.map(|b| b as u8);
-        activity.nmi_pending = vp::hv_apic_nmi_pending(&page);
+        activity.nmi_pending = self.get_lapic()?.hv_apic_nmi_pending();
         Ok(activity)
     }
 
@@ -92,34 +206,28 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         self.set_register_state(value)?;
         // The NMI pending bit is not part of the register state; it must
         // be set via the APIC page.
-        let mut lapic = self.runner.vcpufd.get_lapic().map_err(Error::VpState)?;
-        let mut page: [u8; 1024] = lapic.regs.map(|b| b as u8);
-        vp::set_hv_apic_nmi_pending(&mut page, value.nmi_pending);
-        lapic.regs = page.map(|b| b as std::os::raw::c_char);
-        self.runner
-            .vcpufd
-            .set_lapic(&lapic)
-            .map_err(Error::VpState)?;
+        let mut lapic = self.get_lapic()?;
+        if lapic.hv_apic_nmi_pending() != value.nmi_pending {
+            lapic.set_hv_apic_nmi_pending(value.nmi_pending);
+            self.set_lapic(&lapic)?;
+        }
         Ok(())
     }
 
     fn xsave(&mut self) -> Result<vp::Xsave, Self::Error> {
-        let xsave = self.runner.vcpufd.get_xsave().map_err(Error::VpState)?;
-        Ok(vp::Xsave::from_compact(&xsave.buffer, &self.partition.caps))
+        let xsave = self.get_state(
+            mshv_bindings::MSHV_VP_STATE_XSAVE,
+            self.partition.caps.xsave.compact_len as usize,
+        )?;
+        Ok(vp::Xsave::from_compact(
+            xsave.as_bytes(),
+            &self.partition.caps,
+        ))
     }
 
     fn set_xsave(&mut self, value: &vp::Xsave) -> Result<(), Self::Error> {
-        let data = value.compact();
-        let vp_state = mshv_get_set_vp_state {
-            type_: mshv_bindings::MSHV_VP_STATE_XSAVE as u8,
-            buf_sz: data.len() as u32,
-            buf_ptr: data.as_ptr() as u64,
-            ..Default::default()
-        };
-        self.runner
-            .vcpufd
-            .set_vp_state_ioctl(&vp_state)
-            .map_err(Error::VpState)
+        self.set_state(mshv_bindings::MSHV_VP_STATE_XSAVE, value.compact())?;
+        Ok(())
     }
 
     fn apic(&mut self) -> Result<vp::Apic, Self::Error> {
@@ -136,13 +244,10 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         let apic_base = assoc[0].value.as_u64();
 
         // Get the LAPIC state page.
-        let lapic = self.runner.vcpufd.get_lapic().map_err(Error::VpState)?;
-        let mut page: [u8; 1024] = lapic.regs.map(|b| b as u8);
-
+        let mut lapic = self.get_lapic()?;
         // Clear the non-architectural NMI pending bit.
-        vp::set_hv_apic_nmi_pending(&mut page, false);
-
-        Ok(vp::Apic::from_page(apic_base, &page))
+        lapic.set_hv_apic_nmi_pending(false);
+        Ok(vp::Apic::new(apic_base.into(), lapic, [0; 8]))
     }
 
     fn set_apic(&mut self, value: &vp::Apic) -> Result<(), Self::Error> {
@@ -157,20 +262,12 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
             .map_err(Error::Register)?;
 
         // Preserve the current NMI pending state across the restore.
-        let current_lapic = self.runner.vcpufd.get_lapic().map_err(Error::VpState)?;
-        let current_page: [u8; 1024] = current_lapic.regs.map(|b| b as u8);
-        let nmi_pending = vp::hv_apic_nmi_pending(&current_page);
+        let nmi_pending = self.get_lapic()?.hv_apic_nmi_pending();
 
         // Set the LAPIC state page, restoring the NMI pending bit.
-        let mut page = value.as_page();
-        vp::set_hv_apic_nmi_pending(&mut page, nmi_pending);
-        let lapic = LapicState {
-            regs: page.map(|b| b as std::os::raw::c_char),
-        };
-        self.runner
-            .vcpufd
-            .set_lapic(&lapic)
-            .map_err(Error::VpState)?;
+        let mut lapic = *value.registers();
+        lapic.set_hv_apic_nmi_pending(nmi_pending);
+        self.set_lapic(&lapic)?;
 
         Ok(())
     }
@@ -264,32 +361,14 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
     }
 
     fn synic_timers(&mut self) -> Result<vp::SynicTimers, Self::Error> {
-        let mut state = hvdef::HvSyntheticTimersState::new_zeroed();
-        let mut vp_state = mshv_get_set_vp_state {
-            type_: MSHV_VP_STATE_SYNTHETIC_TIMERS as u8,
-            buf_sz: size_of_val(&state) as u32,
-            buf_ptr: state.as_mut_bytes().as_mut_ptr() as u64,
-            ..Default::default()
-        };
-        self.runner
-            .vcpufd
-            .get_vp_state_ioctl(&mut vp_state)
-            .map_err(Error::VpState)?;
-        Ok(vp::SynicTimers::from_hv(state))
+        Ok(vp::SynicTimers::from_hv(
+            self.get_fixed_state(MSHV_VP_STATE_SYNTHETIC_TIMERS)?,
+        ))
     }
 
     fn set_synic_timers(&mut self, value: &vp::SynicTimers) -> Result<(), Self::Error> {
-        let state = value.as_hv();
-        let vp_state = mshv_get_set_vp_state {
-            type_: MSHV_VP_STATE_SYNTHETIC_TIMERS as u8,
-            buf_sz: size_of_val(&state) as u32,
-            buf_ptr: state.as_bytes().as_ptr() as u64,
-            ..Default::default()
-        };
-        self.runner
-            .vcpufd
-            .set_vp_state_ioctl(&vp_state)
-            .map_err(Error::VpState)
+        self.set_state(MSHV_VP_STATE_SYNTHETIC_TIMERS, value.as_hv().as_bytes())?;
+        Ok(())
     }
 
     fn synic_message_queues(&mut self) -> Result<vp::SynicMessageQueues, Self::Error> {
@@ -305,61 +384,23 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
     }
 
     fn synic_message_page(&mut self) -> Result<vp::SynicMessagePage, Self::Error> {
-        let mut state = vp::SynicMessagePage { data: [0; 4096] };
-        let mut vp_state = mshv_get_set_vp_state {
-            type_: MSHV_VP_STATE_SIMP as u8,
-            buf_sz: size_of_val(&state.data) as u32,
-            buf_ptr: state.data.as_mut_ptr() as u64,
-            ..Default::default()
-        };
-        self.runner
-            .vcpufd
-            .get_vp_state_ioctl(&mut vp_state)
-            .map_err(Error::VpState)?;
-        Ok(state)
+        let data = self.get_fixed_state(MSHV_VP_STATE_SIMP)?;
+        Ok(vp::SynicMessagePage { data })
     }
 
     fn set_synic_message_page(&mut self, value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
-        let vp_state = mshv_get_set_vp_state {
-            type_: MSHV_VP_STATE_SIMP as u8,
-            buf_sz: size_of_val(&value.data) as u32,
-            buf_ptr: value.data.as_ptr() as u64,
-            ..Default::default()
-        };
-        self.runner
-            .vcpufd
-            .set_vp_state_ioctl(&vp_state)
-            .map_err(Error::VpState)
+        self.set_state(MSHV_VP_STATE_SIMP, &value.data)
     }
 
     fn synic_event_flags_page(&mut self) -> Result<vp::SynicEventFlagsPage, Self::Error> {
-        let mut state = vp::SynicEventFlagsPage { data: [0; 4096] };
-        let mut vp_state = mshv_get_set_vp_state {
-            type_: MSHV_VP_STATE_SIEFP as u8,
-            buf_sz: size_of_val(&state.data) as u32,
-            buf_ptr: state.data.as_mut_ptr() as u64,
-            ..Default::default()
-        };
-        self.runner
-            .vcpufd
-            .get_vp_state_ioctl(&mut vp_state)
-            .map_err(Error::VpState)?;
-        Ok(state)
+        let data = self.get_fixed_state(MSHV_VP_STATE_SIEFP)?;
+        Ok(vp::SynicEventFlagsPage { data })
     }
 
     fn set_synic_event_flags_page(
         &mut self,
         value: &vp::SynicEventFlagsPage,
     ) -> Result<(), Self::Error> {
-        let vp_state = mshv_get_set_vp_state {
-            type_: MSHV_VP_STATE_SIEFP as u8,
-            buf_sz: size_of_val(&value.data) as u32,
-            buf_ptr: value.data.as_ptr() as u64,
-            ..Default::default()
-        };
-        self.runner
-            .vcpufd
-            .set_vp_state_ioctl(&vp_state)
-            .map_err(Error::VpState)
+        self.set_state(MSHV_VP_STATE_SIEFP, &value.data)
     }
 }

--- a/vmm_core/virt_support_apic/src/lib.rs
+++ b/vmm_core/virt_support_apic/src/lib.rs
@@ -1844,11 +1844,7 @@ impl LocalApic {
             timer_dcr: self.timer_dcr,
             reserved_3f: 0,
         };
-        virt::x86::vp::Apic {
-            apic_base: self.apic_base,
-            registers: registers.into(),
-            auto_eoi: self.auto_eoi,
-        }
+        virt::x86::vp::Apic::new(self.apic_base.into(), registers, self.auto_eoi)
     }
 
     /// Restores the APIC register state.
@@ -1857,7 +1853,7 @@ impl LocalApic {
 
         let virt::x86::vp::Apic {
             apic_base,
-            registers,
+            registers: _,
             auto_eoi,
         } = state;
 
@@ -1899,7 +1895,7 @@ impl LocalApic {
             reserved_3a: _,
             timer_dcr,
             reserved_3f: _,
-        } = registers.into();
+        } = *state.registers();
 
         self.id = if self.x2apic_enabled() { id } else { id >> 24 };
         self.version = version;

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -25,8 +25,6 @@ use virt::io::CpuIo;
 use virt::irqcon::MsiRequest;
 use virt::x86::MsrError;
 use virt::x86::vp;
-use virt::x86::vp::hv_apic_nmi_pending;
-use virt::x86::vp::set_hv_apic_nmi_pending;
 use virt_support_apic::ApicClient;
 use virt_support_apic::ApicWork;
 use virt_support_apic::LocalApic;
@@ -212,8 +210,10 @@ impl WhpProcessor<'_> {
             LocalApicKind::Offloaded => {
                 // Get the NMI pending bit from the APIC.
                 let mut activity: vp::Activity = self.vp.get_register_state(vtl)?;
-                let apic = self.vp.whp(vtl).get_apic().for_op("get apic state")?;
-                activity.nmi_pending = hv_apic_nmi_pending(&apic);
+                let apic = vp::ApicRegisters::from_page(
+                    &self.vp.whp(vtl).get_apic().for_op("get apic state")?,
+                );
+                activity.nmi_pending = apic.hv_apic_nmi_pending();
                 activity
             }
         };
@@ -260,9 +260,16 @@ impl WhpProcessor<'_> {
             LocalApicKind::Offloaded => {
                 self.vp.set_register_state(vtl, value)?;
                 // Set the NMI pending bit via the APIC.
-                let mut apic = self.vp.whp(vtl).get_apic().for_op("get apic state")?;
-                set_hv_apic_nmi_pending(&mut apic, value.nmi_pending);
-                self.vp.whp(vtl).set_apic(&apic).for_op("set apic state")?;
+                let mut apic = vp::ApicRegisters::from_page(
+                    &self.vp.whp(vtl).get_apic().for_op("get apic state")?,
+                );
+                if value.nmi_pending != apic.hv_apic_nmi_pending() {
+                    apic.set_hv_apic_nmi_pending(value.nmi_pending);
+                    self.vp
+                        .whp(vtl)
+                        .set_apic(&apic.as_page())
+                        .for_op("set apic state")?;
+                }
             }
         }
         Ok(())
@@ -281,10 +288,12 @@ impl WhpProcessor<'_> {
                 lapic.apic.save()
             }
             LocalApicKind::Offloaded => {
-                let mut apic = self.vp.whp(vtl).get_apic().for_op("get apic state")?;
+                let mut apic = vp::ApicRegisters::from_page(
+                    &self.vp.whp(vtl).get_apic().for_op("get apic state")?,
+                );
                 // Clear the non-architectural NMI pending bit.
-                set_hv_apic_nmi_pending(&mut apic, false);
-                vp::Apic::from_page(apic_base, &apic[..1024].try_into().unwrap())
+                apic.set_hv_apic_nmi_pending(false);
+                vp::Apic::new(apic_base.into(), apic, [0; 8])
             }
         };
 
@@ -306,11 +315,16 @@ impl WhpProcessor<'_> {
             }
             LocalApicKind::Offloaded => {
                 // Preserve NMI pending.
-                let mut apic = self.vp.whp(vtl).get_apic().for_op("get apic state")?;
-                let nmi_pending = hv_apic_nmi_pending(&apic);
-                apic[..1024].copy_from_slice(&value.as_page());
-                set_hv_apic_nmi_pending(&mut apic, nmi_pending);
-                self.vp.whp(vtl).set_apic(&apic).for_op("set apic state")?;
+                let nmi_pending = vp::ApicRegisters::from_page(
+                    &self.vp.whp(vtl).get_apic().for_op("get apic state")?,
+                )
+                .hv_apic_nmi_pending();
+                let mut apic = *value.registers();
+                apic.set_hv_apic_nmi_pending(nmi_pending);
+                self.vp
+                    .whp(vtl)
+                    .set_apic(&apic.as_page())
+                    .for_op("set apic state")?;
             }
         }
 


### PR DESCRIPTION
Save/restore and reset were broken under virt_mshv for two reasons:

1. The mshv kernel driver requires page-aligned buffers for VP state ioctls (xsave, LAPIC, synic timers, SIMP, SIEFP), but the existing code passed stack/heap pointers with arbitrary alignment, causing ioctl failures.

2. The xsaves_state_bv_broken capability flag was not being set, causing xsave state to be incorrectly interpreted during save/restore.

To fix the alignment issue, introduce a PageAlignedBuffer helper in virt_mshv and centralize all VP state get/set operations through get_state/set_state/get_fixed_state methods, replacing the scattered inline ioctl calls.

As part of this, clean up LAPIC register handling across the different backends. There are three different LAPIC state formats in use; try to make it a little clearer which is which, and to use a single one internally.