### PR TITLE
Add PIIX4 PCI-ISA bridge support to chipset resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
 name = "chipset_legacy"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "chipset",
  "chipset_device",
  "chipset_device_resources",
@@ -667,6 +668,7 @@ dependencies = [
  "pal_async",
  "pci_bus",
  "pci_core",
+ "power_resources",
  "thiserror 2.0.16",
  "tracelimit",
  "tracing",

--- a/openhcl/openvmm_hcl_resources/src/lib.rs
+++ b/openhcl/openvmm_hcl_resources/src/lib.rs
@@ -17,6 +17,8 @@ vm_resource::register_static_resolvers! {
     #[cfg(guest_arch = "x86_64")]
     chipset_legacy::piix4_uhci::resolver::Piix4PciUsbUhciStubResolver,
     #[cfg(guest_arch = "x86_64")]
+    chipset_legacy::piix4_pci_isa_bridge::resolver::Piix4PciIsaBridgeResolver,
+    #[cfg(guest_arch = "x86_64")]
     chipset::pit::resolver::PitResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pic::resolver::PicResolver,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2777,12 +2777,6 @@ async fn new_underhill_vm(
     let deps_generic_isa_dma = chipset
         .with_generic_isa_dma
         .then_some(dev::GenericIsaDmaDeps);
-    let deps_piix4_pci_isa_bridge =
-        chipset
-            .with_piix4_pci_isa_bridge
-            .then(|| dev::Piix4PciIsaBridgeDeps {
-                attached_to: pci_bus_id_piix4.clone(),
-            });
     let deps_piix4_power_management =
         chipset
             .with_piix4_power_management
@@ -2981,7 +2975,6 @@ async fn new_underhill_vm(
         deps_i440bx_host_pci_bridge,
         deps_piix4_cmos_rtc,
         deps_piix4_pci_bus,
-        deps_piix4_pci_isa_bridge,
         deps_piix4_power_management,
         deps_underhill_vga_proxy,
         deps_winbond_super_io_and_floppy_stub,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1588,10 +1588,6 @@ impl InitializedVm {
             secondary_channel_drives,
         });
 
-        let deps_piix4_pci_isa_bridge =
-            (cfg.chipset.with_piix4_pci_isa_bridge).then_some(dev::Piix4PciIsaBridgeDeps {
-                attached_to: pci_bus_id_piix4.clone(),
-            });
         let deps_piix4_power_management =
             (cfg.chipset.with_piix4_power_management).then_some(dev::Piix4PowerManagementDeps {
                 attached_to: pci_bus_id_piix4.clone(),
@@ -1616,7 +1612,6 @@ impl InitializedVm {
                 deps_i440bx_host_pci_bridge,
                 deps_piix4_cmos_rtc,
                 deps_piix4_pci_bus,
-                deps_piix4_pci_isa_bridge,
                 deps_piix4_power_management,
                 deps_underhill_vga_proxy: None,
                 deps_winbond_super_io_and_floppy_stub: None,

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -14,6 +14,8 @@ vm_resource::register_static_resolvers! {
     #[cfg(guest_arch = "x86_64")]
     chipset_legacy::piix4_uhci::resolver::Piix4PciUsbUhciStubResolver,
     #[cfg(guest_arch = "x86_64")]
+    chipset_legacy::piix4_pci_isa_bridge::resolver::Piix4PciIsaBridgeResolver,
+    #[cfg(guest_arch = "x86_64")]
     chipset::pit::resolver::PitResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pic::resolver::PicResolver,

--- a/vm/devices/chipset_legacy/Cargo.toml
+++ b/vm/devices/chipset_legacy/Cargo.toml
@@ -19,7 +19,9 @@ pci_bus.workspace = true
 pci_core.workspace = true
 memory_range.workspace = true
 vmcore.workspace = true
+power_resources.workspace = true
 
+async-trait.workspace = true
 inspect.workspace = true
 mesh.workspace = true
 open_enum.workspace = true

--- a/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/mod.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/mod.rs
@@ -3,6 +3,8 @@
 
 //! PIIX4 - PCI to ISA Bridge
 
+pub mod resolver;
+
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
@@ -331,7 +333,7 @@ impl PciConfigSpace for PciIsaBridge {
     }
 
     fn suggested_bdf(&mut self) -> Option<(u8, u8, u8)> {
-        Some((0, 7, 0)) // as per PIIX4 spec
+        Some(chipset_resources::piix4_pci_isa_bridge::PIIX4_PCI_ISA_BRIDGE_BDF)
     }
 }
 

--- a/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/resolver.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/resolver.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resolver for the PIIX4 PCI-ISA bridge device.
+
+use super::PciIsaBridge;
+use async_trait::async_trait;
+use chipset_device_resources::ResolveChipsetDeviceHandleParams;
+use chipset_device_resources::ResolvedChipsetDevice;
+use chipset_resources::piix4_pci_isa_bridge::Piix4PciIsaBridgeDeviceHandle;
+use power_resources::PowerRequest;
+use power_resources::PowerRequestHandleKind;
+use thiserror::Error;
+use vm_resource::AsyncResolveResource;
+use vm_resource::IntoResource;
+use vm_resource::PlatformResource;
+use vm_resource::ResolveError;
+use vm_resource::ResourceResolver;
+use vm_resource::declare_static_async_resolver;
+use vm_resource::kind::ChipsetDeviceHandleKind;
+
+/// A resolver for the PIIX4 PCI-ISA bridge device.
+pub struct Piix4PciIsaBridgeResolver;
+
+declare_static_async_resolver! {
+    Piix4PciIsaBridgeResolver,
+    (ChipsetDeviceHandleKind, Piix4PciIsaBridgeDeviceHandle),
+}
+
+/// Errors that can occur when resolving the PIIX4 PCI-ISA bridge.
+#[derive(Debug, Error)]
+#[expect(missing_docs)]
+pub enum ResolvePiix4PciIsaBridgeError {
+    #[error("failed to resolve power request")]
+    ResolvePowerRequest(#[source] ResolveError),
+}
+
+#[async_trait]
+impl AsyncResolveResource<ChipsetDeviceHandleKind, Piix4PciIsaBridgeDeviceHandle>
+    for Piix4PciIsaBridgeResolver
+{
+    type Output = ResolvedChipsetDevice;
+    type Error = ResolvePiix4PciIsaBridgeError;
+
+    async fn resolve(
+        &self,
+        resolver: &ResourceResolver,
+        _resource: Piix4PciIsaBridgeDeviceHandle,
+        _input: ResolveChipsetDeviceHandleParams<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        let power_request = resolver
+            .resolve::<PowerRequestHandleKind, _>(PlatformResource.into_resource(), ())
+            .await
+            .map_err(ResolvePiix4PciIsaBridgeError::ResolvePowerRequest)?;
+
+        let reset = Box::new(move || {
+            power_request.power_request(PowerRequest::Reset);
+        });
+
+        let set_a20_signal =
+            Box::new(move |active| tracing::info!(active, "setting stubbed A20 signal"));
+
+        Ok(PciIsaBridge::new(reset, set_a20_signal).into())
+    }
+}

--- a/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/resolver.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/resolver.rs
@@ -57,8 +57,9 @@ impl AsyncResolveResource<ChipsetDeviceHandleKind, Piix4PciIsaBridgeDeviceHandle
             power_request.power_request(PowerRequest::Reset);
         });
 
-        let set_a20_signal =
-            Box::new(move |active| tracing::info!(active, "setting stubbed A20 signal"));
+        let set_a20_signal = Box::new(move |active| {
+            tracelimit::info_ratelimited!(active, "setting stubbed A20 signal")
+        });
 
         Ok(PciIsaBridge::new(reset, set_a20_signal).into())
     }

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -128,6 +128,25 @@ pub mod battery {
     }
 }
 
+pub mod piix4_pci_isa_bridge {
+    //! Resource definitions for the PIIX4 PCI-ISA bridge device.
+
+    use mesh::MeshPayload;
+    use vm_resource::ResourceId;
+    use vm_resource::kind::ChipsetDeviceHandleKind;
+
+    /// A handle to the PIIX4 PCI-to-ISA bridge (PCI device function 0).
+    #[derive(MeshPayload)]
+    pub struct Piix4PciIsaBridgeDeviceHandle;
+
+    /// The fixed BDF used by the PIIX4 PCI-ISA bridge in the Gen1 chipset.
+    pub const PIIX4_PCI_ISA_BRIDGE_BDF: (u8, u8, u8) = (0, 7, 0);
+
+    impl ResourceId<ChipsetDeviceHandleKind> for Piix4PciIsaBridgeDeviceHandle {
+        const ID: &'static str = "piix4PciIsaBridge";
+    }
+}
+
 pub mod piix4_uhci {
     //! Resource definitions for the PIIX4 USB UHCI stub device.
 

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -22,6 +22,8 @@ use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
 use chipset_resources::i8042::I8042DeviceHandle;
 use chipset_resources::pic::PicDeviceHandle;
+use chipset_resources::piix4_pci_isa_bridge::PIIX4_PCI_ISA_BRIDGE_BDF;
+use chipset_resources::piix4_pci_isa_bridge::Piix4PciIsaBridgeDeviceHandle;
 use chipset_resources::piix4_uhci::PIIX4_PCI_USB_UHCI_STUB_BDF;
 use chipset_resources::piix4_uhci::Piix4PciUsbUhciStubDeviceHandle;
 use chipset_resources::pit::PitDeviceHandle;
@@ -246,6 +248,7 @@ impl VmManifestBuilder {
                 }
                 result.attach_i8042();
                 result.attach_piix4_pci_usb_uhci_stub();
+                result.attach_piix4_pci_isa_bridge();
                 // This chipset always has a serial port even if not requested.
                 result.attach_serial_16550(
                     self.serial_wait_for_rts,
@@ -268,7 +271,6 @@ impl VmManifestBuilder {
                     with_i440bx_host_pci_bridge: true,
                     with_piix4_cmos_rtc: true,
                     with_piix4_pci_bus: true,
-                    with_piix4_pci_isa_bridge: true,
                     with_piix4_power_management: true,
                     with_underhill_vga_proxy: self.proxy_vga,
                     with_winbond_super_io_and_floppy_stub: self.stub_floppy,
@@ -301,7 +303,6 @@ impl VmManifestBuilder {
                     with_i440bx_host_pci_bridge: false,
                     with_piix4_cmos_rtc: false,
                     with_piix4_pci_bus: false,
-                    with_piix4_pci_isa_bridge: false,
                     with_piix4_power_management: false,
                     with_underhill_vga_proxy: false,
                     with_winbond_super_io_and_floppy_stub: false,
@@ -344,7 +345,6 @@ impl VmManifestBuilder {
                     with_i440bx_host_pci_bridge: false,
                     with_piix4_cmos_rtc: false,
                     with_piix4_pci_bus: false,
-                    with_piix4_pci_isa_bridge: false,
                     with_piix4_power_management: false,
                     with_underhill_vga_proxy: false,
                     with_winbond_super_io_and_floppy_stub: false,
@@ -443,6 +443,16 @@ impl VmChipsetResult {
             resource: Piix4PciUsbUhciStubDeviceHandle.into_resource(),
             pci_bus_name: LEGACY_CHIPSET_PCI_BUS_NAME.to_string(),
             bdf: PIIX4_PCI_USB_UHCI_STUB_BDF,
+        });
+        self
+    }
+
+    fn attach_piix4_pci_isa_bridge(&mut self) -> &mut Self {
+        self.pci_chipset_devices.push(LegacyPciChipsetDeviceHandle {
+            name: "piix4-pci-isa-bridge".to_string(),
+            resource: Piix4PciIsaBridgeDeviceHandle.into_resource(),
+            pci_bus_name: LEGACY_CHIPSET_PCI_BUS_NAME.to_string(),
+            bdf: PIIX4_PCI_ISA_BRIDGE_BDF,
         });
         self
     }

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -230,7 +230,6 @@ impl<'a> BaseChipsetBuilder<'a> {
             deps_i440bx_host_pci_bridge,
             deps_piix4_cmos_rtc,
             deps_piix4_pci_bus,
-            deps_piix4_pci_isa_bridge,
             deps_piix4_power_management,
             deps_underhill_vga_proxy,
             deps_winbond_super_io_and_floppy_stub,
@@ -303,29 +302,6 @@ impl<'a> BaseChipsetBuilder<'a> {
                 None
             }
         };
-
-        if let Some(options::dev::Piix4PciIsaBridgeDeps { attached_to }) = deps_piix4_pci_isa_bridge
-        {
-            // TODO: use PowerRequestHandleKind
-            let reset = {
-                let power = foundation.power_event_handler.clone();
-                Box::new(move || power.on_power_event(PowerEvent::Reset))
-            };
-
-            let set_a20_signal = Box::new(move |active| {
-                tracing::info!(CVM_ALLOWED, active, "setting stubbed A20 signal")
-            });
-
-            builder
-                .arc_mutex_device("piix4-pci-isa-bridge")
-                .on_pci_bus(attached_to)
-                .add(|_| {
-                    chipset_legacy::piix4_pci_isa_bridge::PciIsaBridge::new(
-                        reset.clone(),
-                        set_a20_signal,
-                    )
-                })?;
-        }
 
         let _ = dma;
         #[cfg(feature = "dev_generic_isa_floppy")]
@@ -1153,7 +1129,6 @@ pub mod options {
 
             piix4_cmos_rtc:              dev::Piix4CmosRtcDeps,
             piix4_pci_bus:               dev::Piix4PciBusDeps,
-            piix4_pci_isa_bridge:        dev::Piix4PciIsaBridgeDeps,
             piix4_power_management:      dev::Piix4PowerManagementDeps,
 
             underhill_vga_proxy:         dev::UnderhillVgaProxyDeps,
@@ -1198,12 +1173,6 @@ pub mod options {
                 $(#[$m])*
                 pub struct $root_deps $($rest)*
             };
-        }
-
-        /// PIIX4 PCI-ISA bridge (fixed pci address: 0:7.0)
-        pub struct Piix4PciIsaBridgeDeps {
-            /// `vmotherboard` bus identifier
-            pub attached_to: BusIdPci,
         }
 
         /// Hyper-V IDE controller (fixed pci address: 0:7.1)


### PR DESCRIPTION
- Add Piix4PciIsaBridgeDeviceHandle unit struct and PIIX4_PCI_ISA_BRIDGE_BDF constant in chipset_resources
- Add async resolver that resolves PowerRequestHandleKind for the reset callback and inlines the stub A20 signal
- Register Piix4PciIsaBridgeResolver in both OpenVMM and OpenHCL resource registries
- Remove Piix4PciIsaBridgeDeps from base_chipset_devices_and_manifest! macro and direct construction wiring
- Add attach_piix4_pci_isa_bridge() to vm_manifest_builder pushing LegacyPciChipsetDeviceHandle with explicit bus + BDF
- Update suggested_bdf() to reference PIIX4_PCI_ISA_BRIDGE_BDF constant as single source of truth