### PR TITLE
Repo: Cleanup a few remaining allows

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -329,8 +329,6 @@ enum HvcallRepInput<'a, T> {
 }
 
 pub(crate) mod ioctls {
-    #![allow(non_camel_case_types)]
-
     use crate::protocol;
     use hvdef::hypercall::HvRegisterAssoc;
     use nix::ioctl_none;

--- a/openhcl/hcl/src/vmbus.rs
+++ b/openhcl/hcl/src/vmbus.rs
@@ -9,8 +9,6 @@ use std::fs::File;
 use std::os::unix::prelude::*;
 
 mod ioctl {
-    #![allow(non_camel_case_types)]
-
     use nix::ioctl_write_ptr;
     use std::os::unix::prelude::*;
 

--- a/support/open_enum/src/lib.rs
+++ b/support/open_enum/src/lib.rs
@@ -76,7 +76,7 @@ macro_rules! open_enum {
         }
         impl ::core::fmt::Debug for $name {
             fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                #![allow(unreachable_patterns)]
+                //#[allow(unreachable_patterns)]
                 let s = match *self {
                     $( Self::$variant => stringify!($variant), )*
                     _ => {

--- a/support/open_enum/src/lib.rs
+++ b/support/open_enum/src/lib.rs
@@ -76,7 +76,7 @@ macro_rules! open_enum {
         }
         impl ::core::fmt::Debug for $name {
             fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                //#[allow(unreachable_patterns)]
+                #[allow(unreachable_patterns)]
                 let s = match *self {
                     $( Self::$variant => stringify!($variant), )*
                     _ => {

--- a/support/pal/src/windows.rs
+++ b/support/pal/src/windows.rs
@@ -1100,7 +1100,8 @@ macro_rules! delayload {
 
         pub mod is_supported {
             #![expect(non_snake_case)]
-            #![allow(dead_code)]
+            #[expect(clippy::allow_attributes)]
+            #[allow(dead_code)]
             $(
                 $(#[$a])*
                 pub fn $name() -> bool {

--- a/vm/devices/support/fs/fuse/src/protocol.rs
+++ b/vm/devices/support/fs/fuse/src/protocol.rs
@@ -7,7 +7,6 @@
 //! FUSE protocol version 7.31.
 //!
 //! For more details, see fuse.h.
-#![allow(non_camel_case_types)]
 #![expect(unused_parens)]
 
 use bitfield_struct::bitfield;

--- a/vm/devices/vmbus/vmbfs/src/protocol.rs
+++ b/vm/devices/vmbus/vmbfs/src/protocol.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(dead_code)]
+
 use bitfield_struct::bitfield;
 use guid::Guid;
 use open_enum::open_enum;
@@ -76,7 +78,6 @@ pub struct VersionResponse {
     pub status: VersionStatus,
 }
 
-#[expect(dead_code)]
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct GetFileInfoRequest {
@@ -116,7 +117,6 @@ pub struct ReadFileResponse {
     // Followed by the data.
 }
 
-#[expect(dead_code)]
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct ReadFileRdmaRequest {
@@ -127,7 +127,6 @@ pub struct ReadFileRdmaRequest {
     // Followed by a UTF-16 file path.
 }
 
-#[expect(dead_code)]
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct ReadFileRdmaResponse {

--- a/vm/devices/vmbus/vmbfs/src/protocol.rs
+++ b/vm/devices/vmbus/vmbfs/src/protocol.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
-
 use bitfield_struct::bitfield;
 use guid::Guid;
 use open_enum::open_enum;
@@ -78,6 +76,7 @@ pub struct VersionResponse {
     pub status: VersionStatus,
 }
 
+#[expect(dead_code)]
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct GetFileInfoRequest {
@@ -117,6 +116,7 @@ pub struct ReadFileResponse {
     // Followed by the data.
 }
 
+#[expect(dead_code)]
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct ReadFileRdmaRequest {
@@ -127,6 +127,7 @@ pub struct ReadFileRdmaRequest {
     // Followed by a UTF-16 file path.
 }
 
+#[expect(dead_code)]
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct ReadFileRdmaResponse {


### PR DESCRIPTION
Annoyingly the clippy lint we've recently turned on does not catch #![allows, only #[allows. Fix up the ones that slipped through.