### PR TITLE
vfio_assigned_device: quiesce device via Command register on reset

### DIFF
--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -578,6 +578,21 @@ impl ChangeDeviceState for VfioAssignedPciDevice {
             self.msix_disable();
         }
 
+        // Quiesce the physical device by clearing Bus Master Enable,
+        // Memory Space Enable, and I/O Space Enable in the Command
+        // register. VFIO passes these bits through to real hardware (only
+        // INTx Disable is virtualized), so this actually stops the device
+        // from mastering DMA and from decoding MMIO/PIO on the physical
+        // bus. Without this, a device that lacks VFIO_DEVICE_RESET support
+        // would continue mastering the bus after a VM reset.
+        let command = cfg_space::Command::from_bits(
+            self.read_phys_config(HeaderType00::STATUS_COMMAND.0) as u16,
+        )
+        .with_pio_enabled(false)
+        .with_mmio_enabled(false)
+        .with_bus_master(false);
+        self.write_phys_config(HeaderType00::STATUS_COMMAND.0, command.into_bits().into());
+
         // Destructure to ensure every field is explicitly considered for reset.
         let Self {
             pci_id,


### PR DESCRIPTION
Before issuing VFIO_DEVICE_RESET (or when the device doesn't support it at all), clear Bus Master Enable, Memory Space Enable, and I/O Space Enable in the PCI Command register. VFIO passes these bits through to real hardware, so this stops the device from initiating DMA and from decoding MMIO/PIO on the physical bus.

Without this, a device that lacks VFIO_DEVICE_RESET would retain BME after a VM reset, allowing it to continue DMA through the IOMMU with stale mappings.