### PR TITLE
deps: pickup new mu_msvm uefi release

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "25.1.11";
+pub const MU_MSVM: &str = "26.0.0";
 pub const NEXTEST: &str = "0.9.101";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly

--- a/flowey/flowey_lib_hvlite/src/download_uefi_mu_msvm.rs
+++ b/flowey/flowey_lib_hvlite/src/download_uefi_mu_msvm.rs
@@ -100,15 +100,15 @@ impl FlowNodeWithConfig for Node {
         }
 
         let version = version.expect("local paths handled above");
-        let extract_zip_deps = flowey_lib_common::_util::extract::extract_zip_if_new_deps(ctx);
+        let extract_archive_deps = flowey_lib_common::_util::extract::extract_zip_if_new_deps(ctx);
 
         for (arch, out_vars) in reqs {
             let file_name = match arch {
-                CommonArch::X86_64 => "RELEASE-X64-artifacts.zip",
-                CommonArch::Aarch64 => "RELEASE-AARCH64-artifacts.zip",
+                CommonArch::X86_64 => "RELEASE-X64-VS2022-artifacts.tar.gz",
+                CommonArch::Aarch64 => "RELEASE-AARCH64-CLANGPDB-artifacts.tar.gz",
             };
 
-            let mu_msvm_zip = ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
+            let mu_msvm_archive = ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
                 repo_owner: "microsoft".into(),
                 repo_name: "mu_msvm".into(),
                 needs_auth: false,
@@ -117,7 +117,7 @@ impl FlowNodeWithConfig for Node {
                 path: v,
             });
 
-            let zip_file_version = format!("{version}-{file_name}");
+            let archive_file_version = format!("{version}-{file_name}");
 
             ctx.emit_rust_step(
                 {
@@ -130,17 +130,17 @@ impl FlowNodeWithConfig for Node {
                     )
                 },
                 |ctx| {
-                    let extract_zip_deps = extract_zip_deps.clone().claim(ctx);
+                    let extract_archive_deps = extract_archive_deps.clone().claim(ctx);
                     let out_vars = out_vars.claim(ctx);
-                    let mu_msvm_zip = mu_msvm_zip.claim(ctx);
+                    let mu_msvm_archive = mu_msvm_archive.claim(ctx);
                     move |rt| {
-                        let mu_msvm_zip = rt.read(mu_msvm_zip);
+                        let mu_msvm_archive = rt.read(mu_msvm_archive);
 
                         let extract_dir = flowey_lib_common::_util::extract::extract_zip_if_new(
                             rt,
-                            extract_zip_deps,
-                            &mu_msvm_zip,
-                            &zip_file_version,
+                            extract_archive_deps,
+                            &mu_msvm_archive,
+                            &archive_file_version,
                         )?;
 
                         let msvm_fd = extract_dir.join("FV/MSVM.fd");

--- a/nix/uefi_mu_msvm.nix
+++ b/nix/uefi_mu_msvm.nix
@@ -2,23 +2,23 @@
 
 let
   # Allow explicit override of architecture, otherwise derive from host system
-  # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"AARCH64"
-  arch = if targetArch == "x86_64" then "x64"
-         else if targetArch == "aarch64" then "AARCH64"
-         else if system == "aarch64-linux" then "AARCH64"
-         else "x64";
+  # X64 uses VS2022 toolchain, AARCH64 uses CLANGPDB
+  archToolchain = if targetArch == "x86_64" then "X64-VS2022"
+         else if targetArch == "aarch64" then "AARCH64-CLANGPDB"
+         else if system == "aarch64-linux" then "AARCH64-CLANGPDB"
+         else "X64-VS2022";
   hash = {
-    "AARCH64" = "sha256-C0NgBSZ0+CQXpopPiLKbSawD+FISEIlMApXTeEEw2J4=";
-    "x64" = "sha256-lWLFJezfDRgWg+uI7ELKFAGWNsg33kCNjuqGjNa9sOY=";
-  }.${arch};
+    "AARCH64-CLANGPDB" = "sha256-ujHL96/irxRaITtIAxhocbrX+iBQuqNNWDDx8MYQ8i8=";
+    "X64-VS2022" = "sha256-3NJ4wNA7HXLiMIAVbQXS0cralheCok4rJ8CaedduN9I=";
+  }.${archToolchain};
 
 in stdenv.mkDerivation {
-  pname = "uefi-mu-msvm-${arch}";
-  version = "25.1.9";
+  pname = "uefi-mu-msvm-${archToolchain}";
+  version = "26.0.0";
 
   src = fetchzip {
     url =
-      "https://github.com/microsoft/mu_msvm/releases/download/v25.1.9/RELEASE-${arch}-artifacts.zip";
+      "https://github.com/microsoft/mu_msvm/releases/download/v26.0.0/RELEASE-${archToolchain}-artifacts.tar.gz";
     stripRoot = false;
     inherit hash;
   };


### PR DESCRIPTION
New mu_msvm release that slightly changes the artifact file name, along with AArch64 going to CLANGPDB only. 