### PR TITLE
virt_mshv: Build caps from properties when CPUID unavailable

### DIFF
--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -524,7 +524,7 @@ open_enum! {
 }
 
 open_enum! {
-    /// Processor vendor as returned by `HvPartitionPropertyProcessorVendor`.
+    /// Processor vendor as returned by [`HvPartitionPropertyCode::ProcessorVendor`].
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
     pub enum HvProcessorVendor: u32 {
         AMD    = 0x0000,

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -355,6 +355,185 @@ open_enum! {
     }
 }
 
+open_enum! {
+    /// Partition property codes.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum HvPartitionPropertyCode: u32 {
+        #![expect(non_upper_case_globals)]
+
+        // Privilege properties
+        PrivilegeFlags                       = 0x00010000,
+        SyntheticProcFeatures                = 0x00010001,
+        AllowedParentUserModeHypercalls      = 0x00010002,
+
+        // Scheduling properties
+        Suspend                                = 0x00020000,
+        CpuReserve                             = 0x00020001,
+        CpuCap                                 = 0x00020002,
+        CpuWeight                              = 0x00020003,
+        CpuGroupId                             = 0x00020004,
+        HierarchicalIntegratedSchedulerEnabled = 0x00020005,
+
+        // Time properties
+        TimeFreeze                           = 0x00030003,
+        ApicFrequency                        = 0x00030004,
+        ReferenceTime                        = 0x00030005,
+
+        // Debugging properties
+        DebugChannelId                       = 0x00040000,
+        DebugChannelId0                      = 0x00040001,
+        DebugChannelId1                      = 0x00040002,
+        DebugChannelId2                      = 0x00040003,
+
+        // Resource properties
+        VirtualTlbPageCount                  = 0x00050000,
+        VsmConfig                            = 0x00050001,
+        ZeroMemoryOnReset                    = 0x00050002,
+        ProcessorsPerSocket                  = 0x00050003,
+        NestedTlbSize                        = 0x00050004,
+        GpaPageAccessTracking                = 0x00050005,
+        VsmPermissionsDirtySinceLastQuery    = 0x00050006,
+        SgxLaunchControlConfig               = 0x00050007,
+        DefaultSgxLaunchControl0             = 0x00050008,
+        DefaultSgxLaunchControl1             = 0x00050009,
+        DefaultSgxLaunchControl2             = 0x0005000A,
+        DefaultSgxLaunchControl3             = 0x0005000B,
+        IsolationState                       = 0x0005000C,
+        IsolationControl                     = 0x0005000D,
+        AllocationId                         = 0x0005000E,
+        MonitoringId                         = 0x0005000F,
+        ImplementedPhysicalAddressBits       = 0x00050010,
+        NonArchitecturalCoreSharing          = 0x00050011,
+        HypercallDoorbellPage                = 0x00050012,
+        CppcRequestValue                     = 0x00050013,
+        IsolationPolicy                      = 0x00050014,
+        DmaCapableDevices                    = 0x00050015,
+        ProcessorsPerL3                      = 0x00050016,
+        UnimplementedMsrAction               = 0x00050017,
+        AmdNodesPerSocket                    = 0x00050018,
+        ReferenceTscPageActive               = 0x00050019,
+        AutoEoiEnabled                       = 0x0005001A,
+        L3CacheWays                          = 0x0005001B,
+        IsolationType                        = 0x0005001C,
+        PerfmonMode                          = 0x0005001D,
+        DepositStatus                        = 0x0005001E,
+        Mirroring                            = 0x0005001F,
+        MirrorState                          = 0x00050020,
+        MgmtVtlMaxMemorySections             = 0x00050021,
+        SevVmgexitOffloads                   = 0x00050022,
+        PenalizeBusLock                      = 0x00050023,
+        TopologyApicIdOptIn                  = 0x00050024,
+        CppcResourcePrioritiesValue          = 0x00050025,
+        PartitionDiagBufferConfig            = 0x00050026,
+        GicdBaseAddress                      = 0x00050028,
+        GitsTranslaterBaseAddress            = 0x00050029,
+        GicLpiIntIdBits                      = 0x0005002A,
+        GicPpiOverflowInterruptFromCntv      = 0x0005002B,
+        GicPpiOverflowInterruptFromCntp      = 0x0005002C,
+        GicPpiPerformanceMonitorsInterrupt   = 0x0005002D,
+        GicPpiPmbirq                         = 0x0005002E,
+        TdMigrationStreamCount               = 0x0005002F,
+        AutoSuspend                          = 0x00050030,
+        SintReservedInterruptId              = 0x00050031,
+        GpaPinningEnabled                    = 0x00050032,
+        TdMigrationMaxStreamCount            = 0x00050033,
+        TdMigrationNumMemScanContext         = 0x00050034,
+        TdMigrationMaxMemScanRanges          = 0x00050035,
+
+        // Compatibility properties
+        ProcessorVendor                      = 0x00060000,
+        ProcessorFeaturesDeprecated          = 0x00060001,
+        ProcessorXsaveFeatures               = 0x00060002,
+        ProcessorCLFlushSize                 = 0x00060003,
+        EnlightenmentModifications           = 0x00060004,
+        CompatibilityVersion                 = 0x00060005,
+        PhysicalAddressWidth                 = 0x00060006,
+        XsaveStates                          = 0x00060007,
+        MaxXsaveDataSize                     = 0x00060008,
+        ProcessorClockFrequency              = 0x00060009,
+        ProcessorFeatures0                   = 0x0006000A,
+        ProcessorFeatures1                   = 0x0006000B,
+        ProcessorCtrEl0                      = 0x0006000C,
+        ProcessorDczidEl0                    = 0x0006000D,
+        ProcessorIchVtrEl2                   = 0x0006000E,
+        ProcessorIdAa64Dfr0El1               = 0x0006000F,
+        RootProcessorFeatures0               = 0x00060010,
+        RootProcessorFeatures1               = 0x00060011,
+        RootProcessorXsaveFeatures           = 0x00060012,
+        RootSyntheticProcFeatures            = 0x00060013,
+        PhysicalAddressSize                  = 0x00060014,
+        FeatureBankCount                     = 0x00060015,
+        ProcessorIdAa64Dfr1El1               = 0x00060016,
+        ProcessorCntfrqEl0                   = 0x00060017,
+        MaxSveVectorLength                   = 0x00060018,
+        MaxSmeStreamingVectorLength          = 0x00060019,
+
+        // Guest software properties
+        GuestOsId                            = 0x00070000,
+
+        // Nested virtualization properties
+        ProcessorVirtualizationFeatures      = 0x00080000,
+        MaxHardwareIsolatedGuests            = 0x00080001,
+        SnpEnabled                           = 0x00080002,
+        NestedVmxBasic                       = 0x00080003,
+        NestedVmxPinbasedCtls                = 0x00080004,
+        NestedVmxProcbasedCtls               = 0x00080005,
+        NestedVmxExitCtls                    = 0x00080006,
+        NestedVmxEntryCtls                   = 0x00080007,
+        NestedVmxMisc                        = 0x00080008,
+        NestedVmxCr0Fixed0                   = 0x00080009,
+        NestedVmxCr0Fixed1                   = 0x0008000A,
+        NestedVmxCr4Fixed0                   = 0x0008000B,
+        NestedVmxCr4Fixed1                   = 0x0008000C,
+        NestedVmxVmcsEnum                    = 0x0008000D,
+        NestedVmxProcbasedCtls2              = 0x0008000E,
+        NestedVmxEptVpidCap                  = 0x0008000F,
+        NestedVmxTruePinbasedCtls            = 0x00080010,
+        NestedVmxTrueProcbasedCtls           = 0x00080011,
+        NestedVmxTrueExitCtls                = 0x00080012,
+        NestedVmxTrueEntryCtls               = 0x00080013,
+        NestedVmxProcbasedCtls3              = 0x00080014,
+        NestedVmxExitCtls2                   = 0x00080015,
+        VhState                              = 0x00080100,
+        MaxHierarchicalPartitionCount        = 0x00080101,
+        MaxHierarchicalVpCount               = 0x00080102,
+        StateTransferMode                    = 0x00080103,
+        MigrationAbortCleanupCount           = 0x00080104,
+        TdComprehensiveReset                 = 0x00080105,
+
+        // Extended properties with larger property values
+        InheritedDeviceDomainReservedRegions = 0x00090000,
+        TdMrConfigId                         = 0x00090001,
+        TdMrOwner                            = 0x00090002,
+        TdMrOwnerConfig                      = 0x00090003,
+        VNUMATopologyConfig                  = 0x00090004,
+        RootVpSharedPages                    = 0x00090005,
+        VmmCapabilities                      = 0x00090007,
+        CompletePartitionIntercept           = 0x00090008,
+        AssignableSyntheticProcFeatures      = 0x00090009,
+        HwIsolationTdxSupported              = 0x0009000A,
+        HwIsolationSevSupported              = 0x0009000B,
+        MigrationTdInfoHash                  = 0x0009000C,
+        MigrationTdBindingSlot               = 0x0009000D,
+        DisabledProcessorFeaturesEx          = 0x0009000E,
+        RootProcessorFeaturesEx              = 0x0009000F,
+        EnabledProcessorFeaturesEx           = 0x00090010,
+        PmuEventTypes                        = 0x00090011,
+        TdComprehensiveConfigure             = 0x00090012,
+    }
+}
+
+open_enum! {
+    /// Processor vendor as returned by `HvPartitionPropertyProcessorVendor`.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum HvProcessorVendor: u32 {
+        AMD    = 0x0000,
+        INTEL  = 0x0001,
+        HYGON  = 0x0002,
+        ARM    = 0x0010,
+    }
+}
+
 #[bitfield(u128)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvFeatures {
@@ -559,6 +738,7 @@ open_enum! {
         HvCallCheckSparseGpaPageVtlAccess = 0x00D4,
         HvCallAcceptGpaPages = 0x00D9,
         HvCallModifySparseGpaPageHostVisibility = 0x00DB,
+        HvCallGetVpCpuidValues = 0x00F4,
         HvCallRestorePartitionTime = 0x0103,
         HvCallMemoryMappedIoRead = 0x0106,
         HvCallMemoryMappedIoWrite = 0x0107,

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -377,7 +377,7 @@ impl MshvProtoPartition<'_> {
             HvProcessorVendor::AMD => Vendor::AMD,
             HvProcessorVendor::INTEL => Vendor::INTEL,
             HvProcessorVendor::HYGON => Vendor::HYGON,
-            _ => Vendor::INTEL,
+            v => return Err(ErrorInner::UnsupportedProcessorVendor(v).into()),
         };
 
         let xsave_states = self
@@ -1342,6 +1342,8 @@ enum ErrorInner {
     Capabilities(#[source] virt::PartitionCapabilitiesError),
     #[error("too many virtual processors: {0}")]
     TooManyVps(u32),
+    #[error("unsupported processor vendor: {0:?}")]
+    UnsupportedProcessorVendor(HvProcessorVendor),
     #[error("failed to create virtual device")]
     NewDevice(#[source] virt::x86::apic_software_device::DeviceIdInUse),
 }

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -20,6 +20,8 @@ use hvdef::HvDeliverabilityNotificationsRegister;
 use hvdef::HvError;
 use hvdef::HvMessage;
 use hvdef::HvMessageType;
+use hvdef::HvPartitionPropertyCode;
+use hvdef::HvProcessorVendor;
 use hvdef::HvX64RegisterName;
 use hvdef::HvX64RegisterPage;
 use hvdef::Vtl;
@@ -65,7 +67,6 @@ use virt::irqcon::MsiRequest;
 use virt::state::StateElement as _;
 use virt::x86::apic_software_device::ApicSoftwareDevice;
 use virt::x86::apic_software_device::ApicSoftwareDevices;
-use virt::x86::max_physical_address_size_from_cpuid;
 use virt_support_x86emu::emulate::EmuTranslateError;
 use virt_support_x86emu::emulate::EmuTranslateResult;
 use virt_support_x86emu::emulate::EmulatorSupport;
@@ -239,7 +240,7 @@ impl virt::Hypervisor for LinuxMshv {
                 .with_retarget_device_interrupt(true);
 
             vmfd.set_partition_property(
-                mshv_bindings::hv_partition_property_code_HV_PARTITION_PROPERTY_SYNTHETIC_PROC_FEATURES,
+                HvPartitionPropertyCode::SyntheticProcFeatures.0,
                 u64::from(synthetic_features),
             )
             .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
@@ -252,7 +253,7 @@ impl virt::Hypervisor for LinuxMshv {
         // generate the correct topology CPUID leaves (01h, 04h, 0Bh, 1Fh,
         // AMD 80000008h/1Dh/1Eh) automatically.
         vmfd.set_partition_property(
-            mshv_bindings::hv_partition_property_code_HV_PARTITION_PROPERTY_PROCESSORS_PER_SOCKET,
+            HvPartitionPropertyCode::ProcessorsPerSocket.0,
             config.processor_topology.reserved_vps_per_socket() as u64,
         )
         .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
@@ -358,17 +359,98 @@ pub struct MshvProtoPartition<'a> {
     bsp: VcpuFd,
 }
 
+impl MshvProtoPartition<'_> {
+    /// Build partition capabilities from partition properties instead of
+    /// CPUID. Used when CPUID queries are not available.
+    fn caps_from_properties(&self) -> Result<virt::x86::X86PartitionCapabilities, Error> {
+        use virt::x86::X86PartitionCapabilities;
+        use virt::x86::XsaveCapabilities;
+        use x86defs::cpuid::Vendor;
+        use x86defs::xsave::XSAVE_VARIABLE_OFFSET;
+
+        let vendor_id = self
+            .vmfd
+            .get_partition_property(HvPartitionPropertyCode::ProcessorVendor.0)
+            .map_err(|e| ErrorInner::GetPartitionProperty(e.into()))?;
+
+        let vendor = match HvProcessorVendor(vendor_id as u32) {
+            HvProcessorVendor::AMD => Vendor::AMD,
+            HvProcessorVendor::INTEL => Vendor::INTEL,
+            HvProcessorVendor::HYGON => Vendor::HYGON,
+            _ => Vendor::INTEL,
+        };
+
+        let xsave_states = self
+            .vmfd
+            .get_partition_property(HvPartitionPropertyCode::XsaveStates.0)
+            .map_err(|e| ErrorInner::GetPartitionProperty(e.into()))?;
+
+        let max_xsave_data_size = self
+            .vmfd
+            .get_partition_property(HvPartitionPropertyCode::MaxXsaveDataSize.0)
+            .map_err(|e| ErrorInner::GetPartitionProperty(e.into()))?;
+
+        // Read the BSP's RDX register, which the hypervisor initializes
+        // to the CPUID version/stepping value at partition creation.
+        let reset_rdx = {
+            let mut assoc = [HvRegisterAssoc::from((HvX64RegisterName::Rdx, 0u64))];
+            self.bsp
+                .get_hvdef_regs(&mut assoc)
+                .map_err(ErrorInner::Register)?;
+            assoc[0].value.as_u64()
+        };
+
+        let x2apic = matches!(
+            self.config.processor_topology.apic_mode(),
+            vm_topology::processor::x86::ApicMode::X2ApicSupported
+                | vm_topology::processor::x86::ApicMode::X2ApicEnabled
+        );
+        let x2apic_enabled = matches!(
+            self.config.processor_topology.apic_mode(),
+            vm_topology::processor::x86::ApicMode::X2ApicEnabled
+        );
+
+        Ok(X86PartitionCapabilities {
+            vendor,
+            hv1: self.config.hv_config.is_some(),
+            hv1_reference_tsc_page: self.config.hv_config.is_some(),
+            xsave: XsaveCapabilities {
+                // XsaveStates returns user | supervisor features combined.
+                // We don't know which are supervisor, so put everything in
+                // features. This is sufficient since virt_mshv never does
+                // standard<->compact conversion.
+                features: xsave_states,
+                supervisor_features: 0,
+                standard_len: XSAVE_VARIABLE_OFFSET as u32,
+                compact_len: max_xsave_data_size as u32,
+                feature_info: [Default::default(); 63],
+            },
+            x2apic,
+            x2apic_enabled,
+            reset_rdx,
+            cet: false,
+            cet_ss: false,
+            sgx: false,
+            tsc_aux: false,
+            vtom: None,
+            physical_address_width: self.max_physical_address_size(),
+            can_freeze_time: false,
+            xsaves_state_bv_broken: false,
+            dr6_tsx_broken: false,
+            nxe_forced_on: false,
+        })
+    }
+}
+
 impl ProtoPartition for MshvProtoPartition<'_> {
     type Partition = MshvPartition;
     type ProcessorBinder = MshvProcessorBinder;
     type Error = Error;
 
     fn max_physical_address_size(&self) -> u8 {
-        max_physical_address_size_from_cpuid(&|eax, ecx| {
-            self.bsp
-                .get_cpuid_values(eax, ecx, 0, 0)
-                .expect("cpuid should not fail")
-        })
+        self.vmfd
+            .get_partition_property(HvPartitionPropertyCode::PhysicalAddressWidth.0)
+            .expect("failed to get physical address width") as u8
     }
 
     fn build(
@@ -421,17 +503,24 @@ impl ProtoPartition for MshvProtoPartition<'_> {
                 .map_err(|e| ErrorInner::RegisterCpuid(e.into()))?;
         }
 
-        // Get caps via cpuid
+        // Build partition capabilities. Try querying via CPUID first; if
+        // the hypervisor doesn't support CPUID queries (e.g. in some
+        // hierarchical virtualization environments), fall back to
+        // constructing capabilities from partition properties.
         let caps = {
-            let mut caps = virt::PartitionCapabilities::from_cpuid(
-                self.config.processor_topology,
-                &mut |function, index| {
-                    self.bsp
-                        .get_cpuid_values(function, index, 0, 0)
-                        .expect("cpuid should not fail")
-                },
-            )
-            .map_err(ErrorInner::Capabilities)?;
+            let mut caps = match self.bsp.get_cpuid_values(0, 0, 0, 0) {
+                Ok(_) => virt::PartitionCapabilities::from_cpuid(
+                    self.config.processor_topology,
+                    &mut |function, index| {
+                        self.bsp
+                            .get_cpuid_values(function, index, 0, 0)
+                            .map_err(KernelError::from)
+                            .expect("cpuid should not fail")
+                    },
+                )
+                .map_err(ErrorInner::Capabilities)?,
+                Err(_) => self.caps_from_properties()?,
+            };
             caps.xsaves_state_bv_broken = true;
             caps.can_freeze_time = true;
             caps
@@ -659,9 +748,7 @@ impl GetReferenceTime for MshvPartitionInner {
         // deadlocking when VPs are running.
         let ref_time = self
             .vmfd
-            .get_partition_property(
-                mshv_bindings::hv_partition_property_code_HV_PARTITION_PROPERTY_REFERENCE_TIME,
-            )
+            .get_partition_property(HvPartitionPropertyCode::ReferenceTime.0)
             .unwrap();
         ReferenceTimeResult {
             ref_time,
@@ -681,10 +768,7 @@ impl MshvPartitionInner {
         let mut frozen = self.time_frozen.lock();
         if !*frozen {
             self.vmfd
-                .set_partition_property(
-                    mshv_bindings::hv_partition_property_code_HV_PARTITION_PROPERTY_TIME_FREEZE,
-                    1,
-                )
+                .set_partition_property(HvPartitionPropertyCode::TimeFreeze.0, 1)
                 .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
             *frozen = true;
         }
@@ -697,10 +781,7 @@ impl MshvPartitionInner {
         let mut frozen = self.time_frozen.lock();
         if *frozen {
             self.vmfd
-                .set_partition_property(
-                    mshv_bindings::hv_partition_property_code_HV_PARTITION_PROPERTY_TIME_FREEZE,
-                    0,
-                )
+                .set_partition_property(HvPartitionPropertyCode::TimeFreeze.0, 0)
                 .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
             *frozen = false;
         }

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -362,6 +362,11 @@ pub struct MshvProtoPartition<'a> {
 impl MshvProtoPartition<'_> {
     /// Build partition capabilities from partition properties instead of
     /// CPUID. Used when CPUID queries are not available.
+    ///
+    /// Some capabilities (CET, SGX, tsc_aux, vtom, per-feature xsave
+    /// geometry) require CPUID to determine and have no partition property
+    /// equivalents. They default to false/disabled here. This limits save/restore
+    /// fidelity.
     fn caps_from_properties(&self) -> Result<virt::x86::X86PartitionCapabilities, Error> {
         use virt::x86::X86PartitionCapabilities;
         use virt::x86::XsaveCapabilities;
@@ -519,7 +524,12 @@ impl ProtoPartition for MshvProtoPartition<'_> {
                     },
                 )
                 .map_err(ErrorInner::Capabilities)?,
-                Err(_) => self.caps_from_properties()?,
+                Err(_) => {
+                    tracing::warn!(
+                        "failed to query CPUID, falling back to partition properties, some features may be unavailable"
+                    );
+                    self.caps_from_properties()?
+                }
             };
             caps.xsaves_state_bv_broken = true;
             caps.can_freeze_time = true;

--- a/vmm_core/virt_mshv/src/vm_state.rs
+++ b/vmm_core/virt_mshv/src/vm_state.rs
@@ -12,9 +12,9 @@ use super::Error;
 use super::VcpuFdExt;
 use crate::ErrorInner;
 use crate::MshvPartition;
+use hvdef::HvPartitionPropertyCode;
 use hvdef::HvX64RegisterName;
 use hvdef::hypercall::HvRegisterAssoc;
-use mshv_bindings::hv_partition_property_code_HV_PARTITION_PROPERTY_REFERENCE_TIME;
 use virt::state::HvRegisterState;
 use virt::x86::vm;
 use virt::x86::vm::AccessVmState;
@@ -84,7 +84,7 @@ impl AccessVmState for &'_ MshvPartition {
         let ref_time = self
             .inner
             .vmfd
-            .get_partition_property(hv_partition_property_code_HV_PARTITION_PROPERTY_REFERENCE_TIME)
+            .get_partition_property(HvPartitionPropertyCode::ReferenceTime.0)
             .map_err(|e| ErrorInner::GetPartitionProperty(e.into()))?;
         Ok(vm::ReferenceTime { value: ref_time })
     }
@@ -92,10 +92,7 @@ impl AccessVmState for &'_ MshvPartition {
     fn set_reftime(&mut self, value: &vm::ReferenceTime) -> Result<(), Self::Error> {
         self.inner
             .vmfd
-            .set_partition_property(
-                hv_partition_property_code_HV_PARTITION_PROPERTY_REFERENCE_TIME,
-                value.value,
-            )
+            .set_partition_property(HvPartitionPropertyCode::ReferenceTime.0, value.value)
             .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
         Ok(())
     }


### PR DESCRIPTION
Some hierarchical virtualization environments do not support CPUID queries from the VMM. The mshv backend previously required CPUID to build partition capabilities and determine the physical address width, which made it unusable in these environments.

Add a fallback that constructs capabilities entirely from partition properties (ProcessorVendor, XsaveStates, MaxXsaveDataSize, PhysicalAddressWidth) and the BSP's initial RDX register. The CPUID path is tried first and the property path is used only if the CPUID query fails.

Also replace the mshv_bindings property code constants with typed hvdef equivalents throughout.