### PR TITLE
netvsp: bounds-check RX buffer writes

### DIFF
--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -40,6 +40,28 @@ struct RxBufferWriteOverflow {
     total_size: usize,
 }
 
+/// Validates that `offset + len` does not overflow `usize` and
+/// `[offset, offset + len)` fits within `total_size`.
+fn check_rx_write_bounds(
+    offset: usize,
+    len: usize,
+    total_size: usize,
+) -> Result<(), RxBufferWriteOverflow> {
+    let end = offset.checked_add(len).ok_or(RxBufferWriteOverflow {
+        offset,
+        len,
+        total_size,
+    })?;
+    if end > total_size {
+        return Err(RxBufferWriteOverflow {
+            offset,
+            len,
+            total_size,
+        });
+    }
+    Ok(())
+}
+
 /// A type providing access to the netvsp receive buffer.
 pub struct GuestBuffers {
     mem: GuestMemory,
@@ -100,19 +122,7 @@ impl GuestBuffers {
                 len: buf.len(),
                 total_size: usize::MAX,
             })?;
-        // Check for arithmetic overflow.
-        let end = offset.checked_add(buf.len()).ok_or(RxBufferWriteOverflow {
-            offset,
-            len: buf.len(),
-            total_size,
-        })?;
-        if end > total_size {
-            return Err(RxBufferWriteOverflow {
-                offset,
-                len: buf.len(),
-                total_size,
-            });
-        }
+        check_rx_write_bounds(offset, buf.len(), total_size)?;
         while !buf.is_empty() {
             let len = (PAGE_SIZE - offset % PAGE_SIZE).min(buf.len());
             let (this, next) = buf.split_at(len);
@@ -273,6 +283,7 @@ impl BufferAccess for BufferPool {
 
 #[cfg(test)]
 mod tests {
+    use crate::buffers::check_rx_write_bounds;
     use crate::buffers::compute_buffer_segments;
     use net_backend::RxBufferSegment;
 
@@ -296,5 +307,23 @@ mod tests {
             compute_buffer_segments(&mut v, &gpns, range);
             check(&v, data);
         }
+    }
+
+    #[test]
+    fn test_check_rx_write_bounds() {
+        // Empty write at the end is fine.
+        check_rx_write_bounds(0x1000, 0, 0x1000).unwrap();
+        // Write that exactly fills the buffer is fine.
+        check_rx_write_bounds(0, 0x1000, 0x1000).unwrap();
+        // Write entirely inside the buffer is fine.
+        check_rx_write_bounds(0x100, 0x200, 0x1000).unwrap();
+        // Write that runs one byte past the end is rejected.
+        check_rx_write_bounds(0x1000, 1, 0x1000).unwrap_err();
+        check_rx_write_bounds(0xfff, 2, 0x1000).unwrap_err();
+        // Offset already past the end is rejected.
+        check_rx_write_bounds(0x2000, 0, 0x1000).unwrap_err();
+        // Length that overflows usize when added to offset is rejected.
+        check_rx_write_bounds(usize::MAX, 1, usize::MAX).unwrap_err();
+        check_rx_write_bounds(1, usize::MAX, usize::MAX).unwrap_err();
     }
 }

--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -17,6 +17,7 @@ use net_backend::RxMetadata;
 use safeatomic::AtomicSliceOps;
 use std::ops::Range;
 use std::sync::Arc;
+use thiserror::Error;
 use vmbus_channel::gpadl::GpadlView;
 use zerocopy::FromZeros;
 use zerocopy::Immutable;
@@ -25,6 +26,19 @@ use zerocopy::KnownLayout;
 
 const PAGE_SIZE: usize = 4096;
 const PAGE_SIZE32: u32 = 4096;
+
+/// Error returned when a write to the receive buffer would exceed the locked
+/// page range.
+#[derive(Debug, Error)]
+#[error(
+    "rx buffer write overflow: offset={offset} len={len} \
+     total_size={total_size}"
+)]
+struct RxBufferWriteOverflow {
+    offset: usize,
+    len: usize,
+    total_size: usize,
+}
 
 /// A type providing access to the netvsp receive buffer.
 pub struct GuestBuffers {
@@ -74,8 +88,31 @@ impl GuestBuffers {
         })
     }
 
-    fn write_at(&self, offset: u32, mut buf: &[u8]) {
+    fn write_at(&self, offset: u32, mut buf: &[u8]) -> Result<(), RxBufferWriteOverflow> {
         let mut offset = offset as usize;
+        let total_size = self
+            .locked_pages
+            .pages()
+            .len()
+            .checked_mul(PAGE_SIZE)
+            .ok_or(RxBufferWriteOverflow {
+                offset,
+                len: buf.len(),
+                total_size: usize::MAX,
+            })?;
+        // Check for arithmetic overflow.
+        let end = offset.checked_add(buf.len()).ok_or(RxBufferWriteOverflow {
+            offset,
+            len: buf.len(),
+            total_size,
+        })?;
+        if end > total_size {
+            return Err(RxBufferWriteOverflow {
+                offset,
+                len: buf.len(),
+                total_size,
+            });
+        }
         while !buf.is_empty() {
             let len = (PAGE_SIZE - offset % PAGE_SIZE).min(buf.len());
             let (this, next) = buf.split_at(len);
@@ -84,6 +121,7 @@ impl GuestBuffers {
             buf = next;
             offset += len;
         }
+        Ok(())
     }
 }
 
@@ -141,7 +179,14 @@ impl BufferAccess for BufferPool {
     }
 
     fn write_data(&mut self, id: RxId, data: &[u8]) {
-        self.buffers.write_at(self.offset(id) + RX_HEADER_LEN, data);
+        if let Err(err) = self.buffers.write_at(self.offset(id) + RX_HEADER_LEN, data) {
+            tracelimit::warn_ratelimited!(
+                error = &err as &dyn std::error::Error,
+                rx_id = id.0,
+                data_len = data.len(),
+                "rx buffer write overflow in write_data",
+            );
+        }
     }
 
     fn write_header(&mut self, id: RxId, metadata: &RxMetadata) {
@@ -216,7 +261,13 @@ impl BufferAccess for BufferPool {
             },
         };
 
-        self.buffers.write_at(self.offset(id), header.as_bytes());
+        if let Err(err) = self.buffers.write_at(self.offset(id), header.as_bytes()) {
+            tracelimit::warn_ratelimited!(
+                error = &err as &dyn std::error::Error,
+                rx_id = id.0,
+                "rx buffer write overflow in write_header",
+            );
+        }
     }
 }
 

--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -47,17 +47,14 @@ fn check_rx_write_bounds(
     len: usize,
     total_size: usize,
 ) -> Result<(), RxBufferWriteOverflow> {
-    let end = offset.checked_add(len).ok_or(RxBufferWriteOverflow {
+    let rx_overflow_err = || RxBufferWriteOverflow {
         offset,
         len,
         total_size,
-    })?;
+    };
+    let end = offset.checked_add(len).ok_or_else(rx_overflow_err)?;
     if end > total_size {
-        return Err(RxBufferWriteOverflow {
-            offset,
-            len,
-            total_size,
-        });
+        return Err(rx_overflow_err());
     }
     Ok(())
 }


### PR DESCRIPTION
GuestBuffers::write_at previously indexed into locked_pages without validating that offset + buf.len() fit within the locked page range. A misconfigured sub_allocation_size or an out-of-range RxId would panic.

* Offset and buf.len() validated against locked-page size up front, returning a typed RxBufferWriteOverflow error on overflow. 
* The two callers (write_data and write_header) log tracelimited warnings.
* Added unit test.