### PR TITLE
openvmm_helpers: make open_disk_type async

### DIFF
--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -442,14 +442,16 @@ async fn vm_config_from_command_line(
             anyhow::bail!("`--disk` is incompatible with PCIe");
         }
 
-        storage.add(
-            vtl,
-            underhill,
-            storage_builder::DiskLocation::Scsi(None),
-            kind,
-            is_dvd,
-            read_only,
-        )?;
+        storage
+            .add(
+                vtl,
+                underhill,
+                storage_builder::DiskLocation::Scsi(None),
+                kind,
+                is_dvd,
+                read_only,
+            )
+            .await?;
     }
 
     for &cli_args::IdeDiskCli {
@@ -460,14 +462,16 @@ async fn vm_config_from_command_line(
         is_dvd,
     } in &opt.ide
     {
-        storage.add(
-            DeviceVtl::Vtl0,
-            None,
-            storage_builder::DiskLocation::Ide(channel, device),
-            kind,
-            is_dvd,
-            read_only,
-        )?;
+        storage
+            .add(
+                DeviceVtl::Vtl0,
+                None,
+                storage_builder::DiskLocation::Ide(channel, device),
+                kind,
+                is_dvd,
+                read_only,
+            )
+            .await?;
     }
 
     for &cli_args::DiskCli {
@@ -479,14 +483,16 @@ async fn vm_config_from_command_line(
         ref pcie_port,
     } in &opt.nvme
     {
-        storage.add(
-            vtl,
-            underhill,
-            storage_builder::DiskLocation::Nvme(None, pcie_port.clone()),
-            kind,
-            is_dvd,
-            read_only,
-        )?;
+        storage
+            .add(
+                vtl,
+                underhill,
+                storage_builder::DiskLocation::Nvme(None, pcie_port.clone()),
+                kind,
+                is_dvd,
+                read_only,
+            )
+            .await?;
     }
 
     for &cli_args::DiskCli {
@@ -508,23 +514,21 @@ async fn vm_config_from_command_line(
             kind,
             is_dvd,
             read_only,
-        )?;
+        )
+        .await?;
     }
 
-    let floppy_disks: Vec<_> = opt
-        .floppy
-        .iter()
-        .map(|disk| -> anyhow::Result<_> {
-            let &cli_args::FloppyDiskCli {
-                ref kind,
-                read_only,
-            } = disk;
-            Ok(FloppyDiskConfig {
-                disk_type: disk_open(kind, read_only)?,
-                read_only,
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut floppy_disks = Vec::new();
+    for disk in &opt.floppy {
+        let &cli_args::FloppyDiskCli {
+            ref kind,
+            read_only,
+        } = disk;
+        floppy_disks.push(FloppyDiskConfig {
+            disk_type: disk_open(kind, read_only).await?,
+            read_only,
+        });
+    }
 
     let mut vpci_mana_nics = [(); 3].map(|()| None);
     let mut pcie_mana_nics = BTreeMap::<String, GdmaDeviceHandle>::new();
@@ -1005,7 +1009,9 @@ async fn vm_config_from_command_line(
 
     let mut vmgs = Some(if let Some(VmgsCli { kind, provision }) = &opt.vmgs {
         let disk = VmgsDisk {
-            disk: disk_open(kind, false).context("failed to open vmgs disk")?,
+            disk: disk_open(kind, false)
+                .await
+                .context("failed to open vmgs disk")?,
             encryption_policy: if opt.test_gsp_by_id {
                 GuestStateEncryptionPolicy::GspById(true)
             } else {
@@ -1784,9 +1790,12 @@ enum LayerOrDisk {
     Disk(Resource<DiskHandleKind>),
 }
 
-fn disk_open(disk_cli: &DiskCliKind, read_only: bool) -> anyhow::Result<Resource<DiskHandleKind>> {
+async fn disk_open(
+    disk_cli: &DiskCliKind,
+    read_only: bool,
+) -> anyhow::Result<Resource<DiskHandleKind>> {
     let mut layers = Vec::new();
-    disk_open_inner(disk_cli, read_only, &mut layers)?;
+    disk_open_inner(disk_cli, read_only, &mut layers).await?;
     if layers.len() == 1 && matches!(layers[0], LayerOrDisk::Disk(_)) {
         let LayerOrDisk::Disk(disk) = layers.pop().unwrap() else {
             unreachable!()
@@ -1809,161 +1818,168 @@ fn disk_open(disk_cli: &DiskCliKind, read_only: bool) -> anyhow::Result<Resource
     }
 }
 
-fn disk_open_inner(
-    disk_cli: &DiskCliKind,
+fn disk_open_inner<'a>(
+    disk_cli: &'a DiskCliKind,
     read_only: bool,
-    layers: &mut Vec<LayerOrDisk>,
-) -> anyhow::Result<()> {
-    fn layer<T: IntoResource<DiskLayerHandleKind>>(layer: T) -> LayerOrDisk {
-        LayerOrDisk::Layer(layer.into_resource().into())
-    }
-    fn disk<T: IntoResource<DiskHandleKind>>(disk: T) -> LayerOrDisk {
-        LayerOrDisk::Disk(disk.into_resource())
-    }
-    match disk_cli {
-        &DiskCliKind::Memory(len) => {
-            layers.push(layer(RamDiskLayerHandle {
-                len: Some(len),
-                sector_size: None,
-            }));
+    layers: &'a mut Vec<LayerOrDisk>,
+) -> futures::future::BoxFuture<'a, anyhow::Result<()>> {
+    Box::pin(async move {
+        fn layer<T: IntoResource<DiskLayerHandleKind>>(layer: T) -> LayerOrDisk {
+            LayerOrDisk::Layer(layer.into_resource().into())
         }
-        DiskCliKind::File {
-            path,
-            create_with_len,
-            direct,
-        } => layers.push(LayerOrDisk::Disk(if let Some(size) = create_with_len {
-            create_disk_type(
-                path,
-                *size,
-                OpenDiskOptions {
-                    read_only: false,
-                    direct: *direct,
-                },
-            )
-            .with_context(|| format!("failed to create {}", path.display()))?
-        } else {
-            open_disk_type(
-                path,
-                OpenDiskOptions {
-                    read_only,
-                    direct: *direct,
-                },
-            )
-            .with_context(|| format!("failed to open {}", path.display()))?
-        })),
-        DiskCliKind::Blob { kind, url } => {
-            layers.push(disk(disk_backend_resources::BlobDiskHandle {
-                url: url.to_owned(),
-                format: match kind {
-                    cli_args::BlobKind::Flat => disk_backend_resources::BlobDiskFormat::Flat,
-                    cli_args::BlobKind::Vhd1 => disk_backend_resources::BlobDiskFormat::FixedVhd1,
-                },
-            }))
+        fn disk<T: IntoResource<DiskHandleKind>>(disk: T) -> LayerOrDisk {
+            LayerOrDisk::Disk(disk.into_resource())
         }
-        DiskCliKind::MemoryDiff(inner) => {
-            layers.push(layer(RamDiskLayerHandle {
-                len: None,
-                sector_size: None,
-            }));
-            disk_open_inner(inner, true, layers)?;
-        }
-        DiskCliKind::PersistentReservationsWrapper(inner) => layers.push(disk(
-            disk_backend_resources::DiskWithReservationsHandle(disk_open(inner, read_only)?),
-        )),
-        DiskCliKind::DelayDiskWrapper {
-            delay_ms,
-            disk: inner,
-        } => layers.push(disk(DelayDiskHandle {
-            delay: CellUpdater::new(Duration::from_millis(*delay_ms)).cell(),
-            disk: disk_open(inner, read_only)?,
-        })),
-        DiskCliKind::Crypt {
-            disk: inner,
-            cipher,
-            key_file,
-        } => layers.push(disk(disk_crypt_resources::DiskCryptHandle {
-            disk: disk_open(inner, read_only)?,
-            cipher: match cipher {
-                cli_args::DiskCipher::XtsAes256 => disk_crypt_resources::Cipher::XtsAes256,
-            },
-            key: fs_err::read(key_file).context("failed to read key file")?,
-        })),
-        DiskCliKind::Sqlite {
-            path,
-            create_with_len,
-        } => {
-            // FUTURE: this code should be responsible for opening
-            // file-handle(s) itself, and passing them into sqlite via a custom
-            // vfs. For now though - simply check if the file exists or not, and
-            // perform early validation of filesystem-level create options.
-            match (create_with_len.is_some(), path.exists()) {
-                (true, true) => anyhow::bail!(
-                    "cannot create new sqlite disk at {} - file already exists",
-                    path.display()
-                ),
-                (false, false) => anyhow::bail!(
-                    "cannot open sqlite disk at {} - file not found",
-                    path.display()
-                ),
-                _ => {}
+        match disk_cli {
+            &DiskCliKind::Memory(len) => {
+                layers.push(layer(RamDiskLayerHandle {
+                    len: Some(len),
+                    sector_size: None,
+                }));
             }
-
-            layers.push(layer(SqliteDiskLayerHandle {
-                dbhd_path: path.display().to_string(),
-                format_dbhd: create_with_len.map(|len| {
-                    disk_backend_resources::layer::SqliteDiskLayerFormatParams {
-                        logically_read_only: false,
-                        len: Some(len),
-                    }
-                }),
-            }));
-        }
-        DiskCliKind::SqliteDiff { path, create, disk } => {
-            // FUTURE: this code should be responsible for opening
-            // file-handle(s) itself, and passing them into sqlite via a custom
-            // vfs. For now though - simply check if the file exists or not, and
-            // perform early validation of filesystem-level create options.
-            match (create, path.exists()) {
-                (true, true) => anyhow::bail!(
-                    "cannot create new sqlite disk at {} - file already exists",
-                    path.display()
-                ),
-                (false, false) => anyhow::bail!(
-                    "cannot open sqlite disk at {} - file not found",
-                    path.display()
-                ),
-                _ => {}
-            }
-
-            layers.push(layer(SqliteDiskLayerHandle {
-                dbhd_path: path.display().to_string(),
-                format_dbhd: create.then_some(
-                    disk_backend_resources::layer::SqliteDiskLayerFormatParams {
-                        logically_read_only: false,
-                        len: None,
+            DiskCliKind::File {
+                path,
+                create_with_len,
+                direct,
+            } => layers.push(LayerOrDisk::Disk(if let Some(size) = create_with_len {
+                create_disk_type(
+                    path,
+                    *size,
+                    OpenDiskOptions {
+                        read_only: false,
+                        direct: *direct,
                     },
-                ),
-            }));
-            disk_open_inner(disk, true, layers)?;
-        }
-        DiskCliKind::AutoCacheSqlite {
-            cache_path,
-            key,
-            disk,
-        } => {
-            layers.push(LayerOrDisk::Layer(DiskLayerDescription {
-                read_cache: true,
-                write_through: false,
-                layer: SqliteAutoCacheDiskLayerHandle {
-                    cache_path: cache_path.clone(),
-                    cache_key: key.clone(),
+                )
+                .with_context(|| format!("failed to create {}", path.display()))?
+            } else {
+                open_disk_type(
+                    path,
+                    OpenDiskOptions {
+                        read_only,
+                        direct: *direct,
+                    },
+                )
+                .await
+                .with_context(|| format!("failed to open {}", path.display()))?
+            })),
+            DiskCliKind::Blob { kind, url } => {
+                layers.push(disk(disk_backend_resources::BlobDiskHandle {
+                    url: url.to_owned(),
+                    format: match kind {
+                        cli_args::BlobKind::Flat => disk_backend_resources::BlobDiskFormat::Flat,
+                        cli_args::BlobKind::Vhd1 => {
+                            disk_backend_resources::BlobDiskFormat::FixedVhd1
+                        }
+                    },
+                }))
+            }
+            DiskCliKind::MemoryDiff(inner) => {
+                layers.push(layer(RamDiskLayerHandle {
+                    len: None,
+                    sector_size: None,
+                }));
+                disk_open_inner(inner, true, layers).await?;
+            }
+            DiskCliKind::PersistentReservationsWrapper(inner) => {
+                layers.push(disk(disk_backend_resources::DiskWithReservationsHandle(
+                    disk_open(inner, read_only).await?,
+                )))
+            }
+            DiskCliKind::DelayDiskWrapper {
+                delay_ms,
+                disk: inner,
+            } => layers.push(disk(DelayDiskHandle {
+                delay: CellUpdater::new(Duration::from_millis(*delay_ms)).cell(),
+                disk: disk_open(inner, read_only).await?,
+            })),
+            DiskCliKind::Crypt {
+                disk: inner,
+                cipher,
+                key_file,
+            } => layers.push(disk(disk_crypt_resources::DiskCryptHandle {
+                disk: disk_open(inner, read_only).await?,
+                cipher: match cipher {
+                    cli_args::DiskCipher::XtsAes256 => disk_crypt_resources::Cipher::XtsAes256,
+                },
+                key: fs_err::read(key_file).context("failed to read key file")?,
+            })),
+            DiskCliKind::Sqlite {
+                path,
+                create_with_len,
+            } => {
+                // FUTURE: this code should be responsible for opening
+                // file-handle(s) itself, and passing them into sqlite via a custom
+                // vfs. For now though - simply check if the file exists or not, and
+                // perform early validation of filesystem-level create options.
+                match (create_with_len.is_some(), path.exists()) {
+                    (true, true) => anyhow::bail!(
+                        "cannot create new sqlite disk at {} - file already exists",
+                        path.display()
+                    ),
+                    (false, false) => anyhow::bail!(
+                        "cannot open sqlite disk at {} - file not found",
+                        path.display()
+                    ),
+                    _ => {}
                 }
-                .into_resource(),
-            }));
-            disk_open_inner(disk, read_only, layers)?;
+
+                layers.push(layer(SqliteDiskLayerHandle {
+                    dbhd_path: path.display().to_string(),
+                    format_dbhd: create_with_len.map(|len| {
+                        disk_backend_resources::layer::SqliteDiskLayerFormatParams {
+                            logically_read_only: false,
+                            len: Some(len),
+                        }
+                    }),
+                }));
+            }
+            DiskCliKind::SqliteDiff { path, create, disk } => {
+                // FUTURE: this code should be responsible for opening
+                // file-handle(s) itself, and passing them into sqlite via a custom
+                // vfs. For now though - simply check if the file exists or not, and
+                // perform early validation of filesystem-level create options.
+                match (create, path.exists()) {
+                    (true, true) => anyhow::bail!(
+                        "cannot create new sqlite disk at {} - file already exists",
+                        path.display()
+                    ),
+                    (false, false) => anyhow::bail!(
+                        "cannot open sqlite disk at {} - file not found",
+                        path.display()
+                    ),
+                    _ => {}
+                }
+
+                layers.push(layer(SqliteDiskLayerHandle {
+                    dbhd_path: path.display().to_string(),
+                    format_dbhd: create.then_some(
+                        disk_backend_resources::layer::SqliteDiskLayerFormatParams {
+                            logically_read_only: false,
+                            len: None,
+                        },
+                    ),
+                }));
+                disk_open_inner(disk, true, layers).await?;
+            }
+            DiskCliKind::AutoCacheSqlite {
+                cache_path,
+                key,
+                disk,
+            } => {
+                layers.push(LayerOrDisk::Layer(DiskLayerDescription {
+                    read_cache: true,
+                    write_through: false,
+                    layer: SqliteAutoCacheDiskLayerHandle {
+                        cache_path: cache_path.clone(),
+                        cache_key: key.clone(),
+                    }
+                    .into_resource(),
+                }));
+                disk_open_inner(disk, read_only, layers).await?;
+            }
         }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Get the system page size.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -507,15 +507,16 @@ async fn vm_config_from_command_line(
         if underhill.is_some() {
             anyhow::bail!("underhill not supported with virtio-blk");
         }
-        storage.add(
-            vtl,
-            None,
-            storage_builder::DiskLocation::VirtioBlk(pcie_port.clone()),
-            kind,
-            is_dvd,
-            read_only,
-        )
-        .await?;
+        storage
+            .add(
+                vtl,
+                None,
+                storage_builder::DiskLocation::VirtioBlk(pcie_port.clone()),
+                kind,
+                is_dvd,
+                read_only,
+            )
+            .await?;
     }
 
     let mut floppy_disks = Vec::new();

--- a/openvmm/openvmm_entry/src/repl.rs
+++ b/openvmm/openvmm_entry/src/repl.rs
@@ -898,6 +898,7 @@ pub(crate) async fn run_repl(
                                     direct: false,
                                 },
                             )
+                            .await
                             .with_context(|| format!("failed to open {}", path.display()))?
                         }
                         Some(size) => {
@@ -1092,6 +1093,7 @@ pub(crate) async fn run_repl(
                                 direct: false,
                             },
                         )
+                        .await
                         .with_context(|| format!("failed to open {}", path.display()))?,
                         (Some(size), None) => {
                             Resource::new(disk_backend_resources::LayeredDiskHandle::single_layer(

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -131,7 +131,7 @@ impl StorageBuilder {
         !self.vtl0_nvme_namespaces.is_empty() || !self.underhill_nvme_luns.is_empty()
     }
 
-    pub fn add(
+    pub async fn add(
         &mut self,
         vtl: DeviceVtl,
         underhill: Option<UnderhillDiskSource>,
@@ -144,16 +144,17 @@ impl StorageBuilder {
             if vtl != DeviceVtl::Vtl0 {
                 anyhow::bail!("underhill can only offer devices to vtl0");
             }
-            self.add_underhill(source.into(), target, kind, is_dvd, read_only)?;
+            self.add_underhill(source.into(), target, kind, is_dvd, read_only)
+                .await?;
         } else {
-            self.add_inner(vtl, target, kind, is_dvd, read_only)?;
+            self.add_inner(vtl, target, kind, is_dvd, read_only).await?;
         }
         Ok(())
     }
 
     /// Returns the "sub device path" for assigning this into Underhill, or
     /// `None` if Underhill can't use this device as a source.
-    fn add_inner(
+    async fn add_inner(
         &mut self,
         vtl: DeviceVtl,
         target: DiskLocation,
@@ -161,7 +162,7 @@ impl StorageBuilder {
         is_dvd: bool,
         read_only: bool,
     ) -> anyhow::Result<Option<u32>> {
-        let disk = disk_open(kind, read_only || is_dvd)?;
+        let disk = disk_open(kind, read_only || is_dvd).await?;
         let location = match target {
             DiskLocation::Ide(channel, device) => {
                 let guest_media = if is_dvd {
@@ -280,7 +281,7 @@ impl StorageBuilder {
         Ok(location)
     }
 
-    fn add_underhill(
+    async fn add_underhill(
         &mut self,
         source: DiskLocation,
         target: DiskLocation,
@@ -290,7 +291,8 @@ impl StorageBuilder {
     ) -> anyhow::Result<()> {
         let vtl = self.openhcl_vtl.context("openhcl not configured")?;
         let sub_device_path = self
-            .add_inner(vtl, source.clone(), kind, is_dvd, read_only)?
+            .add_inner(vtl, source.clone(), kind, is_dvd, read_only)
+            .await?
             .context("source device not supported by underhill")?;
 
         let (device_type, device_path) = match source {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -618,7 +618,7 @@ impl VmService {
             if !devices_config.scsi_disks.is_empty() {
                 let mut devices = Vec::new();
                 for disk in devices_config.scsi_disks {
-                    devices.push(make_disk_config(disk)?);
+                    devices.push(make_disk_config(disk).await?);
                 }
                 let (send, recv) = mesh::channel();
                 config.vmbus_devices.push((
@@ -815,13 +815,15 @@ impl VmService {
                     if disk.controller != 0 {
                         anyhow::bail!("controller must be 0");
                     }
-                    let config = make_disk_config(disk)?;
-                    let recv = vm
-                        .scsi_rpc
-                        .as_ref()
-                        .context("no scsi controller")?
-                        .call_failable(ScsiControllerRequest::AddDevice, config);
-                    Ok(async move { recv.await.map_err(anyhow::Error::from) }.boxed())
+                    let scsi_rpc = vm.scsi_rpc.as_ref().context("no scsi controller")?.clone();
+                    Ok(async move {
+                        let config = make_disk_config(disk).await?;
+                        scsi_rpc
+                            .call_failable(ScsiControllerRequest::AddDevice, config)
+                            .await
+                            .map_err(anyhow::Error::from)
+                    }
+                    .boxed())
                 } else if request.r#type == vmservice::ModifyType::Remove as i32 {
                     let recv = vm
                         .scsi_rpc
@@ -902,7 +904,7 @@ fn parse_nic_config(
     Ok((DeviceVtl::Vtl0, cfg.into_resource()))
 }
 
-fn make_disk_config(disk: vmservice::ScsiDisk) -> anyhow::Result<ScsiDeviceAndPath> {
+async fn make_disk_config(disk: vmservice::ScsiDisk) -> anyhow::Result<ScsiDeviceAndPath> {
     Ok(ScsiDeviceAndPath {
         path: storvsp_resources::ScsiPath {
             path: 0,
@@ -917,6 +919,7 @@ fn make_disk_config(disk: vmservice::ScsiDisk) -> anyhow::Result<ScsiDeviceAndPa
                     direct: false,
                 },
             )
+            .await
             .with_context(|| format!("failed to open {}", disk.host_path))?,
             read_only: disk.read_only,
             parameters: Default::default(),

--- a/openvmm/openvmm_helpers/src/disk.rs
+++ b/openvmm/openvmm_helpers/src/disk.rs
@@ -36,7 +36,7 @@ pub struct OpenDiskOptions {
 /// If the file ends with .vhd and is a fixed VHD1, it will be opened using
 /// the user-mode VHD parser. Otherwise, if the file ends with .vhd or
 /// .vhdx, the file will be opened using the kernel-mode VHD parser.
-pub fn open_disk_type(
+pub async fn open_disk_type(
     path: &Path,
     options: OpenDiskOptions,
 ) -> anyhow::Result<Resource<DiskHandleKind>> {

--- a/petri/burette/src/tests/disk_io.rs
+++ b/petri/burette/src/tests/disk_io.rs
@@ -175,6 +175,7 @@ impl crate::harness::WarmPerfTest for DiskIoTest {
                 // Build the disk resource before entering the closure (which
                 // can't propagate errors).
                 let disk = make_disk_resource(&data_disk_path, disk_size_bytes)
+                    .await
                     .context("failed to create data disk resource")?;
                 builder = builder.modify_backend(move |b| {
                     b.with_nic()
@@ -337,7 +338,7 @@ impl crate::harness::WarmPerfTest for DiskIoTest {
 }
 
 /// Create a disk resource from either a file path or a RAM-backed disk.
-fn make_disk_resource(
+async fn make_disk_resource(
     path: &Option<PathBuf>,
     size_bytes: u64,
 ) -> anyhow::Result<vm_resource::Resource<vm_resource::kind::DiskHandleKind>> {
@@ -349,6 +350,7 @@ fn make_disk_resource(
                 direct: false,
             },
         )
+        .await
         .with_context(|| format!("failed to open data disk at {}", p.display())),
         None => {
             use disk_backend_resources::LayeredDiskHandle;

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -205,9 +205,9 @@ impl PetriVmConfigOpenVmm {
             None => (None, None, None),
         };
 
-        let ide_disks = ide_controllers_to_openvmm(firmware.ide_controllers())?;
+        let ide_disks = ide_controllers_to_openvmm(firmware.ide_controllers()).await?;
         let (mut vmbus_devices, vpci_devices) =
-            vmbus_storage_controllers_to_openvmm(&vmbus_storage_controllers)?;
+            vmbus_storage_controllers_to_openvmm(&vmbus_storage_controllers).await?;
 
         let pcie_devices = pcie_nvme_drives
             .into_iter()
@@ -250,12 +250,14 @@ impl PetriVmConfigOpenVmm {
         };
 
         let (with_vtl2, vtl2_vmbus, ged, ged_send, vtl2_vsock_path) = if firmware.is_openhcl() {
-            let (ged, ged_send) = setup.config_openhcl_vmbus_devices(
-                &mut emulated_serial_config,
-                &mut vmbus_devices,
-                &firmware_event_send,
-                framebuffer.is_some(),
-            )?;
+            let (ged, ged_send) = setup
+                .config_openhcl_vmbus_devices(
+                    &mut emulated_serial_config,
+                    &mut vmbus_devices,
+                    &firmware_event_send,
+                    framebuffer.is_some(),
+                )
+                .await?;
 
             let late_map_vtl0_memory = match load_mode {
                 LoadMode::Igvm {
@@ -458,7 +460,7 @@ impl PetriVmConfigOpenVmm {
         let vmgs = if firmware.is_openhcl() {
             None
         } else {
-            Some(memdiff_vmgs(&vmgs)?)
+            Some(memdiff_vmgs(&vmgs).await?)
         };
 
         let VmChipsetResult {
@@ -881,7 +883,7 @@ impl PetriVmConfigSetupCore<'_> {
         })
     }
 
-    fn config_openhcl_vmbus_devices(
+    async fn config_openhcl_vmbus_devices(
         &self,
         serial: &mut [Option<Resource<SerialBackendHandle>>],
         devices: &mut impl Extend<(DeviceVtl, Resource<VmbusDeviceHandleKind>)>,
@@ -955,7 +957,7 @@ impl PetriVmConfigSetupCore<'_> {
             serial_tx_only: false,
             vmbus_redirection: *vmbus_redirect,
             vtl2_settings: None, // Will be added at startup to allow tests to modify
-            vmgs: memdiff_vmgs(self.vmgs)?,
+            vmgs: memdiff_vmgs(self.vmgs).await?,
             framebuffer: framebuffer.then(|| SharedFramebufferHandle.into_resource()),
             guest_request_recv,
             enable_tpm: self.tpm_config.is_some(),
@@ -1114,7 +1116,7 @@ fn spawn_dump_handler(driver: &DefaultDriver, logger: &PetriLogSource) -> GuestC
 }
 
 /// Convert the generic IDE configuration to OpenVMM IDE disks.
-fn ide_controllers_to_openvmm(
+async fn ide_controllers_to_openvmm(
     ide_controllers: Option<&[[Option<Drive>; 2]; 2]>,
 ) -> anyhow::Result<Vec<IdeDeviceConfig>> {
     let mut ide_disks = Vec::new();
@@ -1124,7 +1126,7 @@ fn ide_controllers_to_openvmm(
             for (controller_location, drive) in controller.iter().enumerate() {
                 if let Some(drive) = drive {
                     if let Some(disk) = &drive.disk {
-                        let disk = petri_disk_to_openvmm(disk)?;
+                        let disk = petri_disk_to_openvmm(disk).await?;
                         let guest_media = if drive.is_dvd {
                             GuestMedia::Dvd(
                                 SimpleScsiDvdHandle {
@@ -1158,7 +1160,7 @@ fn ide_controllers_to_openvmm(
 }
 
 /// Convert the generic VMBUS storage configuration to OpenVMM VMBUS and VPCI devices.
-fn vmbus_storage_controllers_to_openvmm(
+async fn vmbus_storage_controllers_to_openvmm(
     vmbus_storage_controllers: &HashMap<Guid, VmbusStorageController>,
 ) -> anyhow::Result<(
     Vec<(DeviceVtl, Resource<VmbusDeviceHandleKind>)>,
@@ -1186,7 +1188,7 @@ fn vmbus_storage_controllers_to_openvmm(
                                 lun: (*lun).try_into().expect("invalid scsi lun"),
                             },
                             device: SimpleScsiDiskHandle {
-                                disk: petri_disk_to_openvmm(disk)?,
+                                disk: petri_disk_to_openvmm(disk).await?,
                                 read_only: false,
                                 parameters: Default::default(),
                             }
@@ -1217,7 +1219,7 @@ fn vmbus_storage_controllers_to_openvmm(
                         namespaces.push(NamespaceDefinition {
                             nsid: *nsid,
                             read_only: false,
-                            disk: petri_disk_to_openvmm(disk)?,
+                            disk: petri_disk_to_openvmm(disk).await?,
                         });
                     } else {
                         todo!("dvd ({}) or empty ({})", *is_dvd, disk.is_none())

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -209,37 +209,35 @@ impl PetriVmConfigOpenVmm {
         let (mut vmbus_devices, vpci_devices) =
             vmbus_storage_controllers_to_openvmm(&vmbus_storage_controllers).await?;
 
-        let pcie_devices = pcie_nvme_drives
-            .into_iter()
-            .map(
-                |PcieNvmeDrive {
-                     port_name,
-                     nsid,
-                     drive: Drive { disk, .. },
-                 }| {
-                    let disk = disk.ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "missing disk for PCIe NVMe drive on port '{port_name}' (nsid {nsid})"
-                        )
-                    })?;
-                    petri_disk_to_openvmm(&disk).map(|disk| PcieDeviceConfig {
-                        port_name,
-                        resource: NvmeControllerHandle {
-                            subsystem_id: guid::guid!("a1b2c3d4-e5f6-7890-abcd-ef0123456789"),
-                            max_io_queues: 64,
-                            msix_count: 64,
-                            namespaces: vec![NamespaceDefinition {
-                                nsid,
-                                read_only: false,
-                                disk,
-                            }],
-                            requests: None,
-                        }
-                        .into_resource(),
-                    })
-                },
-            )
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut pcie_devices = Vec::new();
+        for PcieNvmeDrive {
+            port_name,
+            nsid,
+            drive: Drive { disk, .. },
+        } in pcie_nvme_drives
+        {
+            let disk = disk.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "missing disk for PCIe NVMe drive on port '{port_name}' (nsid {nsid})"
+                )
+            })?;
+            let disk = petri_disk_to_openvmm(&disk).await?;
+            pcie_devices.push(PcieDeviceConfig {
+                port_name,
+                resource: NvmeControllerHandle {
+                    subsystem_id: guid::guid!("a1b2c3d4-e5f6-7890-abcd-ef0123456789"),
+                    max_io_queues: 64,
+                    msix_count: 64,
+                    namespaces: vec![NamespaceDefinition {
+                        nsid,
+                        read_only: false,
+                        disk,
+                    }],
+                    requests: None,
+                }
+                .into_resource(),
+            });
+        }
 
         let (firmware_event_send, firmware_event_recv) = mesh::mpsc_channel();
 
@@ -1262,7 +1260,7 @@ async fn vmbus_storage_controllers_to_openvmm(
                         instance_id: drive_id,
                         resource: VirtioPciDeviceHandle(
                             VirtioBlkHandle {
-                                disk: petri_disk_to_openvmm(disk)?,
+                                disk: petri_disk_to_openvmm(disk).await?,
                                 read_only: false,
                             }
                             .into_resource(),

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -193,7 +193,7 @@ struct PetriVmResourcesOpenVmm {
     properties: PetriVmProperties,
 }
 
-fn memdiff_disk(path: &Path) -> anyhow::Result<Resource<DiskHandleKind>> {
+async fn memdiff_disk(path: &Path) -> anyhow::Result<Resource<DiskHandleKind>> {
     let disk = open_disk_type(
         path,
         OpenDiskOptions {
@@ -201,6 +201,7 @@ fn memdiff_disk(path: &Path) -> anyhow::Result<Resource<DiskHandleKind>> {
             direct: false,
         },
     )
+    .await
     .with_context(|| format!("failed to open disk: {}", path.display()))?;
     Ok(LayeredDiskHandle {
         layers: vec![
@@ -270,32 +271,34 @@ fn memdiff_remote_disk(url: &str) -> anyhow::Result<Resource<DiskHandleKind>> {
     .into_resource())
 }
 
-fn memdiff_vmgs(vmgs: &PetriVmgsResource) -> anyhow::Result<VmgsResource> {
-    let convert_disk = |disk: &PetriVmgsDisk| -> anyhow::Result<VmgsDisk> {
+async fn memdiff_vmgs(vmgs: &PetriVmgsResource) -> anyhow::Result<VmgsResource> {
+    async fn convert_disk(disk: &PetriVmgsDisk) -> anyhow::Result<VmgsDisk> {
         Ok(VmgsDisk {
-            disk: petri_disk_to_openvmm(&disk.disk)?,
+            disk: petri_disk_to_openvmm(&disk.disk).await?,
             encryption_policy: disk.encryption_policy,
         })
-    };
+    }
 
     Ok(match vmgs {
-        PetriVmgsResource::Disk(disk) => VmgsResource::Disk(convert_disk(disk)?),
+        PetriVmgsResource::Disk(disk) => VmgsResource::Disk(convert_disk(disk).await?),
         PetriVmgsResource::ReprovisionOnFailure(disk) => {
-            VmgsResource::ReprovisionOnFailure(convert_disk(disk)?)
+            VmgsResource::ReprovisionOnFailure(convert_disk(disk).await?)
         }
-        PetriVmgsResource::Reprovision(disk) => VmgsResource::Reprovision(convert_disk(disk)?),
+        PetriVmgsResource::Reprovision(disk) => {
+            VmgsResource::Reprovision(convert_disk(disk).await?)
+        }
         PetriVmgsResource::Ephemeral => VmgsResource::Ephemeral,
     })
 }
 
-fn petri_disk_to_openvmm(disk: &Disk) -> anyhow::Result<Resource<DiskHandleKind>> {
+async fn petri_disk_to_openvmm(disk: &Disk) -> anyhow::Result<Resource<DiskHandleKind>> {
     Ok(match disk {
         Disk::Memory(len) => LayeredDiskHandle::single_layer(RamDiskLayerHandle {
             len: Some(*len),
             sector_size: None,
         })
         .into_resource(),
-        Disk::Differencing(DiskPath::Local(path)) => memdiff_disk(path)?,
+        Disk::Differencing(DiskPath::Local(path)) => memdiff_disk(path).await?,
         Disk::Differencing(DiskPath::Remote { url }) => memdiff_remote_disk(url)?,
         Disk::Persistent(path) => open_disk_type(
             path.as_ref(),
@@ -303,13 +306,15 @@ fn petri_disk_to_openvmm(disk: &Disk) -> anyhow::Result<Resource<DiskHandleKind>
                 read_only: false,
                 direct: false,
             },
-        )?,
+        )
+        .await?,
         Disk::Temporary(path) => open_disk_type(
             path.as_ref(),
             OpenDiskOptions {
                 read_only: false,
                 direct: false,
             },
-        )?,
+        )
+        .await?,
     })
 }

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -300,21 +300,25 @@ async fn petri_disk_to_openvmm(disk: &Disk) -> anyhow::Result<Resource<DiskHandl
         .into_resource(),
         Disk::Differencing(DiskPath::Local(path)) => memdiff_disk(path).await?,
         Disk::Differencing(DiskPath::Remote { url }) => memdiff_remote_disk(url)?,
-        Disk::Persistent(path) => open_disk_type(
-            path.as_ref(),
-            OpenDiskOptions {
-                read_only: false,
-                direct: false,
-            },
-        )
-        .await?,
-        Disk::Temporary(path) => open_disk_type(
-            path.as_ref(),
-            OpenDiskOptions {
-                read_only: false,
-                direct: false,
-            },
-        )
-        .await?,
+        Disk::Persistent(path) => {
+            open_disk_type(
+                path.as_ref(),
+                OpenDiskOptions {
+                    read_only: false,
+                    direct: false,
+                },
+            )
+            .await?
+        }
+        Disk::Temporary(path) => {
+            open_disk_type(
+                path.as_ref(),
+                OpenDiskOptions {
+                    read_only: false,
+                    direct: false,
+                },
+            )
+            .await?
+        }
     })
 }

--- a/vmm_tests/prep_steps/src/main.rs
+++ b/vmm_tests/prep_steps/src/main.rs
@@ -101,13 +101,16 @@ fn run(
     let drop_guard = DeleteFileOnDrop(result_disk.clone());
     std::fs::copy(source_disk, &result_disk)?;
     tracing::info!("Copied source disk successfully.");
-    let result_disk = openvmm_helpers::disk::open_disk_type(
-        &result_disk,
-        openvmm_helpers::disk::OpenDiskOptions {
-            read_only: false,
-            direct: false,
-        },
-    )?;
+    let result_disk = DefaultPool::run_with(async |_driver| {
+        openvmm_helpers::disk::open_disk_type(
+            &result_disk,
+            openvmm_helpers::disk::OpenDiskOptions {
+                read_only: false,
+                direct: false,
+            },
+        )
+        .await
+    })?;
 
     DefaultPool::run_with(async move |driver| {
         let (vm, agent) = PetriVmBuilder::new(


### PR DESCRIPTION
This is a pure refactor that makes `open_disk_type` async in preparation for adding the pure-Rust VHDX parser, which needs async file I/O to walk differencing disk parent chains at open time. Propagate async up the stack where necessary.