### PR TITLE
Add i440BX Host-PCI Bridge support to chipset resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "arbitrary",
  "inspect",
  "local_clock",
+ "memory_range",
  "mesh",
  "vm_resource",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5477,6 +5477,7 @@ dependencies = [
  "state_unit",
  "storvsp",
  "thiserror 2.0.16",
+ "tracelimit",
  "tracing",
  "uefi_specs",
  "vfio_assigned_device",

--- a/openhcl/openvmm_hcl_resources/src/lib.rs
+++ b/openhcl/openvmm_hcl_resources/src/lib.rs
@@ -23,6 +23,8 @@ vm_resource::register_static_resolvers! {
     #[cfg(guest_arch = "x86_64")]
     chipset_legacy::piix4_pm::resolver::Piix4PowerManagementResolver,
     #[cfg(guest_arch = "x86_64")]
+    chipset_legacy::i440bx_host_pci_bridge::resolver::I440BxHostPciBridgeResolver,
+    #[cfg(guest_arch = "x86_64")]
     chipset::pit::resolver::PitResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pic::resolver::PicResolver,

--- a/openhcl/underhill_core/src/emuplat/i440bx_host_pci_bridge.rs
+++ b/openhcl/underhill_core/src/emuplat/i440bx_host_pci_bridge.rs
@@ -247,6 +247,31 @@ impl AdjustGpaRange for ArcMutexGetBackedAdjustGpaRange {
     }
 }
 
+/// Platform resolver for [`AdjustGpaRangeHandleKind`] in Underhill.
+pub struct AdjustGpaRangeResolver(pub std::sync::Arc<parking_lot::Mutex<GetBackedAdjustGpaRange>>);
+
+impl
+    vm_resource::ResolveResource<
+        chipset_resources::i440bx_host_pci_bridge::AdjustGpaRangeHandleKind,
+        vm_resource::PlatformResource,
+    > for AdjustGpaRangeResolver
+{
+    type Output = chipset_resources::i440bx_host_pci_bridge::ResolvedAdjustGpaRange;
+    type Error = std::convert::Infallible;
+
+    fn resolve(
+        &self,
+        _resource: vm_resource::PlatformResource,
+        _input: (),
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(
+            chipset_resources::i440bx_host_pci_bridge::ResolvedAdjustGpaRange(Box::new(
+                ArcMutexGetBackedAdjustGpaRange(self.0.clone()),
+            )),
+        )
+    }
+}
+
 enum BiosMemoryRangeKind {
     None,
     SystemBios,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -25,7 +25,6 @@ use crate::dispatch::vtl2_settings_worker::wait_for_mana;
 use crate::emuplat::EmuplatServicing;
 use crate::emuplat::cmos_rtc_time_source::UnderhillCmosRtcTimeSourceResolver;
 use crate::emuplat::framebuffer::FramebufferRemoteControl;
-use crate::emuplat::i440bx_host_pci_bridge::ArcMutexGetBackedAdjustGpaRange;
 use crate::emuplat::i440bx_host_pci_bridge::GetBackedAdjustGpaRange;
 use crate::emuplat::local_clock::ArcMutexUnderhillLocalClock;
 use crate::emuplat::local_clock::UnderhillLocalClock;
@@ -2765,46 +2764,42 @@ async fn new_underhill_vm(
         bus_id: pci_bus_id_piix4.clone(),
     });
 
-    let deps_i440bx_host_pci_bridge = if chipset.with_i440bx_host_pci_bridge {
-        Some(dev::I440BxHostPciBridgeDeps {
-            attached_to: pci_bus_id_piix4.clone(),
-            adjust_gpa_range: {
-                // TODO: improve slot range allocation, when there are more API consumers
-                let base_slot = 0;
-                // The host will only consider the first available RAM block when
-                // creating PCAT mappings, so we need to do the same. This only
-                // works because everybody keeps things sorted.
-                const SIZE_1_MB: u64 = 1024 * 1024;
-                const SIZE_4_GB: u64 = 4 * 1024 * SIZE_1_MB;
-                let first_mem_block = &mem_layout.ram()[0];
-                anyhow::ensure!(
-                    first_mem_block.range.end() < SIZE_4_GB,
-                    "first memory block must be below 4GB for adjust_gpa_range"
-                );
-                // Reserve 1MB off the top.
-                let rom_bios_offset = first_mem_block.range.end() - SIZE_1_MB;
+    if capabilities.with_i440bx_host_pci_bridge {
+        // TODO: improve slot range allocation, when there are more API consumers
+        let base_slot = 0;
+        // The host will only consider the first available RAM block when
+        // creating PCAT mappings, so we need to do the same. This only
+        // works because everybody keeps things sorted.
+        const SIZE_1_MB: u64 = 1024 * 1024;
+        const SIZE_4_GB: u64 = 4 * 1024 * SIZE_1_MB;
+        let first_mem_block = &mem_layout.ram()[0];
+        anyhow::ensure!(
+            first_mem_block.range.end() < SIZE_4_GB,
+            "first memory block must be below 4GB for adjust_gpa_range"
+        );
+        // Reserve 1MB off the top.
+        let rom_bios_offset = first_mem_block.range.end() - SIZE_1_MB;
 
-                let adjust_gpa_range = GetBackedAdjustGpaRange::new(
-                    get_client.clone(),
-                    base_slot,
-                    rom_bios_offset,
-                    servicing_state
-                        .emuplat
-                        .get_backed_adjust_gpa_range
-                        .flatten(),
-                )
-                .context("failed to initialize GetBackedAdjustGpaRange emuplat")?;
+        let adjust_gpa_range = GetBackedAdjustGpaRange::new(
+            get_client.clone(),
+            base_slot,
+            rom_bios_offset,
+            servicing_state
+                .emuplat
+                .get_backed_adjust_gpa_range
+                .flatten(),
+        )
+        .context("failed to initialize GetBackedAdjustGpaRange emuplat")?;
 
-                let adjust_gpa_range = Arc::new(Mutex::new(adjust_gpa_range));
+        let adjust_gpa_range = Arc::new(Mutex::new(adjust_gpa_range));
 
-                emuplat_adjust_gpa_range = Some(adjust_gpa_range.clone());
+        emuplat_adjust_gpa_range = Some(adjust_gpa_range.clone());
 
-                Box::new(ArcMutexGetBackedAdjustGpaRange(adjust_gpa_range))
-            },
-        })
+        resolver.add_resolver(
+            crate::emuplat::i440bx_host_pci_bridge::AdjustGpaRangeResolver(adjust_gpa_range),
+        );
     } else {
         emuplat_adjust_gpa_range = None;
-        None
     };
 
     let deps_winbond_super_io_and_floppy_stub = chipset
@@ -2977,7 +2972,6 @@ async fn new_underhill_vm(
         deps_hyperv_framebuffer: None,
         deps_hyperv_ide,
         deps_hyperv_vga: None,
-        deps_i440bx_host_pci_bridge,
         deps_piix4_cmos_rtc,
         deps_piix4_pci_bus,
         deps_underhill_vga_proxy,

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -750,6 +750,7 @@ impl GuestMemoryManager {
 
 /// A client to the [`GuestMemoryManager`] used to control the visibility of
 /// RAM regions.
+#[derive(Clone)]
 pub struct RamVisibilityControl {
     regions: Arc<Vec<RamRegion>>,
 }

--- a/openvmm/openvmm_core/Cargo.toml
+++ b/openvmm/openvmm_core/Cargo.toml
@@ -98,6 +98,7 @@ futures.workspace = true
 futures-concurrency.workspace = true
 getrandom.workspace = true
 thiserror.workspace = true
+tracelimit.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
 

--- a/openvmm/openvmm_core/src/emuplat/i440bx_host_pci_bridge.rs
+++ b/openvmm/openvmm_core/src/emuplat/i440bx_host_pci_bridge.rs
@@ -3,10 +3,15 @@
 
 use chipset_legacy::i440bx_host_pci_bridge::AdjustGpaRange;
 use chipset_legacy::i440bx_host_pci_bridge::GpaState;
+use chipset_resources::i440bx_host_pci_bridge::AdjustGpaRangeHandleKind;
+use chipset_resources::i440bx_host_pci_bridge::ResolvedAdjustGpaRange;
 use futures::executor::block_on;
 use membacking::RamVisibility;
 use membacking::RamVisibilityControl;
 use memory_range::MemoryRange;
+use std::convert::Infallible;
+use vm_resource::PlatformResource;
+use vm_resource::ResolveResource;
 
 /// Implementation of [`AdjustGpaRange`] used by the legacy PCI bus for OpenVMM
 /// and the legacy PCAT and SVGA BIOSes.
@@ -45,5 +50,23 @@ impl AdjustGpaRange for ManageRamGpaRange {
             }
         };
         block_on(self.memory.set_ram_visibility(range, state)).unwrap();
+    }
+}
+
+/// Platform resolver for [`AdjustGpaRangeHandleKind`] in OpenVMM.
+pub struct AdjustGpaRangeResolver(pub RamVisibilityControl);
+
+impl ResolveResource<AdjustGpaRangeHandleKind, PlatformResource> for AdjustGpaRangeResolver {
+    type Output = ResolvedAdjustGpaRange;
+    type Error = Infallible;
+
+    fn resolve(
+        &self,
+        _resource: PlatformResource,
+        _input: (),
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(ResolvedAdjustGpaRange(Box::new(ManageRamGpaRange::new(
+            self.0.clone(),
+        ))))
     }
 }

--- a/openvmm/openvmm_core/src/emuplat/i440bx_host_pci_bridge.rs
+++ b/openvmm/openvmm_core/src/emuplat/i440bx_host_pci_bridge.rs
@@ -10,6 +10,7 @@ use membacking::RamVisibility;
 use membacking::RamVisibilityControl;
 use memory_range::MemoryRange;
 use std::convert::Infallible;
+use tracelimit::error_ratelimited;
 use vm_resource::PlatformResource;
 use vm_resource::ResolveResource;
 
@@ -49,7 +50,9 @@ impl AdjustGpaRange for ManageRamGpaRange {
                 }
             }
         };
-        block_on(self.memory.set_ram_visibility(range, state)).unwrap();
+        if let Err(err) = block_on(self.memory.set_ram_visibility(range, state)) {
+            error_ratelimited!(error = &err as &dyn std::error::Error, %range, "failed to set RAM visibility");
+        }
     }
 }
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1305,6 +1305,9 @@ impl InitializedVm {
         resolver.add_resolver(vmm_core::platform_resolvers::IoApicRoutingResolver(
             partition.clone().ioapic_routing(),
         ));
+        resolver.add_resolver(emuplat::i440bx_host_pci_bridge::AdjustGpaRangeResolver(
+            memory_manager.ram_visibility_control(),
+        ));
 
         let mapper = memory_manager.device_memory_mapper();
 
@@ -1648,16 +1651,6 @@ impl InitializedVm {
             None
         };
 
-        let deps_i440bx_host_pci_bridge =
-            (cfg.chipset.with_i440bx_host_pci_bridge).then(|| dev::I440BxHostPciBridgeDeps {
-                attached_to: pci_bus_id_piix4.clone(),
-                adjust_gpa_range: Box::new(
-                    emuplat::i440bx_host_pci_bridge::ManageRamGpaRange::new(
-                        memory_manager.ram_visibility_control(),
-                    ),
-                ),
-            });
-
         let deps_piix4_pci_bus = (cfg.chipset.with_piix4_pci_bus).then(|| dev::Piix4PciBusDeps {
             bus_id: pci_bus_id_piix4.clone(),
         });
@@ -1690,7 +1683,6 @@ impl InitializedVm {
                 deps_hyperv_framebuffer,
                 deps_hyperv_ide,
                 deps_hyperv_vga,
-                deps_i440bx_host_pci_bridge,
                 deps_piix4_cmos_rtc,
                 deps_piix4_pci_bus,
                 deps_underhill_vga_proxy: None,
@@ -1774,7 +1766,7 @@ impl InitializedVm {
         let pci_inta_line = {
             const PCI_LEGACY_INTA_IRQ: u32 = 11;
             const PCI_INTA_IRQ: u32 = 16;
-            if cfg.chipset.with_i440bx_host_pci_bridge {
+            if cfg.chipset_capabilities.with_i440bx_host_pci_bridge {
                 // Hyper-V hard-wires this to 11.
                 Some(PCI_LEGACY_INTA_IRQ)
             } else if cfg.chipset.with_generic_pci_bus {
@@ -2730,6 +2722,7 @@ impl LoadedVmInner {
                                 add_devices_to_dsdt_x64(
                                     dsdt,
                                     &self.chipset_cfg,
+                                    &self.chipset_capabilities,
                                     enable_serial,
                                     &self.chipset_mmio,
                                     self.virtio_mmio_region,
@@ -3533,6 +3526,7 @@ impl LoadedVm {
 fn add_devices_to_dsdt_x64(
     dsdt: &mut dsdt::Dsdt,
     cfg: &BaseChipsetManifest,
+    capabilities: &VmChipsetCapabilities,
     serial_uarts: bool,
     chipset_mmio: &ChipsetMmioRanges,
     virtio_mmio_region: MemoryRange,
@@ -3574,7 +3568,7 @@ fn add_devices_to_dsdt_x64(
 
     // The chipset MMIO module or PCI bus describes the chipset low/high
     // MMIO regions to the guest.
-    if cfg.with_generic_pci_bus || cfg.with_i440bx_host_pci_bridge {
+    if cfg.with_generic_pci_bus || capabilities.with_i440bx_host_pci_bridge {
         // TODO: actually plumb through legacy PCI interrupts
         dsdt.add_pci(chipset_mmio.low, chipset_mmio.high, pci_legacy_interrupts);
     } else {
@@ -3582,7 +3576,7 @@ fn add_devices_to_dsdt_x64(
     }
 
     dsdt.add_vmbus(
-        cfg.with_generic_pci_bus || cfg.with_i440bx_host_pci_bridge,
+        cfg.with_generic_pci_bus || capabilities.with_i440bx_host_pci_bridge,
         None,
     );
     dsdt.add_rtc();

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -22,6 +22,8 @@ vm_resource::register_static_resolvers! {
     #[cfg(guest_arch = "x86_64")]
     chipset_legacy::piix4_pm::resolver::Piix4PowerManagementResolver,
     #[cfg(guest_arch = "x86_64")]
+    chipset_legacy::i440bx_host_pci_bridge::resolver::I440BxHostPciBridgeResolver,
+    #[cfg(guest_arch = "x86_64")]
     chipset::pit::resolver::PitResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pic::resolver::PicResolver,

--- a/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge/mod.rs
+++ b/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge/mod.rs
@@ -3,7 +3,10 @@
 
 //! 440BX Host to PCI Bridge
 
-pub use pam::GpaState;
+pub mod resolver;
+
+pub use chipset_resources::i440bx_host_pci_bridge::AdjustGpaRange;
+pub use chipset_resources::i440bx_host_pci_bridge::GpaState;
 
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
@@ -20,15 +23,6 @@ use pci_core::spec::hwid::HardwareIds;
 use pci_core::spec::hwid::ProgrammingInterface;
 use pci_core::spec::hwid::Subclass;
 use vmcore::device_state::ChangeDeviceState;
-
-/// A trait to create GPA alias ranges.
-pub trait AdjustGpaRange: Send {
-    /// Adjusts a memory range's mapping state.
-    ///
-    /// This will only be called for memory ranges supported by the i440BX PAM
-    /// registers, or for VGA memory.
-    fn adjust_gpa_range(&mut self, range: MemoryRange, state: GpaState);
-}
 
 struct HostPciBridgeRuntime {
     adjust_gpa_range: Box<dyn AdjustGpaRange>,
@@ -341,20 +335,8 @@ open_enum! {
 }
 
 mod pam {
+    use super::GpaState;
     use memory_range::MemoryRange;
-
-    #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
-    pub enum GpaState {
-        /// Reads and writes go to RAM.
-        #[default]
-        Writable,
-        /// Reads go to RAM, writes go to MMIO.
-        WriteProtected,
-        /// Reads go to ROM, writes go to RAM.
-        WriteOnly,
-        /// Reads and writes go to MMIO.
-        Mmio,
-    }
 
     pub const PAM_RANGES: &[MemoryRange; 13] = &[
         MemoryRange::new(0xf0000..0x100000),

--- a/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge/resolver.rs
+++ b/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge/resolver.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resolver for the i440BX Host-PCI Bridge device.
+
+use super::HostPciBridge;
+use async_trait::async_trait;
+use chipset_device_resources::ResolveChipsetDeviceHandleParams;
+use chipset_device_resources::ResolvedChipsetDevice;
+use chipset_resources::i440bx_host_pci_bridge::AdjustGpaRangeHandleKind;
+use chipset_resources::i440bx_host_pci_bridge::I440BxHostPciBridgeDeviceHandle;
+use chipset_resources::i440bx_host_pci_bridge::ResolvedAdjustGpaRange;
+use thiserror::Error;
+use vm_resource::AsyncResolveResource;
+use vm_resource::ResolveError;
+use vm_resource::ResourceResolver;
+use vm_resource::declare_static_async_resolver;
+use vm_resource::kind::ChipsetDeviceHandleKind;
+
+/// A resolver for the i440BX Host-PCI Bridge device.
+pub struct I440BxHostPciBridgeResolver;
+
+declare_static_async_resolver! {
+    I440BxHostPciBridgeResolver,
+    (ChipsetDeviceHandleKind, I440BxHostPciBridgeDeviceHandle),
+}
+
+/// Errors that can occur when resolving an i440BX Host-PCI Bridge device.
+#[derive(Debug, Error)]
+#[expect(missing_docs)]
+pub enum ResolveI440BxHostPciBridgeError {
+    #[error("failed to resolve adjust_gpa_range platform resource")]
+    ResolveAdjustGpaRange(#[source] ResolveError),
+}
+
+#[async_trait]
+impl AsyncResolveResource<ChipsetDeviceHandleKind, I440BxHostPciBridgeDeviceHandle>
+    for I440BxHostPciBridgeResolver
+{
+    type Output = ResolvedChipsetDevice;
+    type Error = ResolveI440BxHostPciBridgeError;
+
+    async fn resolve(
+        &self,
+        resolver: &ResourceResolver,
+        resource: I440BxHostPciBridgeDeviceHandle,
+        input: ResolveChipsetDeviceHandleParams<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        let ResolvedAdjustGpaRange(adjust_gpa_range) = resolver
+            .resolve::<AdjustGpaRangeHandleKind, _>(resource.adjust_gpa_range, ())
+            .await
+            .map_err(ResolveI440BxHostPciBridgeError::ResolveAdjustGpaRange)?;
+
+        Ok(HostPciBridge::new(adjust_gpa_range, input.is_restoring).into())
+    }
+}

--- a/vm/devices/chipset_resources/Cargo.toml
+++ b/vm/devices/chipset_resources/Cargo.toml
@@ -11,6 +11,7 @@ vm_resource.workspace = true
 local_clock.workspace = true
 
 inspect.workspace = true
+memory_range.workspace = true
 mesh.workspace = true
 
 arbitrary = { workspace = true, optional = true, features = ["derive"] }

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -398,3 +398,66 @@ pub mod pm {
         const ID: &'static str = "piix4_power_management";
     }
 }
+
+pub mod i440bx_host_pci_bridge {
+    //! Resource definitions for the i440BX Host-PCI Bridge.
+
+    use memory_range::MemoryRange;
+    use mesh::MeshPayload;
+    use vm_resource::CanResolveTo;
+    use vm_resource::Resource;
+    use vm_resource::ResourceId;
+    use vm_resource::ResourceKind;
+    use vm_resource::kind::ChipsetDeviceHandleKind;
+
+    /// Memory mapping state for a GPA range managed by the i440BX PAM registers.
+    #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+    pub enum GpaState {
+        /// Reads and writes go to RAM.
+        #[default]
+        Writable,
+        /// Reads go to RAM, writes go to MMIO.
+        WriteProtected,
+        /// Reads go to ROM, writes go to RAM.
+        WriteOnly,
+        /// Reads and writes go to MMIO.
+        Mmio,
+    }
+
+    /// A trait to adjust GPA memory range mappings.
+    ///
+    /// This is called when the i440BX PAM (Physical Address Management) PCI
+    /// configuration registers are modified, or for VGA memory.
+    pub trait AdjustGpaRange: Send {
+        /// Adjusts a memory range's mapping state.
+        fn adjust_gpa_range(&mut self, range: MemoryRange, state: GpaState);
+    }
+
+    /// Resolved platform-specific [`AdjustGpaRange`] implementation.
+    pub struct ResolvedAdjustGpaRange(pub Box<dyn AdjustGpaRange>);
+
+    /// Resource kind for platform-specific [`AdjustGpaRange`] implementations.
+    pub enum AdjustGpaRangeHandleKind {}
+
+    impl ResourceKind for AdjustGpaRangeHandleKind {
+        const NAME: &'static str = "i440bx_adjust_gpa_range";
+    }
+
+    impl CanResolveTo<ResolvedAdjustGpaRange> for AdjustGpaRangeHandleKind {
+        type Input<'a> = ();
+    }
+
+    /// A handle to an i440BX Host-PCI Bridge device.
+    #[derive(MeshPayload)]
+    pub struct I440BxHostPciBridgeDeviceHandle {
+        /// Platform-specific implementation of GPA range adjustment.
+        pub adjust_gpa_range: Resource<AdjustGpaRangeHandleKind>,
+    }
+
+    /// The fixed BDF used by the i440BX Host-PCI Bridge in the Gen1 chipset.
+    pub const I440BX_HOST_PCI_BRIDGE_BDF: (u8, u8, u8) = (0, 0, 0);
+
+    impl ResourceId<ChipsetDeviceHandleKind> for I440BxHostPciBridgeDeviceHandle {
+        const ID: &'static str = "i440bx-host-pci-bridge";
+    }
+}

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -22,6 +22,8 @@ use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
 use chipset_resources::hyperv_guest_watchdog::DEFAULT_WDAT_PORT_BASE;
 use chipset_resources::hyperv_guest_watchdog::HyperVGuestWatchdogDeviceHandle;
+use chipset_resources::i440bx_host_pci_bridge::I440BX_HOST_PCI_BRIDGE_BDF;
+use chipset_resources::i440bx_host_pci_bridge::I440BxHostPciBridgeDeviceHandle;
 use chipset_resources::i8042::I8042DeviceHandle;
 use chipset_resources::ioapic::GenericIoApicDeviceHandle;
 use chipset_resources::isa_dma::GenericIsaDmaDeviceHandle;
@@ -345,6 +347,7 @@ impl VmManifestBuilder {
                 with_generic_isa_dma: false,
                 with_psp: false,
                 with_guest_watchdog: false,
+                with_i440bx_host_pci_bridge: false,
             },
         };
 
@@ -365,6 +368,7 @@ impl VmManifestBuilder {
                 result.attach_generic_isa_dma();
                 result.attach_piix4_pci_usb_uhci_stub();
                 result.attach_piix4_pci_isa_bridge();
+                result.attach_i440bx_host_pci_bridge();
                 // This chipset always has a serial port even if not requested.
                 result.attach_serial_16550(
                     self.serial_wait_for_rts,
@@ -379,7 +383,6 @@ impl VmManifestBuilder {
                     with_hyperv_framebuffer: !self.proxy_vga,
                     with_hyperv_ide: true,
                     with_hyperv_vga: !self.proxy_vga,
-                    with_i440bx_host_pci_bridge: true,
                     with_piix4_cmos_rtc: true,
                     with_piix4_pci_bus: true,
                     with_underhill_vga_proxy: self.proxy_vga,
@@ -388,6 +391,7 @@ impl VmManifestBuilder {
                 };
                 result.attach_generic_ioapic();
                 result.attach_pic();
+                result.capabilities.with_i440bx_host_pci_bridge = true;
                 result.attach_pit();
                 result.attach_piix4_power_management(self.platform_pm_timer_assist);
                 result.attach_missing_arch_ports(self.arch, false);
@@ -406,7 +410,6 @@ impl VmManifestBuilder {
                     with_hyperv_framebuffer: self.framebuffer,
                     with_hyperv_ide: false,
                     with_hyperv_vga: false,
-                    with_i440bx_host_pci_bridge: false,
                     with_piix4_cmos_rtc: false,
                     with_piix4_pci_bus: false,
                     with_underhill_vga_proxy: false,
@@ -448,7 +451,6 @@ impl VmManifestBuilder {
                     with_hyperv_framebuffer: self.framebuffer,
                     with_hyperv_ide: false,
                     with_hyperv_vga: false,
-                    with_i440bx_host_pci_bridge: false,
                     with_piix4_cmos_rtc: false,
                     with_piix4_pci_bus: false,
 
@@ -686,6 +688,19 @@ impl VmChipsetResult {
                 time_source,
             }
             .into_resource(),
+        });
+        self
+    }
+
+    fn attach_i440bx_host_pci_bridge(&mut self) -> &mut Self {
+        self.pci_chipset_devices.push(LegacyPciChipsetDeviceHandle {
+            name: "440bx-host-pci-bridge".to_string(),
+            resource: I440BxHostPciBridgeDeviceHandle {
+                adjust_gpa_range: PlatformResource.into_resource(),
+            }
+            .into_resource(),
+            pci_bus_name: LEGACY_CHIPSET_PCI_BUS_NAME.to_string(),
+            bdf: I440BX_HOST_PCI_BRIDGE_BDF,
         });
         self
     }

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -391,7 +391,6 @@ impl VmManifestBuilder {
                 };
                 result.attach_generic_ioapic();
                 result.attach_pic();
-                result.attach_i440bx_host_pci_bridge();
                 result.attach_pit();
                 result.attach_piix4_power_management(self.platform_pm_timer_assist);
                 result.attach_missing_arch_ports(self.arch, false);

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -693,7 +693,7 @@ impl VmChipsetResult {
 
     fn attach_i440bx_host_pci_bridge(&mut self) -> &mut Self {
         self.pci_chipset_devices.push(LegacyPciChipsetDeviceHandle {
-            name: "i440bx-host-pci-bridge".to_string(),
+            name: "440bx-host-pci-bridge".to_string(),
             resource: I440BxHostPciBridgeDeviceHandle {
                 adjust_gpa_range: PlatformResource.into_resource(),
             }

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -391,7 +391,7 @@ impl VmManifestBuilder {
                 };
                 result.attach_generic_ioapic();
                 result.attach_pic();
-                result.capabilities.with_i440bx_host_pci_bridge = true;
+                result.attach_i440bx_host_pci_bridge();
                 result.attach_pit();
                 result.attach_piix4_power_management(self.platform_pm_timer_assist);
                 result.attach_missing_arch_ports(self.arch, false);
@@ -694,7 +694,7 @@ impl VmChipsetResult {
 
     fn attach_i440bx_host_pci_bridge(&mut self) -> &mut Self {
         self.pci_chipset_devices.push(LegacyPciChipsetDeviceHandle {
-            name: "440bx-host-pci-bridge".to_string(),
+            name: "i440bx-host-pci-bridge".to_string(),
             resource: I440BxHostPciBridgeDeviceHandle {
                 adjust_gpa_range: PlatformResource.into_resource(),
             }
@@ -702,6 +702,7 @@ impl VmChipsetResult {
             pci_bus_name: LEGACY_CHIPSET_PCI_BUS_NAME.to_string(),
             bdf: I440BX_HOST_PCI_BRIDGE_BDF,
         });
+        self.capabilities.with_i440bx_host_pci_bridge = true;
         self
     }
 

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -244,7 +244,6 @@ impl<'a> BaseChipsetBuilder<'a> {
             deps_hyperv_framebuffer,
             deps_hyperv_ide,
             deps_hyperv_vga,
-            deps_i440bx_host_pci_bridge,
             deps_piix4_cmos_rtc,
             deps_piix4_pci_bus,
             deps_underhill_vga_proxy,
@@ -279,22 +278,6 @@ impl<'a> BaseChipsetBuilder<'a> {
                 )
             })?;
             builder.register_weak_mutex_pci_bus(bus_id, Box::new(pci));
-        }
-
-        if let Some(options::dev::I440BxHostPciBridgeDeps {
-            attached_to,
-            adjust_gpa_range,
-        }) = deps_i440bx_host_pci_bridge
-        {
-            builder
-                .arc_mutex_device("440bx-host-pci-bridge")
-                .on_pci_bus(attached_to)
-                .add(|_| {
-                    chipset_legacy::i440bx_host_pci_bridge::HostPciBridge::new(
-                        adjust_gpa_range,
-                        foundation.is_restoring,
-                    )
-                })?;
         }
 
         let dma = if let Some(dma_handle) = isa_dma_handle {
@@ -1015,8 +998,6 @@ pub mod options {
             hyperv_ide:                  dev::HyperVIdeDeps,
             hyperv_vga:                  dev::HyperVVgaDeps,
 
-            i440bx_host_pci_bridge:      dev::I440BxHostPciBridgeDeps,
-
             piix4_cmos_rtc:              dev::Piix4CmosRtcDeps,
             piix4_pci_bus:               dev::Piix4PciBusDeps,
 
@@ -1042,6 +1023,8 @@ pub mod options {
         pub with_psp: bool,
         /// Whether the VM exposes the Hyper-V guest watchdog device.
         pub with_guest_watchdog: bool,
+        /// Whether the VM exposes an i440BX Host-PCI Bridge (Gen1 legacy PCI bus).
+        pub with_i440bx_host_pci_bridge: bool,
     }
 
     /// Device specific dependencies
@@ -1148,14 +1131,6 @@ pub mod options {
         pub struct Piix4PciBusDeps {
             /// `vmotherboard` bus identifier
             pub bus_id: BusIdPci,
-        }
-
-        /// i440BX Host-PCI bridge (fixed pci address: 0:0.0)
-        pub struct I440BxHostPciBridgeDeps {
-            /// `vmotherboard` bus identifier
-            pub attached_to: BusIdPci,
-            /// Interface to create GPA alias ranges.
-            pub adjust_gpa_range: Box<dyn chipset_legacy::i440bx_host_pci_bridge::AdjustGpaRange>,
         }
 
         feature_gated! {


### PR DESCRIPTION
- Add `I440BxHostPciBridgeDeviceHandle` with `AdjustGpaRangeHandleKind` platform resource and `I440BX_HOST_PCI_BRIDGE_BDF` constant.
- Add `I440BxHostPciBridgeResolver` async resolver, registered in both `openvmm_resources` and `openvmm_hcl_resources`.
- Remove `I440BxHostPciBridgeDeps` from `BaseChipsetDevices` and direct construction wiring in `base_chipset.rs`.
- Add `with_i440bx_host_pci_bridge` to `VmChipsetCapabilities`; DSDT generation now reads capabilities instead of the manifest field.