### PR TITLE
vfio_assigned_device: direct-map BAR regions into guest GPA space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8734,6 +8734,7 @@ dependencies = [
  "chipset_device",
  "guestmem",
  "inspect",
+ "memory_range",
  "mesh",
  "pal_async",
  "pci_core",
@@ -8762,7 +8763,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bitfield-struct 0.11.0",
+ "headervec",
  "libc",
+ "memory_range",
  "nix 0.30.1",
  "pal_async",
  "tracing",

--- a/vm/devices/pci/vfio_assigned_device/Cargo.toml
+++ b/vm/devices/pci/vfio_assigned_device/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 chipset_device.workspace = true
 guestmem.workspace = true
 inspect.workspace = true
+memory_range.workspace = true
 mesh.workspace = true
 pal_async.workspace = true
 pci_core.workspace = true

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -7,10 +7,10 @@
 //! and BAR MMIO accesses to a physical device opened via Linux VFIO. The device
 //! appears as a standard PCIe endpoint to the guest. MSI-X table and PBA
 //! accesses are intercepted and handled by a software emulator; all other BAR
-//! MMIO regions are mapped directly into guest GPA space when a `MemoryMapper`
-//! is available, allowing the guest to access device registers without VM
-//! exits. If direct mapping is unavailable or fails for a BAR region, accesses
-//! fall back to trap-and-emulate via pread/pwrite on the VFIO device fd.
+//! MMIO regions are mapped directly into guest GPA space via a `MemoryMapper`,
+//! allowing the guest to access device registers without VM exits. A
+//! `MemoryMapper` is required for VFIO device assignment; mapping failures are
+//! fatal.
 
 #![cfg(target_os = "linux")]
 #![forbid(unsafe_code)]
@@ -266,7 +266,9 @@ impl VfioAssignedPciDevice {
             });
 
             bar_mmio_controls[i] = Some(register_mmio.new_io_region(&format!("bar{i}"), info.size));
-            bar_mmap_areas[i] = vfio_device.region_mmap_areas(i as u32).unwrap_or_default();
+            bar_mmap_areas[i] = vfio_device
+                .region_mmap_areas(i as u32)
+                .with_context(|| format!("failed to query VFIO mmap areas for BAR {i}"))?;
         }
 
         // Discover MSI-X capability from physical device config space.
@@ -586,10 +588,7 @@ fn subtract_msix_regions(bar_mmap_areas: &mut [Vec<MemoryRange>; 6], msix: &Msix
 }
 
 fn page_size() -> u64 {
-    // Use a constant 4K page size. This is correct for x86_64 and aarch64
-    // (base page size). If we ever need the actual runtime page size, it
-    // can be obtained from vfio_sys or pal.
-    4096
+    vfio_sys::host_page_size()
 }
 
 /// Walk the PCI capabilities list to find an MSI-X capability. If found,

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -7,7 +7,10 @@
 //! and BAR MMIO accesses to a physical device opened via Linux VFIO. The device
 //! appears as a standard PCIe endpoint to the guest. MSI-X table and PBA
 //! accesses are intercepted and handled by a software emulator; all other BAR
-//! MMIO is proxied directly to hardware.
+//! MMIO regions are mapped directly into guest GPA space when a `MemoryMapper`
+//! is available, allowing the guest to access device registers without VM
+//! exits. If direct mapping is unavailable or fails for a BAR region, accesses
+//! fall back to trap-and-emulate via pread/pwrite on the VFIO device fd.
 
 #![cfg(target_os = "linux")]
 #![forbid(unsafe_code)]
@@ -20,14 +23,18 @@ use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::PciConfigSpace;
+use guestmem::MappableGuestMemory;
+use guestmem::MemoryMapper;
 use inspect::Inspect;
 use inspect::InspectMut;
+use memory_range::MemoryRange;
 use pci_core::bar_mapping::BarMappings;
 use pci_core::capabilities::PciCapability;
 use pci_core::capabilities::msix::MsixEmulator;
 use pci_core::msi::MsiTarget;
 use pci_core::spec::cfg_space;
 use pci_core::spec::cfg_space::HeaderType00;
+use std::ops::Range;
 use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 use virt::irqfd::IrqFd;
@@ -49,6 +56,24 @@ struct VfioBarInfo {
     pub size: u64,
 }
 
+/// A direct mapping of a VFIO BAR sub-region into guest GPA space.
+///
+/// Created during device initialization for each mmappable sub-region
+/// of a BAR. The `memory` handle is mapped/unmapped from guest GPA space
+/// as the guest enables/disables MMIO via the PCI Command register.
+#[derive(Inspect)]
+struct BarDirectMap {
+    /// Guest memory mapping handle backed by the VFIO device fd.
+    #[inspect(skip)]
+    memory: Box<dyn MappableGuestMemory>,
+    /// BAR index this sub-region belongs to.
+    bar_index: u8,
+    /// The memory range within the BAR.
+    range: MemoryRange,
+    /// Whether this sub-region is currently mapped into guest GPA space.
+    mapped: bool,
+}
+
 /// MSI-X emulation state, discovered from the physical device's capabilities.
 #[derive(Inspect)]
 struct MsixEmulationState {
@@ -67,20 +92,12 @@ struct MsixEmulationState {
     vector_count: u16,
     /// BAR index containing the MSI-X table.
     table_bar: u8,
-    /// Byte offset of the MSI-X table within its BAR.
-    #[inspect(hex)]
-    table_offset: u32,
-    /// Total size of the MSI-X table in bytes (vector_count * 16).
-    #[inspect(hex)]
-    table_size: u64,
+    #[inspect(with = r#"|x| format!("{:#x}-{:#x}", x.start, x.end)"#)]
+    table_range: Range<u64>,
     /// BAR index containing the PBA.
     pba_bar: u8,
-    /// Byte offset of the PBA within its BAR.
-    #[inspect(hex)]
-    pba_offset: u32,
-    /// Total size of the PBA in bytes.
-    #[inspect(hex)]
-    pba_size: u64,
+    #[inspect(with = r#"|x| format!("{:#x}-{:#x}", x.start, x.end)"#)]
+    pba_range: Range<u64>,
     /// Whether MSI-X is currently enabled by the guest.
     enabled: bool,
 }
@@ -149,6 +166,12 @@ pub(crate) struct VfioAssignedPciDevice {
     /// flags at init).
     supports_reset: bool,
 
+    /// Direct guest GPA mappings for BAR sub-regions that support mmap.
+    /// When MMIO is enabled, these are mapped to guest GPA space for direct
+    /// access without VM exits. When MMIO is disabled, they are unmapped.
+    #[inspect(iter_by_index)]
+    bar_direct_maps: Vec<BarDirectMap>,
+
     /// VFIO container/group binding. Keeps the container and group fds alive
     /// and notifies the container manager on drop.
     binding: manager::VfioDeviceBinding,
@@ -167,6 +190,7 @@ impl VfioAssignedPciDevice {
         register_mmio: &mut (dyn chipset_device::mmio::RegisterMmioIntercept + Send),
         msi_target: &MsiTarget,
         irqfd: Arc<dyn IrqFd>,
+        memory_mapper: &dyn MemoryMapper,
     ) -> anyhow::Result<Self> {
         let vfio_device = binding
             .group()
@@ -199,6 +223,7 @@ impl VfioAssignedPciDevice {
 
         let mut bar_regions = [None; 6];
         let mut bar_mmio_controls = [(); 6].map(|_| None);
+        let mut bar_mmap_areas: [Vec<_>; 6] = Default::default();
         let mut processed = 0;
         while processed < 6 {
             let i = processed;
@@ -241,9 +266,12 @@ impl VfioAssignedPciDevice {
             });
 
             bar_mmio_controls[i] = Some(register_mmio.new_io_region(&format!("bar{i}"), info.size));
+            bar_mmap_areas[i] = vfio_device.region_mmap_areas(i as u32).unwrap_or_default();
         }
 
         // Discover MSI-X capability from physical device config space.
+        // This must happen BEFORE creating direct BAR mappings so we can
+        // exclude the MSI-X table/PBA regions.
         let msix = discover_msix(vfio_device.as_ref(), config_offset, config_size, msi_target);
 
         // Cache whether the device supports VFIO_DEVICE_RESET so we can skip
@@ -252,6 +280,53 @@ impl VfioAssignedPciDevice {
             .info()
             .map(|info| info.flags.reset())
             .unwrap_or(false);
+
+        // If the device has MSI-X, remove the table and PBA regions from
+        // the mmap areas so they remain trap-and-emulate.
+        if let Some(msix) = &msix {
+            subtract_msix_regions(&mut bar_mmap_areas, msix);
+        }
+
+        // Create direct BAR mappings for mmappable regions. Each
+        // mmappable sub-region gets a guest memory mapping backed by the
+        // VFIO device fd. These are mapped into guest GPA space when the
+        // guest enables MMIO, allowing direct hardware access without VM
+        // exits. Non-mmappable regions (e.g. MSI-X table/PBA) remain
+        // trap-and-emulate.
+        let mut bar_direct_maps = Vec::new();
+        for (i, areas) in bar_mmap_areas.iter().enumerate() {
+            let Some(region) = &bar_regions[i] else {
+                continue;
+            };
+            for &area in areas {
+                let name = format!("vfio-{pci_id}-bar{i}-{area}");
+                let (memory, mapped_region) = memory_mapper
+                    .new_region(area.len() as usize, name)
+                    .with_context(|| {
+                    format!("failed to create BAR {i} direct mapping region for {pci_id}")
+                })?;
+                mapped_region
+                    .map(
+                        0,
+                        &vfio_device,
+                        region.vfio_offset + area.start(),
+                        area.len() as usize,
+                        true,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "failed to map VFIO BAR {i} region at offset {:#x}",
+                            area.start()
+                        )
+                    })?;
+                bar_direct_maps.push(BarDirectMap {
+                    memory,
+                    bar_index: i as u8,
+                    range: area,
+                    mapped: false,
+                });
+            }
+        }
 
         tracing::info!(
             pci_id = pci_id.as_str(),
@@ -276,6 +351,7 @@ impl VfioAssignedPciDevice {
             bar_regions,
             msix,
             supports_reset,
+            bar_direct_maps,
             binding,
         })
     }
@@ -321,24 +397,16 @@ impl VfioAssignedPciDevice {
         let msix = self.msix.as_ref()?;
 
         // Check MSI-X table region.
-        if bar == msix.table_bar {
-            let table_start = msix.table_offset as u64;
-            let table_end = table_start + msix.table_size;
-            if offset >= table_start && offset < table_end {
-                // Emulator table starts at offset 0.
-                return Some(offset - table_start);
-            }
+        if bar == msix.table_bar && msix.table_range.contains(&offset) {
+            // Emulator table starts at offset 0.
+            return Some(offset - msix.table_range.start);
         }
 
         // Check PBA region.
-        if bar == msix.pba_bar {
-            let pba_start = msix.pba_offset as u64;
-            let pba_end = pba_start + msix.pba_size;
-            if offset >= pba_start && offset < pba_end {
-                // In the emulator, PBA starts right after the table.
-                let emu_pba_start = msix.table_size;
-                return Some(emu_pba_start + (offset - pba_start));
-            }
+        if bar == msix.pba_bar && msix.pba_range.contains(&offset) {
+            // In the emulator, PBA starts right after the table.
+            let emu_pba_start = msix.table_range.end - msix.table_range.start;
+            return Some(emu_pba_start + (offset - msix.pba_range.start));
         }
 
         None
@@ -392,6 +460,46 @@ impl VfioAssignedPciDevice {
             "MSI-X disabled: unmapped vectors"
         );
     }
+
+    /// Map directly-mapped BAR sub-regions into guest GPA space.
+    ///
+    /// Called when MMIO is enabled. For each active BAR, maps its mmappable
+    /// sub-regions at `bar_base_address + offset_in_bar`.
+    fn map_bars_to_guest(&mut self) {
+        for dm in &mut self.bar_direct_maps {
+            let bar_base = self
+                .active_bars
+                .get(dm.bar_index)
+                .expect("BAR with direct map must have an active mapping");
+            let gpa = bar_base + dm.range.start();
+            match dm.memory.map_to_guest(gpa, true) {
+                Ok(()) => dm.mapped = true,
+                Err(e) => {
+                    tracelimit::error_ratelimited!(
+                        bar = dm.bar_index,
+                        gpa,
+                        error = ?e,
+                        pci_id = self.pci_id.as_str(),
+                        "failed to direct-map BAR region to guest"
+                    );
+                }
+            }
+        }
+    }
+
+    fn disable_mmio(&mut self) {
+        // Unmap direct BAR mappings from guest, then unregister
+        // MMIO intercepts.
+        for dm in &mut self.bar_direct_maps {
+            dm.memory.unmap_from_guest();
+            dm.mapped = false;
+        }
+        for control in self.bar_mmio_controls.iter_mut().flatten() {
+            control.unmap();
+        }
+        self.active_bars = BarMappings::default();
+        self.mmio_enabled = false;
+    }
 }
 
 fn read_config_u32(
@@ -432,6 +540,56 @@ fn write_config_u32(
         "short config write at offset {offset:#x}: wrote {n} bytes"
     );
     Ok(())
+}
+
+/// Remove MSI-X table and PBA regions from the mmap areas for the
+/// corresponding BARs. This ensures those regions are NOT direct-mapped
+/// and remain trap-and-emulate so the software MSI-X emulator can
+/// intercept accesses.
+///
+/// Each mmap area that overlaps with the MSI-X table or PBA is split
+/// into up to two non-overlapping areas (before and after the excluded
+/// region). The exclusion zone is expanded to page boundaries since
+/// the resulting areas must be page-aligned for mmap.
+fn subtract_msix_regions(bar_mmap_areas: &mut [Vec<MemoryRange>; 6], msix: &MsixEmulationState) {
+    let page_size = page_size();
+
+    for (i, area) in bar_mmap_areas.iter_mut().enumerate() {
+        let i = i as u8;
+        if area.is_empty() || (msix.table_bar != i && msix.pba_bar != i) {
+            continue;
+        }
+        area.sort();
+        *area = memory_range::subtract_ranges(
+            memory_range::subtract_ranges(
+                area.iter().copied(),
+                if msix.table_bar == i {
+                    Some(MemoryRange::bounding_aligned(
+                        msix.table_range.clone(),
+                        page_size,
+                    ))
+                } else {
+                    None
+                },
+            ),
+            if msix.pba_bar == i {
+                Some(MemoryRange::bounding_aligned(
+                    msix.pba_range.clone(),
+                    page_size,
+                ))
+            } else {
+                None
+            },
+        )
+        .collect();
+    }
+}
+
+fn page_size() -> u64 {
+    // Use a constant 4K page size. This is correct for x86_64 and aarch64
+    // (base page size). If we ever need the actual runtime page size, it
+    // can be obtained from vfio_sys or pal.
+    4096
 }
 
 /// Walk the PCI capabilities list to find an MSI-X capability. If found,
@@ -506,11 +664,9 @@ fn discover_msix(
                 cap_offset: cap_ptr,
                 vector_count: table_count,
                 table_bar: table_bir,
-                table_offset,
-                table_size,
+                table_range: table_offset as u64..table_offset as u64 + table_size,
                 pba_bar: pba_bir,
-                pba_offset,
-                pba_size,
+                pba_range: pba_offset as u64..pba_offset as u64 + pba_size,
                 enabled: false,
             });
         }
@@ -578,6 +734,8 @@ impl ChangeDeviceState for VfioAssignedPciDevice {
             self.msix_disable();
         }
 
+        self.disable_mmio();
+
         // Destructure to ensure every field is explicitly considered for reset.
         let Self {
             pci_id,
@@ -588,10 +746,11 @@ impl ChangeDeviceState for VfioAssignedPciDevice {
             bar_masks: _,     // immutable device geometry
             bars,
             bar_flags,
-            mmio_enabled,
-            active_bars,
-            bar_mmio_controls,
-            bar_regions: _, // immutable device geometry
+            mmio_enabled: _,      // handled by disable_mmio()
+            active_bars: _,       // handled by disable_mmio()
+            bar_mmio_controls: _, // handled by disable_mmio()
+            bar_direct_maps: _,   // handled by disable_mmio()
+            bar_regions: _,       // immutable device geometry
             msix,
             supports_reset,
             binding: _, // lifetime handle — no reset needed
@@ -604,13 +763,6 @@ impl ChangeDeviceState for VfioAssignedPciDevice {
             msix.enabled = false;
             msix.capability.reset();
         }
-
-        // Unmap BAR MMIO regions.
-        for control in bar_mmio_controls.iter_mut().flatten() {
-            control.unmap();
-        }
-        *mmio_enabled = false;
-        *active_bars = BarMappings::default();
 
         // Reset cached BAR addresses to power-on defaults (flags only, no
         // address bits). The guest will re-probe and re-program BARs.
@@ -689,17 +841,15 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                             .expect("BAR MMIO control must be present")
                             .map(mapping.base_address);
                     }
+                    // Map directly-mapped BAR regions into guest GPA space.
+                    self.map_bars_to_guest();
+                    self.mmio_enabled = true;
                     tracing::debug!(pci_id = self.pci_id.as_str(), "MMIO enabled by guest");
                 } else if !new_mmio_enabled && self.mmio_enabled {
-                    // Unregister BAR address ranges.
-                    for control in self.bar_mmio_controls.iter_mut().flatten() {
-                        control.unmap();
-                    }
-                    self.active_bars = BarMappings::default();
+                    self.disable_mmio();
                     tracing::debug!(pci_id = self.pci_id.as_str(), "MMIO disabled by guest");
                 }
 
-                self.mmio_enabled = new_mmio_enabled;
                 self.write_phys_config(offset, value);
             }
             // BAR registers: mask and cache locally.

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -73,6 +73,10 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             .irqfd
             .context("partition does not support irqfd (required for VFIO)")?;
 
+        let memory_mapper = input
+            .shared_mem_mapper
+            .context("memory mapper is required for VFIO device assignment")?;
+
         let device = VfioAssignedPciDevice::new(
             binding,
             pci_id,
@@ -80,6 +84,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             input.register_mmio,
             input.msi_target,
             irqfd,
+            memory_mapper,
         )
         .await?;
 

--- a/vm/devices/user_driver/vfio_sys/Cargo.toml
+++ b/vm/devices/user_driver/vfio_sys/Cargo.toml
@@ -7,9 +7,11 @@ edition.workspace = true
 rust-version.workspace = true
 
 [target.'cfg(unix)'.dependencies]
+memory_range.workspace = true
 pal_async.workspace = true
 
 anyhow.workspace = true
+headervec.workspace = true
 bitfield-struct.workspace = true
 libc.workspace = true
 nix = { workspace = true, features = ["ioctl"] }

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -34,6 +34,12 @@ use vfio_bindings::bindings::vfio::vfio_region_info;
 use vfio_bindings::bindings::vfio::vfio_region_info_cap_sparse_mmap;
 use vfio_bindings::bindings::vfio::vfio_region_sparse_mmap_area;
 
+/// Returns the host page size.
+pub fn host_page_size() -> u64 {
+    // SAFETY: sysconf(_SC_PAGESIZE) is always safe and always succeeds on Linux.
+    unsafe { libc::sysconf(libc::_SC_PAGESIZE) as u64 }
+}
+
 mod ioctl {
     use nix::request_code_none;
     use std::os::raw::c_char;
@@ -521,8 +527,7 @@ impl Device {
             let actual_tail = buf.head.argsz as usize - size_of::<vfio_region_info>();
             // SAFETY: The kernel initialized the tail bytes via the ioctl.
             unsafe { buf.set_tail_len(actual_tail.min(tail_len)) };
-            let areas = parse_sparse_mmap_caps(&buf);
-            if !areas.is_empty() {
+            if let Some(areas) = parse_sparse_mmap_caps(&buf) {
                 return Ok(areas);
             }
         }
@@ -670,7 +675,10 @@ impl Device {
 
 /// Walk the VFIO capability chain in a region info buffer and extract sparse
 /// mmap areas from any `VFIO_REGION_INFO_CAP_SPARSE_MMAP` capability.
-fn parse_sparse_mmap_caps(buf: &HeaderVec<vfio_region_info, u8, 0>) -> Vec<MemoryRange> {
+///
+/// Returns `Some(areas)` if the sparse mmap capability is present (even if
+/// empty), or `None` if it is absent.
+fn parse_sparse_mmap_caps(buf: &HeaderVec<vfio_region_info, u8, 0>) -> Option<Vec<MemoryRange>> {
     let mut offset = buf.head.cap_offset as usize;
 
     // SAFETY: HeaderVec guarantees head + tail are contiguous.
@@ -709,19 +717,20 @@ fn parse_sparse_mmap_caps(buf: &HeaderVec<vfio_region_info, u8, 0>) -> Vec<Memor
             }
             // SAFETY: Bounds checked; flexible array immediately follows the fixed fields.
             let areas = unsafe { cap.areas.as_slice(n) };
-            return areas
-                .iter()
-                .filter(|a| a.size > 0)
-                .map(|a| MemoryRange::new(a.offset..a.offset + a.size))
-                .collect();
+            return Some(
+                areas
+                    .iter()
+                    .filter(|a| a.size > 0)
+                    .map(|a| MemoryRange::new(a.offset..a.offset + a.size))
+                    .collect(),
+            );
         }
 
         offset = header.next as usize;
     }
 
-    // No sparse mmap cap found — return empty (caller should check mmap flag
-    // separately if needed).
-    Vec::new()
+    // No sparse mmap cap found.
+    None
 }
 
 impl AsRef<File> for Device {

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -8,7 +8,9 @@
 
 use anyhow::Context;
 use bitfield_struct::bitfield;
+use headervec::HeaderVec;
 use libc::c_void;
+use memory_range::MemoryRange;
 use pal_async::driver::Driver;
 use pal_async::timer::PolledTimer;
 use std::ffi::CString;
@@ -22,11 +24,15 @@ use vfio_bindings::bindings::vfio::VFIO_IRQ_SET_ACTION_TRIGGER;
 use vfio_bindings::bindings::vfio::VFIO_IRQ_SET_DATA_EVENTFD;
 use vfio_bindings::bindings::vfio::VFIO_IRQ_SET_DATA_NONE;
 use vfio_bindings::bindings::vfio::VFIO_PCI_MSIX_IRQ_INDEX;
+use vfio_bindings::bindings::vfio::VFIO_REGION_INFO_CAP_SPARSE_MMAP;
 use vfio_bindings::bindings::vfio::vfio_device_info;
 use vfio_bindings::bindings::vfio::vfio_group_status;
+use vfio_bindings::bindings::vfio::vfio_info_cap_header;
 use vfio_bindings::bindings::vfio::vfio_irq_info;
 use vfio_bindings::bindings::vfio::vfio_irq_set;
 use vfio_bindings::bindings::vfio::vfio_region_info;
+use vfio_bindings::bindings::vfio::vfio_region_info_cap_sparse_mmap;
+use vfio_bindings::bindings::vfio::vfio_region_sparse_mmap_area;
 
 mod ioctl {
     use nix::request_code_none;
@@ -463,6 +469,71 @@ impl Device {
         })
     }
 
+    /// Query the mmappable sub-regions for a VFIO region.
+    ///
+    /// If the region has a `VFIO_REGION_INFO_CAP_SPARSE_MMAP` capability,
+    /// returns the list of mmappable areas from it. If the region supports
+    /// mmap but has no sparse capability, returns a single area covering
+    /// the entire region. Returns an empty list if the region does not
+    /// support mmap.
+    pub fn region_mmap_areas(&self, index: u32) -> anyhow::Result<Vec<MemoryRange>> {
+        let mut info = vfio_region_info {
+            argsz: size_of::<vfio_region_info>() as u32,
+            index,
+            flags: 0,
+            cap_offset: 0,
+            size: 0,
+            offset: 0,
+        };
+        // SAFETY: The file descriptor is valid and a correctly constructed struct is being passed.
+        unsafe {
+            ioctl::vfio_device_get_region_info(self.file.as_raw_fd(), &mut info)
+                .context("failed to get region info")?;
+        };
+
+        let flags = RegionFlags::from(info.flags);
+
+        // If the kernel indicates capabilities are present and returned a
+        // larger argsz, re-query with a sufficiently large buffer to
+        // retrieve the capability chain.
+        if flags.caps() && info.argsz > size_of::<vfio_region_info>() as u32 {
+            let buf_size = info.argsz as usize;
+            let tail_len = buf_size - size_of::<vfio_region_info>();
+            let mut buf = HeaderVec::<vfio_region_info, u8, 0>::with_capacity(
+                vfio_region_info {
+                    argsz: buf_size as u32,
+                    index,
+                    flags: 0,
+                    cap_offset: 0,
+                    size: 0,
+                    offset: 0,
+                },
+                tail_len,
+            );
+            // SAFETY: The buffer is properly aligned and large enough per the
+            // kernel's argsz, and the fd is valid.
+            unsafe {
+                ioctl::vfio_device_get_region_info(self.file.as_raw_fd(), buf.as_mut_ptr())
+                    .context("failed to get region info with capabilities")?;
+            }
+            // Use the kernel's returned argsz rather than our pre-computed
+            // value, in case it differs.
+            let actual_tail = buf.head.argsz as usize - size_of::<vfio_region_info>();
+            // SAFETY: The kernel initialized the tail bytes via the ioctl.
+            unsafe { buf.set_tail_len(actual_tail.min(tail_len)) };
+            let areas = parse_sparse_mmap_caps(&buf);
+            if !areas.is_empty() {
+                return Ok(areas);
+            }
+        }
+
+        if flags.mmap() {
+            Ok(vec![MemoryRange::new(0..info.size)])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
     pub fn irq_info(&self, index: u32) -> anyhow::Result<IrqInfo> {
         let mut info = vfio_irq_info {
             argsz: size_of::<vfio_irq_info>() as u32,
@@ -595,6 +666,62 @@ impl Device {
         }
         Ok(())
     }
+}
+
+/// Walk the VFIO capability chain in a region info buffer and extract sparse
+/// mmap areas from any `VFIO_REGION_INFO_CAP_SPARSE_MMAP` capability.
+fn parse_sparse_mmap_caps(buf: &HeaderVec<vfio_region_info, u8, 0>) -> Vec<MemoryRange> {
+    let mut offset = buf.head.cap_offset as usize;
+
+    // SAFETY: HeaderVec guarantees head + tail are contiguous.
+    let bytes =
+        unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), buf.total_byte_len()) };
+
+    while offset != 0 {
+        if offset + size_of::<vfio_info_cap_header>() > bytes.len() {
+            tracing::warn!(offset, "VFIO cap header extends beyond buffer");
+            break;
+        }
+
+        // SAFETY: Bounds checked above. The kernel places capabilities at
+        // aligned offsets within the buffer.
+        let header = unsafe { &*bytes.as_ptr().add(offset).cast::<vfio_info_cap_header>() };
+
+        if header.id as u32 == VFIO_REGION_INFO_CAP_SPARSE_MMAP {
+            if offset + size_of::<vfio_region_info_cap_sparse_mmap>() > bytes.len() {
+                tracing::warn!("VFIO sparse mmap cap truncated");
+                break;
+            }
+            // SAFETY: Bounds checked above; repr(C) struct at kernel-aligned offset.
+            let cap = unsafe {
+                &*bytes
+                    .as_ptr()
+                    .add(offset)
+                    .cast::<vfio_region_info_cap_sparse_mmap>()
+            };
+            let n = cap.nr_areas as usize;
+            let areas_end = offset
+                + size_of::<vfio_region_info_cap_sparse_mmap>()
+                + n * size_of::<vfio_region_sparse_mmap_area>();
+            if areas_end > bytes.len() {
+                tracing::warn!(n, "VFIO sparse mmap areas extend beyond buffer");
+                break;
+            }
+            // SAFETY: Bounds checked; flexible array immediately follows the fixed fields.
+            let areas = unsafe { cap.areas.as_slice(n) };
+            return areas
+                .iter()
+                .filter(|a| a.size > 0)
+                .map(|a| MemoryRange::new(a.offset..a.offset + a.size))
+                .collect();
+        }
+
+        offset = header.next as usize;
+    }
+
+    // No sparse mmap cap found — return empty (caller should check mmap flag
+    // separately if needed).
+    Vec::new()
 }
 
 impl AsRef<File> for Device {

--- a/vm/vmcore/memory_range/src/lib.rs
+++ b/vm/vmcore/memory_range/src/lib.rs
@@ -109,10 +109,20 @@ impl MemoryRange {
     /// Panics if the start is after the end or if the end address is in the
     /// last page of the 64-bit space.
     pub fn bounding(range: Range<u64>) -> Self {
+        Self::bounding_aligned(range, PAGE_SIZE)
+    }
+
+    /// Returns the smallest range with the specified alignemnt that contains
+    /// the given address range.
+    ///
+    /// Panics if the start is after the end or if the end address is in the
+    /// last page of the 64-bit space.
+    pub fn bounding_aligned(range: Range<u64>, alignment: u64) -> Self {
         assert!(range.start <= range.end);
         assert!(range.end < u64::MAX - PAGE_SIZE);
-        let start = range.start & !(PAGE_SIZE - 1);
-        let end = (range.end + (PAGE_SIZE - 1)) & !(PAGE_SIZE - 1);
+        assert!(alignment.is_power_of_two());
+        let start = range.start & !(alignment - 1);
+        let end = (range.end + (alignment - 1)) & !(alignment - 1);
         Self::new(start..end)
     }
 

--- a/vm/vmcore/memory_range/src/lib.rs
+++ b/vm/vmcore/memory_range/src/lib.rs
@@ -112,15 +112,15 @@ impl MemoryRange {
         Self::bounding_aligned(range, PAGE_SIZE)
     }
 
-    /// Returns the smallest range with the specified alignemnt that contains
+    /// Returns the smallest range with the specified alignment that contains
     /// the given address range.
     ///
-    /// Panics if the start is after the end or if the end address is in the
-    /// last page of the 64-bit space.
+    /// Panics if the start is after the end or if the aligned end address
+    /// would overflow.
     pub fn bounding_aligned(range: Range<u64>, alignment: u64) -> Self {
         assert!(range.start <= range.end);
-        assert!(range.end < u64::MAX - PAGE_SIZE);
         assert!(alignment.is_power_of_two());
+        assert!(range.end <= u64::MAX - (alignment - 1));
         let start = range.start & !(alignment - 1);
         let end = (range.end + (alignment - 1)) & !(alignment - 1);
         Self::new(start..end)


### PR DESCRIPTION
Map VFIO BAR regions directly into guest physical address space via MemoryMapper instead of trapping every MMIO access and proxying via pread/pwrite. MSI-X table and PBA regions are carved out (page-aligned) so the software emulator still intercepts vector configuration.

Adds region_mmap_areas() to vfio_sys to query VFIO sparse mmap capabilities. MemoryMapper is now required for VFIO device assignment; mapping failures are fatal.