### PR TITLE
gitattributes: mark ADO pipelines as generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,7 +19,7 @@
 # [merge "flowey-theirs"]
 #     name = flowey-theirs merge driver
 #     driver = cp %B %A
-.github/workflows/flowey-* merge=flowey-theirs
+.github/workflows/openvmm-* merge=flowey-theirs
 ci-flowey/*.yaml merge=flowey-theirs
 
 # Mark flowey-generated pipelines as generated code

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,9 +20,11 @@
 #     name = flowey-theirs merge driver
 #     driver = cp %B %A
 .github/workflows/flowey-* merge=flowey-theirs
+ci-flowey/*.yaml merge=flowey-theirs
 
 # Mark flowey-generated pipelines as generated code
 .github/workflows/openvmm-* linguist-generated=true
+ci-flowey/*.yaml linguist-generated=true
 
 # Always display the diff for package lock files
 Cargo.lock linguist-generated=false


### PR DESCRIPTION
Mark flowey ADO pipeline YAML as generated, just like the GitHub YAML is already marked. This improves the GitHub PR experience.