### PR TITLE
Add generic PIC support to chipset resources

### DIFF
--- a/openhcl/openvmm_hcl_resources/src/lib.rs
+++ b/openhcl/openvmm_hcl_resources/src/lib.rs
@@ -18,6 +18,8 @@ vm_resource::register_static_resolvers! {
     chipset_legacy::piix4_uhci::resolver::Piix4PciUsbUhciStubResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pit::resolver::PitResolver,
+    #[cfg(guest_arch = "x86_64")]
+    chipset::pic::resolver::PicResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]
     tpm_device::resolver::TpmDeviceResolver,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2403,7 +2403,7 @@ async fn new_underhill_vm(
                 pcie_host_bridges: &vec![],
                 arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
                     with_ioapic: true, // openhcl always runs with ioapic
-                    with_pic: true,    // pcat always runs with pic and pit
+                    with_pic: capabilities.with_pic,
                     with_pit: capabilities.with_pit,
                     with_psp: dps.general.psp_enabled,
                     pm_base: PM_BASE,
@@ -2774,12 +2774,6 @@ async fn new_underhill_vm(
         None
     };
 
-    #[cfg(guest_arch = "x86_64")]
-    let deps_generic_pic = chipset.with_generic_pic.then_some(dev::GenericPicDeps {});
-
-    #[cfg(not(guest_arch = "x86_64"))]
-    let deps_generic_pic = None;
-
     let deps_generic_isa_dma = chipset
         .with_generic_isa_dma
         .then_some(dev::GenericIsaDmaDeps);
@@ -2980,7 +2974,6 @@ async fn new_underhill_vm(
         deps_generic_isa_dma,
         deps_generic_isa_floppy: None,
         deps_generic_pci_bus: None,
-        deps_generic_pic,
         deps_hyperv_firmware_pcat,
         deps_hyperv_framebuffer: None,
         deps_hyperv_ide,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1203,7 +1203,7 @@ impl InitializedVm {
                             pcie_host_bridges: &Vec::new(),
                             arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
                                 with_ioapic: cfg.chipset.with_generic_ioapic,
-                                with_pic: cfg.chipset.with_generic_pic,
+                                with_pic: cfg.chipset_capabilities.with_pic,
                                 with_pit: cfg.chipset_capabilities.with_pit,
                                 with_psp: cfg.chipset.with_generic_psp,
                                 pm_base: PM_BASE,
@@ -1521,8 +1521,6 @@ impl InitializedVm {
                 pio_data: pci_bus::standard_x86_io_ports::DATA_START,
             });
 
-        let deps_generic_pic = (cfg.chipset.with_generic_pic).then_some(dev::GenericPicDeps {});
-
         let deps_generic_psp = (cfg.chipset.with_generic_psp).then_some(dev::GenericPspDeps {});
 
         let deps_hyperv_framebuffer =
@@ -1603,7 +1601,6 @@ impl InitializedVm {
                 deps_generic_isa_dma,
                 deps_generic_isa_floppy,
                 deps_generic_pci_bus,
-                deps_generic_pic,
                 deps_generic_psp,
                 deps_hyperv_firmware_pcat,
                 deps_hyperv_firmware_uefi,
@@ -1704,7 +1701,7 @@ impl InitializedVm {
                 // Avoid an ISA interrupt to avoid conflicts and to avoid needing to
                 // configure the line as level-triggered in the MADT (necessary for
                 // Linux when the PIC is missing).
-                if cfg.chipset.with_generic_pic {
+                if cfg.chipset_capabilities.with_pic {
                     Some(PCI_LEGACY_INTA_IRQ)
                 } else {
                     Some(PCI_INTA_IRQ)
@@ -2117,7 +2114,7 @@ impl InitializedVm {
         let virtio_mmio_irq = {
             const VIRTIO_MMIO_IOAPIC_IRQ: u32 = 17;
             const VIRTIO_MMIO_PIC_IRQ: u32 = 5;
-            if cfg.chipset.with_generic_pic {
+            if cfg.chipset_capabilities.with_pic {
                 VIRTIO_MMIO_PIC_IRQ
             } else {
                 VIRTIO_MMIO_IOAPIC_IRQ
@@ -2334,7 +2331,7 @@ impl LoadedVmInner {
             arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
                 with_ioapic: self.chipset_cfg.with_generic_ioapic,
                 with_psp: self.chipset_cfg.with_generic_psp,
-                with_pic: self.chipset_cfg.with_generic_pic,
+                with_pic: self.chipset_capabilities.with_pic,
                 with_pit: self.chipset_capabilities.with_pit,
                 pm_base: PM_BASE,
                 acpi_irq: SYSTEM_IRQ_ACPI,

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -15,6 +15,8 @@ vm_resource::register_static_resolvers! {
     chipset_legacy::piix4_uhci::resolver::Piix4PciUsbUhciStubResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pit::resolver::PitResolver,
+    #[cfg(guest_arch = "x86_64")]
+    chipset::pic::resolver::PicResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]
     tpm_device::resolver::TpmDeviceResolver,

--- a/vm/devices/chipset/src/pic/mod.rs
+++ b/vm/devices/chipset/src/pic/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+pub mod resolver;
+
 use bitfield_struct::bitfield;
 use chipset_device::ChipsetDevice;
 use chipset_device::interrupt::AcknowledgePicInterrupt;

--- a/vm/devices/chipset/src/pic/resolver.rs
+++ b/vm/devices/chipset/src/pic/resolver.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resource resolver for the PIC (Programmable Interrupt Controller) chipset device.
+
+use super::DualPic;
+use chipset_device_resources::BSP_LINT_LINE_SET;
+use chipset_device_resources::IRQ_LINE_SET;
+use chipset_device_resources::ResolveChipsetDeviceHandleParams;
+use chipset_device_resources::ResolvedChipsetDevice;
+use chipset_resources::pic::PicDeviceHandle;
+use vm_resource::ResolveResource;
+use vm_resource::declare_static_resolver;
+use vm_resource::kind::ChipsetDeviceHandleKind;
+
+/// A resolver for PIC devices.
+pub struct PicResolver;
+
+declare_static_resolver! {
+    PicResolver,
+    (ChipsetDeviceHandleKind, PicDeviceHandle),
+}
+
+impl ResolveResource<ChipsetDeviceHandleKind, PicDeviceHandle> for PicResolver {
+    type Output = ResolvedChipsetDevice;
+    type Error = std::convert::Infallible;
+
+    fn resolve(
+        &self,
+        _resource: PicDeviceHandle,
+        input: ResolveChipsetDeviceHandleParams<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        // Map IRQ2 to PIC IRQ0 (used by the PIT), since PIC IRQ2 is used to
+        // cascade the secondary PIC's output onto the primary.
+        //
+        // Don't map IRQ0 at all.
+        input.configure.add_line_target(IRQ_LINE_SET, 1..=1, 1);
+        input.configure.add_line_target(IRQ_LINE_SET, 2..=2, 0);
+        input.configure.add_line_target(IRQ_LINE_SET, 3..=15, 3);
+
+        let ready = input.configure.new_line(BSP_LINT_LINE_SET, "ready", 0);
+
+        Ok(DualPic::new(ready, input.register_pio).into())
+    }
+}

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -29,6 +29,22 @@ pub mod i8042 {
     }
 }
 
+pub mod pic {
+    //! Resource definitions for the PIC (dual 8259 Programmable Interrupt Controller).
+
+    use mesh::MeshPayload;
+    use vm_resource::ResourceId;
+    use vm_resource::kind::ChipsetDeviceHandleKind;
+
+    /// A handle to a dual 8259 PIC (Programmable Interrupt Controller) device.
+    #[derive(MeshPayload)]
+    pub struct PicDeviceHandle;
+
+    impl ResourceId<ChipsetDeviceHandleKind> for PicDeviceHandle {
+        const ID: &'static str = "pic";
+    }
+}
+
 pub mod pit {
     //! Resource definitions for the PIT (Programmable Interval Timer).
 

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -21,6 +21,7 @@ use chipset_resources::battery::BatteryDeviceHandleAArch64;
 use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
 use chipset_resources::i8042::I8042DeviceHandle;
+use chipset_resources::pic::PicDeviceHandle;
 use chipset_resources::piix4_uhci::PIIX4_PCI_USB_UHCI_STUB_BDF;
 use chipset_resources::piix4_uhci::Piix4PciUsbUhciStubDeviceHandle;
 use chipset_resources::pit::PitDeviceHandle;
@@ -256,7 +257,6 @@ impl VmManifestBuilder {
                     with_generic_isa_dma: true,
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
-                    with_generic_pic: true,
                     with_generic_psp: false,
                     with_hyperv_firmware_pcat: true,
                     with_hyperv_firmware_uefi: false,
@@ -275,7 +275,7 @@ impl VmManifestBuilder {
                     with_winbond_super_io_and_floppy_full: !self.stub_floppy,
                 };
                 result.capabilities.with_ioapic = true;
-                result.capabilities.with_pic = true;
+                result.attach_pic();
                 result.attach_pit();
                 result.attach_missing_arch_ports(self.arch, false);
                 if let Some(recv) = self.battery_status_recv {
@@ -290,7 +290,6 @@ impl VmManifestBuilder {
                     with_generic_isa_dma: false,
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
-                    with_generic_pic: is_x86,
                     with_generic_psp: self.psp,
                     with_hyperv_firmware_pcat: false,
                     with_hyperv_firmware_uefi: false,
@@ -309,9 +308,9 @@ impl VmManifestBuilder {
                     with_winbond_super_io_and_floppy_full: false,
                 };
                 result.capabilities.with_ioapic = is_x86;
-                result.capabilities.with_pic = is_x86;
                 result.capabilities.with_psp = self.psp;
                 if is_x86 {
+                    result.attach_pic();
                     result.attach_pit();
                 }
                 result
@@ -334,7 +333,6 @@ impl VmManifestBuilder {
                     with_generic_isa_dma: false,
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
-                    with_generic_pic: false,
                     with_generic_psp: self.psp,
                     with_hyperv_firmware_pcat: false,
                     with_hyperv_firmware_uefi: matches!(self.ty, BaseChipsetType::HypervGen2Uefi),
@@ -396,6 +394,15 @@ impl VmChipsetResult {
             }
             .into_resource(),
         });
+        self
+    }
+
+    fn attach_pic(&mut self) -> &mut Self {
+        self.chipset_devices.push(ChipsetDeviceHandle {
+            name: PicDeviceHandle::ID.to_owned(),
+            resource: PicDeviceHandle.into_resource(),
+        });
+        self.capabilities.with_pic = true;
         self
     }
 

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -12,7 +12,6 @@ use crate::chipset::backing::arc_mutex::device::AddDeviceError;
 use crate::chipset::backing::arc_mutex::services::ArcMutexChipsetServices;
 use chipset::*;
 use chipset_device::interrupt::LineInterruptTarget;
-use chipset_device_resources::BSP_LINT_LINE_SET;
 use chipset_device_resources::ConfigureChipsetDevice;
 use chipset_device_resources::GPE0_LINE_SET;
 use chipset_device_resources::IRQ_LINE_SET;
@@ -220,7 +219,6 @@ impl<'a> BaseChipsetBuilder<'a> {
             deps_generic_isa_dma,
             deps_generic_isa_floppy,
             deps_generic_pci_bus,
-            deps_generic_pic,
             deps_generic_psp: _, // not actually a device... yet
             deps_hyperv_firmware_pcat,
             deps_hyperv_firmware_uefi,
@@ -238,24 +236,6 @@ impl<'a> BaseChipsetBuilder<'a> {
             deps_winbond_super_io_and_floppy_stub,
             deps_winbond_super_io_and_floppy_full,
         } = devices;
-
-        if let Some(options::dev::GenericPicDeps {}) = deps_generic_pic {
-            builder.arc_mutex_device("pic").add(|services| {
-                // Map IRQ2 to PIC IRQ0 (used by the PIT), since PIC IRQ2 is used to
-                // cascade the secondary PIC's output onto the primary.
-                //
-                // Don't map IRQ0 at all.
-                services.add_line_target(IRQ_LINE_SET, 1..=1, 1);
-                services.add_line_target(IRQ_LINE_SET, 2..=2, 0);
-                services.add_line_target(IRQ_LINE_SET, 3..=15, 3);
-
-                // Raise interrupt requests by raising the BSP's LINT0.
-                pic::DualPic::new(
-                    services.new_line(BSP_LINT_LINE_SET, "ready", 0),
-                    &mut services.register_pio(),
-                )
-            })?;
-        }
 
         if let Some(options::dev::GenericIoApicDeps {
             num_entries,
@@ -1159,7 +1139,6 @@ pub mod options {
             generic_isa_dma:             dev::GenericIsaDmaDeps,
             generic_isa_floppy:          dev::GenericIsaFloppyDeps,
             generic_pci_bus:             dev::GenericPciBusDeps,
-            generic_pic:                 dev::GenericPicDeps,
             generic_psp:                 dev::GenericPspDeps,
 
             hyperv_firmware_pcat:        dev::HyperVFirmwarePcat,
@@ -1348,9 +1327,6 @@ pub mod options {
                 pub rom: Option<Box<dyn guestmem::MapRom>>,
             }
         }
-
-        /// Generic Dual 8259 Programmable Interrupt Controllers  (PIC)
-        pub struct GenericPicDeps {}
 
         /// Generic IO Advanced Programmable Interrupt Controller (IOAPIC)
         pub struct GenericIoApicDeps {


### PR DESCRIPTION
- Add PicDeviceHandle marker type and PicResolver with IRQ line routing (cascade IRQ2→PIC0, skip IRQ0)
- Register PicResolver in both OpenVMM and OpenHCL resource registries (x86_64-gated)
- Add attach_pic() to VmManifestBuilder as single source of truth for with_pic capability
- Remove GenericPicDeps and direct DualPic instantiation from BaseChipsetBuilder
- Switch all workers from cfg.chipset.with_generic_pic to chipset_capabilities.with_pic