### PR TITLE
deps: fix incorrect VS2022 references for AArch64 mu_msvm

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -46,7 +46,7 @@ AARCH64_OPENVMM_LINUX_DIRECT_INITRD = { value = ".packages/underhill-deps-privat
 # Streamline the OpenVMM `cargo run` experience by setting a sane-default for
 # what UEFI firmware to use (i.e: use the Microsoft MSVM firmware)
 X86_64_OPENVMM_UEFI_FIRMWARE = { value = ".packages/hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV/MSVM.fd", relative = true }
-AARCH64_OPENVMM_UEFI_FIRMWARE = { value = ".packages/hyperv.uefi.mscoreuefi.AARCH64.RELEASE/MsvmAARCH64/RELEASE_VS2022/FV/MSVM.fd", relative = true }
+AARCH64_OPENVMM_UEFI_FIRMWARE = { value = ".packages/hyperv.uefi.mscoreuefi.AARCH64.RELEASE/MsvmAARCH64/RELEASE_CLANGPDB/FV/MSVM.fd", relative = true }
 
 [target.'cfg(all(windows, target_env = "msvc"))']
 rustflags = [

--- a/Guide/src/user_guide/openvmm/run.md
+++ b/Guide/src/user_guide/openvmm/run.md
@@ -57,7 +57,7 @@ If you ran `cargo xflowey restore-packages`, the firmware is at:
 
 ```text
 .packages/hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV/MSVM.fd        # x64
-.packages/hyperv.uefi.mscoreuefi.AARCH64.RELEASE/MsvmAARCH64/RELEASE_VS2022/FV/MSVM.fd # aarch64
+.packages/hyperv.uefi.mscoreuefi.AARCH64.RELEASE/MsvmAARCH64/RELEASE_CLANGPDB/FV/MSVM.fd # aarch64
 ```
 
 If you used `cargo xflowey vmm-tests-run --build-only --dir <out>`, the firmware

--- a/flowey/flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs
+++ b/flowey/flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs
@@ -65,22 +65,14 @@ impl FlowNode for Node {
                 let openvmm_magicpath = rt.read(openvmm_magicpath);
                 for (arch, (msvm_fd, _dones)) in packages {
                     let msvm_fd = rt.read(msvm_fd);
-                    let dst_folder = openvmm_magicpath
-                        .join(format!(
-                            "hyperv.uefi.mscoreuefi.{}.RELEASE",
-                            match arch {
-                                CommonArch::Aarch64 => "AARCH64",
-                                CommonArch::X86_64 => "x64",
-                            }
-                        ))
-                        .join(format!(
-                            "Msvm{}",
-                            match arch {
-                                CommonArch::Aarch64 => "AARCH64",
-                                CommonArch::X86_64 => "X64",
-                            }
-                        ))
-                        .join("RELEASE_VS2022/FV");
+                    let dst_folder = openvmm_magicpath.join(match arch {
+                        CommonArch::Aarch64 => {
+                            "hyperv.uefi.mscoreuefi.AARCH64.RELEASE/MsvmAARCH64/RELEASE_CLANGPDB/FV"
+                        }
+                        CommonArch::X86_64 => {
+                            "hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV"
+                        }
+                    });
                     let dst = dst_folder.join("MSVM.fd");
 
                     if msvm_fd.absolute()? != dst.absolute()? {

--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -429,23 +429,14 @@ impl SimpleFlowNode for Node {
                     test_content_dir.join(arch_dir).join(kernel_file_name),
                 )?;
 
-                let uefi_dir = test_content_dir
-                    .join(format!(
-                        "hyperv.uefi.mscoreuefi.{}.RELEASE",
-                        match arch {
-                            CommonArch::Aarch64 => "AARCH64",
-                            CommonArch::X86_64 => "x64",
-                        }
-                    ))
-                    .join(format!(
-                        "Msvm{}",
-                        match arch {
-                            CommonArch::Aarch64 => "AARCH64",
-                            CommonArch::X86_64 => "X64",
-                        }
-                    ))
-                    .join("RELEASE_VS2022")
-                    .join("FV");
+                let uefi_dir = test_content_dir.join(match arch {
+                    CommonArch::Aarch64 => {
+                        "hyperv.uefi.mscoreuefi.AARCH64.RELEASE/MsvmAARCH64/RELEASE_CLANGPDB/FV"
+                    }
+                    CommonArch::X86_64 => {
+                        "hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV"
+                    }
+                });
                 fs_err::create_dir_all(&uefi_dir)?;
                 fs_err::copy(uefi, uefi_dir.join("MSVM.fd"))?;
 

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -206,7 +206,7 @@ pub fn resolve_bundle_name(id: ErasedArtifactHandle) -> Option<&'static str> {
             Some("hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV/MSVM.fd")
         }
         _ if id == loadable::UEFI_FIRMWARE_AARCH64 => {
-            Some("hyperv.uefi.mscoreuefi.AARCH64.RELEASE/MsvmAARCH64/RELEASE_VS2022/FV/MSVM.fd")
+            Some("hyperv.uefi.mscoreuefi.AARCH64.RELEASE/MsvmAARCH64/RELEASE_CLANGPDB/FV/MSVM.fd")
         }
         _ => {
             // For test VHDs, the bundle name is the artifact filename from


### PR DESCRIPTION
#3320 missed a few cases, that aren't used by CI, but would break if you were running openvmm locally. 