### PR TITLE
openvmm: support multiple numa memory ranges for test only purposes 

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -868,13 +868,40 @@ impl InitializedVm {
         };
 
         // Choose the memory layout of the VM.
-        let mem_layout = MemoryLayout::new(
-            cfg.memory.mem_size,
-            &cfg.memory.mmio_gaps,
-            &cfg.memory.pci_ecam_gaps,
-            &cfg.memory.pci_mmio_gaps,
-            vtl2_range,
-        )
+        let mem_layout = if let Some(ref sizes) = cfg.memory.numa_mem_sizes {
+            // When numa_mem_sizes is set, distribute guest RAM across vNUMA nodes
+            // for ACPI SRAT / FDT reporting.
+            //
+            // TODO: The vNUMA nodes reported are meant for test usage only, as they
+            // are not aligned to any physical NUMA node. There is more work to do
+            // to support useful vNUMA reporting.
+            let total: u64 = sizes
+                .iter()
+                .copied()
+                .try_fold(0u64, |acc, s| acc.checked_add(s))
+                .context("numa memory sizes overflow")?;
+            anyhow::ensure!(
+                total == cfg.memory.mem_size,
+                "numa_mem_sizes total ({total:#x}) does not match mem_size ({:#x})",
+                cfg.memory.mem_size
+            );
+
+            MemoryLayout::new_with_numa(
+                sizes,
+                &cfg.memory.mmio_gaps,
+                &cfg.memory.pci_ecam_gaps,
+                &cfg.memory.pci_mmio_gaps,
+                vtl2_range,
+            )
+        } else {
+            MemoryLayout::new(
+                cfg.memory.mem_size,
+                &cfg.memory.mmio_gaps,
+                &cfg.memory.pci_ecam_gaps,
+                &cfg.memory.pci_mmio_gaps,
+                vtl2_range,
+            )
+        }
         .context("invalid memory configuration")?;
 
         if mem_layout.end_of_layout() > 1 << physical_address_size {

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -338,6 +338,10 @@ pub struct MemoryConfig {
     pub mmio_gaps: Vec<MemoryRange>,
     pub pci_ecam_gaps: Vec<MemoryRange>,
     pub pci_mmio_gaps: Vec<MemoryRange>,
+    /// Per-NUMA-node memory sizes. When set, RAM is distributed across
+    /// vNUMA nodes according to these sizes instead of assigning all
+    /// RAM to node 0. The sum must equal `mem_size`.
+    pub numa_mem_sizes: Option<Vec<u64>>,
 }
 
 #[derive(Debug, MeshPayload, Default)]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -60,7 +60,7 @@ pub struct Options {
     /// TODO: This is informational topology only. Backing pages are not pinned
     /// to any host topology, nor coordinated with CPUs. This should change once
     /// we implement real numa support.
-    #[clap(long, value_name = "SIZES", value_parser = parse_numa_memory, conflicts_with = "memory")]
+    #[clap(long, value_name = "SIZES", value_parser = parse_memory, value_delimiter = ',', conflicts_with = "memory")]
     pub numa_memory: Option<Vec<u64>>,
 
     /// use shared memory segment
@@ -984,10 +984,6 @@ fn parse_memory(s: &str) -> anyhow::Result<u64> {
         }()
         .with_context(|| format!("invalid memory size '{0}'", s))
     }
-}
-
-fn parse_numa_memory(s: &str) -> anyhow::Result<Vec<u64>> {
-    s.split(',').map(|part| parse_memory(part.trim())).collect()
 }
 
 /// Parse a number from a string that could be prefixed with 0x to indicate hex.

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -55,11 +55,10 @@ pub struct Options {
 
     /// per-NUMA-node guest RAM sizes (comma-separated, e.g. "2G,2G").
     /// Distributes memory across vNUMA nodes reported to the guest. Mutually
-    /// exclusive with --memory.
+    /// exclusive with --memory. This is for test-only usage.
     ///
-    /// TODO: This is informational topology only. Backing pages are not pinned
-    /// to any host topology, nor coordinated with CPUs. This should change once
-    /// we implement real numa support.
+    /// TODO: Backing pages are not pinned to any host topology, nor coordinated
+    /// with CPUs. This should change once we implement real numa support.
     #[clap(long, value_name = "SIZES", value_parser = parse_memory, value_delimiter = ',', conflicts_with = "memory")]
     pub numa_memory: Option<Vec<u64>>,
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -54,12 +54,12 @@ pub struct Options {
     pub memory: u64,
 
     /// per-NUMA-node guest RAM sizes (comma-separated, e.g. "2G,2G").
-    /// Distributes memory across vNUMA nodes for ACPI SRAT / FDT reporting.
-    /// Mutually exclusive with --memory.
+    /// Distributes memory across vNUMA nodes reported to the guest. Mutually
+    /// exclusive with --memory.
     ///
-    /// TODO: This is informational topology only — backing pages are not pinned
-    /// to host NUMA nodes. This should change once we implement real numa
-    /// support.
+    /// TODO: This is informational topology only. Backing pages are not pinned
+    /// to any host topology, nor coordinated with CPUs. This should change once
+    /// we implement real numa support.
     #[clap(long, value_name = "SIZES", value_parser = parse_numa_memory, conflicts_with = "memory")]
     pub numa_memory: Option<Vec<u64>>,
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -48,9 +48,20 @@ pub struct Options {
         long,
         value_name = "SIZE",
         default_value = "1GB",
-        value_parser = parse_memory
+        value_parser = parse_memory,
+        conflicts_with = "numa_memory"
     )]
     pub memory: u64,
+
+    /// per-NUMA-node guest RAM sizes (comma-separated, e.g. "2G,2G").
+    /// Distributes memory across vNUMA nodes for ACPI SRAT / FDT reporting.
+    /// Mutually exclusive with --memory.
+    ///
+    /// TODO: This is informational topology only — backing pages are not pinned
+    /// to host NUMA nodes. This should change once we implement real numa
+    /// support.
+    #[clap(long, value_name = "SIZES", value_parser = parse_numa_memory, conflicts_with = "memory")]
+    pub numa_memory: Option<Vec<u64>>,
 
     /// use shared memory segment
     #[clap(short = 'M', long)]
@@ -973,6 +984,10 @@ fn parse_memory(s: &str) -> anyhow::Result<u64> {
         }()
         .with_context(|| format!("invalid memory size '{0}'", s))
     }
+}
+
+fn parse_numa_memory(s: &str) -> anyhow::Result<Vec<u64>> {
+    s.split(',').map(|part| parse_memory(part.trim())).collect()
 }
 
 /// Parse a number from a string that could be prefixed with 0x to indicate hex.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1580,13 +1580,21 @@ async fn vm_config_from_command_line(
         vpci_devices,
         ide_disks: Vec::new(),
         memory: MemoryConfig {
-            mem_size: opt.memory,
+            mem_size: if let Some(ref sizes) = opt.numa_memory {
+                sizes
+                    .iter()
+                    .try_fold(0u64, |acc, &s| acc.checked_add(s))
+                    .context("numa memory sizes overflow")?
+            } else {
+                opt.memory
+            },
             mmio_gaps,
             prefetch_memory: opt.prefetch,
             private_memory: opt.private_memory,
             transparent_hugepages: opt.thp,
             pci_ecam_gaps,
             pci_mmio_gaps,
+            numa_mem_sizes: opt.numa_memory.clone(),
         },
         processor_topology: ProcessorTopologyConfig {
             proc_count: opt.processors,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -575,6 +575,7 @@ impl VmService {
                 prefetch_memory: false,
                 private_memory: false,
                 transparent_hugepages: false,
+                numa_mem_sizes: None,
             },
             chipset: chipset.chipset,
             processor_topology: ProcessorTopologyConfig {

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2129,6 +2129,9 @@ pub struct MemoryConfig {
     pub dynamic_memory_range: Option<(u64, u64)>,
     /// Specifies the mmio gaps to use, either platform or custom.
     pub mmio_gaps: MmioConfig,
+    /// Per-NUMA-node memory sizes. When set, RAM is distributed across
+    /// vNUMA nodes instead of assigning all RAM to node 0.
+    pub numa_mem_sizes: Option<Vec<u64>>,
 }
 
 impl Default for MemoryConfig {
@@ -2137,6 +2140,7 @@ impl Default for MemoryConfig {
             startup_bytes: 4 * 1024 * 1024 * 1024, // 4 GiB
             dynamic_memory_range: None,
             mmio_gaps: MmioConfig::Platform,
+            numa_mem_sizes: None,
         }
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -358,14 +358,24 @@ impl PetriVmConfigOpenVmm {
                 startup_bytes,
                 dynamic_memory_range,
                 mmio_gaps,
+                numa_mem_sizes,
             } = memory;
 
             if dynamic_memory_range.is_some() {
                 anyhow::bail!("dynamic memory not supported in OpenVMM");
             }
 
+            let mem_size = if let Some(ref sizes) = numa_mem_sizes {
+                sizes
+                    .iter()
+                    .try_fold(0u64, |acc, &s| acc.checked_add(s))
+                    .context("numa memory sizes overflow")?
+            } else {
+                startup_bytes
+            };
+
             openvmm_defs::config::MemoryConfig {
-                mem_size: startup_bytes,
+                mem_size,
                 mmio_gaps: match mmio_gaps {
                     MmioConfig::Platform => {
                         if firmware.is_openhcl() {
@@ -387,6 +397,7 @@ impl PetriVmConfigOpenVmm {
                 prefetch_memory: false,
                 private_memory: false,
                 transparent_hugepages: false,
+                numa_mem_sizes,
             }
         };
 

--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -4,6 +4,7 @@
 //! Tools to the compute guest memory layout.
 
 use memory_range::MemoryRange;
+use memory_range::subtract_ranges;
 use thiserror::Error;
 
 const PAGE_SIZE: u64 = 4096;
@@ -205,43 +206,44 @@ impl MemoryLayout {
         combined_gaps.sort();
         validate_ranges(&combined_gaps)?;
 
-        // Walk contiguous address chunks (between gaps), distributing RAM
-        // across NUMA nodes by filling each node's budget in order.
+        let available = subtract_ranges(
+            [MemoryRange::new(0..MemoryRange::MAX_ADDRESS)],
+            combined_gaps,
+        );
+
+        // Distribute RAM across NUMA nodes, filling available ranges in order.
         let mut ram = Vec::new();
         let mut remaining = ram_size;
-        let mut remaining_gaps = combined_gaps.iter().cloned();
-        let mut last_end = 0;
-
         let mut node_idx = 0;
         let mut node_remaining = numa_mem_sizes[0];
 
-        while remaining > 0 {
-            let (chunk_size, next_end) = if let Some(gap) = remaining_gaps.next() {
-                (remaining.min(gap.start() - last_end), gap.end())
-            } else {
-                (remaining, 0)
-            };
+        for range in available {
+            let range_size = remaining.min(range.len());
+            let mut offset = 0;
 
-            // Distribute this chunk across nodes.
-            let mut chunk_offset = 0;
-            while chunk_offset < chunk_size {
-                let piece = (chunk_size - chunk_offset).min(node_remaining);
-                assert!(piece > 0, "node budget exhausted before all RAM placed");
-                let start = last_end + chunk_offset;
+            while offset < range_size {
+                if node_remaining == 0 {
+                    node_idx += 1;
+                    node_remaining = *numa_mem_sizes
+                        .get(node_idx)
+                        .expect("node budget exhausted before all RAM placed");
+                }
+
+                let piece = (range_size - offset).min(node_remaining);
+                let start = range.start() + offset;
                 ram.push(MemoryRangeWithNode {
                     range: MemoryRange::new(start..start + piece),
                     vnode: node_idx as u32,
                 });
-                chunk_offset += piece;
+                offset += piece;
                 node_remaining -= piece;
-                if node_remaining == 0 && node_idx + 1 < numa_mem_sizes.len() {
-                    node_idx += 1;
-                    node_remaining = numa_mem_sizes[node_idx];
-                }
             }
 
-            remaining -= chunk_size;
-            last_end = next_end;
+            remaining -= range_size;
+
+            if remaining == 0 {
+                break;
+            }
         }
 
         Self::build(

--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -75,6 +75,12 @@ pub enum Error {
     /// Invalid memory size.
     #[error("invalid memory size")]
     BadSize,
+    /// Invalid per-NUMA-node memory size.
+    #[error("invalid NUMA node memory size")]
+    BadNumaSize,
+    /// Empty NUMA memory sizes.
+    #[error("empty NUMA memory sizes")]
+    EmptyNumaSizes,
     /// Invalid MMIO gap configuration.
     #[error("invalid MMIO gap configuration")]
     BadMmioGaps,
@@ -145,6 +151,46 @@ impl MemoryLayout {
         if ram_size == 0 || ram_size & (PAGE_SIZE - 1) != 0 {
             return Err(Error::BadSize);
         }
+        Self::new_with_numa(
+            &[ram_size],
+            mmio_gaps,
+            pci_ecam_gaps,
+            pci_mmio_gaps,
+            vtl2_range,
+        )
+    }
+
+    /// Like [`Self::new()`], but distributes RAM across NUMA nodes according
+    /// to the per-node sizes in `numa_mem_sizes`.
+    ///
+    /// `numa_mem_sizes[i]` is the number of RAM bytes for vnode `i`.
+    /// Each size must be page-aligned and non-zero. The sum of all sizes
+    /// is the total guest RAM.
+    ///
+    /// RAM is placed sequentially around MMIO gaps, filling each node's
+    /// budget in order. When a node's budget is exhausted mid-chunk,
+    /// the chunk is split and the next node continues from that address.
+    pub fn new_with_numa(
+        numa_mem_sizes: &[u64],
+        mmio_gaps: &[MemoryRange],
+        pci_ecam_gaps: &[MemoryRange],
+        pci_mmio_gaps: &[MemoryRange],
+        vtl2_range: Option<MemoryRange>,
+    ) -> Result<Self, Error> {
+        if numa_mem_sizes.is_empty() {
+            return Err(Error::EmptyNumaSizes);
+        }
+
+        for &size in numa_mem_sizes {
+            if size == 0 || size & (PAGE_SIZE - 1) != 0 {
+                return Err(Error::BadNumaSize);
+            }
+        }
+
+        let ram_size: u64 = numa_mem_sizes
+            .iter()
+            .try_fold(0u64, |acc, &s| acc.checked_add(s))
+            .ok_or(Error::BadSize)?;
 
         validate_ranges(mmio_gaps)?;
         validate_ranges(pci_ecam_gaps)?;
@@ -159,25 +205,42 @@ impl MemoryLayout {
         combined_gaps.sort();
         validate_ranges(&combined_gaps)?;
 
+        // Walk contiguous address chunks (between gaps), distributing RAM
+        // across NUMA nodes by filling each node's budget in order.
         let mut ram = Vec::new();
         let mut remaining = ram_size;
         let mut remaining_gaps = combined_gaps.iter().cloned();
         let mut last_end = 0;
 
+        let mut node_idx = 0;
+        let mut node_remaining = numa_mem_sizes[0];
+
         while remaining > 0 {
-            let (this, next_end) = if let Some(gap) = remaining_gaps.next() {
+            let (chunk_size, next_end) = if let Some(gap) = remaining_gaps.next() {
                 (remaining.min(gap.start() - last_end), gap.end())
             } else {
                 (remaining, 0)
             };
 
-            if this > 0 {
+            // Distribute this chunk across nodes.
+            let mut chunk_offset = 0;
+            while chunk_offset < chunk_size {
+                let piece = (chunk_size - chunk_offset).min(node_remaining);
+                assert!(piece > 0, "node budget exhausted before all RAM placed");
+                let start = last_end + chunk_offset;
                 ram.push(MemoryRangeWithNode {
-                    range: MemoryRange::new(last_end..last_end + this),
-                    vnode: 0,
+                    range: MemoryRange::new(start..start + piece),
+                    vnode: node_idx as u32,
                 });
+                chunk_offset += piece;
+                node_remaining -= piece;
+                if node_remaining == 0 && node_idx + 1 < numa_mem_sizes.len() {
+                    node_idx += 1;
+                    node_remaining = numa_mem_sizes[node_idx];
+                }
             }
-            remaining -= this;
+
+            remaining -= chunk_size;
             last_end = next_end;
         }
 
@@ -572,5 +635,101 @@ mod tests {
         assert_eq!(layout.probe_address(TB + 2 * GB), None);
         assert_eq!(layout.probe_address(TB + 3 * GB), None);
         assert_eq!(layout.probe_address(4 * TB), None);
+    }
+
+    #[test]
+    fn numa_two_nodes_even_split() {
+        // 4 GB total, 2 nodes of 2 GB each, MMIO gap at 2-3 GB.
+        let mmio = &[MemoryRange::new(2 * GB..3 * GB)];
+        let layout = MemoryLayout::new_with_numa(&[2 * GB, 2 * GB], mmio, &[], &[], None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..2 * GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(3 * GB..5 * GB),
+                    vnode: 1,
+                },
+            ]
+        );
+        assert_eq!(layout.ram_size(), 4 * GB);
+    }
+
+    #[test]
+    fn numa_two_nodes_mid_chunk_split() {
+        // 4 GB total, 2 nodes of 2 GB each, MMIO gap at 3-4 GB.
+        // Node 0's 2 GB fits entirely below the gap; node 1 continues above.
+        // But the first chunk is 3 GB, so node 0 takes 2 GB and node 1
+        // takes the remaining 1 GB of that chunk, plus 1 GB above the gap.
+        let mmio = &[MemoryRange::new(3 * GB..4 * GB)];
+        let layout = MemoryLayout::new_with_numa(&[2 * GB, 2 * GB], mmio, &[], &[], None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..2 * GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(2 * GB..3 * GB),
+                    vnode: 1,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(4 * GB..5 * GB),
+                    vnode: 1,
+                },
+            ]
+        );
+        assert_eq!(layout.ram_size(), 4 * GB);
+    }
+
+    #[test]
+    fn numa_three_nodes() {
+        // 3 GB total, 3 nodes of 1 GB each, no gaps.
+        let layout = MemoryLayout::new_with_numa(&[GB, GB, GB], &[], &[], &[], None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(GB..2 * GB),
+                    vnode: 1,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(2 * GB..3 * GB),
+                    vnode: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn numa_single_node_matches_new() {
+        // Single node should produce the same layout as new().
+        let mmio = &[
+            MemoryRange::new(GB..2 * GB),
+            MemoryRange::new(3 * GB..4 * GB),
+        ];
+        let layout_new = MemoryLayout::new(TB, mmio, &[], &[], None).unwrap();
+        let layout_numa = MemoryLayout::new_with_numa(&[TB], mmio, &[], &[], None).unwrap();
+        assert_eq!(layout_new.ram(), layout_numa.ram());
+    }
+
+    #[test]
+    fn numa_bad_inputs() {
+        // Empty sizes.
+        MemoryLayout::new_with_numa(&[], &[], &[], &[], None).unwrap_err();
+        // Non-page-aligned size.
+        MemoryLayout::new_with_numa(&[GB + 1], &[], &[], &[], None).unwrap_err();
+        // Zero size.
+        MemoryLayout::new_with_numa(&[0], &[], &[], &[], None).unwrap_err();
+        // Mixed: one valid, one zero.
+        MemoryLayout::new_with_numa(&[GB, 0], &[], &[], &[], None).unwrap_err();
     }
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -405,6 +405,7 @@ async fn idle_test<T: PetriVmmBackend>(
                 startup_bytes: 16 * (1024 * 1024 * 1024),
                 dynamic_memory_range: None,
                 mmio_gaps: petri::MmioConfig::Platform,
+                numa_mem_sizes: None,
             }
         })
         .with_openhcl_log_levels(OpenvmmLogConfig::BuiltInDefault)


### PR DESCRIPTION
Not being able to specify numa nodes for memory makes it impossible to test certain behavior in vmm_tests. Add the ability to report this, even if the backing page is not pinned to any specific hardware numa node. This behavior should change once we support real numa pinning for CPUs and memory in openvmm. 

This also refactors `MemoryLayout` to use `subtract_ranges` when finding free sections of the address space to place ram. 

Required for #3312 to have openvmm tests work. 