### PR TITLE
ci: remove paths-ignore from PR triggers to fix checkin gates

### DIFF
--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -21,9 +21,6 @@ on:
     - reopened
     - ready_for_review
     - labeled
-    paths-ignore:
-    - Guide/**
-    - petri/logview/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -20,9 +20,6 @@ on:
     - synchronize
     - reopened
     - ready_for_review
-    paths-ignore:
-    - Guide/**
-    - petri/logview/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -75,15 +75,21 @@ impl IntoPipeline for CheckinGatesCli {
             let branches = vec!["main".into(), "release/*".into()];
 
             // Paths that don't affect the Rust build or tests. Changes
-            // to only these paths will not trigger the checkin-gates pipeline.
-            let paths_ignore = vec!["Guide/**".into(), "petri/logview/**".into()];
+            // to only these paths will not trigger the CI pipeline on push.
+            //
+            // NOTE: The PR pipeline intentionally does NOT use paths-ignore,
+            // because the "openvmm checkin gates" job is a required status
+            // check. If the workflow is skipped due to path filters, the
+            // gate is never reported and the PR is blocked. The CI pipeline
+            // can still use paths-ignore since it has no required checks.
+            let ci_paths_ignore = vec!["Guide/**".into(), "petri/logview/**".into()];
 
             match config {
                 PipelineConfig::Ci => {
                     pipeline
                         .gh_set_ci_triggers(GhCiTriggers {
                             branches,
-                            paths_ignore: paths_ignore.clone(),
+                            paths_ignore: ci_paths_ignore.clone(),
                             ..Default::default()
                         })
                         .gh_set_name("OpenVMM CI");
@@ -92,13 +98,12 @@ impl IntoPipeline for CheckinGatesCli {
                     pipeline
                         .gh_set_pr_triggers(GhPrTriggers {
                             branches,
-                            paths_ignore: paths_ignore.clone(),
                             ..GhPrTriggers::new_draftable()
                         })
                         .gh_set_name("OpenVMM PR")
                         .ado_set_pr_triggers(AdoPrTriggers {
                             branches: vec!["main".into(), "release/*".into(), "embargo/*".into()],
-                            exclude_paths: paths_ignore.clone(),
+                            exclude_paths: ci_paths_ignore.clone(),
                             ..Default::default()
                         });
                 }
@@ -106,7 +111,6 @@ impl IntoPipeline for CheckinGatesCli {
                     // This workflow is triggered when a specific label is present on a PR.
                     let mut triggers = GhPrTriggers::new_draftable();
                     triggers.branches = branches;
-                    triggers.paths_ignore = paths_ignore.clone();
                     triggers.types.push("labeled".into());
                     pipeline
                         .gh_set_pr_triggers(triggers)


### PR DESCRIPTION
The `openvmm-pr` workflow used `paths-ignore` to skip `Guide/**` and `petri/logview/**` changes. This caused the "openvmm checkin gates" required status check to never be reported for doc-only PRs (e.g. #3352), blocking them from merging.

Remove `paths-ignore` from the PR and PR-release triggers so the gate job always runs. Keep `paths-ignore` on the CI (push) trigger since it has no required status checks.