### PR TITLE
virt_mshv: Fix is_gpa_mapped in the MMIO emulation path

### DIFF
--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -450,6 +450,7 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             bsp_vcpufd: self.bsp,
             memory: Default::default(),
             gm: config.guest_memory.clone(),
+            mem_layout: config.mem_layout.clone(),
             vps: self.vps,
             irq_routes: Default::default(),
             gsi_states: Mutex::new(Box::new([irqfd::GsiState::Unallocated; irqfd::NUM_GSIS])),
@@ -500,6 +501,7 @@ struct MshvPartitionInner {
     #[inspect(skip)]
     memory: Mutex<MshvMemoryRangeState>,
     gm: GuestMemory,
+    mem_layout: vm_topology::memory::MemoryLayout,
     #[inspect(skip)]
     vps: Vec<MshvVpInner>,
     irq_routes: virt::irqcon::IrqRoutes,
@@ -1152,19 +1154,12 @@ impl EmulatorSupport for MshvEmulationState<'_> {
             .unwrap();
     }
 
-    fn is_gpa_mapped(&self, gpa: u64, write: bool) -> bool {
+    fn is_gpa_mapped(&self, gpa: u64, _write: bool) -> bool {
         self.partition
-            .memory
-            .lock()
-            .ranges
+            .mem_layout
+            .ram()
             .iter()
-            .flatten()
-            .any(|range| {
-                (range.guest_pfn..range.guest_pfn + range.size).contains(&gpa)
-                    && (!write
-                        || range.flags & set_bits!(u8, MSHV_SET_MEM_BIT_WRITABLE)
-                            == set_bits!(u8, MSHV_SET_MEM_BIT_WRITABLE))
-            })
+            .any(|r| r.range.contains_addr(gpa))
     }
 
     fn lapic_base_address(&self) -> Option<u64> {


### PR DESCRIPTION
The previous implementation scanned the internal mapping list to determine whether a GPA was backed by RAM, but the range check compared page frame numbers against byte addresses, so it could never match correctly. Replace it with a scan of the `MemoryLayout` passed in at partition construction time, since MMIO cannot be in these ranges and RAM cannot be outside them.