### PR TITLE
Add CMOS RTC time source support to chipset resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "inspect",
+ "local_clock",
  "mesh",
  "vm_resource",
 ]
@@ -5502,6 +5503,7 @@ dependencies = [
  "build_rs_guest_arch",
  "chipset",
  "chipset_legacy",
+ "chipset_resources",
  "debug_worker",
  "disk_striped",
  "guest_watchdog",
@@ -5578,6 +5580,7 @@ dependencies = [
  "build_rs_guest_arch",
  "chipset",
  "chipset_legacy",
+ "chipset_resources",
  "debug_worker",
  "disk_blob",
  "disk_blockdevice",

--- a/openhcl/openvmm_hcl_resources/Cargo.toml
+++ b/openhcl/openvmm_hcl_resources/Cargo.toml
@@ -30,6 +30,7 @@ uidevices = { workspace = true, optional = true }
 
 chipset.workspace = true
 chipset_legacy.workspace = true
+chipset_resources.workspace = true
 hyperv_ic.workspace = true
 missing_dev.workspace = true
 serial_16550.workspace = true

--- a/openhcl/openvmm_hcl_resources/src/lib.rs
+++ b/openhcl/openvmm_hcl_resources/src/lib.rs
@@ -28,6 +28,7 @@ vm_resource::register_static_resolvers! {
     chipset::ioapic::resolver::GenericIoApicResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pm::resolver::HyperVPowerManagementResolver,
+    chipset_resources::cmos_rtc_time_source::SystemTimeClockResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]
     tpm_device::resolver::TpmDeviceResolver,

--- a/openhcl/underhill_core/src/emuplat/cmos_rtc_time_source.rs
+++ b/openhcl/underhill_core/src/emuplat/cmos_rtc_time_source.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resource resolver for the CMOS RTC time source.
+
+use super::local_clock::ArcMutexUnderhillLocalClock;
+use chipset_resources::CmosRtcTimeSourceHandleKind;
+use chipset_resources::ResolvedCmosRtcTimeSource;
+use vm_resource::PlatformResource;
+use vm_resource::ResolveResource;
+
+pub struct UnderhillCmosRtcTimeSourceResolver {
+    pub time_source: ArcMutexUnderhillLocalClock,
+}
+
+impl ResolveResource<CmosRtcTimeSourceHandleKind, PlatformResource>
+    for UnderhillCmosRtcTimeSourceResolver
+{
+    type Output = ResolvedCmosRtcTimeSource;
+    type Error = std::convert::Infallible;
+
+    fn resolve(&self, _resource: PlatformResource, (): ()) -> Result<Self::Output, Self::Error> {
+        Ok(ResolvedCmosRtcTimeSource(Box::new(
+            self.time_source.new_linked_clock(),
+        )))
+    }
+}

--- a/openhcl/underhill_core/src/emuplat/mod.rs
+++ b/openhcl/underhill_core/src/emuplat/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+pub mod cmos_rtc_time_source;
 pub mod firmware;
 pub mod framebuffer;
 pub mod i440bx_host_pci_bridge;

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -24,6 +24,7 @@ use crate::dispatch::vtl2_settings_worker::InitialControllers;
 use crate::dispatch::vtl2_settings_worker::disk_from_disk_type;
 use crate::dispatch::vtl2_settings_worker::wait_for_mana;
 use crate::emuplat::EmuplatServicing;
+use crate::emuplat::cmos_rtc_time_source::UnderhillCmosRtcTimeSourceResolver;
 use crate::emuplat::firmware::UnderhillLogger;
 use crate::emuplat::firmware::UnderhillVsmConfig;
 use crate::emuplat::framebuffer::FramebufferRemoteControl;
@@ -65,8 +66,6 @@ use anyhow::Context;
 use async_trait::async_trait;
 use chipset_device::ChipsetDevice;
 use chipset_device_worker_defs::RemoteChipsetDeviceHandle;
-use chipset_resources::CmosRtcTimeSourceHandleKind;
-use chipset_resources::ResolvedCmosRtcTimeSource;
 use closeable_mutex::CloseableMutex;
 use cvm_tracing::CVM_ALLOWED;
 use debug_ptr::DebugPtr;
@@ -155,7 +154,6 @@ use virt_mshv_vtl::UhProtoPartition;
 use vm_loader::initial_regs::initial_regs;
 use vm_resource::IntoResource;
 use vm_resource::PlatformResource;
-use vm_resource::ResolveResource;
 use vm_resource::Resource;
 use vm_resource::ResourceResolver;
 use vm_resource::kind::DiskHandleKind;
@@ -199,22 +197,6 @@ use watchdog_core::platform::WatchdogPlatform;
 use watchdog_core::resources::StaticWatchdogPlatformResolver;
 use zerocopy::FromZeros;
 
-struct UnderhillCmosRtcTimeSourceResolver {
-    time_source: ArcMutexUnderhillLocalClock,
-}
-
-impl ResolveResource<CmosRtcTimeSourceHandleKind, PlatformResource>
-    for UnderhillCmosRtcTimeSourceResolver
-{
-    type Output = ResolvedCmosRtcTimeSource;
-    type Error = std::convert::Infallible;
-
-    fn resolve(&self, _resource: PlatformResource, (): ()) -> Result<Self::Output, Self::Error> {
-        Ok(ResolvedCmosRtcTimeSource(Box::new(
-            self.time_source.new_linked_clock(),
-        )))
-    }
-}
 pub const UNDERHILL_WORKER: WorkerId<UnderhillWorkerParameters> = WorkerId::new("UnderhillWorker");
 
 const MAX_SUBCHANNELS_PER_VNIC: u16 = 32;

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -65,6 +65,8 @@ use anyhow::Context;
 use async_trait::async_trait;
 use chipset_device::ChipsetDevice;
 use chipset_device_worker_defs::RemoteChipsetDeviceHandle;
+use chipset_resources::CmosRtcTimeSourceHandleKind;
+use chipset_resources::ResolvedCmosRtcTimeSource;
 use closeable_mutex::CloseableMutex;
 use cvm_tracing::CVM_ALLOWED;
 use debug_ptr::DebugPtr;
@@ -152,6 +154,8 @@ use virt_mshv_vtl::UhPartitionNewParams;
 use virt_mshv_vtl::UhProtoPartition;
 use vm_loader::initial_regs::initial_regs;
 use vm_resource::IntoResource;
+use vm_resource::PlatformResource;
+use vm_resource::ResolveResource;
 use vm_resource::Resource;
 use vm_resource::ResourceResolver;
 use vm_resource::kind::DiskHandleKind;
@@ -195,6 +199,22 @@ use watchdog_core::platform::WatchdogPlatform;
 use watchdog_core::resources::StaticWatchdogPlatformResolver;
 use zerocopy::FromZeros;
 
+struct UnderhillCmosRtcTimeSourceResolver {
+    time_source: ArcMutexUnderhillLocalClock,
+}
+
+impl ResolveResource<CmosRtcTimeSourceHandleKind, PlatformResource>
+    for UnderhillCmosRtcTimeSourceResolver
+{
+    type Output = ResolvedCmosRtcTimeSource;
+    type Error = std::convert::Infallible;
+
+    fn resolve(&self, _resource: PlatformResource, (): ()) -> Result<Self::Output, Self::Error> {
+        Ok(ResolvedCmosRtcTimeSource(Box::new(
+            self.time_source.new_linked_clock(),
+        )))
+    }
+}
 pub const UNDERHILL_WORKER: WorkerId<UnderhillWorkerParameters> = WorkerId::new("UnderhillWorker");
 
 const MAX_SUBCHANNELS_PER_VNIC: u16 = 32;
@@ -2308,7 +2328,6 @@ async fn new_underhill_vm(
         Some(n) => n.to_ne_bytes(),
     };
 
-    // TODO: move to instantiate via a resource.
     let rtc_time_source = ArcMutexUnderhillLocalClock(Arc::new(Mutex::new(
         UnderhillLocalClock::new(
             get_client.clone(),
@@ -2324,6 +2343,10 @@ async fn new_underhill_vm(
         .await
         .context("failed to initialize UnderhillLocalClock emuplat")?,
     )));
+
+    resolver.add_resolver(UnderhillCmosRtcTimeSourceResolver {
+        time_source: rtc_time_source.new_linked_clock(),
+    });
 
     let mut serial_inputs = [None, None, None, None];
 
@@ -2802,7 +2825,7 @@ async fn new_underhill_vm(
 
     #[cfg(guest_arch = "x86_64")]
     let deps_piix4_cmos_rtc = chipset.with_piix4_cmos_rtc.then(|| dev::Piix4CmosRtcDeps {
-        time_source: Box::new(rtc_time_source.new_linked_clock()),
+        time_source: PlatformResource.into_resource(),
         initial_cmos: Some(firmware_pcat::default_cmos_values(&mem_layout)),
         enlightened_interrupts: true, // As advertised by the PCAT BIOS.
     });
@@ -2861,7 +2884,7 @@ async fn new_underhill_vm(
         .with_generic_cmos_rtc
         .then(|| dev::GenericCmosRtcDeps {
             irq: 8,
-            time_source: Box::new(rtc_time_source.new_linked_clock()),
+            time_source: PlatformResource.into_resource(),
             century_reg_idx: 0x32,
             initial_cmos: None,
         });

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -14,6 +14,7 @@ use anyhow::Context;
 use cfg_if::cfg_if;
 use chipset_device_resources::IRQ_LINE_SET;
 use chipset_resources::LEGACY_CHIPSET_PCI_BUS_NAME;
+use chipset_resources::cmos_rtc_time_source::SystemTimeClockHandle;
 use debug_ptr::DebugPtr;
 use disk_backend::Disk;
 use disk_backend::resolve::ResolveDiskParameters;
@@ -104,6 +105,7 @@ use virtio::VirtioMmioDevice;
 use virtio::VirtioPciDevice;
 use virtio::resolve::VirtioResolveInput;
 use vm_loader::initial_regs::initial_regs;
+use vm_resource::IntoResource;
 use vm_resource::Resource;
 use vm_resource::ResourceResolver;
 use vm_resource::kind::DiskHandleKind;
@@ -1491,14 +1493,12 @@ impl InitializedVm {
         };
 
         let deps_generic_cmos_rtc = (cfg.chipset.with_generic_cmos_rtc).then(|| {
-            // TODO: persist SystemTimeClock time across reboots.
-            // TODO: move to instantiate via a resource.
-            let time_source = Box::new(local_clock::SystemTimeClock::new(
-                LocalClockDelta::from_millis(cfg.rtc_delta_milliseconds),
-            ));
             dev::GenericCmosRtcDeps {
                 irq: 8,
-                time_source,
+                time_source: SystemTimeClockHandle {
+                    delta_milliseconds: cfg.rtc_delta_milliseconds,
+                }
+                .into_resource(),
                 century_reg_idx: 0x32, // TODO: automatically sync with FADT
                 initial_cmos: initial_rtc_cmos,
             }
@@ -1618,13 +1618,11 @@ impl InitializedVm {
         });
 
         let deps_piix4_cmos_rtc = (cfg.chipset.with_piix4_cmos_rtc).then(|| {
-            // TODO: persist SystemTimeClock time across reboots.
-            // TODO: move to instantiate via a resource.
-            let time_source = Box::new(local_clock::SystemTimeClock::new(
-                LocalClockDelta::from_millis(cfg.rtc_delta_milliseconds),
-            ));
             dev::Piix4CmosRtcDeps {
-                time_source,
+                time_source: SystemTimeClockHandle {
+                    delta_milliseconds: cfg.rtc_delta_milliseconds,
+                }
+                .into_resource(),
                 initial_cmos: initial_rtc_cmos,
                 enlightened_interrupts: true, // As advertised by the PCAT BIOS.
             }

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -50,6 +50,7 @@ disklayer_sqlite = { workspace = true, optional = true }
 # Chipset devices
 chipset.workspace = true
 chipset_legacy.workspace = true
+chipset_resources.workspace = true
 missing_dev.workspace = true
 guest_watchdog.workspace = true
 tpm_device = { workspace = true, optional = true, features = ["tpm"] }

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -25,6 +25,7 @@ vm_resource::register_static_resolvers! {
     chipset::ioapic::resolver::GenericIoApicResolver,
     #[cfg(guest_arch = "x86_64")]
     chipset::pm::resolver::HyperVPowerManagementResolver,
+    chipset_resources::cmos_rtc_time_source::SystemTimeClockResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]
     tpm_device::resolver::TpmDeviceResolver,

--- a/vm/devices/chipset_resources/Cargo.toml
+++ b/vm/devices/chipset_resources/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true
+local_clock.workspace = true
 
 inspect.workspace = true
 mesh.workspace = true

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -5,8 +5,76 @@
 
 #![forbid(unsafe_code)]
 
+use local_clock::InspectableLocalClock;
+use vm_resource::CanResolveTo;
+use vm_resource::ResourceKind;
+
 /// The PCI bus name used by the Gen1 (i440BX + PIIX4) chipset.
 pub const LEGACY_CHIPSET_PCI_BUS_NAME: &str = "i440bx";
+
+/// Resource kind for CMOS RTC time-source handles.
+pub enum CmosRtcTimeSourceHandleKind {}
+
+impl ResourceKind for CmosRtcTimeSourceHandleKind {
+    const NAME: &'static str = "cmos_rtc_time_source";
+}
+
+/// Resolved runtime time source for CMOS RTC devices.
+pub struct ResolvedCmosRtcTimeSource(pub Box<dyn InspectableLocalClock>);
+
+impl CanResolveTo<ResolvedCmosRtcTimeSource> for CmosRtcTimeSourceHandleKind {
+    type Input<'a> = ();
+}
+
+pub mod cmos_rtc_time_source {
+    //! Resource definitions and resolvers for CMOS RTC time sources.
+
+    use super::CmosRtcTimeSourceHandleKind;
+    use super::ResolvedCmosRtcTimeSource;
+    use local_clock::LocalClockDelta;
+    use local_clock::SystemTimeClock;
+    use mesh::MeshPayload;
+    use vm_resource::ResolveResource;
+    use vm_resource::ResourceId;
+    use vm_resource::declare_static_resolver;
+
+    /// A time source backed by the host system clock with a configurable
+    /// millisecond delta.
+    #[derive(MeshPayload)]
+    pub struct SystemTimeClockHandle {
+        /// Offset from system time in milliseconds.
+        pub delta_milliseconds: i64,
+    }
+
+    impl ResourceId<CmosRtcTimeSourceHandleKind> for SystemTimeClockHandle {
+        const ID: &'static str = "system_time_clock";
+    }
+
+    /// Resolver for [`SystemTimeClockHandle`].
+    pub struct SystemTimeClockResolver;
+
+    declare_static_resolver! {
+        SystemTimeClockResolver,
+        (CmosRtcTimeSourceHandleKind, SystemTimeClockHandle),
+    }
+
+    impl ResolveResource<CmosRtcTimeSourceHandleKind, SystemTimeClockHandle>
+        for SystemTimeClockResolver
+    {
+        type Output = ResolvedCmosRtcTimeSource;
+        type Error = std::convert::Infallible;
+
+        fn resolve(
+            &self,
+            resource: SystemTimeClockHandle,
+            (): (),
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(ResolvedCmosRtcTimeSource(Box::new(SystemTimeClock::new(
+                LocalClockDelta::from_millis(resource.delta_milliseconds),
+            ))))
+        }
+    }
+}
 
 pub mod i8042 {
     //! Resource definitions for the i8042 PS2 keyboard/mouse controller.

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -44,6 +44,8 @@ pub enum BaseChipsetBuilderError {
     FeatureGatedDevice(&'static str),
     #[error("no valid ISA DMA controller for floppy")]
     NoDmaForFloppy,
+    #[error("failed to resolve resource")]
+    ResolveResource(#[source] vm_resource::ResolveError),
 }
 
 /// A grab-bag of device-specific interfaces that may need to be wired up into
@@ -407,9 +409,13 @@ impl<'a> BaseChipsetBuilder<'a> {
             initial_cmos,
         }) = deps_generic_cmos_rtc
         {
+            let resolved = resolver
+                .resolve(time_source, ())
+                .await
+                .map_err(BaseChipsetBuilderError::ResolveResource)?;
             builder.arc_mutex_device("rtc").add(|services| {
                 cmos_rtc::Rtc::new(
-                    time_source,
+                    resolved.0,
                     services.new_line(IRQ_LINE_SET, "interrupt", irq),
                     services.register_vmtime(),
                     century_reg_idx,
@@ -425,11 +431,15 @@ impl<'a> BaseChipsetBuilder<'a> {
             enlightened_interrupts,
         }) = deps_piix4_cmos_rtc
         {
+            let resolved = resolver
+                .resolve(time_source, ())
+                .await
+                .map_err(BaseChipsetBuilderError::ResolveResource)?;
             builder.arc_mutex_device("piix4-rtc").add(|services| {
                 // hard-coded to IRQ line 8, as per PIIX4 spec
                 let rtc_interrupt = services.new_line(IRQ_LINE_SET, "interrupt", 8);
                 chipset_legacy::piix4_cmos_rtc::Piix4CmosRtc::new(
-                    time_source,
+                    resolved.0,
                     rtc_interrupt,
                     services.register_vmtime(),
                     initial_cmos,
@@ -1179,8 +1189,8 @@ pub mod options {
         pub struct GenericCmosRtcDeps {
             /// IRQ line to signal RTC device events
             pub irq: u32,
-            /// A source of "real time"
-            pub time_source: Box<dyn InspectableLocalClock>,
+            /// A time source resource, resolved at device build time.
+            pub time_source: vm_resource::Resource<chipset_resources::CmosRtcTimeSourceHandleKind>,
             /// Which CMOS RAM register contains the century register
             pub century_reg_idx: u8,
             /// Initial state of CMOS RAM
@@ -1189,8 +1199,8 @@ pub mod options {
 
         /// PIIX4 "flavored" MC146818A compatible RTC + CMOS device
         pub struct Piix4CmosRtcDeps {
-            /// A source of "real time"
-            pub time_source: Box<dyn InspectableLocalClock>,
+            /// A time source resource, resolved at device build time.
+            pub time_source: vm_resource::Resource<chipset_resources::CmosRtcTimeSourceHandleKind>,
             /// Initial state of CMOS RAM
             pub initial_cmos: Option<[u8; 256]>,
             /// Whether enlightened interrupts are enabled. Needed when


### PR DESCRIPTION
- Add CmosRtcTimeSourceHandleKind resource kind with SystemTimeClockHandle as a shared static resolver for system-time-backed clocks.
- Change CMOS RTC deps time_source from Box<dyn InspectableLocalClock> to Resource<CmosRtcTimeSourceHandleKind>, resolved during chipset build.
- Add UnderhillCmosRtcTimeSourceResolver for Underhill's GET-backed clock.