### PR TITLE
consomme: Enable port forwarding from openvmm command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,7 @@ dependencies = [
  "net_backend_resources",
  "pal_async",
  "parking_lot",
+ "socket2",
  "thiserror 2.0.16",
  "tracing",
  "vm_resource",

--- a/Guide/src/reference/backends/consomme.md
+++ b/Guide/src/reference/backends/consomme.md
@@ -62,7 +62,7 @@ host ports into the guest:
 This binds host port 2222 and forwards incoming TCP connections to
 guest port 22. The general syntax is:
 
-```
+```text
 hostfwd=<proto>:[<hostaddr>]:<hostport>-[<guestaddr>]:<guestport>
 ```
 

--- a/Guide/src/reference/backends/consomme.md
+++ b/Guide/src/reference/backends/consomme.md
@@ -69,7 +69,7 @@ hostfwd=<proto>:[<hostaddr>]:<hostport>-[<guestaddr>]:<guestport>
 | Field | Description |
 |-------|-------------|
 | `proto` | `tcp` or `udp` |
-| `hostaddr` | Host IP to bind (default: all interfaces). Use `[addr]` brackets for IPv6 |
+| `hostaddr` | Host IP to bind (default: all IPv4 interfaces, `0.0.0.0`). Use `[addr]` brackets for IPv6 addresses |
 | `hostport` | Host port to listen on. Use `0` for any available port |
 | `guestaddr` | Currently ignored — traffic always forwards to the guest IP |
 | `guestport` | Guest port to forward to |

--- a/Guide/src/reference/backends/consomme.md
+++ b/Guide/src/reference/backends/consomme.md
@@ -49,6 +49,59 @@ flowchart TB
 The subnet is configurable via the `--net consomme:<cidr>` CLI option.
 The gateway is always `.1` and the guest is always `.2`.
 
+## Port forwarding
+
+By default, Consomme only provides outbound connectivity from the guest.
+To accept inbound connections, use the `hostfwd=` option to forward
+host ports into the guest:
+
+```bash
+--net consomme:hostfwd=tcp::2222-:22
+```
+
+This binds host port 2222 and forwards incoming TCP connections to
+guest port 22. The general syntax is:
+
+```
+hostfwd=<proto>:[<hostaddr>]:<hostport>-[<guestaddr>]:<guestport>
+```
+
+| Field | Description |
+|-------|-------------|
+| `proto` | `tcp` or `udp` |
+| `hostaddr` | Host IP to bind (default: all interfaces). Use `[addr]` brackets for IPv6 |
+| `hostport` | Host port to listen on. Use `0` for any available port |
+| `guestaddr` | Currently ignored — traffic always forwards to the guest IP |
+| `guestport` | Guest port to forward to |
+
+Multiple forwards can be specified with commas:
+
+```bash
+--net consomme:hostfwd=tcp::2222-:22,hostfwd=tcp::3389-:3389
+```
+
+Port forwards can also be combined with a CIDR:
+
+```bash
+--net consomme:10.0.0.0/24,hostfwd=tcp::2222-:22
+```
+
+Examples:
+
+```bash
+# Forward host port 8080 to guest port 80
+--net consomme:hostfwd=tcp::8080-:80
+
+# Bind only to localhost
+--net consomme:hostfwd=tcp:127.0.0.1:8080-:80
+
+# IPv6 localhost
+--net consomme:hostfwd=tcp:[::1]:8080-:80
+
+# UDP forwarding
+--net consomme:hostfwd=udp::5353-:53
+```
+
 IPv6 is enabled when the host has a routable IPv6 address. Consomme
 advertises a prefix via SLAAC and the guest auto-configures its own
 address. IPv6 DNS servers are advertised via RDNSS (in Router

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -277,6 +277,12 @@ options:
     /// Prefix with `uh:` to add this NIC via Mana emulation through OpenHCL,
     /// `vtl2:` to assign this NIC to VTL2, or `pcie_port=<port_name>:` to
     /// expose the NIC over emulated PCIe at the specified port.
+    ///
+    /// For consomme, forward host ports into the guest with `hostfwd=`:
+    ///   --net consomme:hostfwd=tcp::3389-:3389
+    ///   --net consomme:hostfwd=tcp:127.0.0.1:8080-:80
+    ///   --net consomme:hostfwd=tcp:[::1]:8080-:80
+    ///   --net consomme:10.0.0.0/24,hostfwd=tcp::22-:22,hostfwd=udp::5000-:5000
     #[clap(long)]
     pub net: Vec<NicConfigCli>,
 
@@ -1527,9 +1533,101 @@ impl SerialConfigCli {
 #[derive(Clone, Debug, PartialEq)]
 pub enum EndpointConfigCli {
     None,
-    Consomme { cidr: Option<String> },
-    Dio { id: Option<String> },
-    Tap { name: String },
+    Consomme {
+        cidr: Option<String>,
+        host_fwd: Vec<HostPortConfigCli>,
+    },
+    Dio {
+        id: Option<String>,
+    },
+    Tap {
+        name: String,
+    },
+}
+
+/// Parsed host port forwarding configuration from the CLI.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HostPortConfigCli {
+    pub protocol: HostPortProtocolCli,
+    pub host_address: Option<String>,
+    pub host_port: u16,
+    pub guest_port: u16,
+}
+
+/// Protocol for host port forwarding.
+#[derive(Clone, Debug, PartialEq)]
+pub enum HostPortProtocolCli {
+    Tcp,
+    Udp,
+}
+
+fn parse_hostfwd(s: &str) -> Result<HostPortConfigCli, String> {
+    // Format: protocol:[hostaddr]:hostport-[guestaddr]:guestport
+    // Examples: "tcp::3389-:3389", "tcp:127.0.0.1:8080-:80", "tcp:[::1]:8080-:80"
+    let (host_part, guest_part) = s.split_once('-').ok_or_else(|| {
+        format!(
+            "invalid hostfwd format '{s}', \
+             expected 'proto:[hostaddr]:hostport-[guestaddr]:guestport'"
+        )
+    })?;
+
+    // Extract protocol from host part (first colon-delimited field)
+    let (proto, host_addr_port) = host_part.split_once(':').ok_or_else(|| {
+        format!("invalid hostfwd host part '{host_part}', expected 'proto:[hostaddr]:hostport'")
+    })?;
+    let protocol = match proto {
+        "tcp" => HostPortProtocolCli::Tcp,
+        "udp" => HostPortProtocolCli::Udp,
+        other => {
+            return Err(format!(
+                "unknown hostfwd protocol '{other}', expected 'tcp' or 'udp'"
+            ));
+        }
+    };
+
+    let (host_address, host_port) = parse_addr_port(host_addr_port)
+        .map_err(|e| format!("invalid hostfwd host address/port: {e}"))?;
+    let (_, guest_port) = parse_addr_port(guest_part)
+        .map_err(|e| format!("invalid hostfwd guest address/port: {e}"))?;
+
+    Ok(HostPortConfigCli {
+        protocol,
+        host_address,
+        host_port,
+        guest_port,
+    })
+}
+
+/// Parse an address-port pair in one of these forms:
+/// - `[ipv6addr]:port`
+/// - `addr:port`
+/// - `:port`  (empty address)
+/// - `port`   (no address)
+fn parse_addr_port(s: &str) -> Result<(Option<String>, u16), String> {
+    if let Some(rest) = s.strip_prefix('[') {
+        // Bracketed IPv6 address: [addr]:port
+        let (addr, port) = rest
+            .split_once("]:")
+            .ok_or_else(|| format!("expected '[addr]:port', got '[{rest}'"))?;
+        let port: u16 = port.parse().map_err(|_| format!("invalid port '{port}'"))?;
+        Ok((Some(addr.to_owned()), port))
+    } else {
+        match s.rsplit_once(':') {
+            Some((addr, port)) => {
+                let port: u16 = port.parse().map_err(|_| format!("invalid port '{port}'"))?;
+                let addr = if addr.is_empty() {
+                    None
+                } else {
+                    Some(addr.to_owned())
+                };
+                Ok((addr, port))
+            }
+            None => {
+                let port: u16 = s.parse().map_err(|_| format!("invalid port '{s}'"))?;
+                Ok((None, port))
+            }
+        }
+    }
 }
 
 impl FromStr for EndpointConfigCli {
@@ -1538,9 +1636,21 @@ impl FromStr for EndpointConfigCli {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let ret = match s.split(':').collect::<Vec<_>>().as_slice() {
             ["none"] => EndpointConfigCli::None,
-            ["consomme", s @ ..] => EndpointConfigCli::Consomme {
-                cidr: s.first().map(|&s| s.to_owned()),
-            },
+            ["consomme", rest @ ..] => {
+                let remaining = rest.join(":");
+                let mut cidr = None;
+                let mut host_fwd = Vec::new();
+                for opt in remaining.split(',').filter(|s| !s.is_empty()) {
+                    if let Some(fwd) = opt.strip_prefix("hostfwd=") {
+                        host_fwd.push(parse_hostfwd(fwd)?);
+                    } else if cidr.is_none() {
+                        cidr = Some(opt.to_owned());
+                    } else {
+                        return Err(format!("unexpected consomme option '{opt}'"));
+                    }
+                }
+                EndpointConfigCli::Consomme { cidr, host_fwd }
+            }
             ["dio", s @ ..] => EndpointConfigCli::Dio {
                 id: s.first().map(|s| (*s).to_owned()),
             },
@@ -2637,16 +2747,109 @@ mod tests {
 
         // Test consomme without cidr
         match EndpointConfigCli::from_str("consomme").unwrap() {
-            EndpointConfigCli::Consomme { cidr: None } => (),
+            EndpointConfigCli::Consomme {
+                cidr: None,
+                host_fwd,
+            } => assert!(host_fwd.is_empty()),
             _ => panic!("Expected Consomme variant without cidr"),
         }
 
         // Test consomme with cidr
         match EndpointConfigCli::from_str("consomme:192.168.0.0/24").unwrap() {
-            EndpointConfigCli::Consomme { cidr: Some(cidr) } => {
+            EndpointConfigCli::Consomme {
+                cidr: Some(cidr),
+                host_fwd,
+            } => {
                 assert_eq!(cidr, "192.168.0.0/24");
+                assert!(host_fwd.is_empty());
             }
             _ => panic!("Expected Consomme variant with cidr"),
+        }
+
+        // Test consomme with hostfwd
+        match EndpointConfigCli::from_str("consomme:hostfwd=udp:127.0.0.1:5000-:5000").unwrap() {
+            EndpointConfigCli::Consomme { cidr, host_fwd } => {
+                assert!(cidr.is_none());
+                assert_eq!(host_fwd.len(), 1);
+                assert_eq!(host_fwd[0].protocol, HostPortProtocolCli::Udp);
+                assert_eq!(host_fwd[0].host_address.as_deref(), Some("127.0.0.1"));
+                assert_eq!(host_fwd[0].host_port, 5000);
+                assert_eq!(host_fwd[0].guest_port, 5000);
+            }
+            _ => panic!("Expected Consomme variant with hostfwd"),
+        }
+
+        // Test consomme with cidr and hostfwd
+        match EndpointConfigCli::from_str("consomme:10.0.0.0/24,hostfwd=tcp::2222-:22").unwrap() {
+            EndpointConfigCli::Consomme { cidr, host_fwd } => {
+                assert_eq!(cidr.as_deref(), Some("10.0.0.0/24"));
+                assert_eq!(host_fwd.len(), 1);
+                assert_eq!(host_fwd[0].protocol, HostPortProtocolCli::Tcp);
+                assert_eq!(host_fwd[0].host_port, 2222);
+                assert_eq!(host_fwd[0].guest_port, 22);
+            }
+            _ => panic!("Expected Consomme variant with cidr and hostfwd"),
+        }
+
+        // Test consomme with multiple hostfwd
+        match EndpointConfigCli::from_str("consomme:hostfwd=tcp::2222-:22,hostfwd=tcp::3389-:3389")
+            .unwrap()
+        {
+            EndpointConfigCli::Consomme { cidr, host_fwd } => {
+                assert!(cidr.is_none());
+                assert_eq!(host_fwd.len(), 2);
+                assert_eq!(host_fwd[0].host_port, 2222);
+                assert_eq!(host_fwd[0].guest_port, 22);
+                assert_eq!(host_fwd[1].host_port, 3389);
+                assert_eq!(host_fwd[1].guest_port, 3389);
+            }
+            _ => panic!("Expected Consomme variant with multiple hostfwd"),
+        }
+
+        // Test consomme with different host and guest ports
+        match EndpointConfigCli::from_str("consomme:hostfwd=tcp:127.0.0.1:8080-:80").unwrap() {
+            EndpointConfigCli::Consomme { cidr, host_fwd } => {
+                assert!(cidr.is_none());
+                assert_eq!(host_fwd.len(), 1);
+                assert_eq!(host_fwd[0].protocol, HostPortProtocolCli::Tcp);
+                assert_eq!(host_fwd[0].host_address.as_deref(), Some("127.0.0.1"));
+                assert_eq!(host_fwd[0].host_port, 8080);
+                assert_eq!(host_fwd[0].guest_port, 80);
+            }
+            _ => panic!("Expected Consomme variant with host/guest port mapping"),
+        }
+
+        // Test consomme with guest address (accepted but ignored by backend)
+        match EndpointConfigCli::from_str("consomme:hostfwd=tcp::8080-10.0.0.2:80").unwrap() {
+            EndpointConfigCli::Consomme { cidr, host_fwd } => {
+                assert!(cidr.is_none());
+                assert_eq!(host_fwd[0].host_port, 8080);
+                assert_eq!(host_fwd[0].guest_port, 80);
+            }
+            _ => panic!("Expected Consomme variant with guest address"),
+        }
+
+        // Test consomme with IPv6 host address (bracketed)
+        match EndpointConfigCli::from_str("consomme:hostfwd=tcp:[::1]:8080-:80").unwrap() {
+            EndpointConfigCli::Consomme { cidr, host_fwd } => {
+                assert!(cidr.is_none());
+                assert_eq!(host_fwd.len(), 1);
+                assert_eq!(host_fwd[0].protocol, HostPortProtocolCli::Tcp);
+                assert_eq!(host_fwd[0].host_address.as_deref(), Some("::1"));
+                assert_eq!(host_fwd[0].host_port, 8080);
+                assert_eq!(host_fwd[0].guest_port, 80);
+            }
+            _ => panic!("Expected Consomme variant with IPv6 hostfwd"),
+        }
+
+        // Test consomme with IPv6 guest address (bracketed)
+        match EndpointConfigCli::from_str("consomme:hostfwd=tcp::8080-[::1]:80").unwrap() {
+            EndpointConfigCli::Consomme { cidr, host_fwd } => {
+                assert!(cidr.is_none());
+                assert_eq!(host_fwd[0].host_port, 8080);
+                assert_eq!(host_fwd[0].guest_port, 80);
+            }
+            _ => panic!("Expected Consomme variant with IPv6 guest address"),
         }
 
         // Test dio without id

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1549,7 +1549,7 @@ pub enum EndpointConfigCli {
 #[derive(Clone, Debug, PartialEq)]
 pub struct HostPortConfigCli {
     pub protocol: HostPortProtocolCli,
-    pub host_address: Option<String>,
+    pub host_address: Option<std::net::IpAddr>,
     pub host_port: u16,
     pub guest_port: u16,
 }
@@ -1603,14 +1603,17 @@ fn parse_hostfwd(s: &str) -> Result<HostPortConfigCli, String> {
 /// - `addr:port`
 /// - `:port`  (empty address)
 /// - `port`   (no address)
-fn parse_addr_port(s: &str) -> Result<(Option<String>, u16), String> {
+fn parse_addr_port(s: &str) -> Result<(Option<std::net::IpAddr>, u16), String> {
     if let Some(rest) = s.strip_prefix('[') {
         // Bracketed IPv6 address: [addr]:port
         let (addr, port) = rest
             .split_once("]:")
             .ok_or_else(|| format!("expected '[addr]:port', got '[{rest}'"))?;
         let port: u16 = port.parse().map_err(|_| format!("invalid port '{port}'"))?;
-        Ok((Some(addr.to_owned()), port))
+        let addr: std::net::IpAddr = addr
+            .parse()
+            .map_err(|e| format!("invalid address '{addr}': {e}"))?;
+        Ok((Some(addr), port))
     } else {
         match s.rsplit_once(':') {
             Some((addr, port)) => {
@@ -1618,7 +1621,10 @@ fn parse_addr_port(s: &str) -> Result<(Option<String>, u16), String> {
                 let addr = if addr.is_empty() {
                     None
                 } else {
-                    Some(addr.to_owned())
+                    let parsed: std::net::IpAddr = addr
+                        .parse()
+                        .map_err(|e| format!("invalid address '{addr}': {e}"))?;
+                    Some(parsed)
                 };
                 Ok((addr, port))
             }
@@ -2772,7 +2778,10 @@ mod tests {
                 assert!(cidr.is_none());
                 assert_eq!(host_fwd.len(), 1);
                 assert_eq!(host_fwd[0].protocol, HostPortProtocolCli::Udp);
-                assert_eq!(host_fwd[0].host_address.as_deref(), Some("127.0.0.1"));
+                assert_eq!(
+                    host_fwd[0].host_address,
+                    Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
+                );
                 assert_eq!(host_fwd[0].host_port, 5000);
                 assert_eq!(host_fwd[0].guest_port, 5000);
             }
@@ -2812,7 +2821,10 @@ mod tests {
                 assert!(cidr.is_none());
                 assert_eq!(host_fwd.len(), 1);
                 assert_eq!(host_fwd[0].protocol, HostPortProtocolCli::Tcp);
-                assert_eq!(host_fwd[0].host_address.as_deref(), Some("127.0.0.1"));
+                assert_eq!(
+                    host_fwd[0].host_address,
+                    Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
+                );
                 assert_eq!(host_fwd[0].host_port, 8080);
                 assert_eq!(host_fwd[0].guest_port, 80);
             }
@@ -2835,7 +2847,10 @@ mod tests {
                 assert!(cidr.is_none());
                 assert_eq!(host_fwd.len(), 1);
                 assert_eq!(host_fwd[0].protocol, HostPortProtocolCli::Tcp);
-                assert_eq!(host_fwd[0].host_address.as_deref(), Some("::1"));
+                assert_eq!(
+                    host_fwd[0].host_address,
+                    Some(std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))
+                );
                 assert_eq!(host_fwd[0].host_port, 8080);
                 assert_eq!(host_fwd[0].guest_port, 80);
             }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -281,7 +281,7 @@ options:
     /// For consomme, forward host ports into the guest with `hostfwd=`:
     ///   --net consomme:hostfwd=tcp::3389-:3389
     ///   --net consomme:hostfwd=tcp:127.0.0.1:8080-:80
-    ///   --net consomme:hostfwd=tcp:[::1]:8080-:80
+    ///   --net consomme:hostfwd=tcp:\[::1\]:8080-:80
     ///   --net consomme:10.0.0.0/24,hostfwd=tcp::22-:22,hostfwd=udp::5000-:5000
     #[clap(long)]
     pub net: Vec<NicConfigCli>,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -568,7 +568,10 @@ async fn vm_config_from_command_line(
         let nic_config = parse_endpoint(
             &NicConfigCli {
                 vtl: DeviceVtl::Vtl0,
-                endpoint: EndpointConfigCli::Consomme { cidr: None },
+                endpoint: EndpointConfigCli::Consomme {
+                    cidr: None,
+                    host_fwd: Vec::new(),
+                },
                 max_queues: None,
                 underhill: false,
                 pcie_port: None,
@@ -1714,8 +1717,27 @@ fn parse_endpoint(
 ) -> anyhow::Result<NicConfig> {
     let _ = resources;
     let endpoint = match &cli_cfg.endpoint {
-        EndpointConfigCli::Consomme { cidr } => {
-            net_backend_resources::consomme::ConsommeHandle { cidr: cidr.clone() }.into_resource()
+        EndpointConfigCli::Consomme { cidr, host_fwd } => {
+            let ports = host_fwd
+                .iter()
+                .map(|fwd| {
+                    use net_backend_resources::consomme::HostPortProtocol;
+                    net_backend_resources::consomme::HostPortConfig {
+                        protocol: match fwd.protocol {
+                            cli_args::HostPortProtocolCli::Tcp => HostPortProtocol::Tcp,
+                            cli_args::HostPortProtocolCli::Udp => HostPortProtocol::Udp,
+                        },
+                        host_address: fwd.host_address.clone(),
+                        host_port: fwd.host_port,
+                        guest_port: fwd.guest_port,
+                    }
+                })
+                .collect();
+            net_backend_resources::consomme::ConsommeHandle {
+                cidr: cidr.clone(),
+                ports,
+            }
+            .into_resource()
         }
         EndpointConfigCli::None => net_backend_resources::null::NullHandle.into_resource(),
         EndpointConfigCli::Dio { id } => {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1727,7 +1727,9 @@ fn parse_endpoint(
                             cli_args::HostPortProtocolCli::Tcp => HostPortProtocol::Tcp,
                             cli_args::HostPortProtocolCli::Udp => HostPortProtocol::Udp,
                         },
-                        host_address: fwd.host_address.clone(),
+                        host_address: fwd
+                            .host_address
+                            .map(net_backend_resources::consomme::HostIpAddress::from),
                         host_port: fwd.host_port,
                         guest_port: fwd.guest_port,
                     }

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -87,8 +87,11 @@ impl PetriVmConfigOpenVmm {
     ///
     /// Uses a mana emulator and the paravisor if a paravisor is present.
     pub fn with_nic(mut self) -> Self {
-        let endpoint =
-            net_backend_resources::consomme::ConsommeHandle { cidr: None }.into_resource();
+        let endpoint = net_backend_resources::consomme::ConsommeHandle {
+            cidr: None,
+            ports: Vec::new(),
+        }
+        .into_resource();
         if let Some(vtl2_settings) = self.runtime_config.vtl2_settings.as_mut() {
             self.config.vpci_devices.push(VpciDeviceConfig {
                 vtl: DeviceVtl::Vtl2,
@@ -128,8 +131,11 @@ impl PetriVmConfigOpenVmm {
 
     /// Add a PCIe NIC to the VM using the MANA emulator.
     pub fn with_pcie_nic(mut self, port_name: &str, mac_address: MacAddress) -> Self {
-        let endpoint =
-            net_backend_resources::consomme::ConsommeHandle { cidr: None }.into_resource();
+        let endpoint = net_backend_resources::consomme::ConsommeHandle {
+            cidr: None,
+            ports: Vec::new(),
+        }
+        .into_resource();
         self.config.pcie_devices.push(PcieDeviceConfig {
             port_name: port_name.to_string(),
             resource: GdmaDeviceHandle {
@@ -174,8 +180,11 @@ impl PetriVmConfigOpenVmm {
     /// This exposes a virtio-net device on a PCIe root port, suitable for
     /// guests running virtio drivers (e.g. Linux with UEFI boot).
     pub fn with_virtio_nic(mut self, port_name: &str) -> Self {
-        let endpoint =
-            net_backend_resources::consomme::ConsommeHandle { cidr: None }.into_resource();
+        let endpoint = net_backend_resources::consomme::ConsommeHandle {
+            cidr: None,
+            ports: Vec::new(),
+        }
+        .into_resource();
 
         self.config.pcie_devices.push(PcieDeviceConfig {
             port_name: port_name.to_string(),

--- a/vm/devices/net/net_backend_resources/src/lib.rs
+++ b/vm/devices/net/net_backend_resources/src/lib.rs
@@ -40,13 +40,40 @@ pub mod consomme {
         Udp,
     }
 
+    /// An IP address, suitable for serialization via mesh.
+    #[derive(Clone, Debug, MeshPayload)]
+    pub enum HostIpAddress {
+        /// IPv4 address.
+        Ipv4(std::net::Ipv4Addr),
+        /// IPv6 address.
+        Ipv6(std::net::Ipv6Addr),
+    }
+
+    impl From<std::net::IpAddr> for HostIpAddress {
+        fn from(addr: std::net::IpAddr) -> Self {
+            match addr {
+                std::net::IpAddr::V4(v4) => HostIpAddress::Ipv4(v4),
+                std::net::IpAddr::V6(v6) => HostIpAddress::Ipv6(v6),
+            }
+        }
+    }
+
+    impl From<HostIpAddress> for std::net::IpAddr {
+        fn from(addr: HostIpAddress) -> Self {
+            match addr {
+                HostIpAddress::Ipv4(v4) => std::net::IpAddr::V4(v4),
+                HostIpAddress::Ipv6(v6) => std::net::IpAddr::V6(v6),
+            }
+        }
+    }
+
     /// Configuration for forwarding a host port into the guest.
     #[derive(Clone, Debug, MeshPayload)]
     pub struct HostPortConfig {
         /// The protocol to forward.
         pub protocol: HostPortProtocol,
         /// The host IP address to bind to, or `None` to bind to all interfaces.
-        pub host_address: Option<String>,
+        pub host_address: Option<HostIpAddress>,
         /// The host port to listen on.
         pub host_port: u16,
         /// The guest port to forward to.

--- a/vm/devices/net/net_backend_resources/src/lib.rs
+++ b/vm/devices/net/net_backend_resources/src/lib.rs
@@ -31,11 +31,35 @@ pub mod consomme {
     use vm_resource::ResourceId;
     use vm_resource::kind::NetEndpointHandleKind;
 
+    /// Protocol for host port forwarding.
+    #[derive(Clone, Debug, MeshPayload)]
+    pub enum HostPortProtocol {
+        /// TCP protocol.
+        Tcp,
+        /// UDP protocol.
+        Udp,
+    }
+
+    /// Configuration for forwarding a host port into the guest.
+    #[derive(Clone, Debug, MeshPayload)]
+    pub struct HostPortConfig {
+        /// The protocol to forward.
+        pub protocol: HostPortProtocol,
+        /// The host IP address to bind to, or `None` to bind to all interfaces.
+        pub host_address: Option<String>,
+        /// The host port to listen on.
+        pub host_port: u16,
+        /// The guest port to forward to.
+        pub guest_port: u16,
+    }
+
     /// Handle to a Consomme network endpoint.
     #[derive(MeshPayload)]
     pub struct ConsommeHandle {
         /// The CIDR of the network to use.
         pub cidr: Option<String>,
+        /// Ports to forward from the host into the guest.
+        pub ports: Vec<HostPortConfig>,
     }
 
     impl ResourceId<NetEndpointHandleKind> for ConsommeHandle {

--- a/vm/devices/net/net_consomme/Cargo.toml
+++ b/vm/devices/net/net_consomme/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 consomme.workspace = true
 net_backend.workspace = true
 net_backend_resources.workspace = true
+socket2.workspace = true
 
 vm_resource.workspace = true
 

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -386,12 +386,6 @@ pub enum DropReason {
     /// The TCP state is invalid.
     #[error("bad tcp state")]
     BadTcpState(#[from] tcp::TcpError),
-    /// Specified port is not bound.
-    #[error("port is not bound")]
-    PortNotBound,
-    /// The specified port is already bound.
-    #[error("port {0} is already bound")]
-    PortAlreadyBound(u16),
     /// The DHCPv6 message type is unsupported.
     #[error("unsupported dhcpv6 message type {0:?}")]
     UnsupportedDhcpv6(dhcpv6::MessageType),
@@ -409,6 +403,20 @@ pub enum DropReason {
     /// since IP reassembly is not supported.
     #[error("packet fragmentation is not supported")]
     FragmentedPacket,
+}
+
+/// An error from a port bind or unbind operation.
+#[derive(Debug, Error)]
+pub enum BindError {
+    /// The specified port is already bound.
+    #[error("port {0} is already bound")]
+    PortAlreadyBound(u16),
+    /// The specified port is not bound.
+    #[error("port is not bound")]
+    PortNotBound,
+    /// An IO error occurred during binding.
+    #[error(transparent)]
+    Io(std::io::Error),
 }
 
 /// An error to create a consomme instance.

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -389,6 +389,9 @@ pub enum DropReason {
     /// Specified port is not bound.
     #[error("port is not bound")]
     PortNotBound,
+    /// The specified port is already bound.
+    #[error("port {0} is already bound")]
+    PortAlreadyBound(u16),
     /// The DHCPv6 message type is unsupported.
     #[error("unsupported dhcpv6 message type {0:?}")]
     UnsupportedDhcpv6(dhcpv6::MessageType),

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -5,6 +5,7 @@ mod assembler;
 mod ring;
 
 use super::Access;
+use super::BindError;
 use super::Client;
 use super::DropReason;
 use crate::ChecksumState;
@@ -16,6 +17,7 @@ use futures::AsyncRead;
 use futures::AsyncWrite;
 use inspect::Inspect;
 use inspect::InspectMut;
+use pal_async::driver::Driver;
 use pal_async::interest::PollEvents;
 use pal_async::socket::PollReady;
 use pal_async::socket::PolledSocket;
@@ -46,8 +48,6 @@ use std::io::ErrorKind;
 use std::io::IoSlice;
 use std::io::IoSliceMut;
 use std::net::IpAddr;
-use std::net::Ipv4Addr;
-use std::net::Ipv6Addr;
 use std::net::Shutdown;
 use std::net::SocketAddr;
 use std::net::SocketAddrV4;
@@ -438,56 +438,28 @@ impl<T: Client> Access<'_, T> {
     }
 
     /// Binds to the specified host IP and port for listening for incoming
-    /// connections. The returned value is the actual port number that was bound.
-    pub fn bind_tcp_port(
-        &mut self,
-        ip_addr: Option<IpAddr>,
-        guest_port: u16,
-        host_port: u16,
-    ) -> Result<u16, DropReason> {
-        let ip_addr = match ip_addr {
-            Some(IpAddr::V4(ip)) => SocketAddr::V4(SocketAddrV4::new(ip, host_port)),
-            Some(IpAddr::V6(ip)) => SocketAddr::V6(SocketAddrV6::new(ip, host_port, 0, 0)),
-            None => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, host_port)),
-        };
-        let listener = match self.inner.tcp.listeners.entry(guest_port) {
+    /// connections.
+    pub fn bind_tcp_port(&mut self, socket: Socket, guest_port: u16) -> Result<(), BindError> {
+        match self.inner.tcp.listeners.entry(guest_port) {
             hash_map::Entry::Occupied(_) => {
-                return Err(DropReason::PortAlreadyBound(guest_port));
+                return Err(BindError::PortAlreadyBound(guest_port));
             }
             hash_map::Entry::Vacant(e) => {
-                let ft = match ip_addr {
-                    SocketAddr::V4(ip) => FourTuple {
-                        dst: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
-                        src: SocketAddr::V4(ip),
-                    },
-                    SocketAddr::V6(ip) => FourTuple {
-                        dst: SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0)),
-                        src: SocketAddr::V6(ip),
-                    },
-                };
-                let mut sender = Sender {
-                    ft: &ft,
-                    client: self.client,
-                    state: &mut self.inner.state,
-                };
-
-                let listener = TcpListener::new(&mut sender)?;
-                e.insert(listener)
+                let listener = TcpListener::from_socket(self.client.driver(), socket)?;
+                e.insert(listener);
             }
         };
-        let local_addr = listener.socket.get().local_addr().map_err(DropReason::Io)?;
-        let host_port = local_addr.as_socket().map_or(0, |addr| addr.port());
-        Ok(host_port)
+        Ok(())
     }
 
     /// Unbinds from the specified host port.
-    pub fn unbind_tcp_port(&mut self, port: u16) -> Result<(), DropReason> {
+    pub fn unbind_tcp_port(&mut self, port: u16) -> Result<(), BindError> {
         match self.inner.tcp.listeners.entry(port) {
             hash_map::Entry::Occupied(e) => {
                 e.remove();
                 Ok(())
             }
-            hash_map::Entry::Vacant(_) => Err(DropReason::PortNotBound),
+            hash_map::Entry::Vacant(_) => Err(BindError::PortNotBound),
         }
     }
 }
@@ -1391,28 +1363,18 @@ impl TcpConnectionInner {
 }
 
 impl TcpListener {
-    pub fn new(sender: &mut Sender<'_, impl Client>) -> Result<Self, DropReason> {
-        let socket = match sender.ft.src {
-            SocketAddr::V4(_) => Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)),
-            SocketAddr::V6(_) => Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP)),
-        }
-        .map_err(DropReason::Io)?;
-
-        let socket = PolledSocket::new(sender.client.driver(), socket).map_err(DropReason::Io)?;
-        if let Err(err) = socket.get().bind(&sender.ft.src.into()) {
-            tracing::warn!(
-                address = ?sender.ft.src,
-                error = &err as &dyn std::error::Error,
-                "socket bind error"
-            );
-            return Err(DropReason::Io(err));
-        }
+    /// Creates a `TcpListener` from an already-bound `socket2::Socket`.
+    ///
+    /// The socket must already be bound to an address. This method will call
+    /// `listen` on it.
+    pub fn from_socket(driver: &dyn Driver, socket: Socket) -> Result<Self, BindError> {
+        let socket = PolledSocket::new(driver, socket).map_err(BindError::Io)?;
         if let Err(err) = socket.listen(10) {
             tracing::warn!(
                 error = &err as &dyn std::error::Error,
                 "socket listen error"
             );
-            return Err(DropReason::Io(err));
+            return Err(BindError::Io(err));
         }
         Ok(Self { socket })
     }

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -438,16 +438,21 @@ impl<T: Client> Access<'_, T> {
     }
 
     /// Binds to the specified host IP and port for listening for incoming
-    /// connections.
-    pub fn bind_tcp_port(&mut self, ip_addr: Option<IpAddr>, port: u16) -> Result<(), DropReason> {
+    /// connections. The returned value is the actual port number that was bound.
+    pub fn bind_tcp_port(
+        &mut self,
+        ip_addr: Option<IpAddr>,
+        guest_port: u16,
+        host_port: u16,
+    ) -> Result<u16, DropReason> {
         let ip_addr = match ip_addr {
-            Some(IpAddr::V4(ip)) => SocketAddr::V4(SocketAddrV4::new(ip, port)),
-            Some(IpAddr::V6(ip)) => SocketAddr::V6(SocketAddrV6::new(ip, port, 0, 0)),
-            None => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)),
+            Some(IpAddr::V4(ip)) => SocketAddr::V4(SocketAddrV4::new(ip, host_port)),
+            Some(IpAddr::V6(ip)) => SocketAddr::V6(SocketAddrV6::new(ip, host_port, 0, 0)),
+            None => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, host_port)),
         };
-        match self.inner.tcp.listeners.entry(port) {
+        let listener = match self.inner.tcp.listeners.entry(guest_port) {
             hash_map::Entry::Occupied(_) => {
-                tracing::warn!(port, "Duplicate TCP bind for port");
+                return Err(DropReason::PortAlreadyBound(guest_port));
             }
             hash_map::Entry::Vacant(e) => {
                 let ft = match ip_addr {
@@ -467,10 +472,12 @@ impl<T: Client> Access<'_, T> {
                 };
 
                 let listener = TcpListener::new(&mut sender)?;
-                e.insert(listener);
+                e.insert(listener)
             }
-        }
-        Ok(())
+        };
+        let local_addr = listener.socket.get().local_addr().map_err(DropReason::Io)?;
+        let host_port = local_addr.as_socket().map_or(0, |addr| addr.port());
+        Ok(host_port)
     }
 
     /// Unbinds from the specified host port.

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -13,6 +13,7 @@ use parking_lot::Mutex;
 use smoltcp::wire::EthernetAddress;
 use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Repr;
+use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 // ── Mock client ────────────────────────────────────────────────────
@@ -32,7 +33,7 @@ impl TestClient {
 }
 
 impl Client for TestClient {
-    fn driver(&self) -> &dyn pal_async::driver::Driver {
+    fn driver(&self) -> &dyn Driver {
         &self.driver
     }
 

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use super::*;
+use crate::BindError;
 use crate::ChecksumState;
 use crate::Client;
 use crate::Consomme;
@@ -14,6 +15,7 @@ use smoltcp::wire::EthernetAddress;
 use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Repr;
 use std::net::Ipv4Addr;
+use std::net::SocketAddrV4;
 use std::sync::Arc;
 
 // ── Mock client ────────────────────────────────────────────────────
@@ -555,5 +557,109 @@ async fn test_tcp_overlapping_retransmit(driver: DefaultDriver) {
         &received[5..7] == b"##" || &received[5..7] == b"BB",
         "overlap region should be from one segment or the other, got {:?}",
         &received[5..7]
+    );
+}
+
+/// Test that `bind_tcp_port` registers a listener and that an external
+/// TCP connection is forwarded to the guest as a SYN packet.
+#[pal_async::async_test]
+async fn test_tcp_bind_port_forward(driver: DefaultDriver) {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+    let mut client = TestClient::new(driver.clone());
+
+    let guest_port = 7777;
+    let received = client.received_packets.clone();
+
+    // Create and bind a TCP socket.
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket
+        .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+        .unwrap();
+    let host_addr = socket.local_addr().unwrap().as_socket().unwrap();
+
+    {
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_tcp_port(socket, guest_port)
+            .expect("bind should succeed");
+
+        assert!(
+            access.inner.tcp.listeners.contains_key(&guest_port),
+            "listener should be registered"
+        );
+    }
+
+    // Connect from a host-side client to trigger the listener.
+    let connector = std::net::TcpStream::connect(host_addr).unwrap();
+    connector.set_nonblocking(true).unwrap();
+
+    // Poll until consomme delivers a SYN to the guest.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        std::future::poll_fn(|cx| {
+            consomme.access(&mut client).poll(cx);
+            Poll::Ready(())
+        })
+        .await;
+
+        let has_syn = received.lock().iter().any(|p| {
+            TcpTestHarness::is_tcp_packet(p)
+                .is_some_and(|t| t.control == TcpControl::Syn && t.dst_port == guest_port)
+        });
+        if has_syn {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for forwarded TCP SYN"
+        );
+        pal_async::timer::PolledTimer::new(&driver)
+            .sleep(std::time::Duration::from_millis(10))
+            .await;
+    }
+
+    // Verify the SYN targets the correct guest port.
+    let packets = received.lock();
+    let syn_pkt = packets
+        .iter()
+        .find(|p| {
+            TcpTestHarness::is_tcp_packet(p)
+                .is_some_and(|t| t.control == TcpControl::Syn && t.dst_port == guest_port)
+        })
+        .expect("should have received a SYN");
+    let (_, _, tcp) = parse_tcp_packet(syn_pkt);
+    assert_eq!(tcp.dst_port, guest_port);
+    assert_eq!(tcp.control, TcpControl::Syn);
+}
+
+/// Test that binding the same guest port twice returns `PortAlreadyBound`.
+#[pal_async::async_test]
+async fn test_tcp_bind_duplicate_port(driver: DefaultDriver) {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+    let mut client = TestClient::new(driver);
+
+    let guest_port = 8888;
+
+    let socket1 = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket1
+        .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+        .unwrap();
+
+    let socket2_inst = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket2_inst
+        .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+        .unwrap();
+
+    let mut access = consomme.access(&mut client);
+    access
+        .bind_tcp_port(socket1, guest_port)
+        .expect("first bind should succeed");
+
+    let err = access
+        .bind_tcp_port(socket2_inst, guest_port)
+        .expect_err("duplicate bind should fail");
+    assert!(
+        matches!(err, BindError::PortAlreadyBound(_)),
+        "error should be PortAlreadyBound"
     );
 }

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use super::Access;
+use super::BindError;
 use super::Client;
 use super::DropReason;
 use super::dhcp::DHCP_SERVER;
@@ -38,6 +39,7 @@ use smoltcp::wire::Ipv6Repr;
 use smoltcp::wire::UDP_HEADER_LEN;
 use smoltcp::wire::UdpPacket;
 use smoltcp::wire::UdpRepr;
+use socket2::Socket;
 use std::collections::HashMap;
 use std::collections::hash_map;
 use std::io::ErrorKind;
@@ -62,6 +64,7 @@ use crate::windows as platform;
 
 pub(crate) struct Udp {
     connections: HashMap<SocketAddr, UdpConnection>,
+    listeners: HashMap<u16, UdpListener>,
     timeout: Duration,
 }
 
@@ -69,6 +72,7 @@ impl Udp {
     pub fn new(timeout: Duration) -> Self {
         Self {
             connections: HashMap::new(),
+            listeners: HashMap::new(),
             timeout,
         }
     }
@@ -81,7 +85,20 @@ impl InspectMut for Udp {
             let key = addr.to_string();
             resp.field_mut(&key, conn);
         }
+        for (port, listener) in &mut self.listeners {
+            resp.field_mut(&format!("listener:{port}"), listener);
+        }
     }
+}
+
+#[derive(InspectMut)]
+struct UdpListener {
+    #[inspect(skip)]
+    socket: Option<PolledSocket<UdpSocket>>,
+    /// The guest port to forward received packets to.
+    #[inspect(display)]
+    guest_port: u16,
+    stats: Stats,
 }
 
 #[derive(InspectMut)]
@@ -192,6 +209,97 @@ impl UdpConnection {
     }
 }
 
+impl UdpListener {
+    fn poll_listener(
+        &mut self,
+        cx: &mut Context<'_>,
+        state: &mut ConsommeState,
+        client: &mut impl Client,
+    ) {
+        let Some(socket) = self.socket.as_mut() else {
+            return;
+        };
+        let mut eth = EthernetFrame::new_unchecked(&mut state.buffer);
+        loop {
+            if client.rx_mtu() == 0 {
+                break;
+            }
+
+            // Determine header offset and guest destination from the bound socket's address family.
+            let local_addr = match socket.get().local_addr() {
+                Ok(addr) => addr,
+                Err(_) => break,
+            };
+            let (header_offset, guest_dst_ip, guest_mac) = match local_addr.ip() {
+                IpAddr::V4(_) => (
+                    IPV4_HEADER_LEN + UDP_HEADER_LEN,
+                    IpAddr::V4(state.params.client_ip),
+                    state.params.client_mac,
+                ),
+                IpAddr::V6(_) => {
+                    let Some(client_ipv6) = state.params.client_ip_ipv6 else {
+                        break;
+                    };
+                    (
+                        IPV6_HEADER_LEN + UDP_HEADER_LEN,
+                        IpAddr::V6(client_ipv6),
+                        state.params.client_mac,
+                    )
+                }
+            };
+
+            match socket.poll_io(cx, InterestSlot::Read, PollEvents::IN, |socket| {
+                socket
+                    .get()
+                    .recv_from(&mut eth.payload_mut()[header_offset..])
+            }) {
+                Poll::Ready(Ok((n, src_addr))) => {
+                    let (packet_len, checksum_state) = match (guest_dst_ip, src_addr.ip()) {
+                        (IpAddr::V4(dst_ip), IpAddr::V4(src_ip)) => {
+                            let len = build_udp_packet(
+                                &mut eth,
+                                src_ip.into(),
+                                dst_ip.into(),
+                                src_addr.port(),
+                                self.guest_port,
+                                n,
+                                state.params.gateway_mac,
+                                guest_mac,
+                            );
+                            (len, ChecksumState::UDP4)
+                        }
+                        (IpAddr::V6(dst_ip), IpAddr::V6(src_ip)) => {
+                            let len = build_udp_packet(
+                                &mut eth,
+                                src_ip.into(),
+                                dst_ip.into(),
+                                src_addr.port(),
+                                self.guest_port,
+                                n,
+                                state.params.gateway_mac,
+                                guest_mac,
+                            );
+                            (len, ChecksumState::NONE)
+                        }
+                        _ => unreachable!("mismatched address families"),
+                    };
+
+                    client.recv(&eth.as_ref()[..packet_len], &checksum_state);
+                    self.stats.rx_packets.increment();
+                }
+                Poll::Ready(Err(err)) => {
+                    tracelimit::error_ratelimited!(
+                        error = &err as &dyn std::error::Error,
+                        "udp listener recv error"
+                    );
+                    break;
+                }
+                Poll::Pending => break,
+            }
+        }
+    }
+}
+
 impl<T: Client> Access<'_, T> {
     pub(crate) fn poll_udp(&mut self, cx: &mut Context<'_>) {
         let timeout = self.inner.udp.timeout;
@@ -209,6 +317,11 @@ impl<T: Client> Access<'_, T> {
 
             conn.poll_conn(cx, dst_addr, &mut self.inner.state, self.client)
         });
+
+        for listener in self.inner.udp.listeners.values_mut() {
+            listener.poll_listener(cx, &mut self.inner.state, self.client);
+        }
+
         while let Some(response) =
             self.inner
                 .dns
@@ -236,6 +349,23 @@ impl<T: Client> Access<'_, T> {
                     tracing::warn!(
                         error = &err as &dyn std::error::Error,
                         "failed to update driver for udp connection"
+                    );
+                    false
+                }
+            }
+        });
+        self.inner.udp.listeners.retain(|port, listener| {
+            let socket = listener.socket.take().unwrap().into_inner();
+            match PolledSocket::new(self.client.driver(), socket) {
+                Ok(socket) => {
+                    listener.socket = Some(socket);
+                    true
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        port,
+                        error = &err as &dyn std::error::Error,
+                        "failed to update driver for udp listener"
                     );
                     false
                 }
@@ -413,38 +543,29 @@ impl<T: Client> Access<'_, T> {
 
     /// Binds to the specified host IP and port for forwarding inbound UDP
     /// packets to the guest.
-    pub fn bind_udp_port(
-        &mut self,
-        ip_addr: Option<IpAddr>,
-        guest_port: u16,
-        host_port: u16,
-    ) -> Result<u16, DropReason> {
-        let guest_addr = match ip_addr {
-            Some(IpAddr::V4(ip)) => SocketAddr::V4(SocketAddrV4::new(ip, guest_port)),
-            Some(IpAddr::V6(ip)) => SocketAddr::V6(SocketAddrV6::new(ip, guest_port, 0, 0)),
-            None => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, guest_port)),
-        };
-        let conn = self.get_or_insert(guest_addr, Some(host_port), None)?;
-        let host_port = conn
-            .socket
-            .as_ref()
-            .map_or(0, |s| s.get().local_addr().map_or(0, |addr| addr.port()));
-        Ok(host_port)
+    pub fn bind_udp_port(&mut self, socket: Socket, guest_port: u16) -> Result<(), BindError> {
+        if self.inner.udp.listeners.contains_key(&guest_port) {
+            return Err(BindError::PortAlreadyBound(guest_port));
+        }
+        let socket: UdpSocket = socket.into();
+        let socket = PolledSocket::new(self.client.driver(), socket).map_err(BindError::Io)?;
+        self.inner.udp.listeners.insert(
+            guest_port,
+            UdpListener {
+                socket: Some(socket),
+                guest_port,
+                stats: Default::default(),
+            },
+        );
+        Ok(())
     }
 
-    /// Unbinds from the specified host port for both IPv4 and IPv6.
-    pub fn unbind_udp_port(&mut self, port: u16) -> Result<(), DropReason> {
-        // Try to remove both IPv4 and IPv6 bindings
-        let v4_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port));
-        let v6_addr = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, port, 0, 0));
-
-        let v4_removed = self.inner.udp.connections.remove(&v4_addr).is_some();
-        let v6_removed = self.inner.udp.connections.remove(&v6_addr).is_some();
-
-        if v4_removed || v6_removed {
+    /// Unbinds from the specified guest port.
+    pub fn unbind_udp_port(&mut self, port: u16) -> Result<(), BindError> {
+        if self.inner.udp.listeners.remove(&port).is_some() {
             Ok(())
         } else {
-            Err(DropReason::PortNotBound)
+            Err(BindError::PortNotBound)
         }
     }
 

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -304,7 +304,7 @@ impl<T: Client> Access<'_, T> {
             }
         };
 
-        let conn = self.get_or_insert(guest_addr, Some(frame.src_addr))?;
+        let conn = self.get_or_insert(guest_addr, None, Some(frame.src_addr))?;
         let socket = conn.socket.as_ref().unwrap().get();
         if conn.gso_size != checksum.gso {
             platform::set_udp_gso_size(socket, checksum.gso.unwrap_or(0))
@@ -332,6 +332,7 @@ impl<T: Client> Access<'_, T> {
     fn get_or_insert(
         &mut self,
         guest_addr: SocketAddr,
+        host_port: Option<u16>,
         guest_mac: Option<EthernetAddress>,
     ) -> Result<&mut UdpConnection, DropReason> {
         let entry = self.inner.udp.connections.entry(guest_addr);
@@ -339,12 +340,16 @@ impl<T: Client> Access<'_, T> {
             hash_map::Entry::Occupied(conn) => Ok(conn.into_mut()),
             hash_map::Entry::Vacant(e) => {
                 let bind_addr: SocketAddr = match guest_addr {
-                    SocketAddr::V4(_) => {
-                        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
-                    }
-                    SocketAddr::V6(_) => {
-                        SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0))
-                    }
+                    SocketAddr::V4(_) => SocketAddr::V4(SocketAddrV4::new(
+                        Ipv4Addr::UNSPECIFIED,
+                        host_port.unwrap_or(0),
+                    )),
+                    SocketAddr::V6(_) => SocketAddr::V6(SocketAddrV6::new(
+                        Ipv6Addr::UNSPECIFIED,
+                        host_port.unwrap_or(0),
+                        0,
+                        0,
+                    )),
                 };
 
                 let socket = UdpSocket::bind(bind_addr).map_err(DropReason::Io)?;
@@ -408,14 +413,23 @@ impl<T: Client> Access<'_, T> {
 
     /// Binds to the specified host IP and port for forwarding inbound UDP
     /// packets to the guest.
-    pub fn bind_udp_port(&mut self, ip_addr: Option<IpAddr>, port: u16) -> Result<(), DropReason> {
+    pub fn bind_udp_port(
+        &mut self,
+        ip_addr: Option<IpAddr>,
+        guest_port: u16,
+        host_port: u16,
+    ) -> Result<u16, DropReason> {
         let guest_addr = match ip_addr {
-            Some(IpAddr::V4(ip)) => SocketAddr::V4(SocketAddrV4::new(ip, port)),
-            Some(IpAddr::V6(ip)) => SocketAddr::V6(SocketAddrV6::new(ip, port, 0, 0)),
-            None => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)),
+            Some(IpAddr::V4(ip)) => SocketAddr::V4(SocketAddrV4::new(ip, guest_port)),
+            Some(IpAddr::V6(ip)) => SocketAddr::V6(SocketAddrV6::new(ip, guest_port, 0, 0)),
+            None => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, guest_port)),
         };
-        let _ = self.get_or_insert(guest_addr, None)?;
-        Ok(())
+        let conn = self.get_or_insert(guest_addr, Some(host_port), None)?;
+        let host_port = conn
+            .socket
+            .as_ref()
+            .map_or(0, |s| s.get().local_addr().map_or(0, |addr| addr.port()));
+        Ok(host_port)
     }
 
     /// Unbinds from the specified host port for both IPv4 and IPv6.

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -254,7 +254,7 @@ impl UdpListener {
                     .recv_from(&mut eth.payload_mut()[header_offset..])
             }) {
                 Poll::Ready(Ok((n, src_addr))) => {
-                    let (packet_len, checksum_state) = match (guest_dst_ip, src_addr.ip()) {
+                    let Some((packet_len, checksum_state)) = (match (guest_dst_ip, src_addr.ip()) {
                         (IpAddr::V4(dst_ip), IpAddr::V4(src_ip)) => {
                             let len = build_udp_packet(
                                 &mut eth,
@@ -266,7 +266,7 @@ impl UdpListener {
                                 state.params.gateway_mac,
                                 guest_mac,
                             );
-                            (len, ChecksumState::UDP4)
+                            Some((len, ChecksumState::UDP4))
                         }
                         (IpAddr::V6(dst_ip), IpAddr::V6(src_ip)) => {
                             let len = build_udp_packet(
@@ -279,9 +279,18 @@ impl UdpListener {
                                 state.params.gateway_mac,
                                 guest_mac,
                             );
-                            (len, ChecksumState::NONE)
+                            Some((len, ChecksumState::NONE))
                         }
-                        _ => unreachable!("mismatched address families"),
+                        _ => {
+                            tracelimit::warn_ratelimited!(
+                                local_addr = %local_addr,
+                                src_addr = %src_addr,
+                                "udp listener received packet with mismatched address family"
+                            );
+                            None
+                        }
+                    }) else {
+                        continue;
                     };
 
                     client.recv(&eth.as_ref()[..packet_len], &checksum_state);
@@ -835,6 +844,102 @@ mod tests {
             access.udp_connection_count(),
             0,
             "Connection should be removed after timeout"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_udp_bind_port_forward(driver: DefaultDriver) {
+        let driver = Arc::new(driver);
+        let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
+        let mut client = TestClient::new(driver.clone());
+
+        // Bind a UDP listener socket on an ephemeral port.
+        let socket = Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        socket
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+        let host_addr: SocketAddr = socket.local_addr().unwrap().as_socket().unwrap();
+
+        let guest_port = 5555;
+        let packets = client.received_packets.clone();
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_udp_port(socket, guest_port)
+            .expect("bind should succeed");
+
+        assert!(
+            access.inner.udp.listeners.contains_key(&guest_port),
+            "listener should be registered"
+        );
+
+        // Send a UDP packet to the listener from another socket.
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        sender.send_to(b"hello", host_addr).unwrap();
+
+        // Poll until the forwarded packet arrives (the first poll registers
+        // interest, subsequent polls receive the data).
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            std::future::poll_fn(|cx| {
+                access.poll(cx);
+                Poll::Ready(())
+            })
+            .await;
+
+            if !packets.lock().is_empty() {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for forwarded UDP packet"
+            );
+            pal_async::timer::PolledTimer::new(&*driver)
+                .sleep(Duration::from_millis(10))
+                .await;
+        }
+
+        // Verify the packet targets the guest IP and the correct guest port.
+        let packets = packets.lock();
+        let pkt = &packets[0];
+        let eth = EthernetFrame::new_unchecked(pkt.as_slice());
+        let ipv4 = Ipv4Packet::new_unchecked(eth.payload());
+        let udp = UdpPacket::new_unchecked(ipv4.payload());
+        assert_eq!(
+            udp.dst_port(),
+            guest_port,
+            "forwarded packet should target the guest port"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_udp_bind_duplicate_port(driver: DefaultDriver) {
+        let driver = Arc::new(driver);
+        let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
+        let mut client = TestClient::new(driver.clone());
+
+        let guest_port = 6666;
+
+        let socket1 = Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        socket1
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+
+        let socket2_inst = Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        socket2_inst
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_udp_port(socket1, guest_port)
+            .expect("first bind should succeed");
+
+        let err = access
+            .bind_udp_port(socket2_inst, guest_port)
+            .expect_err("duplicate bind should fail");
+        assert!(
+            matches!(err, BindError::PortAlreadyBound(_)),
+            "error should be PortAlreadyBound"
         );
     }
 }

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -42,6 +42,8 @@ use std::task::Poll;
 use thiserror::Error;
 
 /// Creates and binds a socket for the given protocol, address, and port.
+///
+/// When `ip_addr` is `None`, binds to `0.0.0.0` (IPv4 only).
 pub fn create_bound_socket(
     protocol: &IpProtocol,
     ip_addr: Option<IpAddr>,

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -32,10 +32,38 @@ use pal_async::driver::Driver;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::net::SocketAddrV4;
+use std::net::SocketAddrV6;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use thiserror::Error;
+
+/// Creates and binds a socket for the given protocol, address, and port.
+pub fn create_bound_socket(
+    protocol: &IpProtocol,
+    ip_addr: Option<IpAddr>,
+    port: u16,
+) -> std::io::Result<socket2::Socket> {
+    let bind_addr: SocketAddr = match ip_addr {
+        Some(IpAddr::V4(ip)) => SocketAddr::V4(SocketAddrV4::new(ip, port)),
+        Some(IpAddr::V6(ip)) => SocketAddr::V6(SocketAddrV6::new(ip, port, 0, 0)),
+        None => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)),
+    };
+    let domain = match bind_addr {
+        SocketAddr::V4(_) => socket2::Domain::IPV4,
+        SocketAddr::V6(_) => socket2::Domain::IPV6,
+    };
+    let (sock_type, sock_protocol) = match protocol {
+        IpProtocol::Tcp => (socket2::Type::STREAM, socket2::Protocol::TCP),
+        IpProtocol::Udp => (socket2::Type::DGRAM, socket2::Protocol::UDP),
+    };
+    let socket = socket2::Socket::new(domain, sock_type, Some(sock_protocol))?;
+    socket.bind(&bind_addr.into())?;
+    Ok(socket)
+}
 
 pub struct ConsommeEndpoint {
     endpoint_state: Arc<Mutex<Option<EndpointState>>>,
@@ -45,12 +73,10 @@ pub struct ConsommeEndpoint {
 pub struct PortForwardConfig {
     /// The protocol to forward.
     pub protocol: IpProtocol,
-    /// The host IP address to bind, or `None` for all interfaces.
-    pub address: Option<IpAddr>,
+    /// An already-bound host socket to forward traffic from.
+    pub socket: socket2::Socket,
     /// The port traffic is forwarded to on the guest.
     pub guest_port: u16,
-    /// The host port to bind, or `None` for any available port.
-    pub host_port: u16,
 }
 
 struct EndpointState {
@@ -119,22 +145,30 @@ pub enum ConsommeMessageError {
     #[error("communication error")]
     Mesh(RpcError),
     /// Error executing request on current network instance.
-    #[error("network err")]
-    Network(consomme::DropReason),
+    #[error("bind error")]
+    Bind(consomme::BindError),
 }
 
 /// Callback to modify network state dynamically.
 pub type ConsommeParamsUpdateFn = Box<dyn Fn(&mut ConsommeParams) + Send>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum IpProtocol {
     Tcp,
     Udp,
 }
 
+/// Configuration for unbinding a previously forwarded port.
+struct PortUnbindConfig {
+    /// The protocol that was forwarded.
+    protocol: IpProtocol,
+    /// The guest port that was forwarded.
+    guest_port: u16,
+}
+
 enum ConsommeMessage {
-    BindPort(Rpc<PortForwardConfig, Result<u16, consomme::DropReason>>),
-    UnbindPort(Rpc<PortForwardConfig, Result<(), consomme::DropReason>>),
+    BindPort(Rpc<PortForwardConfig, Result<(), consomme::BindError>>),
+    UnbindPort(Rpc<PortUnbindConfig, Result<(), consomme::BindError>>),
     UpdateState(Rpc<ConsommeParamsUpdateFn, ()>),
 }
 
@@ -146,21 +180,20 @@ impl ConsommeControl {
         ip_addr: Option<IpAddr>,
         port: u16,
     ) -> Result<(), ConsommeMessageError> {
-        let _ = self
-            .send
+        let socket = create_bound_socket(&protocol, ip_addr, port)
+            .map_err(|e| ConsommeMessageError::Bind(consomme::BindError::Io(e)))?;
+        self.send
             .call(
                 ConsommeMessage::BindPort,
                 PortForwardConfig {
                     protocol,
-                    address: ip_addr,
+                    socket,
                     guest_port: port,
-                    host_port: port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map_err(ConsommeMessageError::Network)?;
-        Ok(())
+            .map_err(ConsommeMessageError::Bind)
     }
 
     /// Unbinds a port previously reserved with bind_port()
@@ -172,16 +205,14 @@ impl ConsommeControl {
         self.send
             .call(
                 ConsommeMessage::UnbindPort,
-                PortForwardConfig {
+                PortUnbindConfig {
                     protocol,
-                    address: None,
                     guest_port: port,
-                    host_port: 0,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map_err(ConsommeMessageError::Network)
+            .map_err(ConsommeMessageError::Bind)
     }
 
     /// Updates dynamic network state
@@ -224,24 +255,36 @@ impl net_backend::Endpoint for ConsommeEndpoint {
         });
         let port_forwards =
             std::mem::take(&mut queue.endpoint_state.as_mut().unwrap().port_forwards);
-        queue.with_consomme_no_pool(|c| {
+        let bind_result: Result<Vec<_>, _> = queue.with_consomme_no_pool(|c| {
             c.refresh_driver();
+            let mut bound: Vec<(IpProtocol, u16)> = Vec::new();
             for fwd in port_forwards {
-                let result = match fwd.protocol {
-                    IpProtocol::Tcp => c.bind_tcp_port(fwd.address, fwd.guest_port, fwd.host_port),
-                    IpProtocol::Udp => c.bind_udp_port(fwd.address, fwd.guest_port, fwd.host_port),
+                let protocol = fwd.protocol;
+                let guest_port = fwd.guest_port;
+                let result = match protocol {
+                    IpProtocol::Tcp => c.bind_tcp_port(fwd.socket, guest_port),
+                    IpProtocol::Udp => c.bind_udp_port(fwd.socket, guest_port),
                 };
-                if let Err(err) = result {
-                    tracing::error!(
-                        protocol = ?fwd.protocol,
-                        guest_port = fwd.guest_port,
-                        host_port = fwd.host_port,
-                        error = &err as &dyn std::error::Error,
-                        "failed to bind port"
-                    );
+                match result {
+                    Ok(()) => {
+                        tracing::info!(?protocol, guest_port, "bound port forward");
+                        bound.push((protocol, guest_port));
+                    }
+                    Err(err) => {
+                        // Roll back successful binds before returning error.
+                        for (prev_protocol, prev_guest_port) in &bound {
+                            let _ = match prev_protocol {
+                                IpProtocol::Tcp => c.unbind_tcp_port(*prev_guest_port),
+                                IpProtocol::Udp => c.unbind_udp_port(*prev_guest_port),
+                            };
+                        }
+                        return Err(err);
+                    }
                 }
             }
+            Ok(bound)
         });
+        bind_result.map_err(|err| anyhow::anyhow!(err).context("failed to bind port forward"))?;
         queues.push(queue);
         Ok(())
     }
@@ -358,22 +401,18 @@ fn process_message(
     match message {
         ConsommeMessage::BindPort(rpc) => {
             rpc.handle_sync(|bind_message| match bind_message.protocol {
-                IpProtocol::Tcp => consomme.bind_tcp_port(
-                    bind_message.address,
-                    bind_message.guest_port,
-                    bind_message.host_port,
-                ),
-                IpProtocol::Udp => consomme.bind_udp_port(
-                    bind_message.address,
-                    bind_message.guest_port,
-                    bind_message.host_port,
-                ),
+                IpProtocol::Tcp => {
+                    consomme.bind_tcp_port(bind_message.socket, bind_message.guest_port)
+                }
+                IpProtocol::Udp => {
+                    consomme.bind_udp_port(bind_message.socket, bind_message.guest_port)
+                }
             });
         }
         ConsommeMessage::UnbindPort(rpc) => {
-            rpc.handle_sync(|bind_message| match bind_message.protocol {
-                IpProtocol::Tcp => consomme.unbind_tcp_port(bind_message.guest_port),
-                IpProtocol::Udp => consomme.unbind_udp_port(bind_message.guest_port),
+            rpc.handle_sync(|unbind_message| match unbind_message.protocol {
+                IpProtocol::Tcp => consomme.unbind_tcp_port(unbind_message.guest_port),
+                IpProtocol::Udp => consomme.unbind_udp_port(unbind_message.guest_port),
             });
         }
         ConsommeMessage::UpdateState(rpc) => {
@@ -437,8 +476,6 @@ impl net_backend::Queue for ConsommeQueue {
                     | consomme::DropReason::FragmentedPacket
                     | consomme::DropReason::IpLengthMismatch
                     | consomme::DropReason::MalformedPacket => self.stats.tx_errors.increment(),
-                    consomme::DropReason::PortNotBound
-                    | consomme::DropReason::PortAlreadyBound(_) => unreachable!(),
                 }
             }
 

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -182,6 +182,13 @@ impl ConsommeControl {
     ) -> Result<(), ConsommeMessageError> {
         let socket = create_bound_socket(&protocol, ip_addr, port)
             .map_err(|e| ConsommeMessageError::Bind(consomme::BindError::Io(e)))?;
+        let host_addr = socket.local_addr().ok();
+        tracing::info!(
+            ?protocol,
+            ?host_addr,
+            guest_port = port,
+            "port forward socket created"
+        );
         self.send
             .call(
                 ConsommeMessage::BindPort,
@@ -266,10 +273,7 @@ impl net_backend::Endpoint for ConsommeEndpoint {
                     IpProtocol::Udp => c.bind_udp_port(fwd.socket, guest_port),
                 };
                 match result {
-                    Ok(()) => {
-                        tracing::info!(?protocol, guest_port, "bound port forward");
-                        bound.push((protocol, guest_port));
-                    }
+                    Ok(()) => bound.push((protocol, guest_port)),
                     Err(err) => {
                         // Roll back successful binds before returning error.
                         for (prev_protocol, prev_guest_port) in &bound {

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -182,11 +182,11 @@ impl ConsommeControl {
     ) -> Result<(), ConsommeMessageError> {
         let socket = create_bound_socket(&protocol, ip_addr, port)
             .map_err(|e| ConsommeMessageError::Bind(consomme::BindError::Io(e)))?;
-        let host_addr = socket.local_addr().ok();
+        let host_addr = socket.local_addr().ok().and_then(|a| a.as_socket());
         tracing::info!(
             ?protocol,
-            ?host_addr,
-            guest_port = port,
+            host_addr = %host_addr.map(|a| a.to_string()).unwrap_or_default(),
+            guest_port = %port,
             "port forward socket created"
         );
         self.send

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -41,9 +41,22 @@ pub struct ConsommeEndpoint {
     endpoint_state: Arc<Mutex<Option<EndpointState>>>,
 }
 
+/// Configuration for a port to forward from the host to the guest.
+pub struct PortForwardConfig {
+    /// The protocol to forward.
+    pub protocol: IpProtocol,
+    /// The host IP address to bind, or `None` for all interfaces.
+    pub address: Option<IpAddr>,
+    /// The port traffic is forwarded to on the guest.
+    pub guest_port: u16,
+    /// The host port to bind, or `None` for any available port.
+    pub host_port: u16,
+}
+
 struct EndpointState {
     consomme: Consomme,
     recv: Option<mesh::Receiver<ConsommeMessage>>,
+    port_forwards: Vec<PortForwardConfig>,
 }
 
 impl ConsommeEndpoint {
@@ -52,6 +65,18 @@ impl ConsommeEndpoint {
             endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
                 consomme: Consomme::new(state),
                 recv: None,
+                port_forwards: Vec::new(),
+            }))),
+        }
+    }
+
+    /// Creates a new endpoint with ports to forward once the queue starts.
+    pub fn new_with_ports(state: ConsommeParams, ports: Vec<PortForwardConfig>) -> Self {
+        Self {
+            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
+                consomme: Consomme::new(state),
+                recv: None,
+                port_forwards: ports,
             }))),
         }
     }
@@ -64,6 +89,7 @@ impl ConsommeEndpoint {
                 endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
                     consomme,
                     recv: Some(recv),
+                    port_forwards: Vec::new(),
                 }))),
             },
             ConsommeControl { send },
@@ -100,20 +126,15 @@ pub enum ConsommeMessageError {
 /// Callback to modify network state dynamically.
 pub type ConsommeParamsUpdateFn = Box<dyn Fn(&mut ConsommeParams) + Send>;
 
+#[derive(Debug)]
 pub enum IpProtocol {
     Tcp,
     Udp,
 }
 
-struct MessageBindPort {
-    protocol: IpProtocol,
-    address: Option<IpAddr>,
-    port: u16,
-}
-
 enum ConsommeMessage {
-    BindPort(Rpc<MessageBindPort, Result<(), consomme::DropReason>>),
-    UnbindPort(Rpc<MessageBindPort, Result<(), consomme::DropReason>>),
+    BindPort(Rpc<PortForwardConfig, Result<u16, consomme::DropReason>>),
+    UnbindPort(Rpc<PortForwardConfig, Result<(), consomme::DropReason>>),
     UpdateState(Rpc<ConsommeParamsUpdateFn, ()>),
 }
 
@@ -125,18 +146,21 @@ impl ConsommeControl {
         ip_addr: Option<IpAddr>,
         port: u16,
     ) -> Result<(), ConsommeMessageError> {
-        self.send
+        let _ = self
+            .send
             .call(
                 ConsommeMessage::BindPort,
-                MessageBindPort {
+                PortForwardConfig {
                     protocol,
                     address: ip_addr,
-                    port,
+                    guest_port: port,
+                    host_port: port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map_err(ConsommeMessageError::Network)
+            .map_err(ConsommeMessageError::Network)?;
+        Ok(())
     }
 
     /// Unbinds a port previously reserved with bind_port()
@@ -148,10 +172,11 @@ impl ConsommeControl {
         self.send
             .call(
                 ConsommeMessage::UnbindPort,
-                MessageBindPort {
+                PortForwardConfig {
                     protocol,
                     address: None,
-                    port,
+                    guest_port: port,
+                    host_port: 0,
                 },
             )
             .await
@@ -197,7 +222,26 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             stats: Default::default(),
             driver: config.driver,
         });
-        queue.with_consomme_no_pool(|c| c.refresh_driver());
+        let port_forwards =
+            std::mem::take(&mut queue.endpoint_state.as_mut().unwrap().port_forwards);
+        queue.with_consomme_no_pool(|c| {
+            c.refresh_driver();
+            for fwd in port_forwards {
+                let result = match fwd.protocol {
+                    IpProtocol::Tcp => c.bind_tcp_port(fwd.address, fwd.guest_port, fwd.host_port),
+                    IpProtocol::Udp => c.bind_udp_port(fwd.address, fwd.guest_port, fwd.host_port),
+                };
+                if let Err(err) = result {
+                    tracing::error!(
+                        protocol = ?fwd.protocol,
+                        guest_port = fwd.guest_port,
+                        host_port = fwd.host_port,
+                        error = &err as &dyn std::error::Error,
+                        "failed to bind port"
+                    );
+                }
+            }
+        });
         queues.push(queue);
         Ok(())
     }
@@ -314,14 +358,22 @@ fn process_message(
     match message {
         ConsommeMessage::BindPort(rpc) => {
             rpc.handle_sync(|bind_message| match bind_message.protocol {
-                IpProtocol::Tcp => consomme.bind_tcp_port(bind_message.address, bind_message.port),
-                IpProtocol::Udp => consomme.bind_udp_port(bind_message.address, bind_message.port),
+                IpProtocol::Tcp => consomme.bind_tcp_port(
+                    bind_message.address,
+                    bind_message.guest_port,
+                    bind_message.host_port,
+                ),
+                IpProtocol::Udp => consomme.bind_udp_port(
+                    bind_message.address,
+                    bind_message.guest_port,
+                    bind_message.host_port,
+                ),
             });
         }
         ConsommeMessage::UnbindPort(rpc) => {
             rpc.handle_sync(|bind_message| match bind_message.protocol {
-                IpProtocol::Tcp => consomme.unbind_tcp_port(bind_message.port),
-                IpProtocol::Udp => consomme.unbind_udp_port(bind_message.port),
+                IpProtocol::Tcp => consomme.unbind_tcp_port(bind_message.guest_port),
+                IpProtocol::Udp => consomme.unbind_udp_port(bind_message.guest_port),
             });
         }
         ConsommeMessage::UpdateState(rpc) => {
@@ -385,7 +437,8 @@ impl net_backend::Queue for ConsommeQueue {
                     | consomme::DropReason::FragmentedPacket
                     | consomme::DropReason::IpLengthMismatch
                     | consomme::DropReason::MalformedPacket => self.stats.tx_errors.increment(),
-                    consomme::DropReason::PortNotBound => unreachable!(),
+                    consomme::DropReason::PortNotBound
+                    | consomme::DropReason::PortAlreadyBound(_) => unreachable!(),
                 }
             }
 

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 use crate::ConsommeEndpoint;
+use crate::PortForwardConfig;
 use consomme::ConsommeParams;
 use net_backend::resolve::ResolveEndpointParams;
 use net_backend::resolve::ResolvedEndpoint;
 use net_backend_resources::consomme::ConsommeHandle;
+use net_backend_resources::consomme::HostPortProtocol;
 use thiserror::Error;
 use vm_resource::ResolveResource;
 use vm_resource::declare_static_resolver;
@@ -24,6 +26,8 @@ pub enum ResolveConsommeError {
     Consomme(consomme::Error),
     #[error(transparent)]
     InvalidCidr(consomme::InvalidCidr),
+    #[error("invalid host forward address '{0}'")]
+    InvalidAddress(String),
 }
 
 impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver {
@@ -42,7 +46,30 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                 .set_cidr(cidr)
                 .map_err(ResolveConsommeError::InvalidCidr)?;
         }
-        let endpoint = ConsommeEndpoint::new(state);
+        let port_forwards: Vec<PortForwardConfig> = resource
+            .ports
+            .into_iter()
+            .map(|p| {
+                let address = p
+                    .host_address
+                    .as_deref()
+                    .map(|a| {
+                        a.parse()
+                            .map_err(|_| ResolveConsommeError::InvalidAddress(a.to_owned()))
+                    })
+                    .transpose()?;
+                Ok(PortForwardConfig {
+                    protocol: match p.protocol {
+                        HostPortProtocol::Tcp => crate::IpProtocol::Tcp,
+                        HostPortProtocol::Udp => crate::IpProtocol::Udp,
+                    },
+                    address,
+                    host_port: p.host_port,
+                    guest_port: p.guest_port,
+                })
+            })
+            .collect::<Result<_, ResolveConsommeError>>()?;
+        let endpoint = ConsommeEndpoint::new_with_ports(state, port_forwards);
         Ok(endpoint.into())
     }
 }

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 use crate::ConsommeEndpoint;
+use crate::IpProtocol;
 use crate::PortForwardConfig;
+use crate::create_bound_socket;
 use consomme::ConsommeParams;
 use net_backend::resolve::ResolveEndpointParams;
 use net_backend::resolve::ResolvedEndpoint;
@@ -26,8 +28,8 @@ pub enum ResolveConsommeError {
     Consomme(consomme::Error),
     #[error(transparent)]
     InvalidCidr(consomme::InvalidCidr),
-    #[error("invalid host forward address '{0}'")]
-    InvalidAddress(String),
+    #[error("failed to create socket for port forward")]
+    SocketCreation(#[source] std::io::Error),
 }
 
 impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver {
@@ -50,25 +52,20 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
             .ports
             .into_iter()
             .map(|p| {
-                let address = p
-                    .host_address
-                    .as_deref()
-                    .map(|a| {
-                        a.parse()
-                            .map_err(|_| ResolveConsommeError::InvalidAddress(a.to_owned()))
-                    })
-                    .transpose()?;
+                let protocol = match p.protocol {
+                    HostPortProtocol::Tcp => IpProtocol::Tcp,
+                    HostPortProtocol::Udp => IpProtocol::Udp,
+                };
+                let ip_addr = p.host_address.map(std::net::IpAddr::from);
+                let socket = create_bound_socket(&protocol, ip_addr, p.host_port)
+                    .map_err(ResolveConsommeError::SocketCreation)?;
                 Ok(PortForwardConfig {
-                    protocol: match p.protocol {
-                        HostPortProtocol::Tcp => crate::IpProtocol::Tcp,
-                        HostPortProtocol::Udp => crate::IpProtocol::Udp,
-                    },
-                    address,
-                    host_port: p.host_port,
+                    protocol,
+                    socket,
                     guest_port: p.guest_port,
                 })
             })
-            .collect::<Result<_, ResolveConsommeError>>()?;
+            .collect::<Result<Vec<_>, ResolveConsommeError>>()?;
         let endpoint = ConsommeEndpoint::new_with_ports(state, port_forwards);
         Ok(endpoint.into())
     }

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -28,8 +28,12 @@ pub enum ResolveConsommeError {
     Consomme(consomme::Error),
     #[error(transparent)]
     InvalidCidr(consomme::InvalidCidr),
-    #[error("failed to create socket for port forward")]
-    SocketCreation(#[source] std::io::Error),
+    #[error("failed to create socket for port forward ({details})")]
+    SocketCreation {
+        #[source]
+        source: std::io::Error,
+        details: String,
+    },
 }
 
 impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver {
@@ -57,8 +61,26 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                     HostPortProtocol::Udp => IpProtocol::Udp,
                 };
                 let ip_addr = p.host_address.map(std::net::IpAddr::from);
-                let socket = create_bound_socket(&protocol, ip_addr, p.host_port)
-                    .map_err(ResolveConsommeError::SocketCreation)?;
+                let socket = create_bound_socket(&protocol, ip_addr, p.host_port).map_err(|e| {
+                    ResolveConsommeError::SocketCreation {
+                        source: e,
+                        details: format!(
+                            "{:?} {}:{}",
+                            protocol,
+                            ip_addr
+                                .map(|a| a.to_string())
+                                .unwrap_or_else(|| "*".to_string()),
+                            p.host_port,
+                        ),
+                    }
+                })?;
+                let host_addr = socket.local_addr().ok();
+                tracing::info!(
+                    ?protocol,
+                    ?host_addr,
+                    guest_port = p.guest_port,
+                    "port forward socket created"
+                );
                 Ok(PortForwardConfig {
                     protocol,
                     socket,

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -74,11 +74,11 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                         ),
                     }
                 })?;
-                let host_addr = socket.local_addr().ok();
+                let host_addr = socket.local_addr().ok().and_then(|a| a.as_socket());
                 tracing::info!(
                     ?protocol,
-                    ?host_addr,
-                    guest_port = p.guest_port,
+                    host_addr = %host_addr.map(|a| a.to_string()).unwrap_or_default(),
+                    guest_port = %p.guest_port,
                     "port forward socket created"
                 );
                 Ok(PortForwardConfig {


### PR DESCRIPTION
For consomme, forward host ports into the guest with `hostfwd=`:
   --net consomme:hostfwd=tcp::3389-:3389
   --net consomme:hostfwd=tcp:127.0.0.1:8080-:80
   --net consomme:hostfwd=tcp:[::1]:8080-:80
   --net consomme:10.0.0.0/24,hostfwd=tcp::22-:22,hostfwd=udp::5000-:5000