### PR TITLE
virtiofs: await worker shutdown in reset() to fix guest shutdown hang

### DIFF
--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -201,6 +201,14 @@ impl VirtioDevice for VirtioFsDevice {
     }
 
     async fn reset(&mut self) {
+        // Stop all workers before clearing them to ensure in-flight requests
+        // (e.g. FUSE_DESTROY) are fully processed and replied to. Without this,
+        // the guest driver's shutdown callback hangs waiting for a reply.
+        for worker in &mut self.workers {
+            if worker.has_state() {
+                worker.stop().await;
+            }
+        }
         self.workers.clear();
         if let Some(region) = &self.shared_memory_region {
             if let Err(e) = region.unmap(0, self.shmem_size as usize) {


### PR DESCRIPTION
## Problem

`VirtioFsDevice::reset()` drops workers via `self.workers.clear()` without awaiting their completion. If a worker is in the middle of processing a FUSE request (e.g. `FUSE_DESTROY`), it gets cancelled before it can send the reply. The guest driver then blocks forever waiting for that reply, hanging the guest kernel's device shutdown path.

This is triggered by Linux 6.18, whose virtiofs driver now sends `FUSE_DESTROY` during its `.shutdown()` callback. The bug was latent before -- older kernels did not send `FUSE_DESTROY` during shutdown so the race was never hit.

## Fix

Await each worker's `stop()` before clearing them in `reset()`, matching the pattern already used by `stop_queue()` directly above. This ensures in-flight FUSE requests are fully processed and replied to before the device is torn down.