### PR TITLE
openhcl_boot: handle multi numa private pool fallback

### DIFF
--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -33,6 +33,13 @@ const SIDECAR: &str = "OPENHCL_SIDECAR=";
 /// Disable NVME keep alive regardless if the host supports it.
 const DISABLE_NVME_KEEP_ALIVE: &str = "OPENHCL_DISABLE_NVME_KEEP_ALIVE=";
 
+/// Control NUMA allocation behavior for the VTL2 GPA pool.
+///
+/// * `split`: Force the pool to be split evenly across NUMA nodes, skipping
+///   the default "try node 0 first" fast path. Useful for testing multi-range
+///   pool allocation.
+const VTL2_GPA_POOL_NUMA: &str = "OPENHCL_VTL2_GPA_POOL_NUMA=";
+
 /// Lookup table to use for VTL2 GPA pool size heuristics.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Vtl2GpaPoolLookupTable {
@@ -114,6 +121,9 @@ pub struct BootCommandLineOptions {
     pub enable_vtl2_gpa_pool: Vtl2GpaPoolConfig,
     pub sidecar: SidecarOptions,
     pub disable_nvme_keep_alive: bool,
+    /// When true, force the VTL2 GPA pool to be split evenly across NUMA
+    /// nodes instead of trying to allocate entirely on node 0 first.
+    pub vtl2_gpa_pool_numa_split: bool,
 }
 
 impl BootCommandLineOptions {
@@ -123,6 +133,7 @@ impl BootCommandLineOptions {
             enable_vtl2_gpa_pool: Vtl2GpaPoolConfig::Heuristics(Vtl2GpaPoolLookupTable::Release), // use the release config by default
             sidecar: SidecarOptions::default(),
             disable_nvme_keep_alive: true,
+            vtl2_gpa_pool_numa_split: false,
         }
     }
 }
@@ -177,6 +188,13 @@ impl BootCommandLineOptions {
                 let arg = arg.split_once('=').map(|(_, arg)| arg);
                 if arg.is_some_and(|a| a == "0") {
                     self.disable_nvme_keep_alive = false;
+                }
+            } else if arg.starts_with(VTL2_GPA_POOL_NUMA) {
+                if let Some((_, arg)) = arg.split_once('=') {
+                    match arg {
+                        "split" => self.vtl2_gpa_pool_numa_split = true,
+                        _ => log::warn!("Unknown value for OPENHCL_VTL2_GPA_POOL_NUMA: {arg}"),
+                    }
                 }
             }
         }

--- a/openhcl/openhcl_boot/src/host_params/dt/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt/mod.rs
@@ -90,7 +90,15 @@ fn allocate_private_pool(
     vp_count: usize,
     mem_size: u64,
 ) {
-    // Try allocating the entire pool on node 0 first (unless forced to split).
+    // Try allocating the entire pool on node 0 first. We do this to maintain
+    // compatibility with older openhcl_boot images that do not understand how
+    // to handle a split private pool, and to maintain previous behavior where
+    // the pool was completely allocated on numa node 0.
+    //
+    // Allocate from high memory downward to avoid overlapping any used ranges
+    // in low memory when openhcl's usage gets bigger, as otherwise the
+    // used_range by the bootshim could overlap the pool range chosen when
+    // servicing to a new image.
     if !force_numa_split {
         if let Some(pool) = address_space.allocate(
             Some(0),
@@ -107,6 +115,8 @@ fn allocate_private_pool(
     }
 
     // Enumerate unique NUMA nodes from VTL2 RAM.
+    //
+    // FUTURE: Handle cases where the are CPU only or RAM only numa nodes.
     let mut numa_nodes = off_stack!(ArrayVec<u32, MAX_NUMA_NODES>, ArrayVec::new_const());
     for entry in vtl2_ram.iter() {
         match numa_nodes.binary_search(&entry.vnode) {
@@ -118,10 +128,25 @@ fn allocate_private_pool(
     }
 
     let num_nodes = numa_nodes.len() as u64;
+    // Split the per node size to page size aligned chunks, and give the
+    // remainder to the last node.
     let per_node_size = (pool_size_bytes / num_nodes) & !(HV_PAGE_SIZE - 1);
-    // Give the remainder (due to rounding) to the last node.
     let last_node_size = pool_size_bytes - per_node_size * (num_nodes - 1);
     let mut remaining = pool_size_bytes;
+
+    // If per-node-size is zero, we're in some strange configuration. We should
+    // have been able to allocate this from a single node, as this would mean
+    // the number of nodes is larger than the number of pages requested for the
+    // pool, so fail explicitly.
+    if per_node_size == 0 {
+        panic!(
+            "cannot split VTL2 pool of size {pool_size_bytes:#x} bytes across \
+            {num_nodes} nodes, per node size {per_node_size:#x} bytes; \
+            enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, \
+            device_dma_page_count={device_dma_page_count:#x?}, \
+            vp_count={vp_count}, mem_size={mem_size:#x}"
+        );
+    }
 
     for (i, vnode) in numa_nodes.iter().enumerate() {
         if remaining == 0 {
@@ -135,6 +160,8 @@ fn allocate_private_pool(
             per_node_size
         };
 
+        // Make sure to allocate high memory downward, for the same reason as
+        // described in the numa 0 case.
         match address_space.allocate(
             Some(*vnode),
             alloc_size,

--- a/openhcl/openhcl_boot/src/host_params/dt/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt/mod.rs
@@ -75,6 +75,119 @@ pub enum DtError {
     NotEnoughVtl2Mmio,
 }
 
+/// Allocate the private pool across NUMA nodes.
+///
+/// By default, tries to allocate the entire pool on NUMA node 0 (preserving
+/// previous behavior). If that fails, or if `force_numa_split` is true, the
+/// pool is split evenly across all available NUMA nodes (one range per node).
+fn allocate_private_pool(
+    address_space: &mut AddressSpaceManager,
+    vtl2_ram: &[MemoryEntry],
+    pool_size_bytes: u64,
+    force_numa_split: bool,
+    enable_vtl2_gpa_pool: crate::cmdline::Vtl2GpaPoolConfig,
+    device_dma_page_count: Option<u64>,
+    vp_count: usize,
+    mem_size: u64,
+) {
+    // Try allocating the entire pool on node 0 first (unless forced to split).
+    if !force_numa_split {
+        if let Some(pool) = address_space.allocate(
+            Some(0),
+            pool_size_bytes,
+            AllocationType::GpaPool,
+            AllocationPolicy::HighMemory,
+        ) {
+            log::info!("allocated VTL2 pool at {:#x?}", pool.range);
+            return;
+        }
+        log::info!("node 0 cannot fit full pool, splitting across NUMA nodes");
+    } else {
+        log::info!("forcing VTL2 pool NUMA split across nodes");
+    }
+
+    // Enumerate unique NUMA nodes from VTL2 RAM.
+    let mut numa_nodes = off_stack!(ArrayVec<u32, MAX_NUMA_NODES>, ArrayVec::new_const());
+    for entry in vtl2_ram.iter() {
+        match numa_nodes.binary_search(&entry.vnode) {
+            Ok(_) => {}
+            Err(index) => {
+                numa_nodes.insert(index, entry.vnode);
+            }
+        }
+    }
+
+    let num_nodes = numa_nodes.len() as u64;
+    let per_node_size = (pool_size_bytes / num_nodes) & !(HV_PAGE_SIZE - 1);
+    // Give the remainder (due to rounding) to the last node.
+    let last_node_size = pool_size_bytes - per_node_size * (num_nodes - 1);
+    let mut remaining = pool_size_bytes;
+
+    for (i, vnode) in numa_nodes.iter().enumerate() {
+        if remaining == 0 {
+            break;
+        }
+
+        let is_last = i == numa_nodes.len() - 1;
+        let alloc_size = if is_last {
+            last_node_size
+        } else {
+            per_node_size
+        };
+
+        match address_space.allocate(
+            Some(*vnode),
+            alloc_size,
+            AllocationType::GpaPool,
+            AllocationPolicy::HighMemory,
+        ) {
+            Some(pool) => {
+                remaining -= pool.range.len();
+                log::info!(
+                    "allocated VTL2 pool on node {} at {:#x?}",
+                    vnode,
+                    pool.range
+                );
+            }
+            None => {
+                let mut free_ranges = off_stack!(ArrayString<2048>, ArrayString::new_const());
+                for node in numa_nodes.iter() {
+                    for range in address_space.free_ranges(*node) {
+                        if write!(
+                            free_ranges,
+                            "n{}:[{:#x?}, {:#x?}) ",
+                            node,
+                            range.start(),
+                            range.end()
+                        )
+                        .is_err()
+                        {
+                            let _ = write!(free_ranges, "...");
+                            break;
+                        }
+                    }
+                }
+                let highest_numa_node = vtl2_ram.iter().map(|e| e.vnode).max().unwrap_or(0);
+                panic!(
+                    "failed to allocate VTL2 pool on node {vnode}: \
+                     need {alloc_size:#x} bytes, pool total {pool_size_bytes:#x} bytes \
+                     (enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, \
+                     device_dma_page_count={device_dma_page_count:#x?}, \
+                     vp_count={vp_count}, mem_size={mem_size:#x}), \
+                     highest_numa_node={highest_numa_node}, \
+                     free_ranges=[ {}]",
+                    free_ranges.as_str()
+                );
+            }
+        }
+    }
+
+    assert_eq!(
+        remaining, 0,
+        "pool allocation arithmetic error: {remaining:#x} bytes unallocated"
+    );
+}
+
 /// Allocate VTL2 ram from the partition's memory map.
 fn allocate_vtl2_ram(
     params: &ShimParams,
@@ -577,43 +690,16 @@ fn topology_from_host_dt(
             // ranges to figure out which VTL2 memory is free to allocate from.
             let pool_size_bytes = vtl2_gpa_pool_size * HV_PAGE_SIZE;
 
-            // NOTE: For now, allocate all the private pool on NUMA node 0 to
-            // match previous behavior. Allocate from high memory downward to
-            // avoid overlapping any used ranges in low memory when openhcl's
-            // usage gets bigger, as otherwise the used_range by the bootshim
-            // could overlap the pool range chosen, when servicing to a new
-            // image.
-            let vnode = 0;
-            match address_space.allocate(
-                Some(vnode),
+            allocate_private_pool(
+                address_space,
+                &vtl2_ram,
                 pool_size_bytes,
-                AllocationType::GpaPool,
-                AllocationPolicy::HighMemory,
-            ) {
-                Some(pool) => {
-                    log::info!("allocated VTL2 pool at {:#x?}", pool.range);
-                }
-                None => {
-                    // Build a compact string representation of the free ranges
-                    // for diagnostics. Keep the string relatively small, as the
-                    // enlightened panic message can only contain 1 page (4096)
-                    // bytes of output.
-                    let mut free_ranges = off_stack!(ArrayString<2048>, ArrayString::new_const());
-                    for range in address_space.free_ranges(vnode) {
-                        if write!(free_ranges, "[{:#x?}, {:#x?}) ", range.start(), range.end())
-                            .is_err()
-                        {
-                            let _ = write!(free_ranges, "...");
-                            break;
-                        }
-                    }
-                    let highest_numa_node = vtl2_ram.iter().map(|e| e.vnode).max().unwrap_or(0);
-                    panic!(
-                        "failed to allocate VTL2 pool of size {pool_size_bytes:#x} bytes (enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, device_dma_page_count={device_dma_page_count:#x?}, vp_count={vp_count}, mem_size={mem_size:#x}), highest_numa_node={highest_numa_node}, free_ranges=[ {}]",
-                        free_ranges.as_str()
-                    );
-                }
-            };
+                options.vtl2_gpa_pool_numa_split,
+                enable_vtl2_gpa_pool,
+                device_dma_page_count,
+                vp_count,
+                mem_size,
+            );
         }
     }
 
@@ -774,22 +860,15 @@ fn topology_from_persisted_state(
     // allocated vtl2 pool. Today, we do not allocate a new/larger pool if the
     // command line arguments or host device tree changed, as that's not
     // something we expect to happen in practice.
-    let mut pool_ranges = partition_memory.iter().filter_map(|entry| {
+    let pool_ranges = partition_memory.iter().filter_map(|entry| {
         if entry.vtl_type == MemoryVtlType::VTL2_GPA_POOL {
             Some(entry.range)
         } else {
             None
         }
     });
-    let pool_range = pool_ranges.next();
-    assert!(
-        pool_ranges.next().is_none(),
-        "previous instance had multiple pool ranges"
-    );
 
-    if let Some(pool_range) = pool_range {
-        address_space_builder = address_space_builder.with_pool_range(pool_range);
-    }
+    address_space_builder = address_space_builder.with_pool_ranges(pool_ranges);
 
     // As described above, other ranges come from this current boot.
     address_space_builder = add_common_ranges(params, address_space_builder);

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -3,6 +3,7 @@
 
 //! Address space allocator for VTL2 memory used by the bootshim.
 
+use crate::host_params::MAX_NUMA_NODES;
 use crate::host_params::MAX_VTL2_RAM_RANGES;
 use arrayvec::ArrayVec;
 use host_fdt_parser::MemoryEntry;
@@ -39,7 +40,6 @@ pub enum ReservedMemoryType {
     SidecarNode,
     /// Persistent VTL2 memory used for page allocations in usermode. This
     /// memory is persisted, both location and contents, across servicing.
-    /// Today, we only support a single range.
     Vtl2GpaPool,
     /// Page tables that are used for AP startup, on TDX.
     TdxPageTables,
@@ -138,7 +138,7 @@ pub struct AddressSpaceManagerBuilder<'a, I: Iterator<Item = MemoryRange>> {
     sidecar_image: Option<MemoryRange>,
     page_tables: Option<MemoryRange>,
     log_buffer: Option<MemoryRange>,
-    pool_range: Option<MemoryRange>,
+    pool_ranges: ArrayVec<MemoryRange, MAX_NUMA_NODES>,
 }
 
 impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
@@ -171,7 +171,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             sidecar_image: None,
             page_tables: None,
             log_buffer: None,
-            pool_range: None,
+            pool_ranges: ArrayVec::new(),
         }
     }
 
@@ -194,8 +194,16 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
     }
 
     /// Existing VTL2 GPA pool ranges, reported as type [`MemoryVtlType::VTL2_GPA_POOL`].
-    pub fn with_pool_range(mut self, pool_range: MemoryRange) -> Self {
-        self.pool_range = Some(pool_range);
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once.
+    pub fn with_pool_ranges(mut self, pool_ranges: impl Iterator<Item = MemoryRange>) -> Self {
+        assert!(
+            self.pool_ranges.is_empty(),
+            "pool ranges already set on builder"
+        );
+        self.pool_ranges.extend(pool_ranges);
         self
     }
 
@@ -211,7 +219,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             sidecar_image,
             page_tables,
             log_buffer,
-            pool_range,
+            pool_ranges,
         } = self;
 
         if vtl2_ram.len() > MAX_VTL2_RAM_RANGES {
@@ -258,7 +266,8 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
         );
         reserved.sort_unstable_by_key(|(r, _)| r.start());
 
-        let mut used_ranges: ArrayVec<(MemoryRange, AddressUsage), 13> = ArrayVec::new();
+        let mut used_ranges: ArrayVec<(MemoryRange, AddressUsage), { 13 + MAX_NUMA_NODES }> =
+            ArrayVec::new();
 
         // Construct initial used ranges by walking both the bootshim_used range
         // and all reserved ranges that overlap.
@@ -284,8 +293,8 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             }
         }
 
-        // Add any existing pool range as reserved.
-        if let Some(range) = pool_range {
+        // Add any existing pool ranges as reserved.
+        for range in pool_ranges {
             used_ranges.push((
                 range,
                 AddressUsage::Reserved(ReservedMemoryType::Vtl2GpaPool),
@@ -1038,5 +1047,210 @@ mod tests {
         }
     }
 
-    // FIXME: test pool ranges
+    // Tests for multi-NUMA pool range support in the builder.
+
+    #[test]
+    fn test_single_pool_range() {
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[MemoryEntry {
+            range: MemoryRange::new(0x0..0x20000),
+            vnode: 0,
+            mem_type: MemoryMapEntryType::MEMORY,
+        }];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .with_pool_ranges([MemoryRange::new(0x10000..0x18000)].into_iter())
+        .init()
+        .unwrap();
+
+        assert!(address_space.has_vtl2_pool());
+
+        // Pool range should be reserved.
+        let reserved: Vec<_> = address_space.reserved_vtl2_ranges().collect();
+        assert!(
+            reserved
+                .iter()
+                .any(|(r, t)| *r == MemoryRange::new(0x10000..0x18000)
+                    && *t == ReservedMemoryType::Vtl2GpaPool)
+        );
+    }
+
+    #[test]
+    fn test_multiple_pool_ranges() {
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x20000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x100000..0x120000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .with_pool_ranges(
+            [
+                MemoryRange::new(0x10000..0x18000),
+                MemoryRange::new(0x110000..0x118000),
+            ]
+            .into_iter(),
+        )
+        .init()
+        .unwrap();
+
+        assert!(address_space.has_vtl2_pool());
+
+        // Both pool ranges should be reserved.
+        let reserved: Vec<_> = address_space
+            .reserved_vtl2_ranges()
+            .filter(|(_, t)| *t == ReservedMemoryType::Vtl2GpaPool)
+            .collect();
+        assert_eq!(reserved.len(), 2);
+        assert_eq!(reserved[0].0, MemoryRange::new(0x10000..0x18000));
+        assert_eq!(reserved[1].0, MemoryRange::new(0x110000..0x118000));
+    }
+
+    #[test]
+    fn test_allocate_pool_single_numa_node() {
+        // With a single NUMA node, pool should be allocated as one range on
+        // node 0 (regardless of force_split, since there's only one node).
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[MemoryEntry {
+            range: MemoryRange::new(0x0..0x100000),
+            vnode: 0,
+            mem_type: MemoryMapEntryType::MEMORY,
+        }];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Allocate pool on node 0.
+        let pool = address_space
+            .allocate(
+                Some(0),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 0);
+        assert_eq!(pool.range.len(), 0x10000);
+        assert!(address_space.has_vtl2_pool());
+    }
+
+    #[test]
+    fn test_allocate_pool_two_numa_nodes_node0_fits() {
+        // With 2 NUMA nodes and enough space on node 0, pool should be
+        // allocated entirely on node 0.
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x100000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x200000..0x300000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Node 0 has plenty of free space, so the pool fits entirely on node 0.
+        let pool = address_space
+            .allocate(
+                Some(0),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 0);
+        assert_eq!(pool.range.len(), 0x10000);
+    }
+
+    #[test]
+    fn test_allocate_pool_two_numa_nodes_node0_exhausted() {
+        // Node 0 has no free space after bootshim. Pool must come from node 1.
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x4000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x200000..0x300000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Node 0 allocation should fail (all used by bootshim).
+        assert!(
+            address_space
+                .allocate(
+                    Some(0),
+                    0x10000,
+                    AllocationType::GpaPool,
+                    AllocationPolicy::HighMemory,
+                )
+                .is_none()
+        );
+
+        // Node 1 should succeed.
+        let pool = address_space
+            .allocate(
+                Some(1),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 1);
+        assert_eq!(pool.range.len(), 0x10000);
+    }
 }

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -5,6 +5,7 @@
 
 use crate::host_params::MAX_NUMA_NODES;
 use crate::host_params::MAX_VTL2_RAM_RANGES;
+use crate::single_threaded::off_stack;
 use arrayvec::ArrayVec;
 use host_fdt_parser::MemoryEntry;
 #[cfg(test)]
@@ -240,7 +241,8 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             persisted_state_region.split_at_offset(PAGE_SIZE_4K);
 
         // The other ranges are reserved, and must overlap with the used range.
-        let mut reserved: ArrayVec<(MemoryRange, ReservedMemoryType), 20> = ArrayVec::new();
+        const MAX_RESERVED_RANGES: usize = 20;
+        let mut reserved = off_stack(ArrayVec<(MemoryRange, ReservedMemoryType), MAX_RESERVED_RANGES>, ArrayVec::new_const());
         reserved.push((persisted_header, ReservedMemoryType::PersistedStateHeader));
         reserved.push((persisted_payload, ReservedMemoryType::PersistedStatePayload));
         reserved.extend(vtl2_config.map(|r| (r, ReservedMemoryType::Vtl2Config)));
@@ -266,8 +268,10 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
         );
         reserved.sort_unstable_by_key(|(r, _)| r.start());
 
-        let mut used_ranges: ArrayVec<(MemoryRange, AddressUsage), { 13 + MAX_NUMA_NODES }> =
-            ArrayVec::new();
+        // Maximum number of used ranges is reserved ranges, plus any allocated
+        // pool ranges (one per node maximally).
+        const MAX_USED_RANGES: usize = MAX_RESERVED_RANGES + MAX_NUMA_NODES;
+        let mut used_ranges = off_stack!(ArrayVec<(MemoryRange, AddressUsage), MAX_USED_RANGES>, ArrayVec::new_const());
 
         // Construct initial used ranges by walking both the bootshim_used range
         // and all reserved ranges that overlap.

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -242,7 +242,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
 
         // The other ranges are reserved, and must overlap with the used range.
         const MAX_RESERVED_RANGES: usize = 20;
-        let mut reserved = off_stack(ArrayVec<(MemoryRange, ReservedMemoryType), MAX_RESERVED_RANGES>, ArrayVec::new_const());
+        let mut reserved = off_stack!(ArrayVec<(MemoryRange, ReservedMemoryType), MAX_RESERVED_RANGES>, ArrayVec::new_const());
         reserved.push((persisted_header, ReservedMemoryType::PersistedStateHeader));
         reserved.push((persisted_payload, ReservedMemoryType::PersistedStatePayload));
         reserved.extend(vtl2_config.map(|r| (r, ReservedMemoryType::Vtl2Config)));

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -243,6 +243,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
         // The other ranges are reserved, and must overlap with the used range.
         const MAX_RESERVED_RANGES: usize = 20;
         let mut reserved = off_stack!(ArrayVec<(MemoryRange, ReservedMemoryType), MAX_RESERVED_RANGES>, ArrayVec::new_const());
+        reserved.clear();
         reserved.push((persisted_header, ReservedMemoryType::PersistedStateHeader));
         reserved.push((persisted_payload, ReservedMemoryType::PersistedStatePayload));
         reserved.extend(vtl2_config.map(|r| (r, ReservedMemoryType::Vtl2Config)));
@@ -272,6 +273,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
         // pool ranges (one per node maximally).
         const MAX_USED_RANGES: usize = MAX_RESERVED_RANGES + MAX_NUMA_NODES;
         let mut used_ranges = off_stack!(ArrayVec<(MemoryRange, AddressUsage), MAX_USED_RANGES>, ArrayVec::new_const());
+        used_ranges.clear();
 
         // Construct initial used ranges by walking both the bootshim_used range
         // and all reserved ranges that overlap.

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -868,13 +868,40 @@ impl InitializedVm {
         };
 
         // Choose the memory layout of the VM.
-        let mem_layout = MemoryLayout::new(
-            cfg.memory.mem_size,
-            &cfg.memory.mmio_gaps,
-            &cfg.memory.pci_ecam_gaps,
-            &cfg.memory.pci_mmio_gaps,
-            vtl2_range,
-        )
+        let mem_layout = if let Some(ref sizes) = cfg.memory.numa_mem_sizes {
+            // When numa_mem_sizes is set, distribute guest RAM across vNUMA nodes
+            // for ACPI SRAT / FDT reporting.
+            //
+            // TODO: The vNUMA nodes reported are meant for test usage only, as they
+            // are not aligned to any physical NUMA node. There is more work to do
+            // to support useful vNUMA reporting.
+            let total: u64 = sizes
+                .iter()
+                .copied()
+                .try_fold(0u64, |acc, s| acc.checked_add(s))
+                .context("numa memory sizes overflow")?;
+            anyhow::ensure!(
+                total == cfg.memory.mem_size,
+                "numa_mem_sizes total ({total:#x}) does not match mem_size ({:#x})",
+                cfg.memory.mem_size
+            );
+
+            MemoryLayout::new_with_numa(
+                sizes,
+                &cfg.memory.mmio_gaps,
+                &cfg.memory.pci_ecam_gaps,
+                &cfg.memory.pci_mmio_gaps,
+                vtl2_range,
+            )
+        } else {
+            MemoryLayout::new(
+                cfg.memory.mem_size,
+                &cfg.memory.mmio_gaps,
+                &cfg.memory.pci_ecam_gaps,
+                &cfg.memory.pci_mmio_gaps,
+                vtl2_range,
+            )
+        }
         .context("invalid memory configuration")?;
 
         if mem_layout.end_of_layout() > 1 << physical_address_size {

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -338,6 +338,10 @@ pub struct MemoryConfig {
     pub mmio_gaps: Vec<MemoryRange>,
     pub pci_ecam_gaps: Vec<MemoryRange>,
     pub pci_mmio_gaps: Vec<MemoryRange>,
+    /// Per-NUMA-node memory sizes. When set, RAM is distributed across
+    /// vNUMA nodes according to these sizes instead of assigning all
+    /// RAM to node 0. The sum must equal `mem_size`.
+    pub numa_mem_sizes: Option<Vec<u64>>,
 }
 
 #[derive(Debug, MeshPayload, Default)]

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -338,9 +338,9 @@ pub struct MemoryConfig {
     pub mmio_gaps: Vec<MemoryRange>,
     pub pci_ecam_gaps: Vec<MemoryRange>,
     pub pci_mmio_gaps: Vec<MemoryRange>,
-    /// Per-NUMA-node memory sizes. When set, RAM is distributed across
-    /// vNUMA nodes according to these sizes instead of assigning all
-    /// RAM to node 0. The sum must equal `mem_size`.
+    /// Test only: per-NUMA-node memory sizes. When set, RAM is distributed
+    /// across vNUMA nodes according to these sizes instead of assigning all RAM
+    /// to node 0. The sum must equal `mem_size`.
     pub numa_mem_sizes: Option<Vec<u64>>,
 }
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -60,7 +60,7 @@ pub struct Options {
     /// TODO: This is informational topology only. Backing pages are not pinned
     /// to any host topology, nor coordinated with CPUs. This should change once
     /// we implement real numa support.
-    #[clap(long, value_name = "SIZES", value_parser = parse_numa_memory, conflicts_with = "memory")]
+    #[clap(long, value_name = "SIZES", value_parser = parse_memory, value_delimiter = ',', conflicts_with = "memory")]
     pub numa_memory: Option<Vec<u64>>,
 
     /// use shared memory segment
@@ -984,10 +984,6 @@ fn parse_memory(s: &str) -> anyhow::Result<u64> {
         }()
         .with_context(|| format!("invalid memory size '{0}'", s))
     }
-}
-
-fn parse_numa_memory(s: &str) -> anyhow::Result<Vec<u64>> {
-    s.split(',').map(|part| parse_memory(part.trim())).collect()
 }
 
 /// Parse a number from a string that could be prefixed with 0x to indicate hex.

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -55,11 +55,10 @@ pub struct Options {
 
     /// per-NUMA-node guest RAM sizes (comma-separated, e.g. "2G,2G").
     /// Distributes memory across vNUMA nodes reported to the guest. Mutually
-    /// exclusive with --memory.
+    /// exclusive with --memory. This is for test-only usage.
     ///
-    /// TODO: This is informational topology only. Backing pages are not pinned
-    /// to any host topology, nor coordinated with CPUs. This should change once
-    /// we implement real numa support.
+    /// TODO: Backing pages are not pinned to any host topology, nor coordinated
+    /// with CPUs. This should change once we implement real numa support.
     #[clap(long, value_name = "SIZES", value_parser = parse_memory, value_delimiter = ',', conflicts_with = "memory")]
     pub numa_memory: Option<Vec<u64>>,
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -54,12 +54,12 @@ pub struct Options {
     pub memory: u64,
 
     /// per-NUMA-node guest RAM sizes (comma-separated, e.g. "2G,2G").
-    /// Distributes memory across vNUMA nodes for ACPI SRAT / FDT reporting.
-    /// Mutually exclusive with --memory.
+    /// Distributes memory across vNUMA nodes reported to the guest. Mutually
+    /// exclusive with --memory.
     ///
-    /// TODO: This is informational topology only — backing pages are not pinned
-    /// to host NUMA nodes. This should change once we implement real numa
-    /// support.
+    /// TODO: This is informational topology only. Backing pages are not pinned
+    /// to any host topology, nor coordinated with CPUs. This should change once
+    /// we implement real numa support.
     #[clap(long, value_name = "SIZES", value_parser = parse_numa_memory, conflicts_with = "memory")]
     pub numa_memory: Option<Vec<u64>>,
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -48,9 +48,20 @@ pub struct Options {
         long,
         value_name = "SIZE",
         default_value = "1GB",
-        value_parser = parse_memory
+        value_parser = parse_memory,
+        conflicts_with = "numa_memory"
     )]
     pub memory: u64,
+
+    /// per-NUMA-node guest RAM sizes (comma-separated, e.g. "2G,2G").
+    /// Distributes memory across vNUMA nodes for ACPI SRAT / FDT reporting.
+    /// Mutually exclusive with --memory.
+    ///
+    /// TODO: This is informational topology only — backing pages are not pinned
+    /// to host NUMA nodes. This should change once we implement real numa
+    /// support.
+    #[clap(long, value_name = "SIZES", value_parser = parse_numa_memory, conflicts_with = "memory")]
+    pub numa_memory: Option<Vec<u64>>,
 
     /// use shared memory segment
     #[clap(short = 'M', long)]
@@ -973,6 +984,10 @@ fn parse_memory(s: &str) -> anyhow::Result<u64> {
         }()
         .with_context(|| format!("invalid memory size '{0}'", s))
     }
+}
+
+fn parse_numa_memory(s: &str) -> anyhow::Result<Vec<u64>> {
+    s.split(',').map(|part| parse_memory(part.trim())).collect()
 }
 
 /// Parse a number from a string that could be prefixed with 0x to indicate hex.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1580,13 +1580,21 @@ async fn vm_config_from_command_line(
         vpci_devices,
         ide_disks: Vec::new(),
         memory: MemoryConfig {
-            mem_size: opt.memory,
+            mem_size: if let Some(ref sizes) = opt.numa_memory {
+                sizes
+                    .iter()
+                    .try_fold(0u64, |acc, &s| acc.checked_add(s))
+                    .context("numa memory sizes overflow")?
+            } else {
+                opt.memory
+            },
             mmio_gaps,
             prefetch_memory: opt.prefetch,
             private_memory: opt.private_memory,
             transparent_hugepages: opt.thp,
             pci_ecam_gaps,
             pci_mmio_gaps,
+            numa_mem_sizes: opt.numa_memory.clone(),
         },
         processor_topology: ProcessorTopologyConfig {
             proc_count: opt.processors,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -575,6 +575,7 @@ impl VmService {
                 prefetch_memory: false,
                 private_memory: false,
                 transparent_hugepages: false,
+                numa_mem_sizes: None,
             },
             chipset: chipset.chipset,
             processor_topology: ProcessorTopologyConfig {

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2129,6 +2129,9 @@ pub struct MemoryConfig {
     pub dynamic_memory_range: Option<(u64, u64)>,
     /// Specifies the mmio gaps to use, either platform or custom.
     pub mmio_gaps: MmioConfig,
+    /// Per-NUMA-node memory sizes. When set, RAM is distributed across
+    /// vNUMA nodes instead of assigning all RAM to node 0.
+    pub numa_mem_sizes: Option<Vec<u64>>,
 }
 
 impl Default for MemoryConfig {
@@ -2137,6 +2140,7 @@ impl Default for MemoryConfig {
             startup_bytes: 4 * 1024 * 1024 * 1024, // 4 GiB
             dynamic_memory_range: None,
             mmio_gaps: MmioConfig::Platform,
+            numa_mem_sizes: None,
         }
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -358,14 +358,24 @@ impl PetriVmConfigOpenVmm {
                 startup_bytes,
                 dynamic_memory_range,
                 mmio_gaps,
+                numa_mem_sizes,
             } = memory;
 
             if dynamic_memory_range.is_some() {
                 anyhow::bail!("dynamic memory not supported in OpenVMM");
             }
 
+            let mem_size = if let Some(ref sizes) = numa_mem_sizes {
+                sizes
+                    .iter()
+                    .try_fold(0u64, |acc, &s| acc.checked_add(s))
+                    .context("numa memory sizes overflow")?
+            } else {
+                startup_bytes
+            };
+
             openvmm_defs::config::MemoryConfig {
-                mem_size: startup_bytes,
+                mem_size,
                 mmio_gaps: match mmio_gaps {
                     MmioConfig::Platform => {
                         if firmware.is_openhcl() {
@@ -387,6 +397,7 @@ impl PetriVmConfigOpenVmm {
                 prefetch_memory: false,
                 private_memory: false,
                 transparent_hugepages: false,
+                numa_mem_sizes,
             }
         };
 

--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -4,6 +4,7 @@
 //! Tools to the compute guest memory layout.
 
 use memory_range::MemoryRange;
+use memory_range::subtract_ranges;
 use thiserror::Error;
 
 const PAGE_SIZE: u64 = 4096;
@@ -205,43 +206,44 @@ impl MemoryLayout {
         combined_gaps.sort();
         validate_ranges(&combined_gaps)?;
 
-        // Walk contiguous address chunks (between gaps), distributing RAM
-        // across NUMA nodes by filling each node's budget in order.
+        let available = subtract_ranges(
+            [MemoryRange::new(0..MemoryRange::MAX_ADDRESS)],
+            combined_gaps,
+        );
+
+        // Distribute RAM across NUMA nodes, filling available ranges in order.
         let mut ram = Vec::new();
         let mut remaining = ram_size;
-        let mut remaining_gaps = combined_gaps.iter().cloned();
-        let mut last_end = 0;
-
         let mut node_idx = 0;
         let mut node_remaining = numa_mem_sizes[0];
 
-        while remaining > 0 {
-            let (chunk_size, next_end) = if let Some(gap) = remaining_gaps.next() {
-                (remaining.min(gap.start() - last_end), gap.end())
-            } else {
-                (remaining, 0)
-            };
+        for range in available {
+            let range_size = remaining.min(range.len());
+            let mut offset = 0;
 
-            // Distribute this chunk across nodes.
-            let mut chunk_offset = 0;
-            while chunk_offset < chunk_size {
-                let piece = (chunk_size - chunk_offset).min(node_remaining);
-                assert!(piece > 0, "node budget exhausted before all RAM placed");
-                let start = last_end + chunk_offset;
+            while offset < range_size {
+                if node_remaining == 0 {
+                    node_idx += 1;
+                    node_remaining = *numa_mem_sizes
+                        .get(node_idx)
+                        .expect("node budget exhausted before all RAM placed");
+                }
+
+                let piece = (range_size - offset).min(node_remaining);
+                let start = range.start() + offset;
                 ram.push(MemoryRangeWithNode {
                     range: MemoryRange::new(start..start + piece),
                     vnode: node_idx as u32,
                 });
-                chunk_offset += piece;
+                offset += piece;
                 node_remaining -= piece;
-                if node_remaining == 0 && node_idx + 1 < numa_mem_sizes.len() {
-                    node_idx += 1;
-                    node_remaining = numa_mem_sizes[node_idx];
-                }
             }
 
-            remaining -= chunk_size;
-            last_end = next_end;
+            remaining -= range_size;
+
+            if remaining == 0 {
+                break;
+            }
         }
 
         Self::build(

--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -75,6 +75,12 @@ pub enum Error {
     /// Invalid memory size.
     #[error("invalid memory size")]
     BadSize,
+    /// Invalid per-NUMA-node memory size.
+    #[error("invalid NUMA node memory size")]
+    BadNumaSize,
+    /// Empty NUMA memory sizes.
+    #[error("empty NUMA memory sizes")]
+    EmptyNumaSizes,
     /// Invalid MMIO gap configuration.
     #[error("invalid MMIO gap configuration")]
     BadMmioGaps,
@@ -145,6 +151,46 @@ impl MemoryLayout {
         if ram_size == 0 || ram_size & (PAGE_SIZE - 1) != 0 {
             return Err(Error::BadSize);
         }
+        Self::new_with_numa(
+            &[ram_size],
+            mmio_gaps,
+            pci_ecam_gaps,
+            pci_mmio_gaps,
+            vtl2_range,
+        )
+    }
+
+    /// Like [`Self::new()`], but distributes RAM across NUMA nodes according
+    /// to the per-node sizes in `numa_mem_sizes`.
+    ///
+    /// `numa_mem_sizes[i]` is the number of RAM bytes for vnode `i`.
+    /// Each size must be page-aligned and non-zero. The sum of all sizes
+    /// is the total guest RAM.
+    ///
+    /// RAM is placed sequentially around MMIO gaps, filling each node's
+    /// budget in order. When a node's budget is exhausted mid-chunk,
+    /// the chunk is split and the next node continues from that address.
+    pub fn new_with_numa(
+        numa_mem_sizes: &[u64],
+        mmio_gaps: &[MemoryRange],
+        pci_ecam_gaps: &[MemoryRange],
+        pci_mmio_gaps: &[MemoryRange],
+        vtl2_range: Option<MemoryRange>,
+    ) -> Result<Self, Error> {
+        if numa_mem_sizes.is_empty() {
+            return Err(Error::EmptyNumaSizes);
+        }
+
+        for &size in numa_mem_sizes {
+            if size == 0 || size & (PAGE_SIZE - 1) != 0 {
+                return Err(Error::BadNumaSize);
+            }
+        }
+
+        let ram_size: u64 = numa_mem_sizes
+            .iter()
+            .try_fold(0u64, |acc, &s| acc.checked_add(s))
+            .ok_or(Error::BadSize)?;
 
         validate_ranges(mmio_gaps)?;
         validate_ranges(pci_ecam_gaps)?;
@@ -159,25 +205,42 @@ impl MemoryLayout {
         combined_gaps.sort();
         validate_ranges(&combined_gaps)?;
 
+        // Walk contiguous address chunks (between gaps), distributing RAM
+        // across NUMA nodes by filling each node's budget in order.
         let mut ram = Vec::new();
         let mut remaining = ram_size;
         let mut remaining_gaps = combined_gaps.iter().cloned();
         let mut last_end = 0;
 
+        let mut node_idx = 0;
+        let mut node_remaining = numa_mem_sizes[0];
+
         while remaining > 0 {
-            let (this, next_end) = if let Some(gap) = remaining_gaps.next() {
+            let (chunk_size, next_end) = if let Some(gap) = remaining_gaps.next() {
                 (remaining.min(gap.start() - last_end), gap.end())
             } else {
                 (remaining, 0)
             };
 
-            if this > 0 {
+            // Distribute this chunk across nodes.
+            let mut chunk_offset = 0;
+            while chunk_offset < chunk_size {
+                let piece = (chunk_size - chunk_offset).min(node_remaining);
+                assert!(piece > 0, "node budget exhausted before all RAM placed");
+                let start = last_end + chunk_offset;
                 ram.push(MemoryRangeWithNode {
-                    range: MemoryRange::new(last_end..last_end + this),
-                    vnode: 0,
+                    range: MemoryRange::new(start..start + piece),
+                    vnode: node_idx as u32,
                 });
+                chunk_offset += piece;
+                node_remaining -= piece;
+                if node_remaining == 0 && node_idx + 1 < numa_mem_sizes.len() {
+                    node_idx += 1;
+                    node_remaining = numa_mem_sizes[node_idx];
+                }
             }
-            remaining -= this;
+
+            remaining -= chunk_size;
             last_end = next_end;
         }
 
@@ -572,5 +635,101 @@ mod tests {
         assert_eq!(layout.probe_address(TB + 2 * GB), None);
         assert_eq!(layout.probe_address(TB + 3 * GB), None);
         assert_eq!(layout.probe_address(4 * TB), None);
+    }
+
+    #[test]
+    fn numa_two_nodes_even_split() {
+        // 4 GB total, 2 nodes of 2 GB each, MMIO gap at 2-3 GB.
+        let mmio = &[MemoryRange::new(2 * GB..3 * GB)];
+        let layout = MemoryLayout::new_with_numa(&[2 * GB, 2 * GB], mmio, &[], &[], None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..2 * GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(3 * GB..5 * GB),
+                    vnode: 1,
+                },
+            ]
+        );
+        assert_eq!(layout.ram_size(), 4 * GB);
+    }
+
+    #[test]
+    fn numa_two_nodes_mid_chunk_split() {
+        // 4 GB total, 2 nodes of 2 GB each, MMIO gap at 3-4 GB.
+        // Node 0's 2 GB fits entirely below the gap; node 1 continues above.
+        // But the first chunk is 3 GB, so node 0 takes 2 GB and node 1
+        // takes the remaining 1 GB of that chunk, plus 1 GB above the gap.
+        let mmio = &[MemoryRange::new(3 * GB..4 * GB)];
+        let layout = MemoryLayout::new_with_numa(&[2 * GB, 2 * GB], mmio, &[], &[], None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..2 * GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(2 * GB..3 * GB),
+                    vnode: 1,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(4 * GB..5 * GB),
+                    vnode: 1,
+                },
+            ]
+        );
+        assert_eq!(layout.ram_size(), 4 * GB);
+    }
+
+    #[test]
+    fn numa_three_nodes() {
+        // 3 GB total, 3 nodes of 1 GB each, no gaps.
+        let layout = MemoryLayout::new_with_numa(&[GB, GB, GB], &[], &[], &[], None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(GB..2 * GB),
+                    vnode: 1,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(2 * GB..3 * GB),
+                    vnode: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn numa_single_node_matches_new() {
+        // Single node should produce the same layout as new().
+        let mmio = &[
+            MemoryRange::new(GB..2 * GB),
+            MemoryRange::new(3 * GB..4 * GB),
+        ];
+        let layout_new = MemoryLayout::new(TB, mmio, &[], &[], None).unwrap();
+        let layout_numa = MemoryLayout::new_with_numa(&[TB], mmio, &[], &[], None).unwrap();
+        assert_eq!(layout_new.ram(), layout_numa.ram());
+    }
+
+    #[test]
+    fn numa_bad_inputs() {
+        // Empty sizes.
+        MemoryLayout::new_with_numa(&[], &[], &[], &[], None).unwrap_err();
+        // Non-page-aligned size.
+        MemoryLayout::new_with_numa(&[GB + 1], &[], &[], &[], None).unwrap_err();
+        // Zero size.
+        MemoryLayout::new_with_numa(&[0], &[], &[], &[], None).unwrap_err();
+        // Mixed: one valid, one zero.
+        MemoryLayout::new_with_numa(&[GB, 0], &[], &[], &[], None).unwrap_err();
     }
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -405,6 +405,7 @@ async fn idle_test<T: PetriVmmBackend>(
                 startup_bytes: 16 * (1024 * 1024 * 1024),
                 dynamic_memory_range: None,
                 mmio_gaps: petri::MmioConfig::Platform,
+                numa_mem_sizes: None,
             }
         })
         .with_openhcl_log_levels(OpenvmmLogConfig::BuiltInDefault)

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -28,6 +28,7 @@ use nvme_resources::fault::PciFaultConfig;
 use nvme_test::command_match::CommandMatchBuilder;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::VpciDeviceConfig;
+use petri::MemoryConfig;
 use petri::OpenHclServicingFlags;
 use petri::PetriGuestStateLifetime;
 use petri::PetriVm;
@@ -171,6 +172,10 @@ async fn servicing_numa_private_pool<T: PetriVmmBackend>(
             .with_processor_topology(ProcessorTopology {
                 vp_count: 4,
                 vps_per_socket: Some(2),
+                ..Default::default()
+            })
+            .with_memory(MemoryConfig {
+                numa_mem_sizes: Some(vec![2 * 1024 * 1024 * 1024, 2 * 1024 * 1024 * 1024]),
                 ..Default::default()
             })
             .with_openhcl_command_line(

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -156,6 +156,33 @@ async fn servicing_keepalive_no_device<T: PetriVmmBackend>(
     .await
 }
 
+/// Test servicing an OpenHCL VM with a multi-NUMA pool split.
+/// The pool is split across NUMA nodes via `OPENHCL_VTL2_GPA_POOL_NUMA=split`,
+/// and pool ranges must be preserved identically across the service boundary.
+#[openvmm_test(openhcl_linux_direct_x64[LATEST_LINUX_DIRECT_TEST_X64])]
+async fn servicing_numa_private_pool<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+    (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
+) -> anyhow::Result<()> {
+    let mut flags = config.default_servicing_flags();
+    flags.override_version_checks = true;
+    openhcl_servicing_core(
+        config
+            .with_processor_topology(ProcessorTopology {
+                vp_count: 4,
+                vps_per_socket: Some(2),
+                ..Default::default()
+            })
+            .with_openhcl_command_line(
+                "OPENHCL_VTL2_GPA_POOL_NUMA=split OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
+            ),
+        igvm_file,
+        flags,
+        DEFAULT_SERVICING_COUNT,
+    )
+    .await
+}
+
 /// Test servicing an OpenHCL VM from the current version to itself
 /// with NVMe keepalive support.
 #[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))[LATEST_STANDARD_X64])]

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -340,15 +340,17 @@ async fn auto_vtl2_range(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<
     Ok(())
 }
 
-/// Boot OpenHCL, and validate that we did not see any numa errors from the
-/// kernel parsing the bootloader provided device tree.
-///
-/// TODO: OpenVMM doesn't support multiple numa nodes yet, but when it does, we
-/// should also validate that the kernel gets two different numa nodes.
+/// Boot OpenHCL with a multi-NUMA topology and validate that the kernel
+/// correctly parses the device tree with memory on multiple NUMA nodes.
+/// Checks the absence of NUMA errors and confirms the kernel brought up
+/// multiple NUMA nodes with memory (not memoryless).
 #[vmm_test_with(noagent(openvmm_openhcl_uefi_x64(none)))]
 async fn no_numa_errors<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> Result<(), anyhow::Error> {
+    // Use Vtl2Allocate so OpenHCL self-allocates from the multi-vnode
+    // partition memory map, giving both nodes actual memory.
+    // Explicitly set per-node memory sizes (2GB per node).
     let vm = config
         .with_openhcl_command_line("OPENHCL_WAIT_FOR_START=1")
         .with_expect_no_boot_event()
@@ -357,16 +359,28 @@ async fn no_numa_errors<T: PetriVmmBackend>(
             vps_per_socket: Some(1),
             ..Default::default()
         })
+        .with_memory(MemoryConfig {
+            numa_mem_sizes: Some(vec![2 * 1024 * 1024 * 1024, 2 * 1024 * 1024 * 1024]),
+            ..Default::default()
+        })
+        .with_vtl2_base_address_type(openvmm_defs::config::Vtl2BaseAddressType::Vtl2Allocate {
+            size: Some(512 * 1024 * 1024), // 512MB — large enough to allocate from both nodes
+        })
         .run_without_agent()
         .await?;
 
     const BAD_PROP: &str = "OF: NUMA: bad property in memory node";
     const NO_NUMA: &str = "NUMA: No NUMA configuration found";
     const FAKING_NODE: &str = "Faking a node at";
+    const MEMORYLESS: &str = "as memoryless";
+    // The kernel prints "Brought up N nodes, M CPUs" during SMP init.
+    const BROUGHT_UP: &str = "Brought up ";
 
     let mut kmsg = vm.kmsg().await?;
+    let mut numa_node_count: Option<u32> = None;
+    let mut found_memoryless = false;
 
-    // Search kmsg and make sure we didn't see any errors from the kernel
+    // Search kmsg for NUMA errors, memoryless nodes, and the node count.
     while let Some(data) = kmsg.next().await {
         let data = data.context("reading kmsg")?;
         let msg = kmsg::KmsgParsedEntry::new(&data).unwrap();
@@ -380,7 +394,29 @@ async fn no_numa_errors<T: PetriVmmBackend>(
         if raw.contains(FAKING_NODE) {
             anyhow::bail!("found faking a node in kmsg");
         }
+        if raw.contains(MEMORYLESS) {
+            found_memoryless = true;
+        }
+        // Parse "Brought up N nodes, M CPUs" to get the NUMA node count.
+        if let Some(idx) = raw.find(BROUGHT_UP) {
+            let rest = &raw[idx + BROUGHT_UP.len()..];
+            if let Some(n_str) = rest.split_whitespace().next() {
+                if let Ok(n) = n_str.parse::<u32>() {
+                    numa_node_count = Some(n);
+                }
+            }
+        }
     }
+
+    let count = numa_node_count.context("did not find 'Brought up N nodes' in kmsg")?;
+    assert!(
+        count >= 2,
+        "expected kernel to bring up at least 2 NUMA nodes, but found: {count}"
+    );
+    assert!(
+        !found_memoryless,
+        "found memoryless NUMA node — all nodes should have memory"
+    );
 
     Ok(())
 }
@@ -395,13 +431,24 @@ async fn numa_private_pool_split<T: PetriVmmBackend>(
     // 2 NUMA nodes (vps_per_socket=2, 4 VPs → 2 sockets → 2 nodes).
     // Force NUMA split via command line flag — the pool will be split
     // across both nodes instead of trying node 0 first.
+    // Use Vtl2Allocate so OpenHCL self-allocates from the multi-vnode
+    // partition memory map, which is required for the pool to see
+    // memory on multiple nodes.
+    // Explicitly set per-node memory sizes (2GB per node).
     let mut vm = config
         .with_processor_topology(ProcessorTopology {
             vp_count: 4,
             vps_per_socket: Some(2),
             ..Default::default()
         })
+        .with_memory(MemoryConfig {
+            numa_mem_sizes: Some(vec![2 * 1024 * 1024 * 1024, 2 * 1024 * 1024 * 1024]),
+            ..Default::default()
+        })
         .with_openhcl_command_line("OPENHCL_VTL2_GPA_POOL_NUMA=split")
+        .with_vtl2_base_address_type(openvmm_defs::config::Vtl2BaseAddressType::Vtl2Allocate {
+            size: Some(512 * 1024 * 1024), // 512MB — large enough to allocate from both nodes
+        })
         .with_expect_no_boot_event()
         .run_without_agent()
         .await?;

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -384,3 +384,33 @@ async fn no_numa_errors<T: PetriVmmBackend>(
 
     Ok(())
 }
+
+/// Boot OpenHCL with a multi-NUMA topology and force the private pool to be
+/// split across NUMA nodes via `OPENHCL_VTL2_GPA_POOL_NUMA=split`. Validates
+/// that multi-range pool allocation works end-to-end.
+#[vmm_test_with(noagent(openvmm_openhcl_uefi_x64(none)))]
+async fn numa_private_pool_spillover<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+) -> Result<(), anyhow::Error> {
+    // 2 NUMA nodes (vps_per_socket=2, 4 VPs → 2 sockets → 2 nodes).
+    // Force NUMA split via command line flag — the pool will be split
+    // across both nodes instead of trying node 0 first.
+    let mut vm = config
+        .with_processor_topology(ProcessorTopology {
+            vp_count: 4,
+            vps_per_socket: Some(2),
+            ..Default::default()
+        })
+        .with_openhcl_command_line("OPENHCL_VTL2_GPA_POOL_NUMA=split")
+        .with_expect_no_boot_event()
+        .run_without_agent()
+        .await?;
+
+    // Wait for VTL2 to be ready — if pool allocation panicked, boot fails.
+    vm.wait_for_vtl2_ready().await?;
+
+    // Inspect the DMA manager's private pool to verify it was created.
+    vm.test_inspect_openhcl().await?;
+
+    Ok(())
+}

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -387,9 +387,9 @@ async fn no_numa_errors<T: PetriVmmBackend>(
 
 /// Boot OpenHCL with a multi-NUMA topology and force the private pool to be
 /// split across NUMA nodes via `OPENHCL_VTL2_GPA_POOL_NUMA=split`. Validates
-/// that multi-range pool allocation works end-to-end.
+/// that the pool was actually allocated on multiple NUMA nodes.
 #[vmm_test_with(noagent(openvmm_openhcl_uefi_x64(none)))]
-async fn numa_private_pool_spillover<T: PetriVmmBackend>(
+async fn numa_private_pool_split<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> Result<(), anyhow::Error> {
     // 2 NUMA nodes (vps_per_socket=2, 4 VPs → 2 sockets → 2 nodes).
@@ -406,11 +406,38 @@ async fn numa_private_pool_spillover<T: PetriVmmBackend>(
         .run_without_agent()
         .await?;
 
-    // Wait for VTL2 to be ready — if pool allocation panicked, boot fails.
     vm.wait_for_vtl2_ready().await?;
 
-    // Inspect the DMA manager's private pool to verify it was created.
-    vm.test_inspect_openhcl().await?;
+    // Inspect the private pool ranges to verify the pool was split across
+    // multiple NUMA nodes.
+    let pool_ranges = vm
+        .inspect_openhcl(
+            "vm/runtime_params/parsed_openhcl_boot/private_pool_ranges",
+            None,
+            None,
+        )
+        .await?;
+    let pool_ranges: serde_json::Value = serde_json::from_str(&format!("{}", pool_ranges.json()))?;
+    tracing::info!(pool_ranges = %pool_ranges, "private pool ranges");
+
+    let ranges = pool_ranges
+        .as_object()
+        .context("pool_ranges is not an object")?;
+    assert!(
+        !ranges.is_empty(),
+        "expected at least one private pool range"
+    );
+
+    // Collect unique vnodes across all pool ranges.
+    let vnodes: std::collections::BTreeSet<u64> = ranges
+        .values()
+        .map(|entry| entry["vnode"].as_u64().expect("vnode field"))
+        .collect();
+
+    assert!(
+        vnodes.len() >= 2,
+        "expected pool ranges on at least 2 NUMA nodes, but found vnodes: {vnodes:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
On some systems, there is not enough ram in numa node 0 to fufill the private pool allocation request. Change the code to support falling back to allocating the private pool across numa nodes if we cannot match the old behavior. This also opens up the possibility of adding numa awareness to dma_manager and drivers in the future. 

Note that previous versions of openhcl_boot only support a single range for the private pool, but those systems shouldn't have been able to boot at all, so this change should be safe. 