### PR TITLE
petri: add NVMe emulator support

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -186,7 +186,6 @@ impl PetriVmmBackend for HyperVPetriBackend {
 
         if let Some(UefiConfig {
             disable_frontpage,
-            enable_vpci_boot,
             secure_boot_enabled,
             default_boot_always_attempt,
             ..
@@ -215,44 +214,65 @@ impl PetriVmmBackend for HyperVPetriBackend {
                     "HCL_DEFAULT_BOOT_ALWAYS_ATTEMPT=0",
                 );
             }
-
-            if *enable_vpci_boot {
-                todo!("hyperv nvme boot");
-            }
         }
 
-        // Map SCSI
-        let mut scsi_controllers = HashMap::new();
-        for (
-            vsid,
-            VmbusStorageController {
-                target_vtl,
-                controller_type,
-                drives,
-            },
-        ) in config.vmbus_storage_controllers.iter()
-        {
-            if !matches!(controller_type, crate::VmbusStorageType::Scsi) {
-                todo!("other storage types for hyper-v")
-            }
+        // Collect NVMe emulator device attachments for post-VM-creation setup.
+        //
+        // HyperV Emulated NVMe controllers have read-only VSIDs, which will
+        // not be known until after the VM is created
+        let mut nvme_emulator_attachments: Vec<(Guid, VmbusStorageController, Vec<PathBuf>, u8)> =
+            Vec::new();
 
-            let mut hyperv_drives = HashMap::new();
-            for (lun, Drive { disk, is_dvd }) in drives {
-                hyperv_drives.insert(
-                    *lun,
-                    powershell::HyperVDrive {
-                        disk: petri_disk_to_hyperv(disk.as_ref(), &temp_dir).await?,
-                        is_dvd: *is_dvd,
-                    },
-                );
+        // Map SCSI and NVMe controllers
+        let mut scsi_controllers = HashMap::new();
+        for (vsid, controller) in config.vmbus_storage_controllers.iter() {
+            match &controller.controller_type {
+                crate::VmbusStorageType::Scsi => {
+                    let mut hyperv_drives = HashMap::new();
+                    for (lun, Drive { disk, is_dvd }) in &controller.drives {
+                        hyperv_drives.insert(
+                            *lun,
+                            powershell::HyperVDrive {
+                                disk: petri_disk_to_hyperv(disk.as_ref(), &temp_dir).await?,
+                                is_dvd: *is_dvd,
+                            },
+                        );
+                    }
+                    scsi_controllers.insert(
+                        *vsid,
+                        powershell::HyperVScsiController {
+                            target_vtl: controller.target_vtl,
+                            drives: hyperv_drives,
+                        },
+                    );
+                }
+                crate::VmbusStorageType::Nvme => {
+                    let mut vhd_paths = Vec::new();
+                    for Drive { disk, is_dvd: _ } in controller.drives.values() {
+                        let vhd = petri_disk_to_hyperv(disk.as_ref(), &temp_dir).await?;
+                        if let Some(path) = vhd {
+                            vhd_paths.push(path);
+                        }
+                    }
+                    let vtl_num = match controller.target_vtl {
+                        crate::Vtl::Vtl0 => 0u8,
+                        crate::Vtl::Vtl2 => 2u8,
+                        _ => {
+                            anyhow::bail!(
+                                "unsupported VTL {:?} for NVMe emulator device",
+                                controller.target_vtl
+                            )
+                        }
+                    };
+                    nvme_emulator_attachments.push((*vsid, controller.clone(), vhd_paths, vtl_num));
+                }
+                _ => {
+                    todo!(
+                        "storage type {:?} not yet supported for hyper-v",
+                        controller.controller_type
+                    )
+                }
             }
-            scsi_controllers.insert(
-                *vsid,
-                powershell::HyperVScsiController {
-                    target_vtl: *target_vtl,
-                    drives: hyperv_drives,
-                },
-            );
         }
 
         // Map IDE
@@ -348,11 +368,82 @@ impl PetriVmmBackend for HyperVPetriBackend {
 
         let vm = HyperVVM::new(hyperv_args, log_source.clone(), driver.clone()).await?;
 
+        let PetriVmConfig {
+            firmware,
+            vmbus_storage_controllers,
+            nvme_emulator_lun_mappings,
+            ..
+        } = config;
+
+        // Start with non-NVMe entries; NVMe entries will be added with their
+        // Hyper-V-assigned VSIDs after attachment.
+        let mut runtime_controllers: HashMap<Guid, VmbusStorageController> =
+            vmbus_storage_controllers
+                .into_iter()
+                .filter(|(_, c)| !matches!(c.controller_type, crate::VmbusStorageType::Nvme))
+                .collect();
+
+        // Attach NVMe emulator devices
+        // Unlike other devices, these are added to the configuration after the VM is created
+        let mut nvme_vsid_assignments: Vec<(Guid, Guid)> = Vec::new();
+        for (placeholder_vsid, controller, vhd_paths, target_vtl) in nvme_emulator_attachments {
+            let vsid = powershell::run_add_nvme_emulator_device(vm.name(), &vhd_paths, target_vtl)
+                .await
+                .context("failed to attach NVMe emulator device")?;
+            tracing::info!(?vsid, %placeholder_vsid, "NVMe emulator device attached");
+            runtime_controllers.insert(vsid, controller);
+            nvme_vsid_assignments.push((placeholder_vsid, vsid));
+        }
+
+        // If any NVMe devices were attached, push corrected VTL2 settings
+        // to the VM before start. Fix placeholder VSIDs and inject any
+        // NVMe emulator LUN mappings declared via the builder.
+        if !nvme_vsid_assignments.is_empty() || !nvme_emulator_lun_mappings.is_empty() {
+            if let Some(openhcl_config) = firmware.openhcl_config() {
+                if let Some(settings) = openhcl_config.vtl2_settings.as_ref() {
+                    let mut fixed_settings = settings.clone();
+
+                    // Fix placeholder VSIDs in existing VTL2 settings.
+                    for (placeholder, vsid) in &nvme_vsid_assignments {
+                        assign_nvme_vsid(&mut fixed_settings, placeholder, vsid);
+                    }
+
+                    // Inject LUNs for NVMe emulator disk mappings.
+                    for mapping in &nvme_emulator_lun_mappings {
+                        // Resolve the placeholder VSID to the actual one.
+                        let actual_vsid = nvme_vsid_assignments
+                            .iter()
+                            .find(|(p, _)| *p == mapping.nvme_vsid)
+                            .map(|(_, v)| *v)
+                            .unwrap_or_else(|| {
+                                tracing::warn!(
+                                    nvme_vsid = %mapping.nvme_vsid,
+                                    "NVMe emulator LUN mapping references unknown VSID; \
+                                     using placeholder (this will likely fail)"
+                                );
+                                mapping.nvme_vsid
+                            });
+                        inject_nvme_emulator_lun(
+                            &mut fixed_settings,
+                            mapping.scsi_controller_instance_id,
+                            mapping.scsi_lun,
+                            actual_vsid,
+                            mapping.nvme_namespace_id,
+                        );
+                    }
+
+                    vm.set_base_vtl2_settings(&fixed_settings).await.context(
+                        "failed to push corrected VTL2 settings after NVMe VSID assignment",
+                    )?;
+                }
+            }
+        }
+
         if properties.is_openhcl {
             // Copy the IGVM file locally, since it may not be accessible by
             // Hyper-V (e.g., if it is in a WSL filesystem).
             let local_path = igvm_file.as_ref().unwrap();
-            fs_err::copy(config.firmware.openhcl_firmware().unwrap(), local_path)
+            fs_err::copy(firmware.openhcl_firmware().unwrap(), local_path)
                 .context("failed to copy igvm file")?;
             acl_read_for_vm(local_path, Some(*vm.vmid()))
                 .context("failed to set ACL for igvm file")?;
@@ -392,6 +483,29 @@ impl PetriVmmBackend for HyperVPetriBackend {
 
         vm.start().await?;
 
+        let mut runtime_config = firmware.into_runtime_config(runtime_controllers);
+        // Fix VTL2 settings in the runtime config — into_runtime_config moved
+        // the settings from firmware, which still had placeholder VSIDs.
+        if let Some(settings) = runtime_config.vtl2_settings.as_mut() {
+            for (placeholder, vsid) in &nvme_vsid_assignments {
+                assign_nvme_vsid(settings, placeholder, vsid);
+            }
+            for mapping in &nvme_emulator_lun_mappings {
+                let actual_vsid = nvme_vsid_assignments
+                    .iter()
+                    .find(|(p, _)| *p == mapping.nvme_vsid)
+                    .map(|(_, v)| *v)
+                    .unwrap_or(mapping.nvme_vsid);
+                inject_nvme_emulator_lun(
+                    settings,
+                    mapping.scsi_controller_instance_id,
+                    mapping.scsi_lun,
+                    actual_vsid,
+                    mapping.nvme_namespace_id,
+                );
+            }
+        }
+
         Ok((
             HyperVPetriRuntime {
                 vm,
@@ -401,9 +515,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
                 driver: driver.clone(),
                 properties,
             },
-            config
-                .firmware
-                .into_runtime_config(config.vmbus_storage_controllers),
+            runtime_config,
         ))
     }
 }
@@ -568,6 +680,102 @@ impl PetriVmRuntime for HyperVPetriRuntime {
             )
             .await
     }
+}
+
+/// Update NVMe physical device paths in VTL2 settings, replacing a placeholder
+/// VSID with the Hyper-V-assigned one. Called once per NVMe controller
+/// immediately after attachment — this is a first-time assignment, not a remap.
+fn assign_nvme_vsid(settings: &mut Vtl2Settings, placeholder: &Guid, vsid: &Guid) {
+    let Some(dynamic) = settings.dynamic.as_mut() else {
+        return;
+    };
+    for controller in &mut dynamic.storage_controllers {
+        for lun in &mut controller.luns {
+            if let Some(pd) = lun.physical_devices.as_mut() {
+                if let Some(dev) = pd.device.as_mut() {
+                    assign_device_path(dev, placeholder, vsid);
+                }
+                for dev in &mut pd.devices {
+                    assign_device_path(dev, placeholder, vsid);
+                }
+            }
+        }
+    }
+}
+
+fn assign_device_path(
+    dev: &mut vtl2_settings_proto::PhysicalDevice,
+    placeholder: &Guid,
+    vsid: &Guid,
+) {
+    if dev.device_type != i32::from(vtl2_settings_proto::physical_device::DeviceType::Nvme) {
+        return;
+    }
+    if let Ok(guid) = dev.device_path.parse::<Guid>() {
+        if guid == *placeholder {
+            tracing::debug!(
+                %placeholder,
+                %vsid,
+                "assigning NVMe VSID in VTL2 settings"
+            );
+            dev.device_path = vsid.to_string();
+        }
+    }
+}
+
+/// Inject an NVMe-emulator-backed SCSI LUN into VTL2 settings.
+///
+/// Finds the SCSI controller matching `scsi_controller_id` and appends a new
+/// LUN at `scsi_lun` backed by the NVMe physical device at
+/// `(actual_vsid, nvme_nsid)`.
+fn inject_nvme_emulator_lun(
+    settings: &mut Vtl2Settings,
+    scsi_controller_id: Guid,
+    scsi_lun: u32,
+    actual_vsid: Guid,
+    nvme_nsid: u32,
+) {
+    use crate::vtl2_settings::ControllerType;
+    use crate::vtl2_settings::Vtl2LunBuilder;
+    use crate::vtl2_settings::Vtl2StorageBackingDeviceBuilder;
+
+    let Some(dynamic) = settings.dynamic.as_mut() else {
+        tracing::warn!("no dynamic VTL2 settings — cannot inject NVMe emulator LUN");
+        return;
+    };
+
+    let controller_id_str = scsi_controller_id.to_string();
+    let controller = dynamic
+        .storage_controllers
+        .iter_mut()
+        .find(|c| c.instance_id == controller_id_str);
+
+    let Some(controller) = controller else {
+        tracing::warn!(
+            %scsi_controller_id,
+            "SCSI controller not found in VTL2 settings — cannot inject NVMe emulator LUN"
+        );
+        return;
+    };
+
+    tracing::info!(
+        %scsi_controller_id,
+        scsi_lun,
+        %actual_vsid,
+        nvme_nsid,
+        "injecting NVMe emulator LUN into VTL2 settings"
+    );
+
+    controller.luns.push(
+        Vtl2LunBuilder::disk()
+            .with_location(scsi_lun)
+            .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
+                ControllerType::Nvme,
+                actual_vsid,
+                nvme_nsid,
+            ))
+            .build(),
+    );
 }
 
 fn acl_read_for_vm(path: &Path, id: Option<Guid>) -> anyhow::Result<()> {

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1243,6 +1243,68 @@ pub async fn run_set_vmbus_redirect(
     .context("set_vmbus_redirect")
 }
 
+/// Environment variable name for the directory containing NVMe emulator
+/// scripts (Register-NvmeEmulator.ps1, Add-NvmeEmulatorDevice.ps1,
+/// NvmeEmulatorCommon.psm1).
+pub const PETRI_NVME_EMULATOR_SCRIPTS_DIR: &str = "PETRI_NVME_EMULATOR_SCRIPTS_DIR";
+
+/// Returns the path to the NVMe emulator scripts directory, read from the
+/// `PETRI_NVME_EMULATOR_SCRIPTS_DIR` environment variable. Returns an error if the
+/// env var is unset or the required scripts are missing.
+pub fn get_nvme_emulator_scripts_dir() -> anyhow::Result<PathBuf> {
+    let dir = std::env::var(PETRI_NVME_EMULATOR_SCRIPTS_DIR).map_err(|_| {
+        anyhow::anyhow!(
+            "NVMe emulator scripts not found. Set {PETRI_NVME_EMULATOR_SCRIPTS_DIR} to the \
+             directory containing NVMe emulation management scripts \
+             (Register-NvmeEmulator.ps1, Add-NvmeEmulatorDevice.ps1, NvmeEmulatorCommon.psm1)."
+        )
+    })?;
+    let dir = PathBuf::from(dir);
+    for script in [
+        "Register-NvmeEmulator.ps1",
+        "Add-NvmeEmulatorDevice.ps1",
+        "NvmeEmulatorCommon.psm1",
+    ] {
+        if !dir.join(script).exists() {
+            anyhow::bail!(
+                "Required script '{script}' not found in {PETRI_NVME_EMULATOR_SCRIPTS_DIR}='{}'",
+                dir.display()
+            );
+        }
+    }
+    Ok(dir)
+}
+
+/// Invokes Add-NvmeEmulatorDevice.ps1 to attach an NVMe emulator device
+/// to a Hyper-V VM. Each VHD path becomes an NVMe namespace backed by that
+/// VHD. Returns the Hyper-V-assigned VMBus channel VSID for the new device.
+pub async fn run_add_nvme_emulator_device(
+    vm_name: &str,
+    vhd_paths: &[PathBuf],
+    target_vtl: u8,
+) -> anyhow::Result<Guid> {
+    let scripts_dir = get_nvme_emulator_scripts_dir()?;
+    let script = scripts_dir.join("Add-NvmeEmulatorDevice.ps1");
+    let vhd_args: Vec<String> = vhd_paths.iter().map(|p| p.display().to_string()).collect();
+    let vhd_refs: Vec<&str> = vhd_args.iter().map(|s| s.as_str()).collect();
+    let script_str = format!("& \"{}\"", script.display());
+    let output = run_host_cmd(
+        PowerShellBuilder::new()
+            .cmdlet(script_str)
+            .arg("VmName", vm_name)
+            .arg("VhdPaths", ps::Array::new(&vhd_refs))
+            .arg("TargetVtl", target_vtl)
+            .finish()
+            .build(),
+    )
+    .await
+    .context("add_nvme_emulator_device")?;
+    let vsid_str = output.trim();
+    vsid_str.parse::<Guid>().with_context(|| {
+        format!("failed to parse NVMe emulator VSID from script output: {vsid_str:?}")
+    })
+}
+
 /// Runs Restart-OpenHCL, which will perform and OpenHCL servicing operation.
 pub async fn run_restart_openhcl(
     vmid: &Guid,

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -228,6 +228,11 @@ pub struct PetriVmConfig {
     pub vmbus_storage_controllers: HashMap<Guid, VmbusStorageController>,
     /// PCIe NVMe drives.
     pub pcie_nvme_drives: Vec<PcieNvmeDrive>,
+    /// NVMe emulator LUN mappings — declare that an NVMe emulator disk
+    /// should be relayed as a SCSI LUN to VTL0 via OpenHCL's storvsp.
+    /// The backend injects these into VTL2 settings during VM creation,
+    /// using the actual VSID assigned by the hypervisor.
+    pub nvme_emulator_lun_mappings: Vec<NvmeEmulatorLunMapping>,
 }
 
 /// PCIe NVMe drive configuration.
@@ -412,6 +417,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 tpm: None,
                 vmbus_storage_controllers: HashMap::new(),
                 pcie_nvme_drives: Vec::new(),
+                nvme_emulator_lun_mappings: Vec::new(),
             },
             modify_vmm_config: None,
             resources: PetriVmResources {
@@ -485,6 +491,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 tpm: None,
                 vmbus_storage_controllers: HashMap::new(),
                 pcie_nvme_drives: Vec::new(),
+                nvme_emulator_lun_mappings: Vec::new(),
             },
             modify_vmm_config: None,
             resources: PetriVmResources {
@@ -940,7 +947,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         let uses_pipette_as_init = self.uses_pipette_as_init();
         let properties = self.properties();
 
-        let (mut runtime, config) = self
+        let (mut runtime, mut config) = self
             .backend
             .run(
                 self.config,
@@ -949,6 +956,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 properties,
             )
             .await?;
+        runtime.apply_post_creation_config(&mut config);
         let openhcl_diag_handler = runtime.openhcl_diag();
         let watchdog_tasks =
             Self::start_watchdog_tasks(&self.resources, &mut runtime, self.enable_screenshots)?;
@@ -1476,6 +1484,31 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         self
     }
 
+    /// Declare that an NVMe emulator namespace should be relayed as a SCSI LUN
+    /// to the VTL0 guest.
+    ///
+    /// The `nvme_vsid` must match a VMBus NVMe controller previously added via
+    /// [`Self::add_vmbus_storage_controller`]. The backend will resolve the
+    /// placeholder VSID to the actual one assigned by the hypervisor and inject
+    /// the mapping into VTL2 settings during VM creation.
+    pub fn add_nvme_emulator_lun_mapping(
+        mut self,
+        nvme_vsid: Guid,
+        nvme_namespace_id: u32,
+        scsi_controller_instance_id: Guid,
+        scsi_lun: u32,
+    ) -> Self {
+        self.config
+            .nvme_emulator_lun_mappings
+            .push(NvmeEmulatorLunMapping {
+                nvme_vsid,
+                nvme_namespace_id,
+                scsi_controller_instance_id,
+                scsi_lun,
+            });
+        self
+    }
+
     /// Add a VMBus disk drive to the VM
     pub fn add_ide_drive(
         mut self,
@@ -1980,6 +2013,12 @@ pub trait PetriVmRuntime: Send + Sync + 'static {
     async fn get_guest_state_file(&self) -> anyhow::Result<Option<PathBuf>> {
         Ok(None)
     }
+    /// Apply backend-specific modifications to the runtime config after VM
+    /// creation. Some backends need to reconcile the generic config with
+    /// backend-assigned values (e.g., device identifiers that differ from
+    /// what the test config specified). Called once, after the backend's
+    /// `run()` returns and before the VM is used by tests.
+    fn apply_post_creation_config(&self, _config: &mut PetriVmRuntimeConfig) {}
     /// Set the OpenHCL VTL2 settings
     async fn set_vtl2_settings(&mut self, settings: &Vtl2Settings) -> anyhow::Result<()>;
     /// Add or modify a VMBus disk drive
@@ -3146,6 +3185,24 @@ pub enum VmbusStorageType {
     Nvme,
     /// Virtio block device
     VirtioBlk,
+}
+
+/// Maps an NVMe emulator-backed disk to a SCSI LUN presented to the VTL0
+/// guest. The backend attaches the NVMe emulator device during VM creation,
+/// learns the actual VMBus VSID from the hypervisor, and injects the mapping
+/// into VTL2 settings so OpenHCL's storvsp can relay the disk.
+#[derive(Debug, Clone)]
+pub struct NvmeEmulatorLunMapping {
+    /// VSID of the NVMe VMBus controller that owns the backing namespace.
+    /// This is a placeholder — the backend resolves it to the actual VSID
+    /// at attachment time.
+    pub nvme_vsid: Guid,
+    /// NVMe namespace ID within the emulator device.
+    pub nvme_namespace_id: u32,
+    /// Instance ID of the VTL2 SCSI controller that presents this disk to VTL0.
+    pub scsi_controller_instance_id: Guid,
+    /// LUN on the SCSI controller where this disk appears to the guest.
+    pub scsi_lun: u32,
 }
 
 /// VM disk drive

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -121,6 +121,7 @@ impl PetriVmConfigOpenVmm {
             tpm: tpm_config,
             vmbus_storage_controllers,
             pcie_nvme_drives,
+            nvme_emulator_lun_mappings: _, // only used by Hyper-V backend
         } = petri_vm_config;
 
         tracing::debug!(?firmware, ?arch, "Petri VM firmware configuration");

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -381,6 +381,87 @@ async fn storvsp_hyperv<T: PetriVmmBackend>(
     Ok(())
 }
 
+/// Test a Linux VM with an NVMe emulator-backed disk assigned to VTL2,
+#[cfg(windows)]
+#[vmm_test(unstable_hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)))]
+async fn storvsp_nvme_hyperv<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+    (release_igvm,): (
+        petri::ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
+    ),
+) -> Result<(), anyhow::Error> {
+    // Skip if NVMe emulator scripts are not available.
+    if std::env::var(petri::hyperv::powershell::PETRI_NVME_EMULATOR_SCRIPTS_DIR).is_err() {
+        tracing::warn!(
+            "Skipping storvsp_nvme_hyperv: {} not set",
+            petri::hyperv::powershell::PETRI_NVME_EMULATOR_SCRIPTS_DIR
+        );
+        return Ok(());
+    }
+
+    let vtl2_nsid = 1;
+    let vtl0_scsi_lun = 0;
+    let scsi_instance = Guid::new_random();
+    let nvme_vsid = Guid::new_random();
+    const NVME_DISK_SECTORS: u64 = 0x4_0000;
+    const SECTOR_SIZE: u64 = 512;
+    const EXPECTED_DISK_SIZE_BYTES: u64 = NVME_DISK_SECTORS * SECTOR_SIZE;
+
+    // Assumptions made by test infra & routines:
+    //
+    // 1. Some test-infra added disks are 64MiB in size. Since we find disks by size,
+    // ensure that our test disks are a different size.
+    // 2. Disks under test need to be at least 100MiB for the IO tests (see [`test_storage_linux`]),
+    // with some arbitrary buffer (5MiB in this case).
+    static_assertions::const_assert_ne!(EXPECTED_DISK_SIZE_BYTES, 64 * 1024 * 1024);
+    static_assertions::const_assert!(EXPECTED_DISK_SIZE_BYTES > 105 * 1024 * 1024);
+
+    let mut vhd =
+        tempfile::NamedTempFile::with_suffix("nvme_vtl2.vhd").context("create temp nvme vhd")?;
+    vhd.as_file()
+        .set_len(EXPECTED_DISK_SIZE_BYTES)
+        .context("set file length")?;
+
+    disk_vhd1::Vhd1Disk::make_fixed(vhd.as_file_mut()).context("make fixed")?;
+
+    // Close the handle so Hyper-V can open the VHD.
+    let vhd_path = vhd.into_temp_path();
+
+    let (vm, agent) = config
+        .with_custom_openhcl(release_igvm)
+        .with_vmbus_redirect(true)
+        .add_vtl2_storage_controller(
+            Vtl2StorageControllerBuilder::new(ControllerType::Scsi)
+                .with_instance_id(scsi_instance)
+                .build(),
+        )
+        .add_vmbus_storage_controller(&nvme_vsid, petri::Vtl::Vtl2, petri::VmbusStorageType::Nvme)
+        .add_vmbus_drive(
+            petri::Drive::new(Some(petri::Disk::Persistent(vhd_path.to_path_buf())), false),
+            &nvme_vsid,
+            Some(vtl2_nsid),
+        )
+        .add_nvme_emulator_lun_mapping(nvme_vsid, vtl2_nsid, scsi_instance, vtl0_scsi_lun)
+        .run()
+        .await?;
+
+    test_storage_linux(
+        &agent,
+        scsi_instance,
+        vec![ExpectedGuestDevice {
+            lun: vtl0_scsi_lun,
+            disk_size_sectors: NVME_DISK_SECTORS as usize,
+            friendly_name: "nvme_scsi".to_string(),
+        }],
+    )
+    .await?;
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+
+    Ok(())
+}
+
 /// Test an OpenHCL Linux Stripe VM with two SCSI disk assigned to VTL2 via NVMe Emulator
 #[openvmm_test(
     openhcl_linux_direct_x64,

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -381,7 +381,7 @@ async fn storvsp_hyperv<T: PetriVmmBackend>(
     Ok(())
 }
 
-/// Test a Linux VM with an NVMe emulator-backed disk assigned to VTL2,
+/// Test a Linux VM with an NVMe emulator-backed disk assigned to VTL2.
 #[cfg(windows)]
 #[vmm_test(unstable_hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)))]
 async fn storvsp_nvme_hyperv<T: PetriVmmBackend>(


### PR DESCRIPTION
Adds coverage for HyperV NVMe devices leveraging a closed source emulator

This test is currently marked as unstable for two reasons:
1. The runners that pick up this job are not yet guaranteed to have NVMe emulators and setup scripts
2. This test only passes locally when we force-enable bounce buffering. This is being investigated separately as a potential emulator bug, getting this running in CI will be a useful signal in the meantime 