### PR TITLE
Add generic IO-APIC support to chipset resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9930,6 +9930,7 @@ dependencies = [
  "cache_topology",
  "chipset",
  "chipset_device_resources",
+ "chipset_resources",
  "closeable_mutex",
  "cvm_tracing",
  "futures",

--- a/openhcl/openvmm_hcl_resources/src/lib.rs
+++ b/openhcl/openvmm_hcl_resources/src/lib.rs
@@ -22,6 +22,8 @@ vm_resource::register_static_resolvers! {
     chipset::pit::resolver::PitResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pic::resolver::PicResolver,
+    #[cfg(guest_arch = "x86_64")]
+    chipset::ioapic::resolver::GenericIoApicResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]
     tpm_device::resolver::TpmDeviceResolver,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2207,6 +2207,9 @@ async fn new_underhill_vm(
     let halt_vps = Arc::new(halt_vps);
 
     resolver.add_resolver(vmm_core::platform_resolvers::HaltResolver(halt_vps.clone()));
+    resolver.add_resolver(vmm_core::platform_resolvers::IoApicRoutingResolver(
+        partition.ioapic_routing(),
+    ));
 
     let bounce_buffer_tracker = {
         let size = {
@@ -2402,7 +2405,7 @@ async fn new_underhill_vm(
                 cache_topology: None,
                 pcie_host_bridges: &vec![],
                 arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
-                    with_ioapic: true, // openhcl always runs with ioapic
+                    with_ioapic: capabilities.with_ioapic,
                     with_pic: capabilities.with_pic,
                     with_pit: capabilities.with_pit,
                     with_psp: dps.general.psp_enabled,
@@ -2717,13 +2720,6 @@ async fn new_underhill_vm(
 
     let synic = virt::Hv1::synic(partition.as_ref());
 
-    let deps_generic_ioapic = chipset.with_generic_ioapic.then(|| dev::GenericIoApicDeps {
-        num_entries: virt::irqcon::IRQ_LINES as u8,
-        routing: Box::new(vmm_core::emuplat::ioapic::IoApicRouting(
-            partition.ioapic_routing(),
-        )),
-    });
-
     use vmotherboard::options::dev;
 
     let pci_bus_id_piix4 = vmotherboard::BusId::new("i440bx");
@@ -2960,7 +2956,6 @@ async fn new_underhill_vm(
 
     let devices = BaseChipsetDevices {
         deps_generic_cmos_rtc,
-        deps_generic_ioapic,
         deps_generic_psp,
         deps_hyperv_firmware_uefi,
         deps_hyperv_guest_watchdog,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -141,6 +141,7 @@ use underhill_threadpool::ThreadpoolBuilder;
 use user_driver::vfio::VfioDmaClients;
 use virt::Partition;
 use virt::VpIndex;
+#[cfg(guest_arch = "x86_64")]
 use virt::X86Partition;
 use virt::state::HvRegisterState;
 use virt_mshv_vtl::UhPartition;
@@ -2207,6 +2208,7 @@ async fn new_underhill_vm(
     let halt_vps = Arc::new(halt_vps);
 
     resolver.add_resolver(vmm_core::platform_resolvers::HaltResolver(halt_vps.clone()));
+    #[cfg(guest_arch = "x86_64")]
     resolver.add_resolver(vmm_core::platform_resolvers::IoApicRoutingResolver(
         partition.ioapic_routing(),
     ));

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1096,6 +1096,7 @@ impl InitializedVm {
         let halt_vps = Arc::new(halt_vps);
 
         resolver.add_resolver(vmm_core::platform_resolvers::HaltResolver(halt_vps.clone()));
+        #[cfg(guest_arch = "x86_64")]
         resolver.add_resolver(vmm_core::platform_resolvers::IoApicRoutingResolver(
             partition.clone().ioapic_routing(),
         ));

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1096,6 +1096,9 @@ impl InitializedVm {
         let halt_vps = Arc::new(halt_vps);
 
         resolver.add_resolver(vmm_core::platform_resolvers::HaltResolver(halt_vps.clone()));
+        resolver.add_resolver(vmm_core::platform_resolvers::IoApicRoutingResolver(
+            partition.clone().ioapic_routing(),
+        ));
 
         let generation_id_recv = cfg.generation_id_recv.unwrap_or_else(|| mesh::channel().1);
 
@@ -1204,7 +1207,7 @@ impl InitializedVm {
                             cache_topology: None,
                             pcie_host_bridges: &Vec::new(),
                             arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
-                                with_ioapic: cfg.chipset.with_generic_ioapic,
+                                with_ioapic: cfg.chipset_capabilities.with_ioapic,
                                 with_pic: cfg.chipset_capabilities.with_pic,
                                 with_pit: cfg.chipset_capabilities.with_pit,
                                 with_psp: cfg.chipset.with_generic_psp,
@@ -1430,22 +1433,6 @@ impl InitializedVm {
             }
         });
 
-        #[cfg(guest_arch = "x86_64")]
-        let deps_generic_ioapic =
-            (cfg.chipset.with_generic_ioapic).then(|| dev::GenericIoApicDeps {
-                num_entries: virt::irqcon::IRQ_LINES as u8,
-                routing: Box::new(vmm_core::emuplat::ioapic::IoApicRouting(
-                    partition.clone().ioapic_routing(),
-                )),
-            });
-
-        #[cfg(guest_arch = "aarch64")]
-        let deps_generic_ioapic = if cfg.chipset.with_generic_ioapic {
-            anyhow::bail!("ioapic not supported on this architecture");
-        } else {
-            None
-        };
-
         let deps_generic_isa_dma =
             (cfg.chipset.with_generic_isa_dma).then_some(dev::GenericIsaDmaDeps {});
 
@@ -1595,7 +1582,6 @@ impl InitializedVm {
         let base_chipset_devices = {
             BaseChipsetDevices {
                 deps_generic_cmos_rtc,
-                deps_generic_ioapic,
                 deps_generic_isa_dma,
                 deps_generic_isa_floppy,
                 deps_generic_pci_bus,
@@ -2356,7 +2342,7 @@ impl LoadedVmInner {
             pcie_host_bridges: &self.pcie_host_bridges,
             #[cfg(guest_arch = "x86_64")]
             arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
-                with_ioapic: self.chipset_cfg.with_generic_ioapic,
+                with_ioapic: self.chipset_capabilities.with_ioapic,
                 with_psp: self.chipset_cfg.with_generic_psp,
                 with_pic: self.chipset_capabilities.with_pic,
                 with_pit: self.chipset_capabilities.with_pit,

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -19,6 +19,8 @@ vm_resource::register_static_resolvers! {
     chipset::pit::resolver::PitResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pic::resolver::PicResolver,
+    #[cfg(guest_arch = "x86_64")]
+    chipset::ioapic::resolver::GenericIoApicResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]
     tpm_device::resolver::TpmDeviceResolver,

--- a/vm/devices/chipset/src/ioapic/mod.rs
+++ b/vm/devices/chipset/src/ioapic/mod.rs
@@ -21,16 +21,18 @@ use chipset_device::interrupt::LineInterruptTarget;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::MmioIntercept;
+use chipset_resources::ioapic::IoApicRouting;
 use inspect::Inspect;
 use inspect::InspectMut;
 use inspect_counters::Counter;
-use std::fmt;
 use std::fmt::Debug;
 use std::ops::RangeInclusive;
 use vmcore::device_state::ChangeDeviceState;
 use x86defs::apic::DeliveryMode;
 use x86defs::msi::MsiAddress;
 use x86defs::msi::MsiData;
+
+pub mod resolver;
 
 pub const IOAPIC_DEVICE_MMIO_REGION_BASE_ADDRESS: u64 = 0xfec00000;
 
@@ -231,21 +233,6 @@ struct IoApicStats {
     #[inspect(iter_by_index)]
     interrupts_per_irq: Vec<Counter>,
     interrupts: Counter,
-}
-
-/// Trait allowing the IO-APIC device to assert VM interrupts.
-pub trait IoApicRouting: Send + Sync {
-    /// Asserts virtual interrupt line `irq`.
-    fn assert(&self, irq: u8);
-    /// Sets the MSI parameters to use when virtual interrupt line `irq` is
-    /// asserted.
-    fn set_route(&self, irq: u8, request: Option<(u64, u32)>);
-}
-
-impl Debug for dyn IoApicRouting {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad("IoApicRouting")
-    }
 }
 
 impl IoApicDevice {

--- a/vm/devices/chipset/src/ioapic/resolver.rs
+++ b/vm/devices/chipset/src/ioapic/resolver.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resource resolver for the generic IO-APIC chipset device.
+
+use super::IoApicDevice;
+use async_trait::async_trait;
+use chipset_device_resources::IRQ_LINE_SET;
+use chipset_device_resources::ResolveChipsetDeviceHandleParams;
+use chipset_device_resources::ResolvedChipsetDevice;
+use chipset_resources::ioapic::GenericIoApicDeviceHandle;
+use chipset_resources::ioapic::IOAPIC_NUM_ENTRIES;
+use chipset_resources::ioapic::IoApicRoutingHandleKind;
+use thiserror::Error;
+use vm_resource::AsyncResolveResource;
+use vm_resource::ResolveError;
+use vm_resource::ResourceResolver;
+use vm_resource::declare_static_async_resolver;
+use vm_resource::kind::ChipsetDeviceHandleKind;
+
+/// A resolver for generic IO-APIC devices.
+pub struct GenericIoApicResolver;
+
+declare_static_async_resolver! {
+    GenericIoApicResolver,
+    (ChipsetDeviceHandleKind, GenericIoApicDeviceHandle),
+}
+
+/// Errors that can occur when resolving a generic IO-APIC device.
+#[derive(Debug, Error)]
+#[expect(missing_docs)]
+pub enum ResolveGenericIoApicError {
+    #[error("failed to resolve ioapic routing")]
+    ResolveRouting(#[source] ResolveError),
+}
+
+#[async_trait]
+impl AsyncResolveResource<ChipsetDeviceHandleKind, GenericIoApicDeviceHandle>
+    for GenericIoApicResolver
+{
+    type Output = ResolvedChipsetDevice;
+    type Error = ResolveGenericIoApicError;
+
+    async fn resolve(
+        &self,
+        resolver: &ResourceResolver,
+        resource: GenericIoApicDeviceHandle,
+        input: ResolveChipsetDeviceHandleParams<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        let routing = resolver
+            .resolve::<IoApicRoutingHandleKind, _>(resource.routing, ())
+            .await
+            .map_err(ResolveGenericIoApicError::ResolveRouting)?;
+
+        input
+            .configure
+            .add_line_target(IRQ_LINE_SET, 0..=IOAPIC_NUM_ENTRIES as u32 - 1, 0);
+
+        Ok(IoApicDevice::new(IOAPIC_NUM_ENTRIES, routing.0).into())
+    }
+}

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -147,6 +147,65 @@ pub mod piix4_pci_isa_bridge {
     }
 }
 
+pub mod ioapic {
+    //! Resource definitions for the generic IO-APIC device.
+
+    use mesh::MeshPayload;
+    use std::fmt;
+    use std::fmt::Debug;
+    use vm_resource::CanResolveTo;
+    use vm_resource::Resource;
+    use vm_resource::ResourceId;
+    use vm_resource::ResourceKind;
+    use vm_resource::kind::ChipsetDeviceHandleKind;
+
+    /// The number of IO-APIC entries used by the platform.
+    pub const IOAPIC_NUM_ENTRIES: u8 = 24;
+
+    /// Trait allowing the IO-APIC device to assert VM interrupts.
+    pub trait IoApicRouting: Send + Sync {
+        /// Asserts virtual interrupt line `irq`.
+        fn assert(&self, irq: u8);
+        /// Sets the MSI parameters to use when virtual interrupt line `irq` is
+        /// asserted.
+        fn set_route(&self, irq: u8, request: Option<(u64, u32)>);
+    }
+
+    impl Debug for dyn IoApicRouting {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.pad("IoApicRouting")
+        }
+    }
+
+    /// Resource kind for resolving IO-APIC routing implementations.
+    pub enum IoApicRoutingHandleKind {}
+
+    impl ResourceKind for IoApicRoutingHandleKind {
+        const NAME: &'static str = "ioapic_routing";
+    }
+
+    /// Resolved IO-APIC routing implementation.
+    ///
+    /// Wraps `Box<dyn IoApicRouting>` in a newtype to avoid lifetime issues
+    /// with `async_trait` and `CanResolveTo`.
+    pub struct ResolvedIoApicRouting(pub Box<dyn IoApicRouting>);
+
+    impl CanResolveTo<ResolvedIoApicRouting> for IoApicRoutingHandleKind {
+        type Input<'a> = ();
+    }
+
+    /// A handle to a generic IO-APIC device.
+    #[derive(MeshPayload)]
+    pub struct GenericIoApicDeviceHandle {
+        /// Resource for resolving the IoApicRouting implementation.
+        pub routing: Resource<IoApicRoutingHandleKind>,
+    }
+
+    impl ResourceId<ChipsetDeviceHandleKind> for GenericIoApicDeviceHandle {
+        const ID: &'static str = "generic-ioapic";
+    }
+}
+
 pub mod piix4_uhci {
     //! Resource definitions for the PIIX4 USB UHCI stub device.
 

--- a/vmm_core/Cargo.toml
+++ b/vmm_core/Cargo.toml
@@ -20,6 +20,7 @@ aarch64defs.workspace = true
 acpi_spec = { workspace = true, features = ["std"] }
 acpi.workspace = true
 chipset_device_resources.workspace = true
+chipset_resources.workspace = true
 hcl_compat_uefi_nvram_storage.workspace = true
 hvdef.workspace = true
 memory_range = { workspace = true, features = ["inspect"] }

--- a/vmm_core/src/emuplat/ioapic.rs
+++ b/vmm_core/src/emuplat/ioapic.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 pub struct IoApicRouting<T: ?Sized>(pub Arc<T>);
 
-impl<T: ?Sized + virt::irqcon::IoApicRouting> chipset::ioapic::IoApicRouting for IoApicRouting<T> {
+impl<T: ?Sized + virt::irqcon::IoApicRouting> chipset_resources::ioapic::IoApicRouting
+    for IoApicRouting<T>
+{
     fn assert(&self, index: u8) {
         self.0.assert_irq(index);
     }

--- a/vmm_core/src/platform_resolvers.rs
+++ b/vmm_core/src/platform_resolvers.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::partition_unit::Halt;
+use chipset_resources::ioapic::IoApicRoutingHandleKind;
 use power_resources::PowerRequest;
 use power_resources::PowerRequestClient;
 use power_resources::PowerRequestHandleKind;
@@ -34,5 +35,27 @@ impl ResolveResource<PowerRequestHandleKind, PlatformResource> for HaltResolver 
             }),
         })
         .into())
+    }
+}
+
+/// Platform IO-APIC routing resolver.
+///
+/// Wraps a `virt::irqcon::IoApicRouting` into a `chipset_resources::ioapic::IoApicRouting`.
+pub struct IoApicRoutingResolver<T: ?Sized>(pub Arc<T>);
+
+impl<T: ?Sized + virt::irqcon::IoApicRouting + 'static>
+    ResolveResource<IoApicRoutingHandleKind, PlatformResource> for IoApicRoutingResolver<T>
+{
+    type Output = chipset_resources::ioapic::ResolvedIoApicRouting;
+    type Error = Infallible;
+
+    fn resolve(
+        &self,
+        _resource: PlatformResource,
+        _input: (),
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(chipset_resources::ioapic::ResolvedIoApicRouting(Box::new(
+            crate::emuplat::ioapic::IoApicRouting(self.0.clone()),
+        )))
     }
 }

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -21,6 +21,7 @@ use chipset_resources::battery::BatteryDeviceHandleAArch64;
 use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
 use chipset_resources::i8042::I8042DeviceHandle;
+use chipset_resources::ioapic::GenericIoApicDeviceHandle;
 use chipset_resources::pic::PicDeviceHandle;
 use chipset_resources::piix4_pci_isa_bridge::PIIX4_PCI_ISA_BRIDGE_BDF;
 use chipset_resources::piix4_pci_isa_bridge::Piix4PciIsaBridgeDeviceHandle;
@@ -36,6 +37,7 @@ use serial_pl011_resources::SerialPl011DeviceHandle;
 use std::iter::zip;
 use thiserror::Error;
 use vm_resource::IntoResource;
+use vm_resource::PlatformResource;
 use vm_resource::Resource;
 use vm_resource::ResourceId;
 use vm_resource::kind::SerialBackendHandle;
@@ -256,7 +258,6 @@ impl VmManifestBuilder {
                 );
                 result.chipset = BaseChipsetManifest {
                     with_generic_cmos_rtc: false,
-                    with_generic_ioapic: true,
                     with_generic_isa_dma: true,
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
@@ -276,7 +277,7 @@ impl VmManifestBuilder {
                     with_winbond_super_io_and_floppy_stub: self.stub_floppy,
                     with_winbond_super_io_and_floppy_full: !self.stub_floppy,
                 };
-                result.capabilities.with_ioapic = true;
+                result.attach_generic_ioapic();
                 result.attach_pic();
                 result.attach_pit();
                 result.attach_missing_arch_ports(self.arch, false);
@@ -288,7 +289,6 @@ impl VmManifestBuilder {
                 let is_x86 = matches!(self.arch, MachineArch::X86_64);
                 result.chipset = BaseChipsetManifest {
                     with_generic_cmos_rtc: is_x86,
-                    with_generic_ioapic: is_x86,
                     with_generic_isa_dma: false,
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
@@ -308,7 +308,9 @@ impl VmManifestBuilder {
                     with_winbond_super_io_and_floppy_stub: false,
                     with_winbond_super_io_and_floppy_full: false,
                 };
-                result.capabilities.with_ioapic = is_x86;
+                if is_x86 {
+                    result.attach_generic_ioapic();
+                }
                 result.capabilities.with_psp = self.psp;
                 if is_x86 {
                     result.attach_pic();
@@ -330,7 +332,6 @@ impl VmManifestBuilder {
                 let is_x86 = matches!(self.arch, MachineArch::X86_64);
                 result.chipset = BaseChipsetManifest {
                     with_generic_cmos_rtc: is_x86,
-                    with_generic_ioapic: is_x86,
                     with_generic_isa_dma: false,
                     with_generic_isa_floppy: false,
                     with_generic_pci_bus: false,
@@ -350,7 +351,9 @@ impl VmManifestBuilder {
                     with_winbond_super_io_and_floppy_stub: false,
                     with_winbond_super_io_and_floppy_full: false,
                 };
-                result.capabilities.with_ioapic = is_x86;
+                if is_x86 {
+                    result.attach_generic_ioapic();
+                }
                 result.capabilities.with_psp = self.psp;
                 result
                     .maybe_attach_arch_serial(
@@ -412,6 +415,22 @@ impl VmChipsetResult {
             resource: PitDeviceHandle.into_resource(),
         });
         self.capabilities.with_pit = true;
+        self
+    }
+
+    fn attach_generic_ioapic(&mut self) -> &mut Self {
+        self.chipset_devices.push(ChipsetDeviceHandle {
+            // Use "ioapic" (not GenericIoApicDeviceHandle::ID) to match the
+            // device unit name used by the old inline construction path. This
+            // is required for servicing compatibility (upgrade from old ->
+            // new OpenHCL).
+            name: "ioapic".to_owned(),
+            resource: GenericIoApicDeviceHandle {
+                routing: PlatformResource.into_resource(),
+            }
+            .into_resource(),
+        });
+        self.capabilities.with_ioapic = true;
         self
     }
 

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -215,7 +215,6 @@ impl<'a> BaseChipsetBuilder<'a> {
         // oh boy, time to build all the devices!
         let options::BaseChipsetDevices {
             deps_generic_cmos_rtc,
-            deps_generic_ioapic,
             deps_generic_isa_dma,
             deps_generic_isa_floppy,
             deps_generic_pci_bus,
@@ -235,17 +234,6 @@ impl<'a> BaseChipsetBuilder<'a> {
             deps_winbond_super_io_and_floppy_stub,
             deps_winbond_super_io_and_floppy_full,
         } = devices;
-
-        if let Some(options::dev::GenericIoApicDeps {
-            num_entries,
-            routing,
-        }) = deps_generic_ioapic
-        {
-            builder.arc_mutex_device("ioapic").add(|services| {
-                services.add_line_target(IRQ_LINE_SET, 0..=num_entries as u32 - 1, 0);
-                ioapic::IoApicDevice::new(num_entries, routing)
-            })?;
-        }
 
         if let Some(options::dev::GenericPciBusDeps {
             bus_id,
@@ -1111,7 +1099,6 @@ pub mod options {
 
         devices {
             generic_cmos_rtc:            dev::GenericCmosRtcDeps,
-            generic_ioapic:              dev::GenericIoApicDeps,
             generic_isa_dma:             dev::GenericIsaDmaDeps,
             generic_isa_floppy:          dev::GenericIsaFloppyDeps,
             generic_pci_bus:             dev::GenericPciBusDeps,
@@ -1295,14 +1282,6 @@ pub mod options {
                 /// handled externally, by the platform itself)
                 pub rom: Option<Box<dyn guestmem::MapRom>>,
             }
-        }
-
-        /// Generic IO Advanced Programmable Interrupt Controller (IOAPIC)
-        pub struct GenericIoApicDeps {
-            /// Number of IO-APIC entries
-            pub num_entries: u8,
-            /// Trait allowing the IO-APIC device to assert VM interrupts.
-            pub routing: Box<dyn ioapic::IoApicRouting>,
         }
 
         /// Generic MC146818A compatible RTC + CMOS device


### PR DESCRIPTION
- Move IoApicRouting trait to chipset_resources crate with re-export
- Add IoApicRoutingHandleKind resource kind and GenericIoApicDeviceHandle
- Add async resolver that registers line interrupt targets
- Add IoApicRoutingResolver platform resolver in vmm_core
- Make num_entries constant (IOAPIC_NUM_ENTRIES = 24)
- Remove GenericIoApicDeps from base_chipset macro and workers