### PR TITLE
hypervisor: pass backend-specific params via --hypervisor

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -10,6 +10,23 @@ as well as the generated CLI help (via `cargo run -- --help`).
 * `--processors <COUNT>`: The number of processors. Defaults to 1.
 * `--memory <SIZE>`: The VM's memory size. Defaults to 1GB.
 * `--hv`: Exposes Hyper-V enlightenments and VMBus support.
+* `--hypervisor <SPEC>`: Select a specific hypervisor backend, optionally with
+  backend-specific parameters. The format is `name` or `name:key=val,key,...`.
+  Available backends: `whp` (Windows), `kvm` (Linux), `mshv` (Linux), `hvf`
+  (macOS). When omitted, OpenVMM auto-detects the best available backend.
+
+  WHP accepts the following parameters:
+  * `user_mode_apic` — use the user-mode APIC emulator instead of WHP's
+    in-hypervisor APIC
+  * `no_enlightenments` — disable in-hypervisor Hyper-V enlightenment support
+
+  Examples:
+  ```sh
+  --hypervisor whp
+  --hypervisor whp:user_mode_apic
+  --hypervisor whp:user_mode_apic,no_enlightenments
+  --hypervisor kvm
+  ```
 * `--uefi`: Boot using `mu_msvm` UEFI
 * `--uefi-firmware <FILE>`: Path to the UEFI firmware file (`MSVM.fd`). When `--uefi` is specified, this option is required only if you do not set the environment variable `OPENVMM_UEFI_FIRMWARE` (or the architecture-specific variants `X86_64_OPENVMM_UEFI_FIRMWARE`, or `AARCH64_OPENVMM_UEFI_FIRMWARE`). If omitted, the default is read from `OPENVMM_UEFI_FIRMWARE` first, then falls back to the architecture-specific variables.
 * `--pcat`: Boot using the Microsoft Hyper-V PCAT BIOS

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -12,8 +12,9 @@ as well as the generated CLI help (via `cargo run -- --help`).
 * `--hv`: Exposes Hyper-V enlightenments and VMBus support.
 * `--hypervisor <SPEC>`: Select a specific hypervisor backend, optionally with
   backend-specific parameters. The format is `name` or `name:key=val,key,...`.
-  Available backends: `whp` (Windows), `kvm` (Linux), `mshv` (Linux), `hvf`
-  (macOS). When omitted, OpenVMM auto-detects the best available backend.
+  Available backends: `whp` (Windows), `kvm` (Linux), `mshv` (Linux,
+  `x86_64` guests only), `hvf` (macOS). When omitted, OpenVMM
+  auto-detects the best available backend.
 
   WHP accepts the following parameters:
   * `user_mode_apic` — use the user-mode APIC emulator instead of WHP's
@@ -21,7 +22,7 @@ as well as the generated CLI help (via `cargo run -- --help`).
   * `no_enlightenments` — disable in-hypervisor Hyper-V enlightenment support
 
   Examples:
-  ```sh
+  ```bash
   --hypervisor whp
   --hypervisor whp:user_mode_apic
   --hypervisor whp:user_mode_apic,no_enlightenments

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -16,7 +16,7 @@ as well as the generated CLI help (via `cargo run -- --help`).
   `x86_64` guests only), `hvf` (macOS). When omitted, OpenVMM
   auto-detects the best available backend.
 
-  WHP accepts the following parameters:
+  WHP accepts the following parameters (x86_64 guests only):
   * `user_mode_apic` — use the user-mode APIC emulator instead of WHP's
     in-hypervisor APIC
   * `no_enlightenments` — disable in-hypervisor Hyper-V enlightenment support

--- a/openvmm/hypervisor_resources/src/lib.rs
+++ b/openvmm/hypervisor_resources/src/lib.rs
@@ -54,7 +54,21 @@ impl ResourceId<HypervisorKind> for MshvHandle {
 
 /// Handle for the WHP hypervisor backend.
 #[derive(MeshPayload)]
-pub struct WhpHandle;
+pub struct WhpHandle {
+    /// Use the user-mode APIC emulator instead of the in-hypervisor one.
+    pub user_mode_apic: bool,
+    /// Use the hypervisor's in-built enlightenment support if available.
+    pub offload_enlightenments: bool,
+}
+
+impl Default for WhpHandle {
+    fn default() -> Self {
+        Self {
+            user_mode_apic: false,
+            offload_enlightenments: true,
+        }
+    }
+}
 
 impl ResourceId<HypervisorKind> for WhpHandle {
     const ID: &'static str = "whp";
@@ -77,10 +91,24 @@ pub trait HypervisorProbe: Send + Sync + 'static {
     fn name(&self) -> &str;
 
     /// Checks whether this backend is available and, if so, returns a new
-    /// [`Resource<HypervisorKind>`] for it.
+    /// [`Resource<HypervisorKind>`] for it with default settings.
     ///
-    /// Returns `Ok(None)` if the backend is not available on this system.
+    /// Used for auto-detection: backends are tried in priority order, and
+    /// `Ok(None)` means "skip me, try the next one".
     fn try_new_resource(&self) -> anyhow::Result<Option<Resource<HypervisorKind>>>;
+
+    /// Constructs a [`Resource<HypervisorKind>`] for an explicitly selected
+    /// backend, with optional parameters.
+    ///
+    /// Unlike [`try_new_resource`](Self::try_new_resource), this returns
+    /// `Err` (not `Ok(None)`) if the backend is unavailable, so the caller
+    /// gets a specific error message.
+    ///
+    /// `params` contains backend-specific key-value pairs parsed from the
+    /// `--hypervisor name:key=val,...` CLI syntax. A bare key (no `=`) is
+    /// passed as `(key, "true")`. Backends should return an error for
+    /// unrecognized keys.
+    fn new_resource(&self, params: &[(&str, &str)]) -> anyhow::Result<Resource<HypervisorKind>>;
 }
 
 /// Private module for linkme infrastructure.

--- a/openvmm/hypervisor_resources/src/lib.rs
+++ b/openvmm/hypervisor_resources/src/lib.rs
@@ -56,8 +56,14 @@ impl ResourceId<HypervisorKind> for MshvHandle {
 #[derive(MeshPayload)]
 pub struct WhpHandle {
     /// Use the user-mode APIC emulator instead of the in-hypervisor one.
+    ///
+    /// Only supported on x86_64. Setting this on aarch64 will cause partition
+    /// creation to fail.
     pub user_mode_apic: bool,
     /// Use the hypervisor's in-built enlightenment support if available.
+    ///
+    /// Only supported on x86_64. Setting this to `false` on aarch64 will cause
+    /// partition creation to fail.
     pub offload_enlightenments: bool,
 }
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -802,7 +802,6 @@ impl InitializedVm {
             }
 
             Some(virt::HvConfig {
-                offload_enlightenments: !cfg.hypervisor.user_mode_hv_enlightenments,
                 allow_device_assignment,
                 vtl2: convert_vtl2_config(
                     cfg.hypervisor.with_vtl2.as_ref(),
@@ -821,7 +820,6 @@ impl InitializedVm {
                 processor_topology: &processor_topology,
                 hv_config,
                 vmtime: &vmtime_source,
-                user_mode_apic: cfg.hypervisor.user_mode_apic,
                 isolation: cfg
                     .hypervisor
                     .with_isolation

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -353,8 +353,6 @@ pub struct VmbusConfig {
 #[derive(Debug, MeshPayload, Default)]
 pub struct HypervisorConfig {
     pub with_hv: bool,
-    pub user_mode_hv_enlightenments: bool,
-    pub user_mode_apic: bool,
     pub with_vtl2: Option<Vtl2Config>,
     pub with_isolation: Option<IsolationType>,
 }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -141,14 +141,6 @@ pub struct Options {
     #[clap(long, requires("vtl2"), default_value = "halt")]
     pub late_map_vtl0_policy: Vtl0LateMapPolicyCli,
 
-    /// disable in-hypervisor enlightenment implementation (where possible)
-    #[clap(long)]
-    pub no_enlightenments: bool,
-
-    /// disable the in-hypervisor APIC and use the user-mode one (where possible)
-    #[clap(long)]
-    pub user_mode_apic: bool,
-
     /// attach a disk (can be passed multiple times)
     #[clap(long_help = r#"
 e.g: --disk memdiff:file:/path/to/disk.vhd
@@ -596,7 +588,19 @@ flags:
     #[clap(long)]
     pub mana: Vec<NicConfigCli>,
 
-    /// use a specific hypervisor interface
+    /// use a specific hypervisor interface, with optional backend-specific
+    /// parameters.
+    ///
+    /// Format: `name` or `name:key=val,key,...`
+    ///
+    /// WHP parameters:
+    ///   user_mode_apic       - use user-mode APIC emulator
+    ///   no_enlightenments    - disable in-hypervisor enlightenments
+    ///
+    /// Examples:
+    ///   --hypervisor whp
+    ///   --hypervisor whp:user_mode_apic
+    ///   --hypervisor whp:user_mode_apic,no_enlightenments
     #[clap(long)]
     pub hypervisor: Option<String>,
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -593,7 +593,7 @@ flags:
     ///
     /// Format: `name` or `name:key=val,key,...`
     ///
-    /// WHP parameters:
+    /// WHP parameters (x86_64 guests only):
     ///   user_mode_apic       - use user-mode APIC emulator
     ///   no_enlightenments    - disable in-hypervisor enlightenments
     ///

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1588,8 +1588,6 @@ async fn vm_config_from_command_line(
                 },
             }),
             with_isolation,
-            user_mode_hv_enlightenments: opt.no_enlightenments,
-            user_mode_apic: opt.user_mode_apic,
         },
         #[cfg(windows)]
         kernel_vmnics,

--- a/openvmm/openvmm_helpers/src/hypervisor.rs
+++ b/openvmm/openvmm_helpers/src/hypervisor.rs
@@ -24,16 +24,22 @@ pub fn choose_hypervisor() -> anyhow::Result<Resource<HypervisorKind>> {
 ///
 /// Returns `(name, params)` where `params` is a list of `(key, value)` pairs.
 /// A bare key (no `=`) is treated as a boolean flag with value `"true"`.
-fn parse_hypervisor_spec(spec: &str) -> (&str, Vec<(&str, &str)>) {
+fn parse_hypervisor_spec(spec: &str) -> anyhow::Result<(&str, Vec<(&str, &str)>)> {
     let (name, rest) = spec.split_once(':').unwrap_or((spec, ""));
+    anyhow::ensure!(!name.is_empty(), "empty hypervisor name in spec: {spec}");
     let params = if rest.is_empty() {
         Vec::new()
     } else {
         rest.split(',')
-            .map(|item| item.split_once('=').unwrap_or((item, "true")))
-            .collect()
+            .filter(|item| !item.is_empty())
+            .map(|item| {
+                let (key, val) = item.split_once('=').unwrap_or((item, "true"));
+                anyhow::ensure!(!key.is_empty(), "empty parameter key in spec: {spec}");
+                Ok((key, val))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?
     };
-    (name, params)
+    Ok((name, params))
 }
 
 /// Returns a [`Resource<HypervisorKind>`] for the named backend, with
@@ -43,7 +49,7 @@ fn parse_hypervisor_spec(spec: &str) -> (&str, Vec<(&str, &str)>) {
 /// Each backend validates its own parameters — see the probe
 /// implementations for supported keys.
 pub fn hypervisor_resource(spec: &str) -> anyhow::Result<Resource<HypervisorKind>> {
-    let (name, params) = parse_hypervisor_spec(spec);
+    let (name, params) = parse_hypervisor_spec(spec)?;
     let probe = hypervisor_resources::probe_by_name(name)
         .ok_or_else(|| anyhow::anyhow!("unknown hypervisor: {name}"))?;
     probe.new_resource(&params)

--- a/openvmm/openvmm_helpers/src/hypervisor.rs
+++ b/openvmm/openvmm_helpers/src/hypervisor.rs
@@ -20,14 +20,31 @@ pub fn choose_hypervisor() -> anyhow::Result<Resource<HypervisorKind>> {
     anyhow::bail!("no hypervisor available");
 }
 
-/// Returns a [`Resource<HypervisorKind>`] for the named backend.
+/// Parses a hypervisor specifier of the form `name` or `name:key=val,key,...`.
 ///
-/// This validates that the name matches a registered probe and checks
-/// availability.
-pub fn hypervisor_resource(name: &str) -> anyhow::Result<Resource<HypervisorKind>> {
+/// Returns `(name, params)` where `params` is a list of `(key, value)` pairs.
+/// A bare key (no `=`) is treated as a boolean flag with value `"true"`.
+fn parse_hypervisor_spec(spec: &str) -> (&str, Vec<(&str, &str)>) {
+    let (name, rest) = spec.split_once(':').unwrap_or((spec, ""));
+    let params = if rest.is_empty() {
+        Vec::new()
+    } else {
+        rest.split(',')
+            .map(|item| item.split_once('=').unwrap_or((item, "true")))
+            .collect()
+    };
+    (name, params)
+}
+
+/// Returns a [`Resource<HypervisorKind>`] for the named backend, with
+/// optional parameters.
+///
+/// The specifier format is `name` or `name:key=val,key,...`.
+/// Each backend validates its own parameters — see the probe
+/// implementations for supported keys.
+pub fn hypervisor_resource(spec: &str) -> anyhow::Result<Resource<HypervisorKind>> {
+    let (name, params) = parse_hypervisor_spec(spec);
     let probe = hypervisor_resources::probe_by_name(name)
         .ok_or_else(|| anyhow::anyhow!("unknown hypervisor: {name}"))?;
-    probe
-        .try_new_resource()?
-        .ok_or_else(|| anyhow::anyhow!("hypervisor {name} is not available"))
+    probe.new_resource(&params)
 }

--- a/openvmm/openvmm_hypervisors/src/hvf.rs
+++ b/openvmm/openvmm_hypervisors/src/hvf.rs
@@ -26,6 +26,13 @@ impl hypervisor_resources::HypervisorProbe for HvfProbe {
     fn try_new_resource(&self) -> anyhow::Result<Option<Resource<HypervisorKind>>> {
         Ok(Some(Resource::new(HvfHandle)))
     }
+
+    fn new_resource(&self, params: &[(&str, &str)]) -> anyhow::Result<Resource<HypervisorKind>> {
+        if let Some(&(key, _)) = params.first() {
+            anyhow::bail!("unknown hvf parameter: {key}");
+        }
+        Ok(Resource::new(HvfHandle))
+    }
 }
 
 /// HVF resource resolver.

--- a/openvmm/openvmm_hypervisors/src/kvm.rs
+++ b/openvmm/openvmm_hypervisors/src/kvm.rs
@@ -5,6 +5,7 @@
 
 #![cfg(all(target_os = "linux", feature = "virt_kvm", guest_is_native))]
 
+use anyhow::Context as _;
 use hypervisor_resources::HypervisorKind;
 use hypervisor_resources::KvmHandle;
 use openvmm_core::hypervisor_backend::ResolvedHypervisorBackend;
@@ -20,17 +21,28 @@ impl hypervisor_resources::HypervisorProbe for KvmProbe {
     }
 
     fn try_new_resource(&self) -> anyhow::Result<Option<Resource<HypervisorKind>>> {
-        let kvm = match fs_err::File::options()
-            .read(true)
-            .write(true)
-            .open("/dev/kvm")
-        {
+        let kvm = match open_kvm() {
             Ok(kvm) => kvm,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(err) => return Err(err.into()),
         };
         Ok(Some(KvmHandle { kvm: kvm.into() }.into_resource()))
     }
+
+    fn new_resource(&self, params: &[(&str, &str)]) -> anyhow::Result<Resource<HypervisorKind>> {
+        if let Some(&(key, _)) = params.first() {
+            anyhow::bail!("unknown kvm parameter: {key}");
+        }
+        let kvm = open_kvm().context("KVM is not available")?;
+        Ok(KvmHandle { kvm: kvm.into() }.into_resource())
+    }
+}
+
+fn open_kvm() -> std::io::Result<fs_err::File> {
+    fs_err::File::options()
+        .read(true)
+        .write(true)
+        .open("/dev/kvm")
 }
 
 /// KVM resource resolver.

--- a/openvmm/openvmm_hypervisors/src/mshv.rs
+++ b/openvmm/openvmm_hypervisors/src/mshv.rs
@@ -38,7 +38,9 @@ impl hypervisor_resources::HypervisorProbe for MshvProbe {
             anyhow::bail!("unknown mshv parameter: {key}");
         }
         anyhow::ensure!(virt_mshv::is_available()?, "MSHV is not available");
-        Ok(Resource::new(MshvHandle))
+        Ok(Resource::new(MshvHandle{
+            mshv: fs_err::File::open("/dev/mshv")?.into(),
+        }))
     }
 }
 

--- a/openvmm/openvmm_hypervisors/src/mshv.rs
+++ b/openvmm/openvmm_hypervisors/src/mshv.rs
@@ -38,7 +38,7 @@ impl hypervisor_resources::HypervisorProbe for MshvProbe {
             anyhow::bail!("unknown mshv parameter: {key}");
         }
         anyhow::ensure!(virt_mshv::is_available()?, "MSHV is not available");
-        Ok(Resource::new(MshvHandle{
+        Ok(Resource::new(MshvHandle {
             mshv: fs_err::File::open("/dev/mshv")?.into(),
         }))
     }

--- a/openvmm/openvmm_hypervisors/src/mshv.rs
+++ b/openvmm/openvmm_hypervisors/src/mshv.rs
@@ -32,6 +32,14 @@ impl hypervisor_resources::HypervisorProbe for MshvProbe {
         };
         Ok(Some(MshvHandle { mshv: mshv.into() }.into_resource()))
     }
+
+    fn new_resource(&self, params: &[(&str, &str)]) -> anyhow::Result<Resource<HypervisorKind>> {
+        if let Some(&(key, _)) = params.first() {
+            anyhow::bail!("unknown mshv parameter: {key}");
+        }
+        anyhow::ensure!(virt_mshv::is_available()?, "MSHV is not available");
+        Ok(Resource::new(MshvHandle))
+    }
 }
 
 /// MSHV resource resolver.

--- a/openvmm/openvmm_hypervisors/src/whp.rs
+++ b/openvmm/openvmm_hypervisors/src/whp.rs
@@ -26,12 +26,10 @@ impl hypervisor_resources::HypervisorProbe for WhpProbe {
         let mut handle = WhpHandle::default();
         for &(key, val) in params {
             match key {
-                #[cfg(guest_arch = "x86_64")]
-                "user_mode_apic" => {
+                "user_mode_apic" if cfg!(guest_arch = "x86_64") => {
                     handle.user_mode_apic = parse_bool_param(key, val)?;
                 }
-                #[cfg(guest_arch = "x86_64")]
-                "no_enlightenments" => {
+                "no_enlightenments" if cfg!(guest_arch = "x86_64") => {
                     handle.offload_enlightenments = !parse_bool_param(key, val)?;
                 }
                 _ => anyhow::bail!("unknown whp parameter: {key}"),

--- a/openvmm/openvmm_hypervisors/src/whp.rs
+++ b/openvmm/openvmm_hypervisors/src/whp.rs
@@ -26,9 +26,11 @@ impl hypervisor_resources::HypervisorProbe for WhpProbe {
         let mut handle = WhpHandle::default();
         for &(key, val) in params {
             match key {
+                #[cfg(guest_arch = "x86_64")]
                 "user_mode_apic" => {
                     handle.user_mode_apic = parse_bool_param(key, val)?;
                 }
+                #[cfg(guest_arch = "x86_64")]
                 "no_enlightenments" => {
                     handle.offload_enlightenments = !parse_bool_param(key, val)?;
                 }

--- a/openvmm/openvmm_hypervisors/src/whp.rs
+++ b/openvmm/openvmm_hypervisors/src/whp.rs
@@ -26,11 +26,19 @@ impl hypervisor_resources::HypervisorProbe for WhpProbe {
         let mut handle = WhpHandle::default();
         for &(key, val) in params {
             match key {
-                "user_mode_apic" if cfg!(guest_arch = "x86_64") => {
-                    handle.user_mode_apic = parse_bool_param(key, val)?;
+                "user_mode_apic" => {
+                    if cfg!(guest_arch = "x86_64") {
+                        handle.user_mode_apic = parse_bool_param(key, val)?;
+                    } else {
+                        anyhow::bail!("whp parameter {key} is only supported for x86_64 guests");
+                    }
                 }
-                "no_enlightenments" if cfg!(guest_arch = "x86_64") => {
-                    handle.offload_enlightenments = !parse_bool_param(key, val)?;
+                "no_enlightenments" => {
+                    if cfg!(guest_arch = "x86_64") {
+                        handle.offload_enlightenments = !parse_bool_param(key, val)?;
+                    } else {
+                        anyhow::bail!("whp parameter {key} is only supported for x86_64 guests");
+                    }
                 }
                 _ => anyhow::bail!("unknown whp parameter: {key}"),
             }

--- a/openvmm/openvmm_hypervisors/src/whp.rs
+++ b/openvmm/openvmm_hypervisors/src/whp.rs
@@ -19,7 +19,32 @@ impl hypervisor_resources::HypervisorProbe for WhpProbe {
     }
 
     fn try_new_resource(&self) -> anyhow::Result<Option<Resource<HypervisorKind>>> {
-        Ok(virt_whp::is_available()?.then(|| Resource::new(WhpHandle)))
+        Ok(virt_whp::is_available()?.then(|| Resource::new(WhpHandle::default())))
+    }
+
+    fn new_resource(&self, params: &[(&str, &str)]) -> anyhow::Result<Resource<HypervisorKind>> {
+        let mut handle = WhpHandle::default();
+        for &(key, val) in params {
+            match key {
+                "user_mode_apic" => {
+                    handle.user_mode_apic = parse_bool_param(key, val)?;
+                }
+                "no_enlightenments" => {
+                    handle.offload_enlightenments = !parse_bool_param(key, val)?;
+                }
+                _ => anyhow::bail!("unknown whp parameter: {key}"),
+            }
+        }
+        anyhow::ensure!(virt_whp::is_available()?, "WHP is not available");
+        Ok(Resource::new(handle))
+    }
+}
+
+fn parse_bool_param(key: &str, val: &str) -> anyhow::Result<bool> {
+    match val {
+        "true" | "1" | "yes" => Ok(true),
+        "false" | "0" | "no" => Ok(false),
+        _ => anyhow::bail!("invalid boolean value for {key}: {val}"),
     }
 }
 
@@ -30,8 +55,11 @@ impl vm_resource::ResolveResource<HypervisorKind, WhpHandle> for WhpResolver {
     type Output = ResolvedHypervisorBackend;
     type Error = std::convert::Infallible;
 
-    fn resolve(&self, _resource: WhpHandle, _input: ()) -> Result<Self::Output, Self::Error> {
-        Ok(ResolvedHypervisorBackend::new(virt_whp::Whp))
+    fn resolve(&self, resource: WhpHandle, _input: ()) -> Result<Self::Output, Self::Error> {
+        Ok(ResolvedHypervisorBackend::new(virt_whp::Whp {
+            user_mode_apic: resource.user_mode_apic,
+            offload_enlightenments: resource.offload_enlightenments,
+        }))
     }
 }
 

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -491,8 +491,6 @@ impl PetriVmConfigOpenVmm {
             // Basic virtualization device support
             hypervisor: HypervisorConfig {
                 with_hv: true,
-                user_mode_hv_enlightenments: false,
-                user_mode_apic: false,
                 with_vtl2,
                 with_isolation: match firmware.isolation() {
                     Some(IsolationType::Vbs) => Some(openvmm_defs::config::IsolationType::Vbs),

--- a/tmk/tmk_vmm/src/host_vmm.rs
+++ b/tmk/tmk_vmm/src/host_vmm.rs
@@ -43,7 +43,6 @@ impl RunContext<'_> {
                 processor_topology: &self.state.processor_topology,
                 hv_config: None,
                 vmtime: self.vmtime_source,
-                user_mode_apic: self.state.opts.disable_offloads,
                 isolation: virt::IsolationType::None,
             })
             .context("failed to create proto partition")?;

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -119,7 +119,17 @@ async fn do_main(driver: DefaultDriver) -> anyhow::Result<()> {
                         .await
                 }
                 #[cfg(windows)]
-                HypervisorOpt::Whp => state.run_host_vmm(virt_whp::Whp, test).await,
+                HypervisorOpt::Whp => {
+                    state
+                        .run_host_vmm(
+                            virt_whp::Whp {
+                                user_mode_apic: state.state.opts.disable_offloads,
+                                offload_enlightenments: !state.state.opts.disable_offloads,
+                            },
+                            test,
+                        )
+                        .await
+                }
                 #[cfg(target_os = "macos")]
                 HypervisorOpt::Hvf => state.run_host_vmm(virt_hvf::HvfHypervisor, test).await,
             })

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -151,8 +151,6 @@ pub struct ProtoPartitionConfig<'a> {
     pub hv_config: Option<HvConfig>,
     /// VM time access.
     pub vmtime: &'a VmTimeSource,
-    /// Use the user-mode APIC emulator, if supported.
-    pub user_mode_apic: bool,
     /// Isolation type for this partition.
     pub isolation: IsolationType,
 }
@@ -257,8 +255,6 @@ pub struct Vtl2Config {
 /// Hypervisor configuration.
 #[derive(Debug)]
 pub struct HvConfig {
-    /// Use the hypervisor's in-built enlightenment support if available.
-    pub offload_enlightenments: bool,
     /// Allow device assignment on the partition.
     pub allow_device_assignment: bool,
     /// Enable VTL2 support if set. Additional options are described by

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1244,7 +1244,7 @@ impl VtlPartition {
         user_mode_apic: bool,
         offload_enlightenments: bool,
     ) -> Result<Self, Error> {
-        #[cfg(guest_arch = "aarch64")]
+        #[cfg(not(guest_arch = "x86_64"))]
         {
             if user_mode_apic {
                 return Err(Error::UnsupportedParameter("user_mode_apic"));

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -742,6 +742,8 @@ pub enum Error {
     GicV2NotSupported,
     #[error("failed to compute topology cpuid")]
     TopologyCpuid(#[source] virt::x86::topology::UnknownVendor),
+    #[error("{0} is not supported on this architecture")]
+    UnsupportedParameter(&'static str),
 }
 
 trait WhpResultExt<T> {
@@ -954,6 +956,9 @@ impl WhpPartitionInner {
         user_mode_apic: bool,
         offload_enlightenments: bool,
     ) -> Result<Self, Error> {
+        // These are validated by VtlPartition::new and only consumed on x86_64.
+        let _ = (user_mode_apic, offload_enlightenments);
+
         // FUTURE: register cpuid results with the hypervisor, and register
         // appropriate per-VP results where necessary (or tell the hypervisor
         // the AMD topology information so that it can provide per-VP results
@@ -1239,6 +1244,16 @@ impl VtlPartition {
         user_mode_apic: bool,
         offload_enlightenments: bool,
     ) -> Result<Self, Error> {
+        #[cfg(guest_arch = "aarch64")]
+        {
+            if user_mode_apic {
+                return Err(Error::UnsupportedParameter("user_mode_apic"));
+            }
+            if !offload_enlightenments {
+                return Err(Error::UnsupportedParameter("no_enlightenments"));
+            }
+        }
+
         let mut hypervisor_enlightened = false;
 
         let mut extended_exits = whp::abi::WHV_EXTENDED_VM_EXITS(0);

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -78,7 +78,12 @@ use x86defs::cpuid::Vendor;
 pub use aarch64::WHP_PMU_GSIV;
 
 #[derive(Debug)]
-pub struct Whp;
+pub struct Whp {
+    /// Use the user-mode APIC emulator instead of the in-hypervisor one.
+    pub user_mode_apic: bool,
+    /// Use the hypervisor's in-built enlightenment support if available.
+    pub offload_enlightenments: bool,
+}
 
 #[derive(Inspect)]
 #[inspect(transparent)]
@@ -775,18 +780,31 @@ impl virt::Hypervisor for Whp {
         &mut self,
         config: ProtoPartitionConfig<'a>,
     ) -> Result<WhpProtoPartition<'a>, Error> {
-        let vtl0 = VtlPartition::new(&config, Vtl::Vtl0)?;
+        let user_mode_apic = self.user_mode_apic;
+        let offload_enlightenments = self.offload_enlightenments;
+        let vtl0 = VtlPartition::new(&config, Vtl::Vtl0, user_mode_apic, offload_enlightenments)?;
         let vtl2 = if config
             .hv_config
             .as_ref()
             .is_some_and(|cfg| cfg.vtl2.is_some())
         {
-            Some(VtlPartition::new(&config, Vtl::Vtl2)?)
+            Some(VtlPartition::new(
+                &config,
+                Vtl::Vtl2,
+                user_mode_apic,
+                offload_enlightenments,
+            )?)
         } else {
             None
         };
 
-        Ok(WhpProtoPartition { vtl0, vtl2, config })
+        Ok(WhpProtoPartition {
+            vtl0,
+            vtl2,
+            config,
+            user_mode_apic,
+            offload_enlightenments,
+        })
     }
 }
 
@@ -800,6 +818,8 @@ pub struct WhpProtoPartition<'a> {
     vtl0: VtlPartition,
     vtl2: Option<VtlPartition>,
     config: ProtoPartitionConfig<'a>,
+    user_mode_apic: bool,
+    offload_enlightenments: bool,
 }
 
 impl ProtoPartition for WhpProtoPartition<'_> {
@@ -842,6 +862,8 @@ impl ProtoPartition for WhpProtoPartition<'_> {
             &self.config,
             self.vtl0,
             self.vtl2,
+            self.user_mode_apic,
+            self.offload_enlightenments,
         )?);
 
         let with_vtl0 = Arc::new(WhpPartitionAndVtl {
@@ -929,6 +951,8 @@ impl WhpPartitionInner {
         proto_config: &ProtoPartitionConfig<'_>,
         vtl0: VtlPartition,
         vtl2: Option<VtlPartition>,
+        user_mode_apic: bool,
+        offload_enlightenments: bool,
     ) -> Result<Self, Error> {
         // FUTURE: register cpuid results with the hypervisor, and register
         // appropriate per-VP results where necessary (or tell the hypervisor
@@ -953,8 +977,8 @@ impl WhpPartitionInner {
             );
 
             // Add in the synthetic hv leaves if necessary.
-            if let Some(hv_config) = &proto_config.hv_config {
-                if !hv_config.offload_enlightenments || proto_config.user_mode_apic {
+            if proto_config.hv_config.is_some() {
+                if !offload_enlightenments || user_mode_apic {
                     let enlightenments = hvdef::HvEnlightenmentInformation::new()
                         .with_deprecate_auto_eoi(true)
                         .with_use_relaxed_timing(true)
@@ -1209,16 +1233,21 @@ impl VmTimeReferenceTimeSource {
 }
 
 impl VtlPartition {
-    fn new(config: &ProtoPartitionConfig<'_>, vtl: Vtl) -> Result<Self, Error> {
+    fn new(
+        config: &ProtoPartitionConfig<'_>,
+        vtl: Vtl,
+        user_mode_apic: bool,
+        offload_enlightenments: bool,
+    ) -> Result<Self, Error> {
         let mut hypervisor_enlightened = false;
 
         let mut extended_exits = whp::abi::WHV_EXTENDED_VM_EXITS(0);
 
-        let user_mode_apic = config.user_mode_apic
+        let user_mode_apic = user_mode_apic
             || config
                 .hv_config
                 .as_ref()
-                .is_some_and(|cfg| !cfg.offload_enlightenments);
+                .is_some_and(|_| !offload_enlightenments);
 
         #[cfg(guest_arch = "x86_64")]
         let lapic = if user_mode_apic {
@@ -1334,7 +1363,7 @@ impl VtlPartition {
 
             let supported_synth_features = whp::capabilities::synthetic_processor_features()
                 .for_op("get synth processor features")?;
-            if hv_config.offload_enlightenments
+            if offload_enlightenments
                 && !user_mode_apic
                 && supported_synth_features
                     .bank0


### PR DESCRIPTION
Move `user_mode_apic` and `offload_enlightenments` out of the shared hypervisor abstraction types (`ProtoPartitionConfig`, `HvConfig`, `HypervisorConfig`) and into the WHP-specific `WhpHandle` and `Whp` types.

These knobs were only ever consumed by the WHP backend—KVM, MSHV, and HVF ignored them entirely—so they don't belong in the cross-backend abstraction layer.

The `--hypervisor` CLI flag now accepts `name:key=val,key,...` syntax, allowing backend-specific parameters to be passed at the point where the hypervisor is selected. For example:

    --hypervisor whp:user_mode_apic,no_enlightenments

The `HypervisorProbe` trait is split into two methods: `try_new_resource()` for auto-detection (returns `Ok(None)` to skip) and `new_resource(params)` for explicit selection (returns `Err` with a specific message when unavailable, and validates backend-specific params). This avoids redundant availability checks when the user explicitly selects a backend and gives each probe full control over its own parameter validation.

The old `--user-mode-apic` and `--no-enlightenments` top-level flags are removed in favor of the new per-backend syntax.